### PR TITLE
Fix key error exception and update children place selection logic

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Main entry module specified in app.yaml.
 
 This module contains the request handler codes and the main app.
@@ -31,11 +30,8 @@ from lib import translator
 from __init__ import create_app
 from cache import cache
 
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s %(levelname)s %(lineno)d : %(message)s')
-
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s %(levelname)s %(lineno)d : %(message)s')
 
 app = create_app()
 
@@ -60,10 +56,9 @@ def api_placeid2dcid(placeid):
 
 @app.route('/translator')
 def translator_handler():
-    return flask.render_template(
-        'translator.html',
-        schema_mapping=translator.SCHEMA_MAPPING,
-        sample_query=translator.SAMPLE_QUERY)
+    return flask.render_template('translator.html',
+                                 schema_mapping=translator.SCHEMA_MAPPING,
+                                 sample_query=translator.SAMPLE_QUERY)
 
 
 @app.route('/search')
@@ -93,8 +88,8 @@ def search_dc():
             name_tokens = set(name_tokens)
             if not name_tokens & query_tokens:
                 continue
-            entity['rank'] = len(name_tokens & query_tokens) / len(name_tokens
-                                                                   | query_tokens)
+            entity['rank'] = len(name_tokens & query_tokens) / len(name_tokens |
+                                                                   query_tokens)
             entities.append(entity)
         entities = sorted(entities, key=lambda e: (e['rank']), reverse=True)
         if entities:
@@ -102,7 +97,9 @@ def search_dc():
                 'type': section['typeName'],
                 'entities': entities,
             })
-    return flask.render_template('search_dc.html', query_text=query_text, results=results)
+    return flask.render_template('search_dc.html',
+                                 query_text=query_text,
+                                 results=results)
 
 
 @app.route('/weather')
@@ -121,13 +118,15 @@ def get_weather():
                     ' ?o measuredProperty {prop} .'
                     ' ?o observationDate ?date .'
                     ' ?o unit ?unit .'
-                    ' ?o meanValue ?mean .}}').format(
-        dcid=dcid, prop=prop)
+                    ' ?o meanValue ?mean .}}').format(dcid=dcid, prop=prop)
 
     _, rows = dc.query(query_string)
 
     observations = []
     for row in rows:
+        if ('value' not in row['cells'][0] or 'value' not in row['cells'][1] or
+                'value' not in row['cells'][2]):
+            continue
         date = row['cells'][0]['value']
         if date < '2000':
             continue

--- a/static/js/place/place_template.tsx
+++ b/static/js/place/place_template.tsx
@@ -783,12 +783,24 @@ class Chart extends Component<ChartPropType, ChartStateType> {
             } else if (this.placeRelation === placeRelationEnum.CONTAINING) {
               placesPromise = this.props.childPlacesPromise.then(
                 (childPlaces) => {
-                  // TODO(boxu): figure out a better way to pick child places.
+                  // Choose the place type that has the highest average
+                  // population
+                  let avgPop = 0;
+                  let result: string[];
                   for (const placeType in childPlaces) {
-                    return childPlaces[placeType]
-                      .slice(0, 5)
-                      .map((place) => place.dcid);
+                    const children = childPlaces[placeType];
+                    const pop =
+                      children
+                        .map((place) => place["pop"])
+                        .reduce(function (a, b) {
+                          return a + b;
+                        }, 0) / children.length;
+                    if (pop > avgPop) {
+                      avgPop = pop;
+                      result = children.slice(0, 5).map((place) => place.dcid);
+                    }
                   }
+                  return result;
                 }
               );
             } else if (this.placeRelation === placeRelationEnum.SIMILAR) {


### PR DESCRIPTION
Note there are some auto-formatting by yapf on the modified files.

webdriver tests revealed a bug in current children places selection. With new places from wikidata, there are more children place types. For example, California has a village children that has 0 population, thus making the "containing" places chart not showing.

Added a fix to pick the child place type that has the highest average population.

[1] http://staging.datacommons.org/api/place/child/geoId/06  