### PR TITLE
fix dividing by population of 0

### DIFF
--- a/static/js/shared/data_fetcher.test.ts
+++ b/static/js/shared/data_fetcher.test.ts
@@ -191,29 +191,28 @@ test("fetch stats data with per capita with population size 0", () => {
     }
   });
 
-  return fetchStatsData(
-    ["geoId/05"], ["Count_Person_Male"], true).then(
-      (data) => {
-        expect(data).toEqual({
-          data: {
-            Count_Person_Male: {
-              "geoId/05": {
-                data: {
-                  "2011": 0,
-                  "2012": 0,
-                },
-                placeName: "Arkansas",
-                provenanceDomain: "source1",
+  return fetchStatsData(["geoId/05"], ["Count_Person_Male"], true).then(
+    (data) => {
+      expect(data).toEqual({
+        data: {
+          Count_Person_Male: {
+            "geoId/05": {
+              data: {
+                "2011": 0,
+                "2012": 0,
               },
+              placeName: "Arkansas",
+              provenanceDomain: "source1",
             },
           },
-          dates: ["2011", "2012"],
-          places: ["geoId/05"],
-          statsVars: ["Count_Person_Male"],
-          sources: new Set(["source1"]),
-        });
-      }
-    );
+        },
+        dates: ["2011", "2012"],
+        places: ["geoId/05"],
+        sources: new Set(["source1"]),
+        statsVars: ["Count_Person_Male"],
+      });
+    }
+  );
 });
 
 test("StatsData test", () => {

--- a/static/js/shared/data_fetcher.test.ts
+++ b/static/js/shared/data_fetcher.test.ts
@@ -160,6 +160,89 @@ test("fetch stats data", () => {
   });
 });
 
+test("fetch stats data with per capita", () => {
+  mockedAxios.get.mockImplementation((url: string) => {
+    if (url === "/api/stats/Count_Person?&dcid=geoId/05&dcid=geoId/06") {
+      return Promise.resolve({
+        data: {
+          "geoId/05": {
+            data: {
+              "2011": 0,
+              "2012": 0,
+            },
+            placeName: "Arkansas",
+            provenanceDomain: "source1",
+          },
+          "geoId/06": {
+            data: {
+              "2011": 31000,
+              "2012": 32000,
+            },
+            placeName: "California",
+            provenanceDomain: "source2",
+          },
+        },
+      });
+    } else if (
+      url === "/api/stats/Count_Person_Male?&dcid=geoId/05&dcid=geoId/06"
+    ) {
+      return Promise.resolve({
+        data: {
+          "geoId/05": {
+            data: {
+              "2011": 11000,
+              "2012": 13000,
+            },
+            placeName: "Arkansas",
+            provenanceDomain: "source1",
+          },
+          "geoId/06": {
+            data: {
+              "2011": 15000,
+              "2012": 16000,
+            },
+            placeName: "California",
+            provenanceDomain: "source2",
+          },
+        },
+      });
+    }
+  });
+
+  return fetchStatsData(
+    ["geoId/05", "geoId/06"],
+    ["Count_Person_Male"],
+    true
+  ).then((data) => {
+    expect(data).toEqual({
+      data: {
+        Count_Person_Male: {
+          "geoId/05": {
+            data: {
+              "2011": 0,
+              "2012": 0,
+            },
+            placeName: "Arkansas",
+            provenanceDomain: "source1",
+          },
+          "geoId/06": {
+            data: {
+              "2011": 15000 / 31000,
+              "2012": 16000 / 32000,
+            },
+            placeName: "California",
+            provenanceDomain: "source2",
+          },
+        },
+      },
+      dates: ["2011", "2012"],
+      places: ["geoId/05", "geoId/06"],
+      statsVars: ["Count_Person_Male"],
+      sources: new Set(["source1", "source2"]),
+    });
+  });
+});
+
 test("StatsData test", () => {
   // Test partial data
   const statsData = new StatsData([], [], [], {

--- a/static/js/shared/data_fetcher.test.ts
+++ b/static/js/shared/data_fetcher.test.ts
@@ -160,9 +160,9 @@ test("fetch stats data", () => {
   });
 });
 
-test("fetch stats data with per capita", () => {
+test("fetch stats data with per capita with population size 0", () => {
   mockedAxios.get.mockImplementation((url: string) => {
-    if (url === "/api/stats/Count_Person?&dcid=geoId/05&dcid=geoId/06") {
+    if (url === "/api/stats/Count_Person?&dcid=geoId/05") {
       return Promise.resolve({
         data: {
           "geoId/05": {
@@ -173,18 +173,10 @@ test("fetch stats data with per capita", () => {
             placeName: "Arkansas",
             provenanceDomain: "source1",
           },
-          "geoId/06": {
-            data: {
-              "2011": 31000,
-              "2012": 32000,
-            },
-            placeName: "California",
-            provenanceDomain: "source2",
-          },
         },
       });
     } else if (
-      url === "/api/stats/Count_Person_Male?&dcid=geoId/05&dcid=geoId/06"
+      url === "/api/stats/Count_Person_Male?&dcid=geoId/05"
     ) {
       return Promise.resolve({
         data: {
@@ -196,21 +188,13 @@ test("fetch stats data with per capita", () => {
             placeName: "Arkansas",
             provenanceDomain: "source1",
           },
-          "geoId/06": {
-            data: {
-              "2011": 15000,
-              "2012": 16000,
-            },
-            placeName: "California",
-            provenanceDomain: "source2",
-          },
         },
       });
     }
   });
 
   return fetchStatsData(
-    ["geoId/05", "geoId/06"],
+    ["geoId/05"],
     ["Count_Person_Male"],
     true
   ).then((data) => {
@@ -225,20 +209,12 @@ test("fetch stats data with per capita", () => {
             placeName: "Arkansas",
             provenanceDomain: "source1",
           },
-          "geoId/06": {
-            data: {
-              "2011": 15000 / 31000,
-              "2012": 16000 / 32000,
-            },
-            placeName: "California",
-            provenanceDomain: "source2",
-          },
         },
       },
       dates: ["2011", "2012"],
-      places: ["geoId/05", "geoId/06"],
+      places: ["geoId/05"],
       statsVars: ["Count_Person_Male"],
-      sources: new Set(["source1", "source2"]),
+      sources: new Set(["source1"]),
     });
   });
 });

--- a/static/js/shared/data_fetcher.test.ts
+++ b/static/js/shared/data_fetcher.test.ts
@@ -175,9 +175,7 @@ test("fetch stats data with per capita with population size 0", () => {
           },
         },
       });
-    } else if (
-      url === "/api/stats/Count_Person_Male?&dcid=geoId/05"
-    ) {
+    } else if (url === "/api/stats/Count_Person_Male?&dcid=geoId/05") {
       return Promise.resolve({
         data: {
           "geoId/05": {
@@ -194,29 +192,28 @@ test("fetch stats data with per capita with population size 0", () => {
   });
 
   return fetchStatsData(
-    ["geoId/05"],
-    ["Count_Person_Male"],
-    true
-  ).then((data) => {
-    expect(data).toEqual({
-      data: {
-        Count_Person_Male: {
-          "geoId/05": {
-            data: {
-              "2011": 0,
-              "2012": 0,
+    ["geoId/05"], ["Count_Person_Male"], true).then(
+      (data) => {
+        expect(data).toEqual({
+          data: {
+            Count_Person_Male: {
+              "geoId/05": {
+                data: {
+                  "2011": 0,
+                  "2012": 0,
+                },
+                placeName: "Arkansas",
+                provenanceDomain: "source1",
+              },
             },
-            placeName: "Arkansas",
-            provenanceDomain: "source1",
           },
-        },
-      },
-      dates: ["2011", "2012"],
-      places: ["geoId/05"],
-      statsVars: ["Count_Person_Male"],
-      sources: new Set(["source1"]),
-    });
-  });
+          dates: ["2011", "2012"],
+          places: ["geoId/05"],
+          statsVars: ["Count_Person_Male"],
+          sources: new Set(["source1"]),
+        });
+      }
+    );
 });
 
 test("StatsData test", () => {

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -323,7 +323,11 @@ function computePerCapita(
       } else {
         pop = population[yearMax];
       }
-      result[place].data[date] /= pop / scaling;
+      if (pop === 0) {
+        result[place].data[date] = 0;
+      } else {
+        result[place].data[date] /= pop / scaling;
+      }
     }
   }
   return result;

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -20,6 +20,7 @@ import { DataPoint, DataGroup } from "../chart/base";
 import { STATS_VAR_TEXT } from "./stats_var";
 
 const TOTAL_POPULATION_SV = "Count_Person";
+const ZERO_POPULATION = 0;
 
 interface TimeSeries {
   data: {
@@ -323,8 +324,8 @@ function computePerCapita(
       } else {
         pop = population[yearMax];
       }
-      if (pop === 0) {
-        result[place].data[date] = 0;
+      if (pop === ZERO_POPULATION) {
+        result[place].data[date] = ZERO_POPULATION;
       } else {
         result[place].data[date] /= pop / scaling;
       }


### PR DESCRIPTION
When doing per capita calculation, if population is 0, we want to set the result for that calculation to be 0, not NaN. 