### PR TITLE
Do not show parent places chart if there is no data for parent places.

### DIFF
--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -95,7 +95,6 @@ class Chart extends Component<ChartPropType, ChartStateType> {
   parentRef: React.RefObject<HTMLOptionElement>;
   childrenRef: React.RefObject<HTMLOptionElement>;
   dcid: string;
-  placeRelation: string;
 
   constructor(props: ChartPropType) {
     super(props);
@@ -205,7 +204,10 @@ class Chart extends Component<ChartPropType, ChartStateType> {
         dg &&
         dg.reduce((accum, group) => {
           return accum || group.value.length === 1;
-        }, false))
+        }, false)) ||
+      (this.props.config.placeRelation === placeRelationEnum.CONTAINED &&
+        dg &&
+        dg.length === 1)
     ) {
       // When there is no data, do not show the current chart.
       console.log(


### PR DESCRIPTION
One example would be the health outcome page where there is only data for cdc500 cities.

![image](https://user-images.githubusercontent.com/5951856/94464600-8342ec00-0173-11eb-816e-7d6b6d845c46.png)
