### PR TITLE
add event propagation in timeline_search and timeline_chart

### DIFF
--- a/static/js/tools/mock_functions.tsx
+++ b/static/js/tools/mock_functions.tsx
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jest.mock("axios");
+import { when } from "jest-when";
+import axios from "axios";
+import hierarchy from "../../data/hierarchy_top.json";
+import { drawGroupLineChart } from "../chart/draw";
+import * as d3 from "d3";
+
+export function axios_mock(): void {
+  // Mock all the async axios call.
+  axios.get = jest.fn();
+  // get stats.
+  when(axios.get)
+    .calledWith("/api/stats/Median_Age_Person?&dcid=geoId/05")
+    .mockResolvedValue({
+      data: {
+        "geoId/05": {
+          place_dcid: "geoId/05",
+          place_name: "Arkansas",
+          provenance_domain: "census.gov",
+          data: { "2011": 37.3, "2012": 37.4, "2013": 37.5, "2014": 37.6 },
+        },
+      },
+    });
+  // get hierachy.json
+  when(axios.get)
+    .calledWith("../../data/hierarchy_statsvar.json")
+    .mockResolvedValue({ data: hierarchy });
+
+  // get statsvar properties
+  when(axios.get)
+    .calledWith("/api/stats/stats-var-property?dcid=Median_Age_Person")
+    .mockResolvedValue({
+      data: {
+        Median_Age_Person: { md: "", mprop: "age", pt: "Person", pvs: {} },
+      },
+    });
+  // get place stats vars
+  when(axios.get)
+    .calledWith("/api/place/statsvars/geoId/05")
+    .mockResolvedValue({ data: ["Count_Person", "Median_Age_Person"] });
+  // get place names
+  when(axios.get)
+    .calledWith("/api/place/name?dcid=geoId/05")
+    .mockResolvedValue({ data: { "geoId/05": "Place" } });
+}
+
+// Mock drawGroupLineChart() as getComputedTextLength can has issue with jest
+// and jsdom.
+export function drawGroupLineChart_mock(): void {
+  (drawGroupLineChart as jest.Mock).mockImplementation(
+    (selector: string | HTMLDivElement) => {
+      let container: d3.Selection<any, any, any, any>;
+      if (typeof selector === "string") {
+        container = d3.select("#" + selector);
+      } else if (selector instanceof HTMLDivElement) {
+        container = d3.select(selector);
+      } else {
+        return;
+      }
+      container.selectAll("svg").remove();
+
+      const svg = container
+        .append("svg")
+        .attr("width", 500)
+        .attr("height", 500);
+      svg.append("text").text("svg text");
+    }
+  );
+}

--- a/static/js/tools/timeline_chart.tsx
+++ b/static/js/tools/timeline_chart.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { Component } from "react";
-import { StatsVarInfo, updateUrl } from "./timeline_util";
+import { StatsVarInfo } from "./timeline_util";
 import { fetchStatsData, StatsData } from "../shared/data_fetcher";
 import { drawGroupLineChart } from "../chart/draw";
 import { PlotParams, computePlotParams } from "../chart/base";
@@ -25,8 +25,8 @@ const CHART_HEIGHT = 300;
 interface StatsVarChipPropsType {
   statsVar: string;
   color: string;
-  deleteStatsVarChip: (statsVar: string) => void;
   title: string;
+  removeStatsVar: (statsVar: string, nodePath?: string[]) => void;
 }
 
 class StatsVarChip extends Component<StatsVarChipPropsType, unknown> {
@@ -40,7 +40,7 @@ class StatsVarChip extends Component<StatsVarChipPropsType, unknown> {
         <button className="mdl-chip__action">
           <i
             className="material-icons"
-            onClick={() => this.props.deleteStatsVarChip(this.props.statsVar)}
+            onClick={() => this.props.removeStatsVar(this.props.statsVar)}
           >
             cancel
           </i>
@@ -58,6 +58,7 @@ interface ChartPropsType {
   perCapita: boolean;
   onDataUpdate: (mprop: string, data: StatsData) => void;
   statsVarTitle: Record<string, string>;
+  removeStatsVar: (statsVar: string, nodePath?: string[]) => void;
 }
 
 class Chart extends Component<ChartPropsType, unknown> {
@@ -99,7 +100,7 @@ class Chart extends Component<ChartPropsType, unknown> {
                   statsVar={statsVar}
                   title={title}
                   color={color}
-                  deleteStatsVarChip={this.deleteStatsVarChip}
+                  removeStatsVar={this.props.removeStatsVar}
                 />
               );
             }.bind(this)
@@ -161,11 +162,6 @@ class Chart extends Component<ChartPropsType, unknown> {
       this.plotParams,
       Array.from(this.statsData.sources)
     );
-  }
-
-  // TODO(shifucun): no need to pass this function from parent?
-  private deleteStatsVarChip(statsVarUpdate: string) {
-    updateUrl({ statsVar: { statsVar: statsVarUpdate, shouldAdd: false } });
   }
 }
 

--- a/static/js/tools/timeline_chart_region.tsx
+++ b/static/js/tools/timeline_chart_region.tsx
@@ -25,6 +25,7 @@ interface ChartRegionPropsType {
   statsVars: { [key: string]: StatsVarInfo };
   perCapita: boolean;
   statsVarTitle: Record<string, string>;
+  removeStatsVar: (statsVar: string, nodePath?: string[]) => void;
 }
 
 class ChartRegion extends Component<ChartRegionPropsType, unknown> {
@@ -71,6 +72,7 @@ class ChartRegion extends Component<ChartRegionPropsType, unknown> {
               perCapita={this.props.perCapita}
               onDataUpdate={this.onDataUpdate.bind(this)}
               statsVarTitle={statsVarTitle}
+              removeStatsVar={this.props.removeStatsVar}
             ></Chart>
           );
         }, this)}

--- a/static/js/tools/timeline_page.test.tsx
+++ b/static/js/tools/timeline_page.test.tsx
@@ -19,15 +19,11 @@ jest.mock("../chart/draw");
 
 import Enzyme, { mount } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import { when } from "jest-when";
 
 import React from "react";
-import axios from "axios";
-import * as d3 from "d3";
 
 import { Page } from "./timeline_page";
-import { drawGroupLineChart } from "../chart/draw";
-import hierarchy from "../../data/hierarchy_top.json";
+import { axios_mock, drawGroupLineChart_mock } from "./mock_functions";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -44,65 +40,11 @@ test("Single place and single stats var", () => {
   });
   // Mock drawGroupLineChart() as getComputedTextLength can has issue with jest
   // and jsdom.
-  (drawGroupLineChart as jest.Mock).mockImplementation(
-    (selector: string | HTMLDivElement) => {
-      let container: d3.Selection<any, any, any, any>;
-      if (typeof selector === "string") {
-        container = d3.select("#" + selector);
-      } else if (selector instanceof HTMLDivElement) {
-        container = d3.select(selector);
-      } else {
-        return;
-      }
-      container.selectAll("svg").remove();
-
-      const svg = container
-        .append("svg")
-        .attr("width", 500)
-        .attr("height", 500);
-      svg.append("text").text("svg text");
-    }
-  );
-
-  // Mock all the async axios call.
-  axios.get = jest.fn();
-  // get stats.
-  when(axios.get)
-    .calledWith("/api/stats/Median_Age_Person?&dcid=geoId/05")
-    .mockResolvedValue({
-      data: {
-        "geoId/05": {
-          place_dcid: "geoId/05",
-          place_name: "Arkansas",
-          provenance_domain: "census.gov",
-          data: { "2011": 37.3, "2012": 37.4, "2013": 37.5, "2014": 37.6 },
-        },
-      },
-    });
-  // get hierachy.json
-  when(axios.get)
-    .calledWith("../../data/hierarchy_statsvar.json")
-    .mockResolvedValue({ data: hierarchy });
-  // get statsvar properties
-  when(axios.get)
-    .calledWith("/api/stats/stats-var-property?dcid=Median_Age_Person")
-    .mockResolvedValue({
-      data: {
-        Median_Age_Person: { md: "", mprop: "age", pt: "Person", pvs: {} },
-      },
-    });
-  // get place stats vars
-  when(axios.get)
-    .calledWith("/api/place/statsvars/geoId/05")
-    .mockResolvedValue({ data: ["Count_Person", "Median_Age_Person"] });
-  // get place names
-  when(axios.get)
-    .calledWith("/api/place/name?dcid=geoId/05")
-    .mockResolvedValue({ data: { "geoId/05": "Place" } });
-
+  drawGroupLineChart_mock();
+  // mock all the async axios call
+  axios_mock();
   // Do the actual render!
   const wrapper = mount(<Page />);
-
   // There are 3 promises to resolve:
   // 1) all for [statsVarInfo, placeName, validStatsVar]
   // 2) get hierachy.json
@@ -123,3 +65,7 @@ test("Single place and single stats var", () => {
       );
     });
 });
+
+// TODO(Lijuan)
+// add test functions mocking check/uncheck a statsVar, delete statsVar chip
+// and delete place chips etc.

--- a/static/js/tools/timeline_page.tsx
+++ b/static/js/tools/timeline_page.tsx
@@ -66,13 +66,12 @@ class Page extends Component<Record<string, unknown>, PageStateType> {
       statsVarInfoPromise = getStatsVarInfo(this.params.getStatsVarDcids());
     }
     let placesPromise = Promise.resolve({});
-    if (this.params.placeDcids.length !== 0) {
-      placesPromise = getPlaceNames(this.params.placeDcids);
-    }
     let validStatsVarPromise = Promise.resolve(new Set<string>());
     if (this.params.placeDcids.length !== 0) {
+      placesPromise = getPlaceNames(this.params.placeDcids);
       validStatsVarPromise = getStatsVar(this.params.placeDcids);
     }
+    
     Promise.all([
       statsVarInfoPromise,
       placesPromise,

--- a/static/js/tools/timeline_page.tsx
+++ b/static/js/tools/timeline_page.tsx
@@ -59,9 +59,20 @@ class Page extends Component<Record<string, unknown>, PageStateType> {
   }
 
   componentDidMount(): void {
-    const statsVarInfoPromise = getStatsVarInfo(this.params.getStatsVarDcids());
-    const placesPromise = getPlaceNames(this.params.placeDcids);
-    const validStatsVarPromise = getStatsVar(this.params.placeDcids);
+    // Initial rendering has emmpty state. This proactively parse the url hash
+    // and re-render.
+    let statsVarInfoPromise = Promise.resolve({});
+    if (this.params.getStatsVarDcids().length !== 0) {
+      statsVarInfoPromise = getStatsVarInfo(this.params.getStatsVarDcids());
+    }
+    let placesPromise = Promise.resolve({});
+    if (this.params.placeDcids.length !== 0) {
+      placesPromise = getPlaceNames(this.params.placeDcids);
+    }
+    let validStatsVarPromise = Promise.resolve(new Set<string>());
+    if (this.params.placeDcids.length !== 0) {
+      validStatsVarPromise = getStatsVar(this.params.placeDcids);
+    }
     Promise.all([
       statsVarInfoPromise,
       placesPromise,
@@ -167,7 +178,11 @@ class Page extends Component<Record<string, unknown>, PageStateType> {
         <div id="plot-container">
           <div className="container">
             <div id="search">
-              <SearchBar places={this.state.placeIdNames} />
+              <SearchBar
+                places={this.state.placeIdNames}
+                addPlace={this.addPlace.bind(this)}
+                removePlace={this.removePlace.bind(this)}
+              />
             </div>
             {Object.keys(this.state.placeIdNames).length === 0 && <Info />}
             {Object.keys(this.state.placeIdNames).length !== 0 &&
@@ -178,6 +193,7 @@ class Page extends Component<Record<string, unknown>, PageStateType> {
                     statsVars={this.state.statsVarInfo}
                     perCapita={this.state.perCapita}
                     statsVarTitle={this.state.statsVarTitle}
+                    removeStatsVar={this.removeStatsVar.bind(this)}
                   ></ChartRegion>
                 </div>
               )}

--- a/static/js/tools/timeline_search.tsx
+++ b/static/js/tools/timeline_search.tsx
@@ -17,25 +17,19 @@
 import React, { Component, PureComponent } from "react";
 import {} from "googlemaps";
 import axios from "axios";
-import { updateUrl } from "./timeline_util";
 
 interface ChipPropType {
   placeName: string;
   placeId: string;
+  removePlace: (place: string) => void;
 }
 
-interface ChipStateType {
-  placeId: string;
-}
-
-class Chip extends PureComponent<ChipPropType, ChipStateType> {
+class Chip extends PureComponent<ChipPropType, Record<string, unknown>> {
   constructor(props) {
     super(props);
     this.deleteChip = this.deleteChip.bind(this);
-    this.state = {
-      placeId: props.placeId,
-    };
   }
+
   render() {
     return (
       <span className="mdl-chip mdl-chip--deletable">
@@ -46,13 +40,16 @@ class Chip extends PureComponent<ChipPropType, ChipStateType> {
       </span>
     );
   }
-  deleteChip() {
-    updateUrl({ place: { place: this.state.placeId, shouldAdd: false } });
+
+  private deleteChip() {
+    this.props.removePlace(this.props.placeId);
   }
 }
 
 interface SearchBarPropType {
   places: Record<string, string>;
+  addPlace: (place: string) => void;
+  removePlace: (place: string) => void;
 }
 
 class SearchBar extends Component<SearchBarPropType, unknown> {
@@ -64,11 +61,6 @@ class SearchBar extends Component<SearchBarPropType, unknown> {
     this.getPlaceAndRender = this.getPlaceAndRender.bind(this);
     this.inputElem = React.createRef();
     this.ac = null;
-  }
-  shouldComponentUpdate(nextProps: SearchBarPropType): boolean {
-    return (
-      JSON.stringify(this.props.places) !== JSON.stringify(nextProps.places)
-    );
   }
 
   render(): JSX.Element {
@@ -86,6 +78,7 @@ class SearchBar extends Component<SearchBarPropType, unknown> {
                   : placeId
               }
               key={placeId}
+              removePlace={this.props.removePlace}
             ></Chip>
           ))}
         </span>
@@ -117,7 +110,7 @@ class SearchBar extends Component<SearchBarPropType, unknown> {
     axios
       .get(`/api/placeid2dcid/${place.place_id}`)
       .then((resp) => {
-        updateUrl({ place: { place: resp.data, shouldAdd: true } });
+        this.props.addPlace(resp.data);
       })
       .catch(() => {
         alert("Sorry, but we don't have any data about " + name);


### PR DESCRIPTION
- pass addPlace/removePlace, and removeStatsVar functions to search bar and chart region
- move the mock functions into a separate file for reusing by different tests
- fix the error of calling api when no statsVar/ places are selected
