### PR TITLE
Added map resizing.

### DIFF
--- a/static/css/tools/choropleth.scss
+++ b/static/css/tools/choropleth.scss
@@ -19,7 +19,7 @@
 @import '../draw';
 
 #map_container {
-  margin-left: 12%;
+  margin-left: 5%;
   margin-right: 12%;
 }
 
@@ -44,6 +44,7 @@
 
 #legend {
   float: right;
+  margin-right: 20%;
 }
 
 #explore #percapita-link {

--- a/static/js/tools/choropleth/choropleth.tsx
+++ b/static/js/tools/choropleth/choropleth.tsx
@@ -421,11 +421,16 @@ class ChoroplethMap extends Component {
   }
 
   render(): JSX.Element {
+    // TODO(fpernice-google): Handle window resize event to update map size.
     const w = window.innerWidth;
     const h = window.innerHeight;
     return (
       <React.Fragment>
-        <svg id="map_container" width={`${w * 2/3}px`} height={`${h * 2/3}px`}>
+        <svg
+          id="map_container"
+          width={`${(w * 2) / 3}px`}
+          height={`${(h * 2) / 3}px`}
+        >
           <g className="map"></g>
         </svg>
       </React.Fragment>

--- a/static/js/tools/choropleth/choropleth.tsx
+++ b/static/js/tools/choropleth/choropleth.tsx
@@ -421,10 +421,11 @@ class ChoroplethMap extends Component {
   }
 
   render(): JSX.Element {
-    // TODO(iancostello): capture size from parent.
+    const w = window.innerWidth;
+    const h = window.innerHeight;
     return (
       <React.Fragment>
-        <svg id="map_container" width="800px" height="500px">
+        <svg id="map_container" width={`${w * 2/3}px`} height={`${h * 2/3}px`}>
           <g className="map"></g>
         </svg>
       </React.Fragment>


### PR DESCRIPTION
After investigating for a few hours, I could find no better way of resizing the map to the screen than setting it to a size that is some fraction of the screen size. I suspect there must be a way of telling a React component to "take up as much screen as it can without overstepping other components," but I have not found a way of doing this. 

Below is a picture of the finished product, on a large screen size (such that before it would have taken up a small fraction of the screen):

![Screenshot 2020-08-24 at 2 37 09 PM](https://user-images.githubusercontent.com/66977152/91099403-14282400-e618-11ea-9b49-e37d466e36ef.png)
