### PR TITLE
Alter chart drawing area to account for growing x-axis bounding box if required

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -296,7 +296,6 @@ function drawSingleBarChart(
     .paddingOuter(0.1);
 
   const bottomHeight = addXAxis(svg, chartHeight, x);
-  console.log(bottomHeight);
 
   const y = d3
     .scaleLinear()


### PR DESCRIPTION
Note: this means the x-axis isn't always aligned across charts, but only if labels are very long and it's required.

![image](https://user-images.githubusercontent.com/6052978/93963203-650f6300-fd11-11ea-8aab-6794cb37a8a8.png)
