### PR TITLE
Fix 0 range in d3 y axis plot

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -594,7 +594,10 @@ function drawGroupLineChart(
   // Adjust the width of in-chart legends.
   const yRange = computeRanges(dataGroupsDict);
   const minV = yRange.minV;
-  const maxV = yRange.maxV;
+  let maxV = yRange.maxV;
+  if (minV === maxV) {
+    maxV = minV + 1;
+  }
 
   let container: d3.Selection<any, any, any, any>;
   if (typeof selector === "string") {


### PR DESCRIPTION
Current behavior:
![image](https://user-images.githubusercontent.com/5951856/88983793-d5a18280-d280-11ea-9d72-c184b692a995.png)

With this fix:
![image](https://user-images.githubusercontent.com/5951856/88983814-e0f4ae00-d280-11ea-85f1-b39a8c72a4c7.png)
