### PR TITLE
fix issue #272 Chart labels too big 

### DIFF
--- a/static/css/draw.scss
+++ b/static/css/draw.scss
@@ -69,6 +69,6 @@ path.line {
   font-size: 14px;
 }
 
-text {
+.label {
   font-size: 12px;
 }

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -536,6 +536,7 @@ function drawGroupLineChart(
   }
   svg
     .append("text")
+    .attr("class", "label")
     .attr("text-anchor", "start")
     .attr("transform", `translate(${MARGIN.grid}, ${LABELTOPMARGIN})`)
     .text(ylabelText);
@@ -569,6 +570,7 @@ function drawGroupLineChart(
     const sourceText = "Data source: " + source.filter(Boolean).join(", ");
     svg
       .append("text")
+      .attr("class", "label")
       .attr("text-anchor", "start")
       .attr(
         "transform",


### PR DESCRIPTION
Place:
![image](https://user-images.githubusercontent.com/43854757/89923822-28f3c900-dbcf-11ea-8648-e85ea014832e.png)
Timeline:
![image](https://user-images.githubusercontent.com/43854757/89924021-69ebdd80-dbcf-11ea-808e-0f30ae687ddd.png)

