### PR TITLE
fix the chart when statsvar is not available

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -552,7 +552,14 @@ function drawGroupLineChart(
   plotParams: PlotParams,
   unit?: string
 ) {
-  let dataGroups = Object.values(dataGroupsDict)[0];
+  // Get a non-empty array as dataGroups
+  const dataGroupsAll = Object.values(dataGroupsDict);
+  for (let idx = 0; idx < dataGroupsAll.length; idx++){
+    if(dataGroupsAll[idx].length === 0){
+      dataGroupsAll.splice(idx,1);
+    }
+  }
+  let dataGroups =dataGroupsAll[0];
   const dashInLegend = Object.keys(plotParams.dashes).length !== 1;
   const legendTextdWidth = Math.max(width * LEGEND.ratio, LEGEND.minTextWidth);
   const legendWidth = dashInLegend

--- a/static/js/tools/statsvar_menu.tsx
+++ b/static/js/tools/statsvar_menu.tsx
@@ -74,7 +74,8 @@ class Node extends Component<NodePropType, NodeStateType> {
     }
 
     return (
-      // render the node only if it is a valid SV node or it is canExpand
+      // render the node only if it is a valid value node
+      // or it is a property node that can be expanded
       (isValidStatsVar || (this.props.t !== "v" && canExpand)) && (
         <ul className="noborder">
           <li className="value" id={this.props.l}>

--- a/static/js/tools/statsvar_menu.tsx
+++ b/static/js/tools/statsvar_menu.tsx
@@ -161,7 +161,7 @@ class Node extends Component<NodePropType, NodeStateType> {
     if (this.props.t === "p") {
       // a property node can be expanded if it has >= 1 children
       return this.hasChild(this.props.cd);
-    } else if (this.props.t === "c"){
+    } else if (this.props.t === "c") {
       // the top level node is expandable if has valid value node
       // or valid property node
       let hasChild = false;
@@ -170,26 +170,24 @@ class Node extends Component<NodePropType, NodeStateType> {
           item.t === "v" &&
           (!this.props.filter || this.props.statsVarValid.has(item.sv))
         ) {
-          hasChild = true;// valid value node
-        }
-         else if (this.hasChild(item.cd)) {
-          hasChild = true;// valid property node
+          hasChild = true; // valid value node
+        } else if (this.hasChild(item.cd)) {
+          hasChild = true; // valid property node
         }
       });
       return hasChild;
-    }
-    else{
+    } else {
       // a value node is expandable if it has valid property node
       let valid = false;
-      if (this.props.cd){
-      this.props.cd.map((item) => {
-        if (this.hasChild(item.cd)) {
-          valid = true;
-        }
-      });
-      return valid;
+      if (this.props.cd) {
+        this.props.cd.map((item) => {
+          if (this.hasChild(item.cd)) {
+            valid = true;
+          }
+        });
+        return valid;
+      }
     }
-  }
   }
 
   private hasChild(children) {
@@ -197,10 +195,7 @@ class Node extends Component<NodePropType, NodeStateType> {
     let hasChild = false;
     if (children && children.length !== 0) {
       children.map((item) => {
-        if (
-          !this.props.filter ||
-          this.props.statsVarValid.has(item.sv)
-        ) {
+        if (!this.props.filter || this.props.statsVarValid.has(item.sv)) {
           hasChild = true;
         }
       });

--- a/static/js/tools/statsvar_menu.tsx
+++ b/static/js/tools/statsvar_menu.tsx
@@ -158,49 +158,54 @@ class Node extends Component<NodePropType, NodeStateType> {
   }
 
   private canExpand() {
-    if (this.props.t !== "c") {
-      // a node can be expanded if it has >= 1 children
-      return this.childCnt(this.props.cd) !== 0;
-    } else {
-      // if the node is the top level node i.e. this.props.t === "c"
-      // we need to check if its child node has valid nodes.
-      let childCnt = 0; // number of valid child nodes
+    if (this.props.t === "p") {
+      // a property node can be expanded if it has >= 1 children
+      return this.hasChild(this.props.cd);
+    } else if (this.props.t === "c"){
+      // the top level node is expandable if has valid value node
+      // or it has property node which has valid child nodes.
+      let hasChild = false; // number of valid child nodes
       this.props.cd.map((item) => {
-        let valid = false;
         if (
           item.t === "v" &&
           (!this.props.filter || this.props.statsVarValid.has(item.sv))
         ) {
-          valid = true;// the node is valid if it's a valid value node
+          hasChild = true;// valid value node
         }
-         else if (this.childCnt(item.cd) !== 0) {
-          valid = true;// the node is valid if it has non-zero children
-        }
-        if (valid) {
-          childCnt += 1;
+         else if (this.hasChild(item.cd)) {
+          hasChild = true;// valid property node
         }
       });
-      return childCnt !== 0;
+      return hasChild;
+    }
+    else{
+      // a value node is expandable if any of its child property node has valid child nodes
+      let valid = false;
+      if (this.props.cd){
+      this.props.cd.map((item) => {
+        if (this.hasChild(item.cd)) {
+          valid = true;
+        }
+      });
+      return valid;
     }
   }
+  }
 
-  private childCnt(children) {
-    let childCnt = 0;
+  private hasChild(children) {
+    // return if a property node has valid children
+    let hasChild = false;
     if (children && children.length !== 0) {
       children.map((item) => {
         if (
-          // a valid child node is either a property node,
-          // or a value node not filtered
-          // or a value node with valid statsVar id
-          item.t !== "v" ||
           !this.props.filter ||
           this.props.statsVarValid.has(item.sv)
         ) {
-          childCnt += 1;
+          hasChild = true;
         }
       });
     }
-    return childCnt;
+    return hasChild;
   }
 }
 

--- a/static/js/tools/statsvar_menu.tsx
+++ b/static/js/tools/statsvar_menu.tsx
@@ -164,18 +164,18 @@ class Node extends Component<NodePropType, NodeStateType> {
     } else if (this.props.t === "c") {
       // the top level node is expandable if has valid value node
       // or valid property node
-      let hasChild = false;
+      let valid = false;
       this.props.cd.map((item) => {
         if (
           item.t === "v" &&
           (!this.props.filter || this.props.statsVarValid.has(item.sv))
         ) {
-          hasChild = true; // valid value node
+          valid = true; // valid value node
         } else if (this.hasChild(item.cd)) {
-          hasChild = true; // valid property node
+          valid = true; // valid property node
         }
       });
-      return hasChild;
+      return valid;
     } else {
       // a value node is expandable if it has valid property node
       let valid = false;
@@ -185,22 +185,22 @@ class Node extends Component<NodePropType, NodeStateType> {
             valid = true;
           }
         });
-        return valid;
       }
+      return valid;
     }
   }
 
   private hasChild(children) {
-    // return if a property node has valid children
-    let hasChild = false;
+    // return true if a property node has valid children
+    let valid = false;
     if (children && children.length !== 0) {
       children.map((item) => {
         if (!this.props.filter || this.props.statsVarValid.has(item.sv)) {
-          hasChild = true;
+          valid = true;
         }
       });
     }
-    return hasChild;
+    return valid;
   }
 }
 

--- a/static/js/tools/statsvar_menu.tsx
+++ b/static/js/tools/statsvar_menu.tsx
@@ -163,8 +163,8 @@ class Node extends Component<NodePropType, NodeStateType> {
       return this.hasChild(this.props.cd);
     } else if (this.props.t === "c"){
       // the top level node is expandable if has valid value node
-      // or it has property node which has valid child nodes.
-      let hasChild = false; // number of valid child nodes
+      // or valid property node
+      let hasChild = false;
       this.props.cd.map((item) => {
         if (
           item.t === "v" &&
@@ -179,7 +179,7 @@ class Node extends Component<NodePropType, NodeStateType> {
       return hasChild;
     }
     else{
-      // a value node is expandable if any of its child property node has valid child nodes
+      // a value node is expandable if it has valid property node
       let valid = false;
       if (this.props.cd){
       this.props.cd.map((item) => {


### PR DESCRIPTION
- fix the problem that the chart cannot be rendered when the statsvar is not available for one of the places
- fix the filtering logic of menu: need to check two levels for value nodes. 