### PR TITLE
Chart improvements narrow windows

### DIFF
--- a/server/templates/place_overview.html
+++ b/server/templates/place_overview.html
@@ -88,7 +88,7 @@
 
   <div id="body" class="container">
     <div id="body-row" class="row">
-      <div id="sidebar-outer" class="col-md-2 mt-3 mt-md-4 mt-lg-5 d-none d-md-flex">
+      <div id="sidebar-outer" class="col-md-2 d-none d-md-flex">
         <div id="topics"></div>
       </div>
       <div id="main" class="col-md-10 mt-3 mt-md-4 mt-lg-5">

--- a/server/templates/place_overview.html
+++ b/server/templates/place_overview.html
@@ -39,7 +39,7 @@
   <title>{{place_name}} Overview | Data Commons Place Browser</title>
 </head>
 
-<body id="dc-places-overview">
+<body id="dc-places">
   <header>
     <div id="sitename">
       <div class="container">
@@ -88,10 +88,10 @@
 
   <div id="body" class="container">
     <div id="body-row" class="row">
-      <div id="sidebar-outer" class="col-md-2 d-none d-md-flex">
+      <div id="sidebar-outer" class="col-lg-2 d-none d-lg-flex">
         <div id="topics"></div>
       </div>
-      <div id="main" class="col-md-10 mt-3 mt-md-4 mt-lg-5">
+      <div id="main" class="col-lg-10 mt-3 mt-md-4 mt-lg-5">
         <div id="title" class="row">
           <div class="col-12 col-md-6 order-last order-md-2">
             <h1 id="place-name">{{place_name}}</h1>

--- a/static/css/place_overview.css
+++ b/static/css/place_overview.css
@@ -139,36 +139,43 @@ header #selectionbar {
 }
 
 #main-pane h2 {
-  color: var(--dc-red-strong);
+  color: var(--dc-gray);
   font-weight: 500;
   font-size: 1.1rem;
   text-transform: uppercase;
   line-height: 1.5rem;
-  margin-bottom: 10px;
+  margin-top: 10px;
 }
 
-#dc-places-subtopic #main-pane h2 {
-  color: var(--dc-gray);
-}
-
-#dc-places-subtopic #main-pane h2 span {
-  color: var(--dc-red-strong);
-}
-
-.subtopic {
+#main-pane section {
+  border-top: 1px solid var(--dc-gray-lite);
   margin-top: 1rem;
 }
 
-#dc-places-overview .subtopic {
-  border-top: 1px solid var(--dc-gray-lite);
+#main-pane section:first-of-type {
+  border: none;
+  margin-top: 0;
 }
 
 #body .subtopic h3 {
   color: var(--dc-gray);
   font-weight: 700;
-  font-size: 1.1rem;
+  font-size: 1rem;
   text-transform: uppercase;
   margin: 15px 0 10px;
+}
+
+#main-pane h2 .more a,
+#body .subtopic h3 .more a {
+  color: var(--dc-gray);
+  font-weight: 400;
+  font-size: .8rem;
+  float: right;
+  text-decoration: none;
+}
+
+#body .subtopic h3 .more a:hover {
+  text-decoration: underline;
 }
 
 .subtopic .row {

--- a/static/css/place_overview.css
+++ b/static/css/place_overview.css
@@ -258,6 +258,7 @@ header #selectionbar {
 }
 
 #sidebar-outer {
+  margin-top: 150px;
   position: relative;
 }
 #sidebar-outer .fixed {

--- a/static/js/dev.js
+++ b/static/js/dev.js
@@ -129,8 +129,8 @@ window.onload = function () {
   containerId = addChartContainer(width, height);
   drawSingleBarChart(containerId, width, height, dataPoints, "%");
 
-  // Draw single bar chart with potentially weird y-axis values
-  width = 225;
+  // Draw narrow single bar chart with potentially weird y-axis values
+  width = 315;
   dataPoints = [
     new DataPoint("Enrolled in School", 510475),
     new DataPoint("Not Enrolled in School", 1341885),

--- a/static/js/place_overview.jsx
+++ b/static/js/place_overview.jsx
@@ -233,7 +233,7 @@ class MainPane extends Component {
           return (
             <section className="subtopic col-12" key={index}>
               {subtopicHeader}
-              <div className="row row-cols-lg-2 row-cols-md-2 row-cols-sm-2 row-cols-1">
+              <div className="row row-cols-lg-2 row-cols-md-2 row-cols-1">
                 {item.charts.map((config, index) => {
                   let id = randDomId();
                   return (

--- a/static/js/place_overview.jsx
+++ b/static/js/place_overview.jsx
@@ -202,6 +202,7 @@ class MainPane extends Component {
 
   render() {
     let configData = [];
+    let isOverview = !this.props.topic;
     if (!this.props.topic) {
       configData = chartConfig;
     } else {
@@ -216,9 +217,22 @@ class MainPane extends Component {
       <React.Fragment>
         {this.props.dcid != "country/USA" && <Overview topic={this.props.topic} />}
         {configData.map((item, index) => {
+          let subtopicHeader;
+          if (isOverview) {
+            subtopicHeader = (
+              <h3 id={item.label}>
+                <a href={`/place?dcid=${this.props.dcid}&topic=${item.label}`}>{item.label}</a>
+                <span class="more">
+                  <a href={`/place?dcid=${this.props.dcid}&topic=${item.label}`}>More charts ›</a>
+                </span>
+              </h3>
+            );
+          } else {
+            subtopicHeader = <h3 id={item.label}>{item.label}</h3>
+          }
           return (
             <section className="subtopic col-12" key={index}>
-              <h3 id={item.label}>{item.label}</h3>
+              {subtopicHeader}
               <div className="row row-cols-lg-2 row-cols-md-2 row-cols-sm-2 row-cols-1">
                 {item.charts.map((config, index) => {
                   let id = randDomId();
@@ -281,7 +295,7 @@ class Overview extends Component {
     if (!this.props.topic) {
       return (
         <React.Fragment>
-          <h2 className="col-12 pt-2">{!this.props.topic ? "Overview" : this.props.topic}</h2>
+          <h2 className="col-12 pt-2" id="overview">Overview</h2>
           <section className="factoid col-12">
             <div className="row">
               <div className="col-12 col-md-4">
@@ -300,7 +314,13 @@ class Overview extends Component {
         </React.Fragment>
       );
     } else {
-      return <React.Fragment></React.Fragment>;
+      return (
+        <React.Fragment>
+          <h2 className="col-12 pt-2">{this.props.topic}
+          <span class="more"><a href={`/place?dcid=${this.props.dcid}`}>Back to overview ›</a></span>
+          </h2>
+        </React.Fragment>
+      );
     }
   }
 }


### PR DESCRIPTION
* Reduce to 1 chart per row for small windows
* Add navigation elements to subtopics (and back to overview) when the sidebar is hidden
* Slight styling touchups of topics and nav headers

This still doesn't fix very long label names.