### PR TITLE
Fix translation tool schema mapping

### DIFF
--- a/server/lib/translator.py
+++ b/server/lib/translator.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 SCHEMA_MAPPING = '''
-Database: dc
-
 Node: E:StatisticalPopulation->E1
 typeOf: StatisticalPopulation
 dcid: C:StatisticalPopulation->id


### PR DESCRIPTION
Schema mapping now does not take bigquery dataset name any more. Remove it in the translation tool as well.