### PR TITLE
Ranking pages v0

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -44,9 +44,10 @@ def create_app():
 
     # apply the blueprints to the app
     from routes import (
-        browser, dev, factcheck, redirects, place, placelist, static, tools)
+        browser, dev, factcheck, place, placelist, ranking, redirects, static, tools)
     app.register_blueprint(browser.bp)
     app.register_blueprint(dev.bp)
+    app.register_blueprint(ranking.bp)
     app.register_blueprint(redirects.bp)
     app.register_blueprint(place.bp)
     app.register_blueprint(placelist.bp)

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -83,7 +83,16 @@ def get_place_type(place_dcid):
 
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def get_name(dcids):
+def cached_name(dcids):
+    """Returns display names for set of dcids.
+
+    Args:
+        dcids: ^ separated string of dcids. It must be a single string for the cache.
+
+    Returns:
+        A dictionary of display place names, keyed by dcid.
+    """
+    dcids = dcids.split('^')
     response = fetch_data('/node/property-values', {
         'dcids': dcids,
         'property': 'name',
@@ -96,6 +105,18 @@ def get_name(dcids):
         values = response[dcid].get('out')
         result[dcid] = values[0]['value'] if values else ''
     return result
+
+
+def get_name(dcids):
+    """Returns display names for set of dcids.
+
+    Args:
+        dcids: A list of place dcids.
+
+    Returns:
+        A dictionary of display place names, keyed by dcid.
+    """
+    return cached_name('^'.join(dcids))
 
 
 @bp.route('/name')

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -116,7 +116,7 @@ def get_name(dcids):
     Returns:
         A dictionary of display place names, keyed by dcid.
     """
-    return cached_name('^'.join(dcids))
+    return cached_name('^'.join((sorted(dcids))))
 
 
 @bp.route('/name')

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -82,10 +82,8 @@ def get_place_type(place_dcid):
     return chosen_type
 
 
-@bp.route('/name')
-def name():
-    """Get place names."""
-    dcids = request.args.getlist('dcid')
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+def get_name(dcids):
     response = fetch_data('/node/property-values', {
         'dcids': dcids,
         'property': 'name',
@@ -97,6 +95,14 @@ def name():
     for dcid in dcids:
         values = response[dcid].get('out')
         result[dcid] = values[0]['value'] if values else ''
+    return result
+
+
+@bp.route('/name')
+def api_name():
+    """Get place names."""
+    dcids = request.args.getlist('dcid')
+    result = get_name(dcids)
     return Response(json.dumps(result), 200, mimetype='application/json')
 
 

--- a/server/routes/place.py
+++ b/server/routes/place.py
@@ -19,10 +19,6 @@ import services.datacommons as dc
 import routes.api.place as place_api
 
 from cache import cache
-# import main
-# import services.util
-
-# from flask import Blueprint, render_template
 
 bp = flask.Blueprint(
   'place',
@@ -49,4 +45,3 @@ def place():
         place_name=place_name,
         place_dcid=place_dcid,
         topic=topic)
-

--- a/server/routes/ranking.py
+++ b/server/routes/ranking.py
@@ -55,7 +55,6 @@ def ranking(place_type, place_dcid=''):
 
 @bp.route('/api/<place_type>/')
 @bp.route('/api/<place_type>/<path:place>')
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def ranking_api(place_type, place=None):
     """Returns top 100 rankings for a stats var, grouped by place type and
     optionally scoped by a containing place. Each place in the ranking has

--- a/server/routes/ranking.py
+++ b/server/routes/ranking.py
@@ -1,0 +1,86 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Place Ranking related handlers."""
+
+import flask
+import services.datacommons as dc
+import routes.api.place as place_api
+
+from cache import cache
+
+bp = flask.Blueprint('ranking', __name__, url_prefix='/ranking')
+
+# Only show the top 100 places in rankings for now
+RANK_KEYS = ['rankAll', 'rankTop1000']
+RANK_SIZE = 100
+
+
+def stat_var_to_string(stat_var):
+    parts = stat_var.split('_')
+    if len(parts) < 2:
+        return {}
+    measured_property = parts[0]
+    pop_type = parts[1]
+
+
+@bp.route('/<place_type>')
+@bp.route('/<place_type>/<path:place_dcid>')
+def ranking(place_type, place_dcid=''):
+    place_name = ''
+    if place_dcid:
+        place_names = place_api.get_name([place_dcid])
+        place_name = place_names[place_dcid]
+        if place_name == '':
+            place_name = place_dcid
+    else:
+        place_name = 'World'
+    stat_vars = flask.request.args.getlist('stat')
+    return flask.render_template('ranking.html',
+                                 place_name=place_name,
+                                 place_dcid=place_dcid,
+                                 place_type=place_type,
+                                 stat_vars=stat_vars)
+
+
+@bp.route('/api/<place_type>/')
+@bp.route('/api/<place_type>/<path:place>')
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+def ranking_api(place_type, place=None):
+    """Returns top 100 rankings for a stats var, grouped by place type and
+    optionally scoped by a containing place. Each place in the ranking has
+    it's named returned, if available.
+    """
+    stats = flask.request.args.getlist('stat')
+    ranking_results = dc.get_place_ranking(stats, place_type, place)
+    if not 'payload' in ranking_results:
+        return ranking_results
+    payload = ranking_results['payload']
+    dcids = set()
+    for sv in payload:
+        try:
+            del payload[sv]['rankBottom1000']
+        except KeyError:
+            pass  # key might not exist for fewer than 1000 places
+        for k in RANK_KEYS:
+            if k in payload[sv] and 'info' in payload[sv][k]:
+                payload[sv][k]['info'] = payload[sv][k]['info'][:RANK_SIZE]
+                for r in payload[sv][k]['info']:
+                    dcids.add(r['placeDcid'])
+    place_names = place_api.get_name(list(dcids))
+    for sv in payload:
+        for k in RANK_KEYS:
+            if k in payload[sv] and 'info' in payload[sv][k]:
+                for r in payload[sv][k]['info']:
+                    r['placeName'] = place_names[r['placeDcid']]
+    return ranking_results

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -59,6 +59,7 @@ API_ENDPOINTS = {
     'get_observations': '/node/observations',
     'get_pop_obs': '/bulk/pop-obs',
     'get_place_obs': '/bulk/place-obs',
+    'get_place_ranking': '/node/ranking-locations',
     'get_chart_data': '/node/chart-data',
     'get_stats': '/bulk/stats',
     # TODO(shifucun): switch back to /node/related-places after data switch.
@@ -102,6 +103,16 @@ def get_chart_data(keys):
         'keys': keys,
     }
     return send_request(url, req_json=req_json)
+
+
+def get_place_ranking(stat_vars, place_type, within_place=None):
+    url = API_ROOT + API_ENDPOINTS['get_place_ranking']
+    req_json = {
+        'stat_var_dcids': stat_vars,
+        'place_type': place_type,
+        'within_place': within_place,
+    }
+    return send_request(url, req_json=req_json, post=True, has_payload=False)
 
 
 def get_property_labels(dcids, out=True):

--- a/server/templates/ranking.html
+++ b/server/templates/ranking.html
@@ -39,6 +39,4 @@
 
 {% block footer %}
 <script src={{url_for('static', filename='ranking.js', t=config['GAE_VERSION'])}}></script>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDAMcc9QlTtAd4liELMgJSj0gwDojTS2eQ&libraries=places" async
-  defer></script>
 {% endblock %}

--- a/server/templates/ranking.html
+++ b/server/templates/ranking.html
@@ -1,0 +1,44 @@
+{#
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+#}
+{%- extends 'base.html' -%}
+
+{% set is_hide_full_footer = true %}
+{% set title = place_name + ' | Place Rankings' %} {# TODO: Add stats var to title #}
+{% set subpage_title = 'Place Rankings' %}
+
+{% block head %}
+<link rel="stylesheet" href={{url_for('static', filename='css/ranking.min.css', t=config['GAE_VERSION'])}}>
+{% endblock %}
+
+{% block content %}
+<div id="within-place-dcid" data-pwp="{{ place_dcid }}"></div>
+<div id="place-type" data-pt="{{ place_type }}"></div>
+<div id="body" class="container">
+  <div class="row">
+    <h1 class="col-12">{{ place_name }} Rankings</h1>
+  </div>
+  <div class="row mt-3">
+    <div id="main-pane" class="col-12"></div>
+  </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block footer %}
+<script src={{url_for('static', filename='ranking.js', t=config['GAE_VERSION'])}}></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDAMcc9QlTtAd4liELMgJSj0gwDojTS2eQ&libraries=places" async
+  defer></script>
+{% endblock %}

--- a/static/css/ranking.scss
+++ b/static/css/ranking.scss
@@ -14,15 +14,10 @@
  * limitations under the License.
  */
 
-import { STATS_VAR_TEXT } from "./stats_var";
-import chartConfig from "../../../server/chart_config.json";
+@import "base";
+@import "draw";
 
-test("stats var names", () => {
-  for (const section of chartConfig) {
-    for (const chart of section.charts) {
-      for (const statsVar of chart.statsVars) {
-        expect(STATS_VAR_TEXT[statsVar]).toBeTruthy();
-      }
-    }
-  }
-});
+.chart-container {
+  width: 100%;
+  height: 280px;
+}

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -105,7 +105,7 @@ function addXAxis(
   xScale: d3.AxisScale<any>,
   shouldRotate?: boolean
 ) {
-  let d3Axis = d3.axisBottom(xScale).ticks(NUM_X_TICKS).tickSizeOuter(0);
+  const d3Axis = d3.axisBottom(xScale).ticks(NUM_X_TICKS).tickSizeOuter(0);
   if (shouldRotate && typeof xScale.bandwidth == "function") {
     if (xScale.bandwidth() < 5) {
       d3Axis.tickValues(xScale.domain().filter((v, i) => i % 5 == 0));

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -21,6 +21,7 @@ import { DataGroup, DataPoint, PlotParams, Style, getColorFn } from "./base";
 const NUM_X_TICKS = 5;
 const NUM_Y_TICKS = 5;
 const MARGIN = { top: 20, right: 10, bottom: 30, left: 35, yAxis: 3, grid: 5 };
+const ROTATE_MARGIN_BOTTOM = 75; // margin bottom to use for histogram
 const LEGEND = {
   ratio: 0.2,
   minTextWidth: 100,
@@ -101,16 +102,34 @@ function wrap(
 function addXAxis(
   svg: d3.Selection<SVGElement, any, any, any>,
   height: number,
-  xScale: d3.AxisScale<any>
+  xScale: d3.AxisScale<any>,
+  shouldRotate?: boolean
 ) {
+  let d3Axis = d3.axisBottom(xScale).ticks(NUM_X_TICKS).tickSizeOuter(0);
+  if (shouldRotate && typeof xScale.bandwidth == "function") {
+    if (xScale.bandwidth() < 5) {
+      d3Axis.tickValues(xScale.domain().filter((v, i) => i % 5 == 0));
+    } else if (xScale.bandwidth() < 15) {
+      d3Axis.tickValues(xScale.domain().filter((v, i) => i % 3 == 0));
+    }
+  }
+
   const axis = svg
     .append("g")
     .attr("class", "x axis")
     .attr("transform", `translate(0, ${height - MARGIN.bottom})`)
-    .call(d3.axisBottom(xScale).ticks(NUM_X_TICKS).tickSizeOuter(0))
+    .call(d3Axis)
     .call((g) => g.select(".domain").remove());
 
-  if (typeof xScale.bandwidth === "function") {
+  if (shouldRotate) {
+    axis
+      .attr("transform", `translate(0, ${height - ROTATE_MARGIN_BOTTOM})`)
+      .selectAll("text")
+      .style("text-anchor", "end")
+      .attr("dx", "-.8em")
+      .attr("dy", ".15em")
+      .attr("transform", "rotate(-35)");
+  } else if (typeof xScale.bandwidth === "function") {
     axis.selectAll(".tick text").call(wrap, xScale.bandwidth());
   }
 }
@@ -162,6 +181,60 @@ function addYAxis(
         .attr("x", -width + MARGIN.left + MARGIN.yAxis)
         .attr("dy", -4)
     );
+}
+
+/**
+ * Draw histogram. Used for ranking pages.
+ * @param id
+ * @param width
+ * @param height
+ * @param dataPoints
+ * @param unit
+ */
+function drawHistogram(
+  id: string,
+  width: number,
+  height: number,
+  dataPoints: DataPoint[],
+  unit?: string
+): void {
+  const textList = dataPoints.map((dataPoint) => dataPoint.label);
+  const values = dataPoints.map((dataPoint) => dataPoint.value);
+
+  const x = d3
+    .scaleBand()
+    .domain(textList)
+    .rangeRound([MARGIN.left, width - MARGIN.right])
+    .paddingInner(0.1)
+    .paddingOuter(0.1);
+
+  const y = d3
+    .scaleLinear()
+    .domain([0, d3.max(values)])
+    .nice()
+    .rangeRound([height - ROTATE_MARGIN_BOTTOM, MARGIN.top]);
+
+  const color = getColorFn(["a"])("a"); // we only need one color
+
+  const svg = d3
+    .select("#" + id)
+    .append("svg")
+    .attr("width", width)
+    .attr("height", height);
+
+  addXAxis(svg, height, x, true);
+  addYAxis(svg, width, y, unit);
+
+  svg
+    .append("g")
+    .selectAll("rect")
+    .data(dataPoints)
+    .join("rect")
+    .attr("x", (d) => x(d.label))
+    .attr("y", (d) => y(d.value))
+    .attr("width", x.bandwidth())
+    .attr("height", (d) => y(0) - y(d.value))
+    .attr("fill", color);
 }
 
 /**
@@ -664,9 +737,10 @@ function buildInChartLegend(
 
 export {
   appendLegendElem,
-  drawLineChart,
+  drawGroupBarChart,
   drawGroupLineChart,
+  drawHistogram,
+  drawLineChart,
   drawSingleBarChart,
   drawStackBarChart,
-  drawGroupBarChart,
 };

--- a/static/js/place/place_template.tsx
+++ b/static/js/place/place_template.tsx
@@ -28,7 +28,7 @@ import {
 } from "../chart/draw";
 import { CachedStatVarDataMap, fetchStatsData } from "../shared/data_fetcher";
 import { updatePageLayoutState } from "./place";
-import { STATS_VAR_TEXT } from "../shared/stats_var";
+import { STATS_VAR_LABEL } from "../shared/stats_var_labels";
 
 const chartTypeEnum = {
   LINE: "LINE",
@@ -221,7 +221,7 @@ class Ranking extends Component<RankingPropsType, RankingStateType> {
   }
 
   componentDidMount() {
-    axios.get(`api/place/ranking/${this.props.dcid}`).then((resp) => {
+    axios.get(`/api/place/ranking/${this.props.dcid}`).then((resp) => {
       this.setState({ data: resp.data });
     });
   }
@@ -752,7 +752,7 @@ class Chart extends Component<ChartPropType, ChartStateType> {
         ).then((data) => {
           const dataGroups = data.getStatsVarGroupWithTime(dcid);
           for (const dataGroup of dataGroups) {
-            dataGroup.label = STATS_VAR_TEXT[dataGroup.label];
+            dataGroup.label = STATS_VAR_LABEL[dataGroup.label];
           }
           this.setState({
             dataGroups,

--- a/static/js/ranking/ranking.ts
+++ b/static/js/ranking/ranking.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Entry point for Ranking pages
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { Page } from "./ranking_page";
+
+window.onload = () => {
+  const withinPlace = document.getElementById("within-place-dcid").dataset.pwp;
+  const placeType = document.getElementById("place-type").dataset.pt;
+  const urlParams = new URLSearchParams(window.location.search);
+  const statVars = urlParams.getAll("stat");
+  ReactDOM.render(
+    React.createElement(Page, {
+      placeType,
+      withinPlace,
+      statVars,
+    }),
+    document.getElementById("main-pane")
+  );
+};

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component, createRef } from "react";
+import { Ranking, RankInfo } from "./ranking_types";
+import * as d3 from "d3";
+import { DataPoint } from "../chart/base";
+import { drawHistogram } from "../chart/draw";
+
+interface RankingHistogramPropType {
+  ranking: Ranking;
+  id: string;
+}
+
+interface RankingHistogramStateType {
+  elemWidth: number;
+}
+
+class RankingHistogram extends Component<
+  RankingHistogramPropType,
+  RankingHistogramStateType
+> {
+  chartElement: React.RefObject<HTMLDivElement>;
+
+  constructor(props: RankingHistogramPropType) {
+    super(props);
+    this.state = {
+      elemWidth: 0,
+    };
+    // Consider debouncing / throttling this if it gets expensive at
+    // small screen sizes
+    this._handleWindowResize = this._handleWindowResize.bind(this);
+    this.drawChart = this.drawChart.bind(this);
+    this.chartElement = createRef();
+  }
+
+  render(): JSX.Element {
+    return (
+      <div
+        key={this.props.id}
+        id={this.props.id}
+        ref={this.chartElement}
+        className="chart-container"
+      ></div>
+    );
+  }
+
+  drawChart() {
+    const rankList = this.props.ranking.info;
+    const dataPoints = rankList.map((d) => new DataPoint(d.placeName, d.value));
+
+    const elem = document.getElementById(this.props.id);
+    elem.innerHTML = "";
+    drawHistogram(
+      this.props.id,
+      elem.offsetWidth,
+      elem.offsetHeight,
+      dataPoints
+    );
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this._handleWindowResize);
+  }
+
+  componentDidMount() {
+    window.addEventListener("resize", this._handleWindowResize);
+    this.drawChart();
+  }
+
+  componentDidUpdate() {
+    this.drawChart();
+  }
+
+  _handleWindowResize() {
+    const svgElement = document.getElementById(this.props.id);
+    if (!svgElement) {
+      return;
+    }
+    // Chart resizes at bootstrap breakpoints
+    const width = svgElement.offsetWidth;
+    if (width !== this.state.elemWidth) {
+      this.setState({
+        elemWidth: width,
+      });
+    }
+  }
+}
+
+export { RankingHistogram };

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -33,7 +33,7 @@ class RankingHistogram extends Component<
   RankingHistogramPropType,
   RankingHistogramStateType
 > {
-  chartElement: React.RefObject<HTMLDivElement>;
+  chartElementRef: React.RefObject<HTMLDivElement>;
 
   constructor(props: RankingHistogramPropType) {
     super(props);
@@ -44,7 +44,7 @@ class RankingHistogram extends Component<
     // small screen sizes
     this._handleWindowResize = this._handleWindowResize.bind(this);
     this.drawChart = this.drawChart.bind(this);
-    this.chartElement = createRef();
+    this.chartElementRef = createRef();
   }
 
   render(): JSX.Element {
@@ -52,7 +52,7 @@ class RankingHistogram extends Component<
       <div
         key={this.props.id}
         id={this.props.id}
-        ref={this.chartElement}
+        ref={this.chartElementRef}
         className="chart-container"
       ></div>
     );
@@ -62,12 +62,11 @@ class RankingHistogram extends Component<
     const rankList = this.props.ranking.info;
     const dataPoints = rankList.map((d) => new DataPoint(d.placeName, d.value));
 
-    const elem = document.getElementById(this.props.id);
-    elem.innerHTML = "";
+    this.chartElementRef.current.innerHTML = "";
     drawHistogram(
       this.props.id,
-      elem.offsetWidth,
-      elem.offsetHeight,
+      this.chartElementRef.current.offsetWidth,
+      this.chartElementRef.current.offsetHeight,
       dataPoints
     );
   }

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component } from "react";
+import axios from "axios";
+import { STATS_VAR_TITLES } from "../shared/stats_var_titles";
+import { RankingTable } from "./ranking_table";
+import { LocationRankData } from "./ranking_types";
+import { RankingHistogram } from "./ranking_histogram";
+
+interface RankingPagePropType {
+  placeType: string;
+  withinPlace: string;
+  statVars: string[];
+}
+
+interface RankingPageStateType {
+  data: {
+    [statVar: string]: LocationRankData;
+  };
+}
+
+class Page extends Component<RankingPagePropType, RankingPageStateType> {
+  constructor(props: RankingPagePropType) {
+    super(props);
+    this.state = {
+      data: {},
+    };
+  }
+  render(): JSX.Element {
+    function renderRankInfo(statVar, rankInfo) {
+      return (
+        <tr key={[statVar, "-", rankInfo.rank].join()}>
+          <td>{(rankInfo.rank ? rankInfo.rank : 0) + 1}</td>
+          <td>
+            <a href={`/place?dcid=${rankInfo.placeDcid}`}>
+              {rankInfo.placeName || rankInfo.placeDcid}
+            </a>
+          </td>
+          <td className="text-right">{rankInfo.value.toLocaleString()}</td>
+        </tr>
+      );
+    }
+
+    let statVarFragments = [];
+    for (let statVar in this.state.data) {
+      let svData = this.state.data[statVar];
+      let ranking = svData.rankAll || svData.rankTop1000;
+      console.log(ranking);
+      statVarFragments.push(
+        <div key={statVar}>
+          <h3>{STATS_VAR_TITLES[statVar]}</h3>
+          <RankingHistogram
+            ranking={ranking}
+            id={[statVar, "chart"].join("-")}
+          />
+          <RankingTable ranking={ranking} id={[statVar, "table"].join("-")} />
+        </div>
+      );
+    }
+
+    return <div>{statVarFragments}</div>;
+  }
+
+  componentDidMount() {
+    const statsParam = this.props.statVars.map((x) => `stat=${x}`).join("&");
+    return axios
+      .get(
+        `/ranking/api/${this.props.placeType}/${this.props.withinPlace}?${statsParam}`
+      )
+      .then((resp) => {
+        this.setState({
+          data: resp.data.payload,
+        });
+      });
+  }
+}
+
+export { Page };

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -55,10 +55,10 @@ class Page extends Component<RankingPagePropType, RankingPageStateType> {
       );
     }
 
-    let statVarFragments = [];
-    for (let statVar in this.state.data) {
-      let svData = this.state.data[statVar];
-      let ranking = svData.rankAll || svData.rankTop1000;
+    const statVarFragments = [];
+    for (const statVar in this.state.data) {
+      const svData = this.state.data[statVar];
+      const ranking = svData.rankAll || svData.rankTop1000;
       console.log(ranking);
       statVarFragments.push(
         <div key={statVar}>

--- a/static/js/ranking/ranking_table.tsx
+++ b/static/js/ranking/ranking_table.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component } from "react";
+import { Ranking, RankInfo } from "./ranking_types";
+
+interface RankingTablePropType {
+  ranking: Ranking;
+  id: string;
+}
+
+class RankingTable extends Component<RankingTablePropType> {
+  constructor(props: RankingTablePropType) {
+    super(props);
+  }
+
+  render(): JSX.Element {
+    function renderRankInfo(rankInfo) {
+      return (
+        <tr key={rankInfo.rank}>
+          <td>{rankInfo.rank ? rankInfo.rank : 0}</td>
+          <td>
+            <a href={`/place?dcid=${rankInfo.placeDcid}`}>
+              {rankInfo.placeName || rankInfo.placeDcid}
+            </a>
+          </td>
+          <td className="text-right">{rankInfo.value.toLocaleString()}</td>
+        </tr>
+      );
+    }
+
+    return (
+      <table key={this.props.id} className="table mt-3">
+        <thead>
+          <tr>
+            <th scope="col">Rank</th>
+            <th scope="col">Place</th>
+            <th scope="col" className="text-center">
+              Value
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {this.props.ranking &&
+            this.props.ranking.info.map((rankInfo) => {
+              return renderRankInfo(rankInfo);
+            })}
+        </tbody>
+      </table>
+    );
+  }
+}
+
+export { RankingTable };

--- a/static/js/ranking/ranking_types.ts
+++ b/static/js/ranking/ranking_types.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface RankInfo {
+  rank: number;
+  value: number;
+  placeDcid: string;
+  placeName: string;
+}
+
+interface Ranking {
+  info: RankInfo[];
+}
+
+interface LocationRankData {
+  rankAll: Ranking;
+  rankTop1000: Ranking;
+  rankBottom1000: Ranking;
+}
+
+export { LocationRankData, Ranking, RankInfo };

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -17,7 +17,7 @@
 import axios, { AxiosResponse } from "axios";
 
 import { DataPoint, DataGroup } from "../chart/base";
-import { STATS_VAR_TEXT } from "./stats_var";
+import { STATS_VAR_LABEL } from "./stats_var_labels";
 
 const TOTAL_POPULATION_SV = "Count_Person";
 const ZERO_POPULATION = 0;
@@ -96,7 +96,7 @@ class StatsData {
           placeName = timeSeries.placeName;
         }
         dataPoints.push({
-          label: STATS_VAR_TEXT[statsVar],
+          label: STATS_VAR_LABEL[statsVar],
           value: value,
         });
       }
@@ -159,7 +159,7 @@ class StatsData {
           value = timeSeries.data[date];
         }
         dataPoints.push({
-          label: STATS_VAR_TEXT[statsVar],
+          label: STATS_VAR_LABEL[statsVar],
           value: value,
         });
       }
@@ -192,7 +192,7 @@ class StatsData {
       if (!this.data[statsVar][place]) continue;
       const timeSeries = this.data[statsVar][place];
       result.push({
-        label: STATS_VAR_TEXT[statsVar],
+        label: STATS_VAR_LABEL[statsVar],
         value: timeSeries.data[date],
       });
     }

--- a/static/js/shared/stats_var_labels.test.ts
+++ b/static/js/shared/stats_var_labels.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { STATS_VAR_LABEL } from "./stats_var_labels";
+import chartConfig from "../../../server/chart_config.json";
+
+test("stats var label", () => {
+  for (const section of chartConfig) {
+    for (const chart of section.charts) {
+      for (const statsVar of chart.statsVars) {
+        expect(STATS_VAR_LABEL[statsVar]).toBeTruthy();
+      }
+    }
+    for (const child of section.children) {
+      for (const chart of child.charts) {
+        for (const statsVar of chart.statsVars) {
+          expect(STATS_VAR_LABEL[statsVar]).toBeTruthy();
+        }
+      }
+    }
+  }
+});

--- a/static/js/shared/stats_var_labels.ts
+++ b/static/js/shared/stats_var_labels.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-const STATS_VAR_TEXT: { [key: string]: string } = {
+/**
+ * Chart labels for each stats var. Used to distinguish between stats var in
+ * grouped charts.
+ */
+const STATS_VAR_LABEL: { [key: string]: string } = {
   // No PVs
   Median_Age_Person: "Median Age",
   Median_Income_Person: "Median Income",
@@ -32,7 +36,7 @@ const STATS_VAR_TEXT: { [key: string]: string } = {
   // Economics
   Amount_EconomicActivity_GrossDomesticProduction_Nominal: "GDP",
   GrowthRate_Amount_EconomicActivity_GrossDomesticProduction: "GDP Growth Rate",
-  Amount_Debt_Government: "GDP",
+  Amount_Debt_Government: "Government Debt",
   Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita:
     "GDP Per Capita",
   Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity_PerCapita:
@@ -135,6 +139,7 @@ const STATS_VAR_TEXT: { [key: string]: string } = {
   Count_Household_IncomeOf125000To149999USDollar: "$125K to $150K",
   Count_Household_IncomeOf150000To199999USDollar: "$150K to $200K",
   Count_Household_IncomeOf200000OrMoreUSDollar: "Over $200K",
+  Median_Income_Household: "Median Household Income",
   // COVID-19
   CumulativeCount_MedicalConditionIncident_COVID_19_ConfirmedOrProbableCase:
     "COVID-19 Cumulative Cases",
@@ -223,4 +228,4 @@ const STATS_VAR_TEXT: { [key: string]: string } = {
     "Male",
 };
 
-export { STATS_VAR_TEXT };
+export { STATS_VAR_LABEL };

--- a/static/js/shared/stats_var_titles.test.ts
+++ b/static/js/shared/stats_var_titles.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { STATS_VAR_TITLES } from "./stats_var_titles";
+import chartConfig from "../../../server/chart_config.json";
+
+test("stats var label", () => {
+  for (const section of chartConfig) {
+    for (const chart of section.charts) {
+      for (const statsVar of chart.statsVars) {
+        expect(STATS_VAR_TITLES[statsVar]).toBeTruthy();
+      }
+    }
+    for (const child of section.children) {
+      for (const chart of child.charts) {
+        for (const statsVar of chart.statsVars) {
+          expect(STATS_VAR_TITLES[statsVar]).toBeTruthy();
+        }
+      }
+    }
+  }
+});

--- a/static/js/shared/stats_var_titles.ts
+++ b/static/js/shared/stats_var_titles.ts
@@ -1,0 +1,315 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Titles for each stats var. Used as titles in Ranking pages to describe each
+ * stats var.
+ */
+const STATS_VAR_TITLES: { [key: string]: string } = {
+  // No PVs
+  Median_Age_Person: "Median Age",
+  Median_Income_Person: "Individual Median Income",
+  UnemploymentRate_Person: "Unemployment Rate",
+  Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance:
+    "State Unemployment Insurance Claims",
+  Count_Person_Employed: "Count of Employed People",
+  Count_Person_InLaborForce: "Count of People in Labor Force",
+  Count_Person: "Population",
+  Count_Person_PerArea: "Person per Area",
+  LifeExpectancy_Person: "Life Expectancy",
+  GrowthRate_Count_Person: "Population Growth Rate",
+  FertilityRate_Person_Female: "Fertility Rate",
+
+  // Economics
+  Amount_EconomicActivity_GrossDomesticProduction_Nominal:
+    "Gross Domestic Product (Nominal)",
+  GrowthRate_Amount_EconomicActivity_GrossDomesticProduction:
+    "Gross Domestic Product Growth Rate",
+  Amount_Debt_Government: "Government Debt",
+  Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita:
+    "Gross Domestic Product (Nominal) Per Capita",
+  Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity_PerCapita:
+    "Gross National Income (Purchasing Power Parity) Per Capita",
+  Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity:
+    "Gross National Income (Purchasing Power Parity)",
+
+  // Environment
+  Amount_Consumption_Energy_PerCapita: "Energy comsumption Per Capita",
+  Amount_Emissions_CarbonDioxide_PerCapita:
+    "Carbon Dioxide Emissions Per Capita",
+  Amount_Consumption_Electricity_PerCapita:
+    "Electricity Consumption Per Capita",
+  Count_EarthquakeEvent: "Earthquake Events",
+  Count_CycloneEvent: "Cyclone Events",
+  Count_StormSurgeTideEvent: "Storm Surge Tide Events",
+  Count_WildlandFireEvent: "Wildland Fire Events",
+  Count_TornadoEvent: "Tornado Events",
+  Count_ThunderstormWindEvent: "Thunderstorm Events",
+  Count_FloodEvent: "Flood Events",
+  Count_DroughtEvent: "Drought Events",
+
+  // age
+  Count_Person_Upto5Years: "Population Ages 0-5",
+  Count_Person_5To17Years: "Population Ages 5-17",
+  Count_Person_15To19Years: "Population Ages 15-19",
+  Count_Person_20To24Years: "Population Ages 20-24",
+  Count_Person_25To29Years: "Population Ages 25-29",
+  Count_Person_25To34Years: "Population Ages 25-34",
+  Count_Person_30To34Years: "Population Ages 30-34",
+  Count_Person_35To39Years: "Population Ages 35-39",
+  Count_Person_35To44Years: "Population Ages 35-44",
+  Count_Person_40To44Years: "Population Ages 40-44",
+  Count_Person_45To49Years: "Population Ages 45-49",
+  Count_Person_45To54Years: "Population Ages 45-54",
+  Count_Person_50To54Years: "Population Ages 50-54",
+  Count_Person_55To59Years: "Population Ages 55-59",
+  Count_Person_60To64Years: "Population Ages 60-64",
+  Count_Person_65To69Years: "Population Ages 65-69",
+  Count_Person_65OrMoreYears: "Population Ages 65+",
+  Count_Person_70To74Years: "Population Ages 70-74",
+  Count_Person_75To79Years: "Population Ages 75-79",
+  Count_Person_80To84Years: "Population Ages 80-84",
+  Count_Person_85To89Years: "Population Ages 85-89",
+
+  // gender
+  Count_Person_Male: "Population (Male)",
+  Count_Person_Female: "Population (Female)",
+  Median_Age_Person_Male: "Median Age of Males",
+  Median_Age_Person_Female: "Median Age of Females",
+
+  // race
+  Count_Person_AmericanIndianOrAlaskaNativeAlone:
+    "Population (American Indians or Alaska Native)",
+  Count_Person_AsianAlone: "Population (Asian Alone)",
+  Count_Person_BlackOrAfricanAmericanAlone:
+    "Population (Black or African American)",
+  Count_Person_HispanicOrLatino: "Population (Hispanic or Latino)",
+  Count_Person_NativeHawaiianAndOtherPacificIslanderAlone:
+    "Population (Native Hawaiian and Pacific Islander)",
+  Count_Person_SomeOtherRaceAlone: "Population (Some other race)",
+  Count_Person_TwoOrMoreRaces: "Population (Two or more races)",
+  Count_Person_WhiteAlone: "Population (White Alone)",
+
+  Median_Age_Person_AmericanIndianOrAlaskaNativeAlone:
+    "Median Age (American Indian or Alaska Native)",
+  Median_Age_Person_AsianAlone: "Median Age (Asian Alone)",
+  Median_Age_Person_BlackOrAfricanAmericanAlone:
+    "Median Age (Black or African American)",
+  Median_Age_Person_HispanicOrLatino: "Median Age (Hispanic or Latino)",
+  Median_Age_Person_NativeHawaiianAndOtherPacificIslanderAlone:
+    "Median Age (Native Hawaiian and Pacific Islander)",
+  Median_Age_Person_SomeOtherRaceAlone: "Median Age (Some other race)",
+  Median_Age_Person_TwoOrMoreRaces: "Median Age (Two or more races)",
+  Median_Age_Person_WhiteAlone: "Median Age (White Alone)",
+
+  // income
+  Count_Person_IncomeOfUpto9999USDollar:
+    "People with Individual Income (Under $10K)",
+  Count_Person_IncomeOf10000To14999USDollar:
+    "People with Individual Income ($10K to $15K)",
+  Count_Person_IncomeOf15000To24999USDollar:
+    "People with Individual Income ($15K to $25K)",
+  Count_Person_IncomeOf25000To34999USDollar:
+    "People with Individual Income ($25K to $35K)",
+  Count_Person_IncomeOf35000To49999USDollar:
+    "People with Individual Income ($35K to $50K)",
+  Count_Person_IncomeOf50000To64999USDollar:
+    "People with Individual Income ($50K to $65K)",
+  Count_Person_IncomeOf65000To74999USDollar:
+    "People with Individual Income ($65K to $75K)",
+  Count_Person_IncomeOf75000OrMoreUSDollar:
+    "People with Individual Income (Over $75K)",
+
+  // marital status
+  Count_Person_MarriedAndNotSeparated: "Population (Married And Not Separated)",
+  Count_Person_Divorced: "Population (Divorced)",
+  Count_Person_NeverMarried: "Population (Never Married)",
+  Count_Person_Widowed: "Population (Widowed)",
+  Count_Person_Separated: "Population (Separated)",
+
+  // education/poulation
+  Count_Person_EducationalAttainmentNoSchoolingCompleted:
+    "Population (No Schooling)",
+  Count_Person_EducationalAttainmentRegularHighSchoolDiploma:
+    "Population (High School)",
+  Count_Person_EducationalAttainmentBachelorsDegree: "Population (Bachelors)",
+  Count_Person_EducationalAttainmentMastersDegree: "Population (Masters)",
+  Count_Person_EducationalAttainmentDoctorateDegree: "Population (Doctorate)",
+
+  // household/income
+  Count_Household_IncomeOfUpto10000USDollar:
+    "Households with Income (Under $10K)",
+  Count_Household_IncomeOf10000To14999USDollar:
+    "Households with Income ($10K to $15K)",
+  Count_Household_IncomeOf20000To24999USDollar:
+    "Households with Income ($20K to $25K)",
+  Count_Household_IncomeOf30000To34999USDollar:
+    "Households with Income ($30K to $35K)",
+  Count_Household_IncomeOf40000To44999USDollar:
+    "Households with Income ($40K to $45K)",
+  Count_Household_IncomeOf50000To59999USDollar:
+    "Households with Income ($50K to $60K)",
+  Count_Household_IncomeOf60000To74999USDollar:
+    "Households with Income ($60K to $75K)",
+  Count_Household_IncomeOf75000To99999USDollar:
+    "Households with Income ($75K to $100K)",
+  Count_Household_IncomeOf100000To124999USDollar:
+    "Households with Income ($100K to $125K)",
+  Count_Household_IncomeOf125000To149999USDollar:
+    "Households with Income ($125K to $150K)",
+  Count_Household_IncomeOf150000To199999USDollar:
+    "Households with Income ($150K to $200K)",
+  Count_Household_IncomeOf200000OrMoreUSDollar:
+    "Households with Income (Over $200K)",
+
+  Median_Income_Household: "Median Household Income",
+
+  // COVID-19
+  CumulativeCount_MedicalConditionIncident_COVID_19_ConfirmedOrProbableCase:
+    "COVID-19 Cumulative Cases",
+  CumulativeCount_MedicalConditionIncident_COVID_19_PatientDeceased:
+    "COVID-19 Cumulative Deaths",
+
+  // Citizenship
+  Count_Person_USCitizenBornInTheUnitedStates: "Population (Born in USA)",
+  Count_Person_USCitizenByNaturalization:
+    "Population (Citizen by Naturalization)",
+  Count_Person_NotAUSCitizen: "Population (Not a Citizen)",
+  Count_Person_USCitizenBornAbroadOfAmericanParents: "Population (Born Abroad)",
+
+  // Mortality cause
+  Count_Death_DiseasesOfTheCirculatorySystem:
+    "Deaths Caused By Diseases of the Circulatory System",
+  Count_Death_Neoplasms: "Deaths Caused By Neoplasms",
+  Count_Death_DiseasesOfTheRespiratorySystem:
+    "Deaths Caused By Diseases of the Respiratory System",
+  Count_Death_ExternalCauses: "Deaths Caused By External Causes",
+  Count_Death_DiseasesOfTheNervousSystem:
+    "Deaths Caused By Diseases of the jNervous System",
+
+  // Outcomes
+  Percent_Person_WithHighCholesterol:
+    "Percentage of People with High Cholesterol",
+  Percent_Person_WithHighBloodPressure:
+    "Percentage of People with High Blood Pressure",
+  Percent_Person_WithArthritis: "Percentage of People with Arthritis",
+  Percent_Person_WithMentalHealthNotGood:
+    "Percentage of People with Mental Health Not Good",
+  Percent_Person_WithPhysicalHealthNotGood:
+    "Percentage of People with Physical Health Not Good",
+
+  // Behaviors
+  Percent_Person_SleepLessThan7Hours:
+    "Percentage of People Who Sleep Less Than 7 Hours",
+  Percent_Person_Obesity: "Percentage of People with Obesity",
+  Percent_Person_BingeDrinking: "Percentage of People with Binge Drinking",
+  Percent_Person_PhysicalInactivity:
+    "Percentage of People with Physical Inactivity",
+  Percent_Person_Smoking: "Percentage of People who Smoking",
+
+  // Drug Prescribed
+  RetailDrugDistribution_DrugDistribution_Oxycodone:
+    "Total Retail Drug Distribution of Oxycodone",
+  RetailDrugDistribution_DrugDistribution_Hydrocodone:
+    "Total Retail Drug Distribution of Hydrocodone",
+  RetailDrugDistribution_DrugDistribution_Codeine:
+    "Total Retail Drug Distribution of Codeine",
+  RetailDrugDistribution_DrugDistribution_Amphetamine:
+    "Total Retail Drug Distribution of Amphetamine",
+  RetailDrugDistribution_DrugDistribution_Morphine:
+    "Total Retail Drug Distribution of Morphine",
+
+  // School Enrollment
+  Count_Person_EnrolledInSchool: "Population (Enrolled in School)",
+  Count_Person_NotEnrolledInSchool: "Population (Not Enrolled in School)",
+
+  // Crime
+  Count_CriminalActivities_CombinedCrime:
+    "Criminal Activity Count (Combined Crimes)",
+  Count_CriminalActivities_ViolentCrime:
+    "Criminal Activity Count (Violent Crimes)",
+  Count_CriminalActivities_PropertyCrime:
+    "Criminal Activity Count (Property Crimes)",
+  Count_CriminalActivities_Arson: "Criminal Activity Count (Arson)",
+
+  // Employment
+  UnemploymentRate_Person_Male: "Unemployment Rate (Male)",
+  UnemploymentRate_Person_Female: "Unemployment Rate (Female)",
+
+  // Inequality
+  Count_Person_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone:
+    "Population Below Poverty Level in the Past 12 Months (American Indian or Alaska Native)",
+  Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone:
+    "Population Below Poverty Level in the Past 12 Months (Asian)",
+  Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone:
+    "Population Below Poverty Level in the Past 12 Months (Black or African American)",
+  Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino:
+    "Population Below Poverty Level in the Past 12 Months (Hispanic or Latino)",
+  Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone:
+    "Population Below Poverty Level in the Past 12 Months (Native Hawaiian or Other Paciific Islander)",
+  Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone:
+    "Population Below Poverty Level in the Past 12 Months (White)",
+
+  Median_Income_Person_15OrMoreYears_Male_WithIncome:
+    "Individual Median Income (Male)",
+  Median_Income_Person_15OrMoreYears_Female_WithIncome:
+    "Individual Median Income (Female)",
+
+  Count_Person_Female_BelowPovertyLevelInThePast12Months:
+    "Population Below Poverty Level in the Past 12 Months (Female)",
+  Count_Person_Male_BelowPovertyLevelInThePast12Months:
+    "Population Below Poverty Level in the Past 12 Months (Male)",
+
+  Median_Income_Household_HouseholderRaceAmericanIndianOrAlaskaNativeAlone:
+    "Median Individual Income (American Indian or Alaska Native)",
+  Median_Income_Household_HouseholderRaceAsianAlone:
+    "Median Individual Income (Asian)",
+  Median_Income_Household_HouseholderRaceBlackOrAfricanAmericanAlone:
+    "Median Individual Income (Black or African American)",
+  Median_Income_Household_HouseholderRaceHispanicOrLatino:
+    "Median Individual Income (Hispanic or Latino)",
+  Median_Income_Household_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone:
+    "Median Individual Income (Native Hawaiian or Other Pacific Islander)",
+  Median_Income_Household_HouseholderRaceWhiteAlone:
+    "Median Individual Income (White)",
+
+  Percent_Person_18To64Years_Female_NoHealthInsurance:
+    "Percentage of Females without Health Insurance",
+  Percent_Person_18To64Years_Male_NoHealthInsurance:
+    "Percentage of Males without Health Insurance",
+
+  Percent_Person_18To64Years_NoHealthInsurance_BlackOrAfricanAmericanAlone:
+    "Percentage of Blacks Or African Americans without Health Insurance",
+  Percent_Person_18To64Years_NoHealthInsurance_HispanicOrLatino:
+    "Percentage of Hispanics or Latinos without Health Insurance",
+  Percent_Person_18To64Years_NoHealthInsurance_WhiteAlone:
+    "Percentage of Whites without Health Insurance",
+
+  Count_Person_25To34Years_EducationalAttainmentAssociatesDegree_Female:
+    "Count of Females with Associates Degrees",
+  Count_Person_25To34Years_EducationalAttainmentAssociatesDegree_Male:
+    "Count of Males with Associates Degrees",
+  Count_Person_25To34Years_EducationalAttainmentBachelorsDegree_Female:
+    "Count of Females with Bachelors Degrees",
+  Count_Person_25To34Years_EducationalAttainmentBachelorsDegree_Male:
+    "Count of Males with Bachelors Degrees",
+  Count_Person_25To34Years_EducationalAttainmentGraduateOrProfessionalDegree_Female:
+    "Count of Females with Graduate or Professional Degrees",
+  Count_Person_25To34Years_EducationalAttainmentGraduateOrProfessionalDegree_Male:
+    "Count of Males with Graduate or Professional Degrees",
+};
+
+export { STATS_VAR_TITLES };

--- a/static/webpack.config.js
+++ b/static/webpack.config.js
@@ -35,6 +35,10 @@ const config = {
       __dirname + "/js/place/place.ts",
       __dirname + "/css/place/place.scss",
     ],
+    ranking: [
+      __dirname + "/js/ranking/ranking.ts",
+      __dirname + "/css/ranking.scss",
+    ],
     scatter: [
       __dirname + "/js/tools/scatter.js",
       __dirname + "/css/scatter.scss",


### PR DESCRIPTION
Adds basic ranking pages, supporting rankings of stat vars from the chart config, grouped by place type and optionally scoped by a containing place. There is support for multiple stat vars as well, though we won't use it for now.

![image](https://user-images.githubusercontent.com/6052978/92680983-3771f500-f2e1-11ea-9370-aaccb84adab0.png)

![image](https://user-images.githubusercontent.com/6052978/92681012-4789d480-f2e1-11ea-819a-1a04ebfe33d4.png)
