### PR TITLE
[place charts] Handle missing data for some places

### DIFF
--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -40,7 +40,7 @@ def filter_charts(charts, all_stats_vars):
     """Filter charts from template specs based on statsitical variable.
 
     The input charts might have statistical variables that do not exist in the
-    valid statstical variable set for a given place. This function filters and
+    valid statistical variable set for a given place. This function filters and
     keep the ones that are valid.
 
     Args:

--- a/server/routes/api/stats.py
+++ b/server/routes/api/stats.py
@@ -14,7 +14,7 @@
 
 import json
 
-from flask import Blueprint, request
+from flask import Blueprint, request, Response
 from cache import cache
 import services.datacommons as dc
 
@@ -84,7 +84,8 @@ def stats(stats_var):
         with value to be the observation time series.
     """
     place_dcids = request.args.getlist('dcid')
-    return get_stats_wrapper('^'.join(place_dcids), stats_var)
+    result = get_stats_wrapper('^'.join(place_dcids), stats_var)
+    return Response(result, 200, mimetype='application/json')
 
 
 @bp.route('/api/stats/stats-var-property')
@@ -96,7 +97,8 @@ def stats_var_property():
         all the properties of each stats var.
     """
     dcids = request.args.getlist('dcid')
-    return stats_var_property_wrapper(dcids)
+    result = stats_var_property_wrapper(dcids)
+    return Response(json.dumps(result), 200, mimetype='application/json')
 
 
 def stats_var_property_wrapper(dcids):

--- a/static/js/shared/data_fetcher.test.ts
+++ b/static/js/shared/data_fetcher.test.ts
@@ -456,3 +456,112 @@ test("Per capita with specified denominators test from cache", () => {
     });
   });
 });
+
+test("Per capita with specified denominators test - missing place data", () => {
+  mockedAxios.get.mockImplementation((url: string) => {
+    if (
+      url ===
+      "/api/stats/UnemploymentRate_Person_Male?&dcid=geoId/05&dcid=country/USA"
+    ) {
+      return Promise.resolve({
+        data: {
+          "geoId/05": null,
+          "country/USA": {
+            data: {
+              "2011": 21000,
+              "2012": 22000,
+            },
+            placeName: "USA",
+            provenanceDomain: "source1",
+          },
+        },
+      });
+    } else if (
+      url ===
+      "/api/stats/UnemploymentRate_Person_Female?&dcid=geoId/05&dcid=country/USA"
+    ) {
+      return Promise.resolve({
+        data: {
+          "geoId/05": {
+            data: {
+              "2011": 1,
+              "2012": 2,
+            },
+            placeName: "Arkansas",
+            provenanceDomain: "source2",
+          },
+          "country/USA": null,
+        },
+      });
+    }
+  });
+
+  return fetchStatsData(
+    ["geoId/05", "country/USA"],
+    ["UnemploymentRate_Person_Male", "UnemploymentRate_Person_Female"],
+    false,
+    1,
+    []
+  ).then((data) => {
+    expect(data).toEqual({
+      data: {
+        UnemploymentRate_Person_Male: {
+          "geoId/05": null,
+          "country/USA": {
+            data: {
+              "2011": 21000,
+              "2012": 22000,
+            },
+            placeName: "USA",
+            provenanceDomain: "source1",
+          },
+        },
+        UnemploymentRate_Person_Female: {
+          "geoId/05": {
+            data: {
+              "2011": 1,
+              "2012": 2,
+            },
+            placeName: "Arkansas",
+            provenanceDomain: "source2",
+          },
+          "country/USA": null,
+        },
+      },
+      dates: ["2011", "2012"],
+      places: ["geoId/05", "country/USA"],
+      statsVars: [
+        "UnemploymentRate_Person_Male",
+        "UnemploymentRate_Person_Female",
+      ],
+      sources: new Set(["source1", "source2"]),
+    });
+
+    expect(data.getPlaceGroupWithStatsVar()).toEqual([
+      new DataGroup("Arkansas", [
+        { label: "Male", value: 0 },
+        { label: "Female", value: 2 },
+      ]),
+      new DataGroup("USA", [
+        { label: "Male", value: 22000 },
+        { label: "Female", value: 0 },
+      ]),
+    ]);
+
+    expect(data.getStatsVarGroupWithTime("geoId/05")).toEqual([
+      new DataGroup("UnemploymentRate_Person_Female", [
+        { label: "2011", value: 1 },
+        { label: "2012", value: 2 },
+      ]),
+    ]);
+
+    expect(data.getTimeGroupWithStatsVar("geoId/05")).toEqual([
+      new DataGroup("2011", [{ label: "Female", value: 1 }]),
+      new DataGroup("2012", [{ label: "Female", value: 2 }]),
+    ]);
+
+    expect(data.getStatsPoint("geoId/05")).toEqual([
+      { label: "Female", value: 2 },
+    ]);
+  });
+});

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -82,18 +82,18 @@ class StatsData {
       const dataPoints: DataPoint[] = [];
       let placeName: string;
       for (const statsVar of this.statsVars) {
-        if (!this.data[statsVar]) {
-          continue;
-        }
-        if (!this.data[statsVar][place]) continue;
-        const timeSeries = this.data[statsVar][place];
-        if (timeSeries.data) {
-          dataPoints.push({
-            label: STATS_VAR_TEXT[statsVar],
-            value: timeSeries.data[date],
-          });
+        let value = 0;
+        if (this.data[statsVar] && this.data[statsVar][place]) {
+          const timeSeries = this.data[statsVar][place];
+          if (timeSeries.data && timeSeries.data[date]) {
+            value = timeSeries.data[date];
+          }
           placeName = timeSeries.placeName;
         }
+        dataPoints.push({
+          label: STATS_VAR_TEXT[statsVar],
+          value: value,
+        });
       }
       if (dataPoints.length > 0) {
         result.push(new DataGroup(placeName, dataPoints));


### PR DESCRIPTION
With some of new comparison charts, we might have data only for some geos. Skip geos so the charts will still get drawn.

@chejennifer fyi