### PR TITLE
Use all place types in contained in (child) place relation

### DIFF
--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -143,7 +143,6 @@ def child_fetch(dcid):
                     'dcid': place['dcid'],
                     'pop': pop.get(place['dcid'], 0)
                 })
-                break
     return result
 
 

--- a/static/js/browser/kg.js
+++ b/static/js/browser/kg.js
@@ -677,9 +677,6 @@ function renderKGPage(
     (t) => t["objectId"] == dcid && t["subjectId"] != dcid
   );
   inArcs = inArcs.map((t) => {
-    if (t["subjectTypes"]) {
-      t["subjectType"] = t["subjectTypes"][0];
-    }
     t["dcid"] = t["subjectId"];
     t["prov"] = t["provenanceId"];
     t["src"] = provDomain[t["provenanceId"]];
@@ -694,10 +691,20 @@ function renderKGPage(
   // Do not show observation in in-arcs as they are handled later.
   inArcs = inArcs.filter((t) => t["subjectType"] != "Observation");
 
-  const inArcsGroup = _.groupBy(inArcs, (arc) => arc["subjectType"]);
+  let inArcsGroup = {};
+  for (let inArc of inArcs) {
+    for (let sType of inArc["subjectTypes"]) {
+      if (!(sType in inArcsGroup)) {
+        inArcsGroup[sType] = [];
+      }
+      inArcsGroup[sType].push(inArc);
+    }
+  }
 
   const inArcsGroupsElem = document.getElementById("in-arcs-groups");
-  for (let parentType in inArcsGroup) {
+  let sortedTypes = Object.keys(inArcsGroup);
+  sortedTypes.sort();
+  for (const parentType of sortedTypes) {
     if (util.isPopulation(parentType)) continue;
     const nodesByPred = _.groupBy(
       inArcsGroup[parentType],

--- a/static/js/shared/util.js
+++ b/static/js/shared/util.js
@@ -20,7 +20,7 @@ const POPULATION = "StatisticalPopulation";
 const OBSERVATION = "Observation";
 const COMPARATIVE_OBSERVATION = "ComparativeObservation";
 
-const MAX_CARD_HEIGHT = 600;
+const MAX_CARD_HEIGHT = 400;
 
 const /** !Array<string> */ STATS = [
     "measuredValue",

--- a/static/webpack.config.js
+++ b/static/webpack.config.js
@@ -21,12 +21,11 @@ const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 const config = {
   entry: {
     dev: [__dirname + "/js/dev.ts", __dirname + "/css/dev.scss"],
-    dev_menu: __dirname + "/js/tools/dev_menu.ts",
-    download: __dirname + "/js/tools/download.js",
     dev_menu: [
       __dirname + "/js/tools/dev_menu.ts",
       __dirname + "/css/dev_menu.scss",
     ],
+    download: __dirname + "/js/tools/download.js",
     kg: [__dirname + "/js/browser/kg.js", __dirname + "/css/kg.scss"],
     mcf_playground: __dirname + "/js/mcf_playground.js",
     place: [


### PR DESCRIPTION
Right now for containing places, only one type is selected. When all child places are grouped by the type, child place are grouped randomly. This fix the bug.