### PR TITLE
[ranking] Add support for per-capita, migrate to get api

### DIFF
--- a/server/routes/ranking.py
+++ b/server/routes/ranking.py
@@ -30,8 +30,10 @@ def ranking(stat_var, place_type, place_dcid=''):
             place_name = place_dcid
     else:
         place_name = 'World'
+    per_capita = flask.request.args.get('pc', False) != False
     return flask.render_template('ranking.html',
                                  place_name=place_name,
                                  place_dcid=place_dcid,
                                  place_type=place_type,
+                                 per_capita=per_capita,
                                  stat_var=stat_var)

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -107,14 +107,18 @@ def get_chart_data(keys):
     return send_request(url, req_json=req_json)
 
 
-def get_place_ranking(stat_vars, place_type, within_place=None):
+def get_place_ranking(stat_vars,
+                      place_type,
+                      within_place=None,
+                      is_per_capita=False):
     url = API_ROOT + API_ENDPOINTS['get_place_ranking']
     req_json = {
         'stat_var_dcids': stat_vars,
         'place_type': place_type,
         'within_place': within_place,
+        'is_per_capita': is_per_capita,
     }
-    return send_request(url, req_json=req_json, post=True, has_payload=False)
+    return send_request(url, req_json=req_json, post=False, has_payload=False)
 
 
 def get_property_labels(dcids, out=True):

--- a/server/templates/ranking.html
+++ b/server/templates/ranking.html
@@ -26,6 +26,7 @@
 <div id="within-place-dcid" data-pwp="{{ place_dcid }}"></div>
 <div id="place-type" data-pt="{{ place_type }}"></div>
 <div id="place-name" data-pn="{{ place_name }}"></div>
+<div id="per-capita" data-pc="{{ per_capita }}"></div>
 <div id="stat-var" data-sv="{{ stat_var }}"></div>
 <div id="body" class="container">
   <div class="row mt-3">

--- a/server/webdriver_tests/screenshot/screenshot_test.py
+++ b/server/webdriver_tests/screenshot/screenshot_test.py
@@ -69,18 +69,18 @@ TEST_URLS = [
         'height':
             1000
     },
-    # {
-    #     'url': '/ranking/Median_Income_Person/County/country/USA',
-    #     'filename_suffix': 'ranking_median_income_counties.png',
-    #     'test_class': 'chart-container',
-    #     'height': 600
-    # },
-    # {
-    #     'url': '/ranking/Count_Person/Country',
-    #     'filename_suffix': 'ranking_population_countries.png',
-    #     'test_class': 'chart-container',
-    #     'height': 600
-    # },
+    {
+        'url': '/ranking/Median_Income_Person/County/country/USA',
+        'filename_suffix': 'ranking_median_income_counties.png',
+        'test_class': 'chart-container',
+        'height': 600
+    },
+    {
+        'url': '/ranking/Count_Person/Country',
+        'filename_suffix': 'ranking_population_countries.png',
+        'test_class': 'chart-container',
+        'height': 600
+    },
 ]
 
 

--- a/static/js/ranking/ranking.ts
+++ b/static/js/ranking/ranking.ts
@@ -27,12 +27,16 @@ window.onload = () => {
   const placeType = document.getElementById("place-type").dataset.pt;
   const placeName = document.getElementById("place-name").dataset.pn;
   const statVar = document.getElementById("stat-var").dataset.sv;
+  const isPerCapita = JSON.parse(
+    document.getElementById("per-capita").dataset.pc.toLowerCase()
+  );
   ReactDOM.render(
     React.createElement(Page, {
       placeName,
       placeType,
       withinPlace,
       statVar,
+      isPerCapita,
     }),
     document.getElementById("main-pane")
   );

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -15,8 +15,7 @@
  */
 
 import React, { Component, createRef } from "react";
-import { Ranking, RankInfo } from "./ranking_types";
-import * as d3 from "d3";
+import { Ranking } from "./ranking_types";
 import { DataPoint } from "../chart/base";
 import { drawHistogram } from "../chart/draw";
 
@@ -58,7 +57,7 @@ class RankingHistogram extends Component<
     );
   }
 
-  drawChart() {
+  drawChart(): void {
     const rankList = this.props.ranking.info;
     const dataPoints = rankList.map((d) => new DataPoint(d.placeName, d.value));
 
@@ -71,20 +70,20 @@ class RankingHistogram extends Component<
     );
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     window.removeEventListener("resize", this._handleWindowResize);
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     window.addEventListener("resize", this._handleWindowResize);
     this.drawChart();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(): void {
     this.drawChart();
   }
 
-  _handleWindowResize() {
+  _handleWindowResize(): void {
     const svgElement = document.getElementById(this.props.id);
     if (!svgElement) {
       return;

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Component, createRef } from "react";
+import React from "react";
 import { Ranking } from "./ranking_types";
 import { DataPoint } from "../chart/base";
 import { drawHistogram } from "../chart/draw";
@@ -28,7 +28,7 @@ interface RankingHistogramStateType {
   elemWidth: number;
 }
 
-class RankingHistogram extends Component<
+class RankingHistogram extends React.Component<
   RankingHistogramPropType,
   RankingHistogramStateType
 > {
@@ -43,7 +43,7 @@ class RankingHistogram extends Component<
     // small screen sizes
     this._handleWindowResize = this._handleWindowResize.bind(this);
     this.drawChart = this.drawChart.bind(this);
-    this.chartElementRef = createRef();
+    this.chartElementRef = React.createRef();
   }
 
   render(): JSX.Element {

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Component } from "react";
+import React from "react";
 import axios from "axios";
 import { STATS_VAR_TITLES } from "../shared/stats_var_titles";
 import { RankingTable } from "./ranking_table";
@@ -34,7 +34,7 @@ interface RankingPageStateType {
   data: LocationRankData;
 }
 
-class Page extends Component<RankingPagePropType, RankingPageStateType> {
+class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
   constructor(props: RankingPagePropType) {
     super(props);
     this.state = {

--- a/static/js/ranking/ranking_table.tsx
+++ b/static/js/ranking/ranking_table.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Component } from "react";
+import React from "react";
 import { Ranking } from "./ranking_types";
 
 interface RankingTablePropType {
@@ -23,7 +23,7 @@ interface RankingTablePropType {
   placeType: string;
 }
 
-class RankingTable extends Component<RankingTablePropType> {
+class RankingTable extends React.Component<RankingTablePropType> {
   constructor(props: RankingTablePropType) {
     super(props);
   }

--- a/static/js/ranking/ranking_table.tsx
+++ b/static/js/ranking/ranking_table.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { Component } from "react";
-import { Ranking, RankInfo } from "./ranking_types";
+import { Ranking } from "./ranking_types";
 
 interface RankingTablePropType {
   ranking: Ranking;


### PR DESCRIPTION
Also adds better error handling and cleans up client lint errors

The Mixer API was updated to get in https://github.com/datacommonsorg/mixer/commit/f6d3c6a61a9450837e00b91bf7289746a78a205a

The change doesn't affect prod since the ranking pages aren't launched yet, but it does break the screenshot tests.