### PR TITLE
Exit tests upon any failure, and propagate errors from test commands

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 # Run test for client side code.
 function run_npm_test {
   cd static


### PR DESCRIPTION
Test failures on datcom-ci were undetected by cloud build because the error codes weren't propagated from the run_test script.