### PR TITLE
extend timeout to 1 hour for website deploy

### DIFF
--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -53,4 +53,4 @@ steps:
         git commit -m "Deployed website to staging at commit https://github.com/datacommonsorg/website/commit/$SHORT_SHA"
         git push origin master
 
-timeout: 1200s
+timeout: 3600s


### PR DESCRIPTION
The dep of google-cloud-secret-manager, grpcio, takes about 10min to complete, should add enough buffer for testing, binary push etc.