### PR TITLE
fix the problem of statsvar title not properly set

### DIFF
--- a/static/js/tools/statsvar_menu.tsx
+++ b/static/js/tools/statsvar_menu.tsx
@@ -227,6 +227,7 @@ class Menu extends Component<MenuPropType, MenuStateType> {
     this.statsVarId2Title = {};
   }
   render() {
+    this.statsVarId2Title = {};
     return (
       <div id="drill">
         <div className="noedge">


### PR DESCRIPTION
The statsvar title is not set when:

- (1) select a statsvar 

- (2) unselect the statsvar 

- (3) select a new statsvar.

The reason is that the variable that stores the statsvar title is not reset, so the condition of setting statsvar title based on count is not satisfied.