### PR TITLE
Dynamically generate chart config based on place's stats vars

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 
 from flask import Flask
@@ -40,11 +41,17 @@ def create_app():
 
     # apply the blueprints to the app
     from routes import factcheck, sitemap, gni
-    from routes.api import place, stats
+    from routes.api import place, stats, chart
     app.register_blueprint(factcheck.bp)
     app.register_blueprint(place.bp)
     app.register_blueprint(sitemap.bp)
     app.register_blueprint(gni.bp)
     app.register_blueprint(stats.bp)
+    app.register_blueprint(chart.bp)
+
+    # Load chart config
+    with open('chart_config.json') as f:
+        chart_config = json.load(f)
+    app.config['CHART_CONFIG'] = chart_config
 
     return app

--- a/server/chart_config.json
+++ b/server/chart_config.json
@@ -11,6 +11,14 @@
         "url": "https://www.census.gov/"
       },
       {
+        "title": "Person Per Area",
+        "topic": "Population",
+        "chartType": "LINE",
+        "statsVars": ["Count_Person_PerArea"],
+        "source": "TODO",
+        "url": "TODO"
+      },
+      {
         "title": "Median Age",
         "topic": "Age",
         "chartType": "LINE",

--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -1,0 +1,105 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import json
+
+from flask import Blueprint, current_app
+
+from cache import cache
+from routes.api.stats import get_stats_info
+from routes.api.place import statsvars
+
+
+# Define blueprint
+bp = Blueprint(
+    "chart",
+    __name__,
+    url_prefix='/api/chart'
+)
+
+def filter_charts(charts, all_stats_vars):
+    result = []
+    for chart in charts:
+        chart_copy = copy.copy(chart)
+        chart_copy['statsVars'] = [
+            x for x in chart_copy['statsVars'] if x in all_stats_vars]
+        if chart_copy['statsVars']:
+            result.append(chart_copy)
+    return result
+
+
+def build_url(dcid, stats_vars, stats_var_info):
+    url = "/gni#&ptpv="
+    parts = []
+    for stats_var in stats_vars:
+        parts.append(stats_var_info[stats_var])
+    url += '__'.join(parts)
+    url += '&place=' + dcid
+    return url
+
+
+@bp.route('/config/<path:dcid>')
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+def config(dcid):
+    """
+    Get chart config for a given place.
+    """
+    all_stats_vars = set(statsvars(dcid))
+    # Build the chart config by filtering the source configuration based on
+    # available statistical variables.
+    cc = []
+    for src_section in current_app.config['CHART_CONFIG']:
+        target_section = {
+          "label": src_section["label"],
+          "charts": filter_charts(src_section['charts'], all_stats_vars),
+          "children": []
+        }
+        for child in src_section['children']:
+            child_charts = filter_charts(child['charts'], all_stats_vars)
+            if child_charts:
+                target_section['children'].append({
+                  'label': child["label"],
+                  'charts': child_charts
+                })
+        if target_section['charts'] or target_section['children']:
+            cc.append(target_section)
+
+    # Gather all stats vars within the final chart config
+    used_stats_vars = set()
+    for section in cc:
+        for chart in section['charts']:
+            used_stats_vars.update(set(chart['statsVars']))
+        for child in section['children']:
+            for chart in child['charts']:
+                used_stats_vars.update(set(chart['statsVars']))
+
+    # Get the stats var info, ie, the partial url used for GNI.
+    stats_var_info = get_stats_info(list(used_stats_vars))
+
+    # Population the GNI url to each chart.
+    for i in range(len(cc)):
+        # Populate gni url for charts
+        for j in range(len(cc[i]['charts'])):
+            cc[i]['charts'][j]['gni'] = build_url(
+                dcid, cc[i]['charts'][j]['statsVars'], stats_var_info)
+        # Populate gni url for children
+        for j in range(len(cc[i].get('children', []))):
+            for k in range(len(cc[i]['children'][j]['charts'])):
+                cc[i]['children'][j]['charts'][k]['gni'] = build_url(
+                    dcid,
+                    cc[i]['children'][j]['charts'][k]['statsVars'],
+                    stats_var_info
+                )
+    return json.dumps(cc)

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -35,6 +35,14 @@ bp = Blueprint(
 @bp.route('/statsvars/<path:dcid>')
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def statsvars_route(dcid):
+    """Get all the statistical variables that exist for a give place.
+
+    Args:
+      dcid: Place dcid.
+
+    Returns:
+      A list of statistical variable dcids.
+    """
     return json.dumps(statsvars(dcid))
 
 

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -32,6 +32,29 @@ bp = Blueprint(
 )
 
 
+@bp.route('/statsvars/<path:dcid>')
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+def statsvars_route(dcid):
+    return json.dumps(statsvars(dcid))
+
+
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+def statsvars(dcid):
+    """
+    Get all the statistical variable dcids for a place.
+    """
+    response = fetch_data(
+        '/place/stats-var',
+        {
+            'dcids': [dcid],
+        },
+        compress=False,
+        post=False,
+        has_payload=False
+    )
+    return response['places'][dcid]['statsVars']
+
+
 @bp.route('/child/<path:dcid>')
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def child(dcid):

--- a/server/routes/api/stats.py
+++ b/server/routes/api/stats.py
@@ -17,7 +17,6 @@ import json
 from flask import Blueprint, request
 from cache import cache
 import services.datacommons as dc
-import logging
 
 # Define blueprint
 bp = Blueprint(
@@ -41,7 +40,6 @@ def get_stats_wrapper(dcid_str, stats_var):
         with value to be the observation time series.
     """
     dcids = dcid_str.split('^')
-    logging.info("%s, %s", dcids, stats_var)
     return json.dumps(dc.get_stats(dcids, stats_var))
 
 
@@ -61,7 +59,7 @@ def stats(stats_var):
     return get_stats_wrapper('^'.join(place_dcids), stats_var)
 
 
-def get_stats_info(dcids):
+def get_stats_url_fragment(dcids):
     """Get stats information give multiple stats var dcids.
 
     The result is used as partial link to GNI.

--- a/server/routes/api/stats.py
+++ b/server/routes/api/stats.py
@@ -17,6 +17,7 @@ import json
 from flask import Blueprint, request
 from cache import cache
 import services.datacommons as dc
+import logging
 
 # Define blueprint
 bp = Blueprint(
@@ -40,6 +41,7 @@ def get_stats_wrapper(dcid_str, stats_var):
         with value to be the observation time series.
     """
     dcids = dcid_str.split('^')
+    logging.info("%s, %s", dcids, stats_var)
     return json.dumps(dc.get_stats(dcids, stats_var))
 
 
@@ -59,14 +61,13 @@ def stats(stats_var):
     return get_stats_wrapper('^'.join(place_dcids), stats_var)
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def get_statsinfo_wrapper(statsvars_string):
-    """Wrapper function to get stats information give multiple stats var.
+def get_stats_info(dcids):
+    """Get stats information give multiple stats var dcids.
 
-    The result is used by chart API.
+    The result is used as partial link to GNI.
 
     Args:
-        statsvars_string: stats var dcids concatenated by "^".
+        dcids: A list of stats var dcids.
     Returns:
         An object keyed by stats dcid, with value being partial url that can
         be used by the /tools/timeline endpoint.
@@ -74,7 +75,6 @@ def get_statsinfo_wrapper(statsvars_string):
             "Count_Person": "Person,count,gender,Female"
         }
     """
-    dcids = statsvars_string.split('^')
     data = dc.fetch_data(
       '/node/triples',
       {
@@ -104,21 +104,3 @@ def get_statsinfo_wrapper(statsvars_string):
             tokens.extend([p, v])
         result[dcid] = ','.join(tokens)
     return result
-
-
-@bp.route('/api/statsinfo')
-def statsinfo():
-    """Handler to get stats information give multiple stats var.
-
-    The result is used by timeline tools page as partial url. It calls the
-    get_statsinfo_wrapper function so the result can be memoized.
-
-    Returns:
-        An object keyed by stats dcid, with value being partial url that can
-        be used by the /tools/timeline endpoint.
-        {
-            "Count_Person": "Person,count,gender,Female"
-        }
-    """
-    stats_vars = sorted(request.args.getlist('dcid'))
-    return get_statsinfo_wrapper('^'.join(stats_vars))

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -333,7 +333,8 @@ def get_interesting_places(dcids):
 # ------------------------- INTERNAL HELPER FUNCTIONS -------------------------
 
 
-def send_request(req_url, req_json={}, compress=False, post=True):
+def send_request(
+        req_url, req_json={}, compress=False, post=True, has_payload=True):
     """ Sends a POST/GET request to req_url with req_json, default to POST.
     Returns:
       The payload returned by sending the POST/GET request formatted as a dict.
@@ -358,22 +359,20 @@ def send_request(req_url, req_json={}, compress=False, post=True):
 
     # Get the JSON
     res_json = response.json()
-    if 'payload' not in res_json:
-        raise ValueError(
-            'Response error: Payload not found. Printing response\n\n'
-            '{}'.format(res_json))
 
     # If the payload is compressed, decompress and decode it
-    payload = res_json['payload']
-    if compress:
-        payload = zlib.decompress(
-            base64.b64decode(payload), zlib.MAX_WBITS | 32)
-    return json.loads(payload)
+    if has_payload:
+        res_json = res_json['payload']
+        if compress:
+            res_json = zlib.decompress(
+                base64.b64decode(res_json), zlib.MAX_WBITS | 32)
+        res_json = json.loads(res_json)
+    return res_json
 
 
-def fetch_data(path, req_json, compress, post):
+def fetch_data(path, req_json, compress, post, has_payload=True):
     req_url = API_ROOT + path
-    return send_request(req_url, req_json, compress, post)
+    return send_request(req_url, req_json, compress, post, has_payload)
 
 
 def _format_expand_payload(payload, new_key, must_exist=[]):

--- a/static/js/place_template.tsx
+++ b/static/js/place_template.tsx
@@ -506,7 +506,11 @@ class Chart extends Component<ChartPropType, ChartStateType> {
               Data from <a href={config.url}>{config.source}</a>
             </div>
             <div>
-              <a target="_blank" className="explore-more" href={config["gni"]}>
+              <a
+                target="_blank"
+                className="explore-more"
+                href={config["exploreUrl"]}
+              >
                 Explore More ›
               </a>
             </div>

--- a/static/js/place_template.tsx
+++ b/static/js/place_template.tsx
@@ -28,7 +28,6 @@ import {
   drawStackBarChart,
   drawGroupBarChart,
 } from "./chart/draw";
-import chartConfig from "./chart_config.json";
 import { fetchStatsData } from "./data_fetcher";
 
 const chartTypeEnum = {
@@ -60,10 +59,15 @@ interface ConfigType {
   source: string;
   url: string;
   axis: string;
-  placeTypes: string[];
   scaling: number;
   perCapita: boolean;
   unit: string;
+}
+
+interface ChartCategory {
+  label: string;
+  charts: ConfigType[];
+  children: { label: string; charts: ConfigType[] }[];
 }
 
 interface ParentPlacePropsType {
@@ -150,6 +154,7 @@ class Ranking extends Component<RankingPropsType, {}> {
 interface MenuPropsType {
   dcid: string;
   topic: string;
+  chartConfig: ChartCategory[];
 }
 
 class Menu extends Component<MenuPropsType, {}> {
@@ -166,46 +171,40 @@ class Menu extends Component<MenuPropsType, {}> {
             Overview
           </a>
         </li>
-        {chartConfig.map(
-          (item: {
-            label: string;
-            charts: ConfigType[];
-            children: {label: string, charts: ConfigType[]}[];
-          }) => {
-            return (
-              <li className="nav-item" key={item.label}>
-                <a
-                  href={`/place?dcid=${dcid}&topic=${item.label}`}
-                  className={`nav-link ${topic == item.label ? "active" : ""}`}
-                >
-                  {item.label}
-                </a>
-                <ul
-                  className={
-                    "nav flex-column ml-3 " +
-                    (item.label != topic ? "collapse" : "")
-                  }
-                  data-parent="#nav-topics"
-                >
-                  <div className="d-block">
-                    {item.children.map((child, index) => {
-                      return (
-                        <li className="nav-item" key={index}>
-                          <a
-                            href={`/place?dcid=${dcid}&topic=${item.label}#${child.label}`}
-                            className="nav-link"
-                          >
-                            {child.label}
-                          </a>
-                        </li>
-                      );
-                    })}
-                  </div>
-                </ul>
-              </li>
-            );
-          }
-        )}
+        {this.props.chartConfig.map((item: ChartCategory) => {
+          return (
+            <li className="nav-item" key={item.label}>
+              <a
+                href={`/place?dcid=${dcid}&topic=${item.label}`}
+                className={`nav-link ${topic == item.label ? "active" : ""}`}
+              >
+                {item.label}
+              </a>
+              <ul
+                className={
+                  "nav flex-column ml-3 " +
+                  (item.label != topic ? "collapse" : "")
+                }
+                data-parent="#nav-topics"
+              >
+                <div className="d-block">
+                  {item.children.map((child, index) => {
+                    return (
+                      <li className="nav-item" key={index}>
+                        <a
+                          href={`/place?dcid=${dcid}&topic=${item.label}#${child.label}`}
+                          className="nav-link"
+                        >
+                          {child.label}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </div>
+              </ul>
+            </li>
+          );
+        })}
       </ul>
     );
   }
@@ -216,10 +215,6 @@ interface MainPanePropType {
    * The place dcid.
    */
   dcid: string;
-  /**
-   * The place type.
-   */
-  placeType: string;
   /**
    * The topic of the current page.
    */
@@ -243,7 +238,7 @@ interface MainPanePropType {
   /**
    * An object from statsvar dcid to the url tokens used by timeline tool.
    */
-  statsVarInfo: { [key: string]: string };
+  chartConfig: ChartCategory[];
 }
 
 class MainPane extends Component<MainPanePropType, {}> {
@@ -255,9 +250,9 @@ class MainPane extends Component<MainPanePropType, {}> {
     let configData = [];
     let isOverview = !this.props.topic;
     if (!this.props.topic) {
-      configData = chartConfig;
+      configData = this.props.chartConfig;
     } else {
-      for (let group of chartConfig) {
+      for (let group of this.props.chartConfig) {
         if (group.label == this.props.topic) {
           configData = group.children;
           break;
@@ -301,12 +296,10 @@ class MainPane extends Component<MainPanePropType, {}> {
                       id={id}
                       config={config}
                       dcid={this.props.dcid}
-                      placeType={this.props.placeType}
                       parentPlaces={this.props.parentPlaces}
                       childPlacesPromise={this.props.childPlacesPromise}
                       similarPlacesPromise={this.props.similarPlacesPromise}
                       nearbyPlacesPromise={this.props.nearbyPlacesPromise}
-                      statsVarInfo={this.props.statsVarInfo}
                     />
                   );
                 })}
@@ -417,10 +410,6 @@ interface ChartPropType {
    */
   config: ConfigType;
   /**
-   * The place type.
-   */
-  placeType: string;
-  /**
    * The parent places object array.
    *
    * Parent object are sorted by enclosing order. For example:
@@ -439,10 +428,6 @@ interface ChartPropType {
    * The nearby places promise.
    */
   nearbyPlacesPromise: Promise<{ dcid: string; name: string }>;
-  /**
-   * An object from statsvar dcid to the url tokens used by timeline tool.
-   */
-  statsVarInfo: { [key: string]: string };
 }
 
 interface ChartStateType {
@@ -453,14 +438,21 @@ interface ChartStateType {
 
 class Chart extends Component<ChartPropType, ChartStateType> {
   chartElement: React.RefObject<HTMLDivElement>;
+  similarRef: React.RefObject<HTMLOptionElement>;
+  nearbyRef: React.RefObject<HTMLOptionElement>;
+  parentRef: React.RefObject<HTMLOptionElement>;
+  childrenRef: React.RefObject<HTMLOptionElement>;
   dcid: string;
   titleSuffix: string;
-  shouldRender: boolean;
   placeRelation: string;
 
   constructor(props) {
     super(props);
     this.chartElement = React.createRef();
+    this.similarRef = React.createRef();
+    this.nearbyRef = React.createRef();
+    this.parentRef = React.createRef();
+    this.childrenRef = React.createRef();
 
     this.state = {
       elemWidth: 0,
@@ -471,61 +463,12 @@ class Chart extends Component<ChartPropType, ChartStateType> {
     this._handlePlaceSelection = this._handlePlaceSelection.bind(this);
     this.dcid = props.dcid;
     this.titleSuffix = "";
-    this.shouldRender = true;
-
     // Default use similar places.
     this.placeRelation = placeRelationEnum.SIMILAR;
-
-    let config = props.config;
-    if (config.placeTypes) {
-      let pagePlaceType = props.placeType;
-      if (
-        config.chartType == chartTypeEnum.LINE ||
-        config.chartType == chartTypeEnum.SINGLE_BAR
-      ) {
-        if (config.placeTypes.includes(pagePlaceType)) {
-          // Renders the chart if it is valid for the page's place type.
-          this.shouldRender = true;
-        } else {
-          // If the page's place type is not valid, use the parent with valid
-          // type. Also reset the dcid of the place to be that of the parent.
-          this.shouldRender = false;
-          for (const parent of props.parentPlaces) {
-            if (_.intersection(config.placeTypes, parent["types"]).length > 0) {
-              this.dcid = parent["dcid"];
-              this.titleSuffix = ` (${parent["name"]})`;
-              this.shouldRender = true;
-              break;
-            }
-          }
-        }
-      } else {
-        // For chart of related places, choose similar places if type matches,
-        // otherwise try use parent places for "contained" selection.
-        if (config.placeTypes.includes(pagePlaceType)) {
-          this.placeRelation = placeRelationEnum.SIMILAR;
-        } else {
-          let isContained = false;
-          for (const parent of props.parentPlaces) {
-            if (_.intersection(config.placeTypes, parent["types"]).length > 0) {
-              this.placeRelation = placeRelationEnum.CONTAINED;
-              isContained = true;
-              break;
-            }
-          }
-          if (!isContained) {
-            this.placeRelation = placeRelationEnum.CONTAINING;
-          }
-        }
-      }
-    }
   }
 
   render() {
     const config = this.props.config;
-    if (!this.shouldRender) {
-      return "";
-    }
     return (
       <div className="col" ref={this.chartElement}>
         <div className="chart-container">
@@ -540,17 +483,20 @@ class Chart extends Component<ChartPropType, ChartStateType> {
                 value={this.placeRelation}
                 onChange={this._handlePlaceSelection}
               >
-                <option value="CONTAINED">contained</option>
-                {this.props.placeType != "City" && (
-                  <option value="CONTAINING">containing</option>
+                <option value="SIMILAR" ref={this.similarRef}>
+                  simliar
+                </option>
+                {this.props.parentPlaces.length > 0 && (
+                  <option value="CONTAINED" ref={this.parentRef}>
+                    contained
+                  </option>
                 )}
-                {(!config.placeTypes ||
-                  config.placeTypes.includes(this.props.placeType)) && (
-                  <React.Fragment>
-                    <option value="SIMILAR">simliar</option>
-                    <option value="NEARBY">nearby</option>
-                  </React.Fragment>
-                )}
+                <option value="CONTAINING" ref={this.childrenRef}>
+                  containing
+                </option>
+                <option value="NEARBY" ref={this.nearbyRef}>
+                  nearby
+                </option>
               </select>
             </label>
           )}
@@ -560,11 +506,7 @@ class Chart extends Component<ChartPropType, ChartStateType> {
               Data from <a href={config.url}>{config.source}</a>
             </div>
             <div>
-              <a
-                target="_blank"
-                className="explore-more"
-                href={this.buildTimelineToolUrl()}
-              >
+              <a target="_blank" className="explore-more" href={config["gni"]}>
                 Explore More ›
               </a>
             </div>
@@ -582,8 +524,7 @@ class Chart extends Component<ChartPropType, ChartStateType> {
       (dp && dp.length == 0) ||
       (dg && (dg.length == 0 || (dg.length == 1 && dg[0].value.length == 0)))
     ) {
-      this.chartElement.current.innerHTML = "";
-      this.chartElement.current.classList.remove("col");
+      alert("No data for selection");
       return;
     }
     // Draw chart.
@@ -601,6 +542,21 @@ class Chart extends Component<ChartPropType, ChartStateType> {
   componentDidMount() {
     window.addEventListener("resize", this._handleWindowResize);
     this.fetchData();
+    Promise.all([
+      this.props.similarPlacesPromise,
+      this.props.childPlacesPromise,
+      this.props.nearbyPlacesPromise,
+    ]).then((values) => {
+      if (this.similarRef.current && Object.keys(values[0]).length == 0) {
+        this.similarRef.current.style.display = "none";
+      }
+      if (this.childrenRef.current && Object.keys(values[1]).length == 0) {
+        this.childrenRef.current.style.display = "none";
+      }
+      if (this.nearbyRef.current && Object.keys(values[2]).length == 0) {
+        this.nearbyRef.current.style.display = "none";
+      }
+    });
   }
 
   _handleWindowResize() {
@@ -620,18 +576,6 @@ class Chart extends Component<ChartPropType, ChartStateType> {
   _handlePlaceSelection(event) {
     this.placeRelation = event.target.value;
     this.fetchData();
-  }
-
-  buildTimelineToolUrl() {
-    // TODO(boxu): change this to /tools/timeline after link migration.
-    let url = "/gni#&ptpv=";
-    let parts = [];
-    for (let statsVar of this.props.config.statsVars) {
-      parts.push(this.props.statsVarInfo[statsVar]);
-    }
-    url += parts.join("__");
-    url += `&place=${this.props.dcid}`;
-    return url;
   }
 
   drawChart() {
@@ -674,9 +618,6 @@ class Chart extends Component<ChartPropType, ChartStateType> {
   }
 
   async fetchData() {
-    if (!this.shouldRender) {
-      return;
-    }
     let dcid = this.dcid;
     const config = this.props.config;
     const chartType = config.chartType;
@@ -714,18 +655,12 @@ class Chart extends Component<ChartPropType, ChartStateType> {
             } else if (this.placeRelation == placeRelationEnum.CONTAINING) {
               placesPromise = this.props.childPlacesPromise.then(
                 (childPlaces) => {
+                  // TODO(boxu): figure out a better way to pick child places.
                   for (let placeType in childPlaces) {
-                    if (
-                      !config.placeTypes ||
-                      config.placeTypes.includes(placeType)
-                    ) {
-                      // Choose the first 5 child places to show in the chart.
-                      return childPlaces[placeType]
-                        .slice(0, 5)
-                        .map((place) => place["dcid"]);
-                    }
+                    return childPlaces[placeType]
+                      .slice(0, 5)
+                      .map((place) => place["dcid"]);
                   }
-                  return [];
                 }
               );
             } else if (this.placeRelation == placeRelationEnum.SIMILAR) {

--- a/static/js/stats_var.test.ts
+++ b/static/js/stats_var.test.ts
@@ -16,11 +16,11 @@
 
 
 import { STATS_VAR_TEXT } from "./stats_var";
-import USChartConfig from "./chart_config.json";
+import chartConfig from "../../server/chart_config.json";
 
 
 test("stats var names", () => {
-  for (let section of USChartConfig) {
+  for (let section of chartConfig) {
     for (let chart of section.charts) {
       for (let statsVar of chart.statsVars) {
         expect(STATS_VAR_TEXT[statsVar]).toBeTruthy();

--- a/static/js/stats_var.ts
+++ b/static/js/stats_var.ts
@@ -23,6 +23,8 @@ const STATS_VAR_TEXT: { [key: string]: string } = {
     "Unemployment Insurance Claim",
   Count_Person_Employed: "Employed People",
   Count_Person_InLaborForce: "People in Labor Force",
+  Count_Person: "Total",
+  Count_Person_PerArea: "Person per Area",
   // age
   Count_Person_Upto5Years: "0-5",
   Count_Person_5To17Years: "5-17",
@@ -32,7 +34,6 @@ const STATS_VAR_TEXT: { [key: string]: string } = {
   Count_Person_55To59Years: "55-59",
   Count_Person_65OrMoreYears: "65+",
   // gender
-  Count_Person: "Total",
   Count_Person_Male: "Male",
   Count_Person_Female: "Female",
   // income


### PR DESCRIPTION
- Move chart config generation to server side.
- Do not show chart sections if not available.
- Better handle child and parent places in dropdown menu.
- Remove places types from config since chart display is based on statsvars.