### PR TITLE
Fix "timelines lines extend beyond the chart area"

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -530,7 +530,7 @@ function drawGroupLineChart(
     .nice(NUM_Y_TICKS);
 
   addXAxis(svg, height, xScale);
-  addYAxis(svg, width - MARGIN.right - legendWidth, yScale, unit);
+  addYAxis(svg, width - legendWidth, yScale, unit);
 
   // add ylabel
   svg


### PR DESCRIPTION
The bug is because the x-axis range and the width for plotting the grids are mismatched. 
Timelines Page after fix:
![image](https://user-images.githubusercontent.com/43854757/90945537-6a684d80-e3f3-11ea-925f-5b286fed84b2.png)
Place Page
![image](https://user-images.githubusercontent.com/43854757/90945539-6dfbd480-e3f3-11ea-8051-414c640e531f.png)
