### PR TITLE
[place charts] Add support for specialized denominators for each stat var

### DIFF
--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -26,7 +26,7 @@ import services.datacommons as dc_service
 import routes.api.place as place_api
 
 from cache import cache
-from flask import Blueprint, current_app, url_for
+from flask import Blueprint, current_app, Response, url_for
 
 # Define blueprint
 bp = Blueprint(
@@ -176,4 +176,4 @@ def config(dcid):
         'data': cached_chart_data,
     }
 
-    return json.dumps(response)
+    return Response(response, 200, mimetype='application/json')

--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -176,4 +176,4 @@ def config(dcid):
         'data': cached_chart_data,
     }
 
-    return Response(response, 200, mimetype='application/json')
+    return Response(json.dumps(response), 200, mimetype='application/json')

--- a/static/js/place/place_template.tsx
+++ b/static/js/place/place_template.tsx
@@ -66,6 +66,7 @@ interface ConfigType {
   topic: string;
   chartType: string;
   statsVars: string[];
+  denominator: string[];
   source: string;
   url: string;
   axis: string;
@@ -747,6 +748,7 @@ class Chart extends Component<ChartPropType, ChartStateType> {
           config.statsVars,
           perCapita,
           scaling,
+          config.denominator,
           this.props.chartData
         ).then((data) => {
           const dataGroups = data.getStatsVarGroupWithTime(dcid);
@@ -764,6 +766,7 @@ class Chart extends Component<ChartPropType, ChartStateType> {
           config.statsVars,
           perCapita,
           scaling,
+          config.denominator,
           this.props.chartData
         ).then((data) => {
           this.setState({
@@ -818,6 +821,7 @@ class Chart extends Component<ChartPropType, ChartStateType> {
                 config.statsVars,
                 perCapita,
                 scaling,
+                config.denominator,
                 this.props.chartData
               ).then((data) => {
                 this.setState({
@@ -835,6 +839,7 @@ class Chart extends Component<ChartPropType, ChartStateType> {
               config.statsVars,
               perCapita,
               scaling,
+              config.denominator,
               this.props.chartData
             ).then((data) => {
               this.setState({

--- a/static/js/shared/data_fetcher.test.ts
+++ b/static/js/shared/data_fetcher.test.ts
@@ -175,3 +175,229 @@ test("StatsData test", () => {
   });
   expect(statsData.getStatsVarGroupWithTime("geoId/01")).toEqual([]);
 });
+
+test("Per capita with specified denominators test", () => {
+  mockedAxios.get.mockImplementation((url: string) => {
+    if (url === "/api/stats/Count_Person_Female?&dcid=geoId/05&dcid=geoId/06") {
+      return Promise.resolve({
+        data: {
+          "geoId/05": {
+            data: {
+              "2011": 21000,
+              "2012": 22000,
+            },
+            placeName: "Arkansas",
+            provenanceDomain: "source1",
+          },
+          "geoId/06": {
+            data: {
+              "2011": 31000,
+              "2012": 32000,
+            },
+            placeName: "California",
+            provenanceDomain: "source2",
+          },
+        },
+      });
+    } else if (
+      url === "/api/stats/Count_Person_Male?&dcid=geoId/05&dcid=geoId/06"
+    ) {
+      return Promise.resolve({
+        data: {
+          "geoId/05": {
+            data: {
+              "2011": 11000,
+              "2012": 13000,
+            },
+            placeName: "Arkansas",
+            provenanceDomain: "source1",
+          },
+          "geoId/06": {
+            data: {
+              "2011": 15000,
+              "2012": 16000,
+            },
+            placeName: "California",
+            provenanceDomain: "source2",
+          },
+        },
+      });
+    }
+  });
+
+  return fetchStatsData(
+    ["geoId/05", "geoId/06"],
+    ["Count_Person_Male", "Count_Person_Female"],
+    false,
+    1,
+    ["Count_Person_Male", "Count_Person_Female"]
+  ).then((data) => {
+    expect(data).toEqual({
+      data: {
+        Count_Person_Male: {
+          "geoId/05": {
+            data: {
+              "2011": 1,
+              "2012": 1,
+            },
+            placeName: "Arkansas",
+            provenanceDomain: "source1",
+          },
+          "geoId/06": {
+            data: {
+              "2011": 1,
+              "2012": 1,
+            },
+            placeName: "California",
+            provenanceDomain: "source2",
+          },
+        },
+        Count_Person_Female: {
+          "geoId/05": {
+            data: {
+              "2011": 1,
+              "2012": 1,
+            },
+            placeName: "Arkansas",
+            provenanceDomain: "source1",
+          },
+          "geoId/06": {
+            data: {
+              "2011": 1,
+              "2012": 1,
+            },
+            placeName: "California",
+            provenanceDomain: "source2",
+          },
+        },
+      },
+      dates: ["2011", "2012"],
+      places: ["geoId/05", "geoId/06"],
+      statsVars: ["Count_Person_Male", "Count_Person_Female"],
+      sources: new Set(["source1", "source2"]),
+    });
+
+    expect(data.getPlaceGroupWithStatsVar()).toEqual([
+      new DataGroup("Arkansas", [
+        { label: "Male", value: 1 },
+        { label: "Female", value: 1 },
+      ]),
+      new DataGroup("California", [
+        { label: "Male", value: 1 },
+        { label: "Female", value: 1 },
+      ]),
+    ]);
+
+    expect(data.getStatsVarGroupWithTime("geoId/06")).toEqual([
+      new DataGroup("Count_Person_Male", [
+        { label: "2011", value: 1 },
+        { label: "2012", value: 1 },
+      ]),
+      new DataGroup("Count_Person_Female", [
+        { label: "2011", value: 1 },
+        { label: "2012", value: 1 },
+      ]),
+    ]);
+
+    expect(data.getTimeGroupWithStatsVar("geoId/06")).toEqual([
+      new DataGroup("2011", [
+        { label: "Male", value: 1 },
+        { label: "Female", value: 1 },
+      ]),
+      new DataGroup("2012", [
+        { label: "Male", value: 1 },
+        { label: "Female", value: 1 },
+      ]),
+    ]);
+
+    expect(data.getStatsPoint("geoId/06")).toEqual([
+      { label: "Male", value: 1 },
+      { label: "Female", value: 1 },
+    ]);
+  });
+});
+
+test("Per capita with specified denominators test from cache", () => {
+  return fetchStatsData(
+    ["geoId/05", "geoId/06"],
+    ["Count_Person_Male", "Count_Person_Female"],
+    false,
+    1,
+    ["Count_Person_Male", "Count_Person_Female"],
+    {
+      "geoId/05": {
+        Count_Person_Male: {
+          data: {
+            "2011": 1300,
+            "2012": 2100
+          },
+          provenanceDomain: "source1"
+        },
+        Count_Person_Female: {
+          data: {
+            "2011": 500,
+            "2012": 300
+          },
+          provenanceDomain: "source1"
+        }
+      },
+      "geoId/06": {
+        Count_Person_Male: {
+          data: {
+            "2011": 200,
+            "2012": 300
+          },
+          provenanceDomain: "source2"
+        },
+        Count_Person_Female: {
+          data: {
+            "2011": 1000,
+            "2012": 3000
+          },
+          provenanceDomain: "source2"
+        }
+      }
+    }
+  ).then((data) => {
+    expect(data).toEqual({
+      data: {
+        Count_Person_Male: {
+          "geoId/05": {
+            data: {
+              "2011": 1,
+              "2012": 1,
+            },
+            provenanceDomain: "source1",
+          },
+          "geoId/06": {
+            data: {
+              "2011": 1,
+              "2012": 1,
+            },
+            provenanceDomain: "source2",
+          },
+        },
+        Count_Person_Female: {
+          "geoId/05": {
+            data: {
+              "2011": 1,
+              "2012": 1,
+            },
+            provenanceDomain: "source1",
+          },
+          "geoId/06": {
+            data: {
+              "2011": 1,
+              "2012": 1,
+            },
+            provenanceDomain: "source2",
+          },
+        },
+      },
+      dates: ["2011", "2012"],
+      places: ["geoId/05", "geoId/06"],
+      statsVars: ["Count_Person_Male", "Count_Person_Female"],
+      sources: new Set(["source1", "source2"]),
+    });
+  });
+});

--- a/static/js/shared/data_fetcher.test.ts
+++ b/static/js/shared/data_fetcher.test.ts
@@ -329,34 +329,34 @@ test("Per capita with specified denominators test from cache", () => {
         Count_Person_Male: {
           data: {
             "2011": 1300,
-            "2012": 2100
+            "2012": 2100,
           },
-          provenanceDomain: "source1"
+          provenanceDomain: "source1",
         },
         Count_Person_Female: {
           data: {
             "2011": 500,
-            "2012": 300
+            "2012": 300,
           },
-          provenanceDomain: "source1"
-        }
+          provenanceDomain: "source1",
+        },
       },
       "geoId/06": {
         Count_Person_Male: {
           data: {
             "2011": 200,
-            "2012": 300
+            "2012": 300,
           },
-          provenanceDomain: "source2"
+          provenanceDomain: "source2",
         },
         Count_Person_Female: {
           data: {
             "2011": 1000,
-            "2012": 3000
+            "2012": 3000,
           },
-          provenanceDomain: "source2"
-        }
-      }
+          provenanceDomain: "source2",
+        },
+      },
     }
   ).then((data) => {
     expect(data).toEqual({

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -255,7 +255,9 @@ function getStatsDataFromCachedData(
   cachedData: CachedStatVarDataMap = {}
 ): StatsData {
   if (denominators.length && denominators.length != statsVars.length) {
-    console.log("StatVars must have the same number of denominators, if specified");
+    console.log(
+      "StatVars must have the same number of denominators, if specified"
+    );
     return;
   }
   const result = new StatsData(places, statsVars, [], {});
@@ -347,7 +349,9 @@ function fetchStatsData(
   cachedData: CachedStatVarDataMap = {}
 ): Promise<StatsData> {
   if (denominators.length && denominators.length != statsVars.length) {
-    console.log("StatVars must have the same number of denominators, if specified");
+    console.log(
+      "StatVars must have the same number of denominators, if specified"
+    );
     return;
   }
 
@@ -420,8 +424,4 @@ function fetchStatsData(
   });
 }
 
-export {
-  CachedStatVarDataMap,
-  StatsData,
-  fetchStatsData,
-};
+export { CachedStatVarDataMap, StatsData, fetchStatsData };

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -254,6 +254,10 @@ function getStatsDataFromCachedData(
   denominators: string[] = [],
   cachedData: CachedStatVarDataMap = {}
 ): StatsData {
+  if (denominators.length && denominators.length != statsVars.length) {
+    console.log("StatVars must have the same number of denominators, if specified");
+    return;
+  }
   const result = new StatsData(places, statsVars, [], {});
   const dates: Set<string> = new Set();
   for (let i = 0; i < statsVars.length; i++) {
@@ -342,6 +346,11 @@ function fetchStatsData(
   denominators: string[] = [],
   cachedData: CachedStatVarDataMap = {}
 ): Promise<StatsData> {
+  if (denominators.length && denominators.length != statsVars.length) {
+    console.log("StatVars must have the same number of denominators, if specified");
+    return;
+  }
+
   if (isAllCachedDataAvailable(places, statsVars, denominators, cachedData)) {
     return new Promise((resolve) => {
       resolve(

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -25,8 +25,8 @@ interface TimeSeries {
   data: {
     [date: string]: number; // Date might be "latest" if it's from the cache
   };
-  placeName: string;
-  placeDcid: string;
+  placeName?: string;
+  placeDcid?: string;
   provenanceDomain: string;
 }
 
@@ -34,7 +34,7 @@ interface StatApiResponse {
   [placeDcid: string]: TimeSeries | null;
 }
 
-interface CachedStatsVarDataMap {
+interface CachedStatVarDataMap {
   [geoId: string]: {
     [statVar: string]: TimeSeries;
   };
@@ -197,13 +197,14 @@ class StatsData {
 function isAllCachedDataAvailable(
   places: string[],
   statsVars: string[],
-  cachedData: CachedStatsVarDataMap
+  denominators: string[],
+  cachedData: CachedStatVarDataMap
 ): boolean {
   for (const place of places) {
     if (!(place in cachedData)) {
       return false;
     }
-    for (const sv of statsVars) {
+    for (const sv of statsVars.concat(denominators)) {
       if (!(sv in cachedData[place])) {
         return false;
       }
@@ -220,9 +221,15 @@ function isAllCachedDataAvailable(
  *
  * @return StatApiResponse object with the place and input.
  */
-function statApiResponse(place: string, input: TimeSeries): StatApiResponse {
+function statApiResponseFromCacheData(
+  statVar: string,
+  places: string[],
+  cachedData: CachedStatVarDataMap
+): StatApiResponse {
   const result = {};
-  result[place] = input;
+  for (const place of places) {
+    result[place] = cachedData[place][statVar];
+  }
   return result;
 }
 
@@ -244,20 +251,28 @@ function getStatsDataFromCachedData(
   statsVars: string[],
   perCapita = false,
   scaling = 1,
-  cachedData: CachedStatsVarDataMap = {}
+  denominators: string[] = [],
+  cachedData: CachedStatVarDataMap = {}
 ): StatsData {
   const result = new StatsData(places, statsVars, [], {});
   const dates: Set<string> = new Set();
-  for (const place of places) {
-    for (const sv of statsVars) {
-      result.data[sv] = statApiResponse(place, cachedData[place][sv]);
-      if (perCapita) {
-        result.data[sv] = computePerCapita(
-          result.data[sv],
-          statApiResponse(place, cachedData[place][TOTAL_POPULATION_SV]),
-          scaling
-        );
-      }
+  for (let i = 0; i < statsVars.length; i++) {
+    const sv = statsVars[i];
+    result.data[sv] = statApiResponseFromCacheData(sv, places, cachedData);
+    if (perCapita) {
+      result.data[sv] = computePerCapita(
+        result.data[sv],
+        statApiResponseFromCacheData(TOTAL_POPULATION_SV, places, cachedData),
+        scaling
+      );
+    } else if (denominators.length) {
+      result.data[sv] = computePerCapita(
+        result.data[sv],
+        statApiResponseFromCacheData(denominators[i], places, cachedData),
+        scaling
+      );
+    }
+    for (const place of places) {
       const timeSeries = result.data[sv][place];
       result.sources.add(timeSeries.provenanceDomain);
       for (const date in timeSeries.data) {
@@ -324,9 +339,10 @@ function fetchStatsData(
   statsVars: string[],
   perCapita = false,
   scaling = 1,
-  cachedData: CachedStatsVarDataMap = {}
+  denominators: string[] = [],
+  cachedData: CachedStatVarDataMap = {}
 ): Promise<StatsData> {
-  if (isAllCachedDataAvailable(places, statsVars, cachedData)) {
+  if (isAllCachedDataAvailable(places, statsVars, denominators, cachedData)) {
     return new Promise((resolve) => {
       resolve(
         getStatsDataFromCachedData(
@@ -334,6 +350,7 @@ function fetchStatsData(
           statsVars,
           perCapita,
           scaling,
+          denominators,
           cachedData
         )
       );
@@ -353,6 +370,10 @@ function fetchStatsData(
     apiDataPromises.push(
       axios.get(`/api/stats/${TOTAL_POPULATION_SV}${dcidParams}`)
     );
+  } else {
+    for (const denom of denominators) {
+      apiDataPromises.push(axios.get(`/api/stats/${denom}${dcidParams}`));
+    }
   }
 
   return Promise.all(apiDataPromises).then((allResp) => {
@@ -365,6 +386,12 @@ function fetchStatsData(
         result.data[sv] = computePerCapita(
           allResp[i].data,
           allResp[numStatsVars].data,
+          scaling
+        );
+      } else if (denominators.length) {
+        result.data[sv] = computePerCapita(
+          allResp[i].data,
+          allResp[i + numStatsVars].data,
           scaling
         );
       }
@@ -385,7 +412,7 @@ function fetchStatsData(
 }
 
 export {
-  CachedStatsVarDataMap as CachedStatVarDataMap,
+  CachedStatVarDataMap,
   StatsData,
   fetchStatsData,
 };

--- a/static/js/shared/stats_var.ts
+++ b/static/js/shared/stats_var.ts
@@ -151,15 +151,6 @@ const STATS_VAR_TEXT: { [key: string]: string } = {
   // Employment
   UnemploymentRate_Person_Male: "Male",
   UnemploymentRate_Person_Female: "Female",
-  // TEST
-  Count_Person_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone: "Native american",
-  Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone: "Asian",
-  Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone: "Black",
-  Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino: "Hispanic",
-  Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone: "Native Hawaiian",
-  Count_Person_BelowPovertyLevelInThePast12Months_SomeOtherRaceAlone: "Other",
-  Count_Person_BelowPovertyLevelInThePast12Months_TwoOrMoreRaces: "Two or more",
-  Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone: "White",
 };
 
 export { STATS_VAR_TEXT };

--- a/static/js/shared/stats_var.ts
+++ b/static/js/shared/stats_var.ts
@@ -151,6 +151,15 @@ const STATS_VAR_TEXT: { [key: string]: string } = {
   // Employment
   UnemploymentRate_Person_Male: "Male",
   UnemploymentRate_Person_Female: "Female",
+  // TEST
+  Count_Person_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone: "Native american",
+  Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone: "Asian",
+  Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone: "Black",
+  Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino: "Hispanic",
+  Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone: "Native Hawaiian",
+  Count_Person_BelowPovertyLevelInThePast12Months_SomeOtherRaceAlone: "Other",
+  Count_Person_BelowPovertyLevelInThePast12Months_TwoOrMoreRaces: "Two or more",
+  Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone: "White",
 };
 
 export { STATS_VAR_TEXT };

--- a/static/js/tools/timeline_chart.tsx
+++ b/static/js/tools/timeline_chart.tsx
@@ -152,6 +152,7 @@ class Chart extends Component<ChartPropsType, unknown> {
       Object.keys(this.props.statsVars),
       this.props.perCapita,
       1,
+      [],
       {}
     ).then((statsData) => {
       this.statsData = statsData;


### PR DESCRIPTION
Requires a list of denominator stat vars of the same length (and in the same order) as the list of stat var for each chart. e.g.

              {
                "title": "Poverty by Race Across Places",
                "chartType": "GROUP_BAR",
                "axis": "PLACE",
                "statsVars": [
                  "Count_Person_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone",
                  "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone",
                  "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone",
                  "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
                  "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
                  "Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone"
                ],
                "denominator": [
                  "Count_Person_AmericanIndianOrAlaskaNativeAlone",
                  "Count_Person_AsianAlone",
                  "Count_Person_BlackOrAfricanAmericanAlone",
                  "Count_Person_HispanicOrLatino",
                  "Count_Person_NativeHawaiianOrOtherPacificIslanderAlone",
                  "Count_Person_WhiteAlone"
                ],
                "scaling": 100,
                "unit": "%",
                "source": "US Census",
                "url": "https://www.census.gov/"
              }