### PR TITLE
Use different Google Analytics account for non-prod instances

### DIFF
--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -9,28 +9,30 @@ class Config:
     TEST = False
     WEBDRIVER = False
     CACHE_TYPE = 'simple'  # Flask-Caching related configs
-    GAE_VERSION = (
-        os.environ.get('GAE_VERSION') or
-        datetime.datetime.today().strftime("%m-%d-%H-%M"))
+    GAE_VERSION = (os.environ.get('GAE_VERSION') or
+                   datetime.datetime.today().strftime("%m-%d-%H-%M"))
 
 
 class ProductionConfig(Config):
     API_PROJECT = 'datcom-mixer'
     API_ROOT = 'https://api.datacommons.org'
-    GCS_BUCKET = "datcom-browser-prod.appspot.com"
+    GCS_BUCKET = 'datcom-browser-prod.appspot.com'
+    GA_ACCOUNT = 'UA-117119267-1'
 
 
 class DevelopmentConfig(Config):
     API_PROJECT = 'datcom-mixer-staging'
     API_ROOT = 'https://datacommons.endpoints.datcom-mixer-staging.cloud.goog'
-    GCS_BUCKET = "datcom-browser-staging.appspot.com"
+    GCS_BUCKET = 'datcom-browser-staging.appspot.com'
+    GA_ACCOUNT = 'UA-117119267-2'
 
 
 class WebdriverConfig(Config):
     WEBDRIVER = True
     API_PROJECT = 'datcom-mixer-staging'
     API_ROOT = 'https://datacommons.endpoints.datcom-mixer-staging.cloud.goog'
-    GCS_BUCKET = ""
+    GCS_BUCKET = ''
+    GA_ACCOUNT = ''
 
 
 class TestConfig(Config):
@@ -38,3 +40,4 @@ class TestConfig(Config):
     API_PROJECT = 'api-project'
     API_ROOT = 'api-root'
     GCS_BUCKET = 'gcs-bucket'
+    GA_ACCOUNT = ''

--- a/server/main.py
+++ b/server/main.py
@@ -34,6 +34,7 @@ logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s %(levelname)s %(lineno)d : %(message)s')
 
 app = create_app()
+app.jinja_env.globals['GA_ACCOUNT'] = app.config['GA_ACCOUNT']
 
 GCS_BUCKET = app.config['GCS_BUCKET']
 _MAX_SEARCH_RESULTS = 1000

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -149,12 +149,14 @@
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
   <script async src="https://cse.google.com/cse.js?cx=010079880385165835740%3Aosnv3q-sw08"></script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-117119267-1"></script>
+  {%- if GA_ACCOUNT -%}
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'UA-117119267-1');
+    gtag('config', '{{ GA_ACCOUNT }}');
   </script>
+  {%- endif -%}
   {% block footer %}
   {% endblock %}
 </body>


### PR DESCRIPTION
I've tried setting up filters within GA but that doesn't seem to apply, and staging data is mixed up with prod. This should keep things much cleaner.