### PR TITLE
[place] Embed chart enhancements

### DIFF
--- a/static/css/draw.scss
+++ b/static/css/draw.scss
@@ -14,42 +14,6 @@
  * limitations under the License.
  */
 
-path.line {
-  fill: none;
-  stroke-width: 2.5;
-}
-
-path.line.fill {
-  opacity: .4;
-  stroke-dasharray: 2;
-}
-
-.axis line {
-  stroke: #999;
-  stroke-width: 0.5;
-}
-
-.axis path {
-  stroke: #999;
-  stroke-width: 0.5;
-  shape-rendering: crispEdges;
-}
-
-.axis text {
-  fill: #2b2929;
-  font-family: Roboto;
-  shape-rendering: crispEdges;
-}
-
-.y.axis line.grid-line {
-  stroke-opacity: 0.5;
-  stroke-dasharray: 2, 2;
-}
-
-.dot {
-  stroke: #fff;
-}
-
 .legend {
   margin-left: 35px;
   text-align: center;
@@ -72,13 +36,4 @@ path.line.fill {
 
 .legend-text {
   font-size: 14px;
-}
-
-.label {
-  font-size: 12px;
-}
-
-.place-tick {
-  cursor: pointer;
-  text-decoration: underline;
 }

--- a/static/css/place/place.scss
+++ b/static/css/place/place.scss
@@ -277,7 +277,7 @@ $chart-border: 0.5px solid #dee2e6;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 4px;
+  padding: 0 10px;
 }
 
 .outlinks a {

--- a/static/css/place/place.scss
+++ b/static/css/place/place.scss
@@ -314,13 +314,22 @@ $chart-border: 0.5px solid #dee2e6;
   display: none;
 }
 
-.modal .copy-svg {
+.modal .modal-chart-container > svg {
+  visibility: hidden;
+}
+
+.modal .modal-chart-container img {
+  border-radius: 3px;
+  border: $chart-border;
+}
+
+.modal textarea {
   background: #efefef;
   border-radius: 3px;
   border: $chart-border;
   display: flex;
   font-family: monospace;
-  height: 6rem;
+  height: 8rem;
   margin: auto;
   padding: .5rem;
 }

--- a/static/css/place/place.scss
+++ b/static/css/place/place.scss
@@ -195,7 +195,7 @@ $chart-border: 0.5px solid #dee2e6;
 
 .factoid footer,
 .chart-container footer {
-  font-size: 0.5rem;
+  font-size: 0.7rem;
   color: var(--dc-gray);
   margin-top: 0.5rem;
 }

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -150,6 +150,8 @@ function addXAxis(
     .append("g")
     .attr("class", "x axis")
     .attr("transform", `translate(0, ${chartHeight - MARGIN.bottom})`)
+    .style("stroke", "#999")
+    .style("stroke-width", "0.5px")
     .call(d3Axis)
     .call((g) => g.select(".domain").remove());
 
@@ -162,7 +164,12 @@ function addXAxis(
       .attr("dy", ".15em")
       .attr("transform", "rotate(-35)");
   } else if (typeof xScale.bandwidth === "function") {
-    axis.selectAll(".tick text").call(wrap, xScale.bandwidth());
+    axis
+      .selectAll(".tick text")
+      .style("fill", "#2b2929")
+      .style("font-family", "Roboto")
+      .style("shape-rendering", "crispEdges")
+      .call(wrap, xScale.bandwidth());
   }
 
   let axisHeight = axis.node().getBBox().height;
@@ -213,13 +220,23 @@ function addYAxis(
     )
     .call((g) => g.select(".domain").remove())
     .call((g) =>
-      g.selectAll(".tick:not(:first-of-type) line").attr("class", "grid-line")
+      g.selectAll("line").style("stroke", "#999").style("stroke-width", "0.5")
+    )
+    .call((g) =>
+      g
+        .selectAll(".tick:not(:first-of-type) line")
+        .attr("class", "grid-line")
+        .style("stroke-opacity", "0.5")
+        .style("stroke-dasharray", "2, 2")
     )
     .call((g) =>
       g
         .selectAll(".tick text")
         .attr("x", -width + MARGIN.left + MARGIN.yAxis)
         .attr("dy", -4)
+        .style("fill", "#2b2929")
+        .style("font-family", "Roboto")
+        .style("shape-rendering", "crispEdges")
     );
 }
 
@@ -259,6 +276,7 @@ function drawHistogram(
   const svg = d3
     .select("#" + id)
     .append("svg")
+    .attr("xmlns", "http://www.w3.org/2000/svg")
     .attr("width", width)
     .attr("height", height);
 
@@ -299,6 +317,7 @@ function drawSingleBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
+    .attr("xmlns", "http://www.w3.org/2000/svg")
     .attr("width", chartWidth)
     .attr("height", chartHeight);
 
@@ -363,6 +382,7 @@ function drawStackBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
+    .attr("xmlns", "http://www.w3.org/2000/svg")
     .attr("width", chartWidth)
     .attr("height", chartHeight);
 
@@ -440,6 +460,7 @@ function drawGroupBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
+    .attr("xmlns", "http://www.w3.org/2000/svg")
     .attr("width", chartWidth)
     .attr("height", chartHeight);
 
@@ -481,6 +502,8 @@ function drawGroupBarChart(
       return !!labelToLink[d3.select(this).text()];
     })
     .attr("class", "place-tick")
+    .style("cursor", "pointer")
+    .style("text-decoration", "underline")
     .on("click", function (this) {
       window.open(labelToLink[d3.select(this).text()], "_blank");
     });
@@ -512,6 +535,7 @@ function drawLineChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
+    .attr("xmlns", "http://www.w3.org/2000/svg")
     .attr("width", width)
     .attr("height", height);
 
@@ -556,8 +580,12 @@ function drawLineChart(
         .append("path")
         .datum(dataset.filter(line.defined())) // Only plot points that are defined
         .attr("class", "line fill")
+        .attr("d", line)
+        .style("fill", "none")
+        .style("stroke-width", "2.5px")
         .style("stroke", colorFn(dataGroup.label))
-        .attr("d", line);
+        .style("opacity", 0.4)
+        .style("stroke-dasharray", 2);
     }
 
     svg
@@ -565,7 +593,10 @@ function drawLineChart(
       .datum(dataset)
       .attr("class", "line")
       .style("stroke", colorFn(dataGroup.label))
-      .attr("d", line);
+      .attr("d", line)
+      .style("fill", "none")
+      .style("stroke-width", "2.5px")
+      .style("stroke", colorFn(dataGroup.label));
 
     if (shouldAddDots) {
       svg
@@ -577,8 +608,9 @@ function drawLineChart(
         .attr("class", "dot")
         .attr("cx", (d) => xScale(d[0]))
         .attr("cy", (d) => yScale(d[1]))
-        .attr("fill", colorFn(dataGroup.label))
-        .attr("r", (d) => (d[1] === null ? 0 : 3));
+        .attr("r", (d) => (d[1] === null ? 0 : 3))
+        .style("fill", colorFn(dataGroup.label))
+        .style("stroke", "#fff");
     }
   }
 
@@ -672,6 +704,7 @@ function drawGroupLineChart(
 
   const svg = container
     .append("svg")
+    .attr("xmlns", "http://www.w3.org/2000/svg")
     .attr("width", width)
     .attr("height", height + SOURCE.height);
 
@@ -695,6 +728,7 @@ function drawGroupLineChart(
     .attr("class", "label")
     .attr("text-anchor", "start")
     .attr("transform", `translate(${MARGIN.grid}, ${YLABEL.topMargin})`)
+    .style("font-size", "12px")
     .text(ylabel);
 
   for (const place in dataGroupsDict) {

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -46,6 +46,8 @@ const YLABEL = {
   topMargin: 10,
   height: 15,
 };
+const SVGNS = "http://www.w3.org/2000/svg";
+const XLINKNS = "http://www.w3.org/1999/xlink";
 
 function appendLegendElem(
   elem: string,
@@ -276,7 +278,8 @@ function drawHistogram(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("xmlns", "http://www.w3.org/2000/svg")
+    .attr("xmlns", SVGNS)
+    .attr("xmlns:xlink", XLINKNS)
     .attr("width", width)
     .attr("height", height);
 
@@ -317,7 +320,8 @@ function drawSingleBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("xmlns", "http://www.w3.org/2000/svg")
+    .attr("xmlns", SVGNS)
+    .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
     .attr("height", chartHeight);
 
@@ -382,7 +386,8 @@ function drawStackBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("xmlns", "http://www.w3.org/2000/svg")
+    .attr("xmlns", SVGNS)
+    .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
     .attr("height", chartHeight);
 
@@ -460,7 +465,8 @@ function drawGroupBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("xmlns", "http://www.w3.org/2000/svg")
+    .attr("xmlns", SVGNS)
+    .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
     .attr("height", chartHeight);
 
@@ -535,7 +541,8 @@ function drawLineChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("xmlns", "http://www.w3.org/2000/svg")
+    .attr("xmlns", SVGNS)
+    .attr("xmlns:xlink", XLINKNS)
     .attr("width", width)
     .attr("height", height);
 
@@ -704,7 +711,8 @@ function drawGroupLineChart(
 
   const svg = container
     .append("svg")
-    .attr("xmlns", "http://www.w3.org/2000/svg")
+    .attr("xmlns", SVGNS)
+    .attr("xmlns:xlink", XLINKNS)
     .attr("width", width)
     .attr("height", height + SOURCE.height);
 

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -49,6 +49,10 @@ const YLABEL = {
 const SVGNS = "http://www.w3.org/2000/svg";
 const XLINKNS = "http://www.w3.org/1999/xlink";
 
+const TEXT_FONT_FAMILY = "Roboto";
+const AXIS_TEXT_FILL = "#2b2929";
+const AXIS_GRID_FILL = "#999";
+
 function appendLegendElem(
   elem: string,
   color: d3.ScaleOrdinal<string, string>,
@@ -152,7 +156,7 @@ function addXAxis(
     .append("g")
     .attr("class", "x axis")
     .attr("transform", `translate(0, ${chartHeight - MARGIN.bottom})`)
-    .style("stroke", "#999")
+    .style("stroke", AXIS_GRID_FILL)
     .style("stroke-width", "0.5px")
     .call(d3Axis)
     .call((g) => g.select(".domain").remove());
@@ -168,8 +172,8 @@ function addXAxis(
   } else if (typeof xScale.bandwidth === "function") {
     axis
       .selectAll(".tick text")
-      .style("fill", "#2b2929")
-      .style("font-family", "Roboto")
+      .style("fill", AXIS_TEXT_FILL)
+      .style("font-family", TEXT_FONT_FAMILY)
       .style("shape-rendering", "crispEdges")
       .call(wrap, xScale.bandwidth());
   }
@@ -222,7 +226,10 @@ function addYAxis(
     )
     .call((g) => g.select(".domain").remove())
     .call((g) =>
-      g.selectAll("line").style("stroke", "#999").style("stroke-width", "0.5")
+      g
+        .selectAll("line")
+        .style("stroke", AXIS_GRID_FILL)
+        .style("stroke-width", "0.5")
     )
     .call((g) =>
       g
@@ -236,8 +243,8 @@ function addYAxis(
         .selectAll(".tick text")
         .attr("x", -width + MARGIN.left + MARGIN.yAxis)
         .attr("dy", -4)
-        .style("fill", "#2b2929")
-        .style("font-family", "Roboto")
+        .style("fill", AXIS_TEXT_FILL)
+        .style("font-family", TEXT_FONT_FAMILY)
         .style("shape-rendering", "crispEdges")
     );
 }

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -180,7 +180,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
             </div>
             <div className="outlinks">
               <a href="#" onClick={this._handleEmbed}>
-                Embed
+                Export
               </a>
               <a className="explore-more" href={config.exploreUrl}>
                 Explore More ›
@@ -279,7 +279,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
     );
     let svgHtml: string;
     if (svgElems.length) {
-      svgHtml = svgElems.item(0).innerHTML;
+      svgHtml = svgElems.item(0).outerHTML;
     }
     const svgDom = this.chartElement.current.cloneNode(true);
     this.embedModalElement.current.show(svgHtml, svgDom, this.dataCsv());

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -273,16 +273,22 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
     e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
   ): void {
     e.preventDefault();
-    // Node does not have innerHTML property so we need to pass both in.
     const svgElems = this.svgContainerElement.current.getElementsByTagName(
       "svg"
     );
-    let svgHtml: string;
+    let svgXml: string;
     if (svgElems.length) {
-      svgHtml = svgElems.item(0).outerHTML;
+      svgXml = svgElems.item(0).outerHTML;
     }
-    const svgDom = this.chartElement.current.cloneNode(true);
-    this.embedModalElement.current.show(svgHtml, svgDom, this.dataCsv());
+    this.embedModalElement.current.show(
+      svgXml,
+      this.dataCsv(),
+      this.chartElement.current.offsetWidth,
+      CHART_HEIGHT,
+      this.props.config.title,
+      this.state.dateSelected,
+      this.state.sources
+    );
   }
 
   drawChart(): void {

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -224,11 +224,11 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
     this.embedModalElement.current.show(
       svgXml,
       this.dataCsv(),
-      this.chartElement.current.offsetWidth,
+      this.svgContainerElement.current.offsetWidth,
       CHART_HEIGHT,
-      this.props.config.title,
-      this.state.dateSelected,
-      this.state.sources
+      this.props.title,
+      this.props.snapshot ? this.props.snapshot.date : "",
+      this.props.snapshot ? this.props.snapshot.sources : []
     );
   }
 

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -21,7 +21,7 @@ import { randDomId, saveToFile } from "../shared/util";
 interface ChartEmbedStateType {
   modal: boolean;
   chartDom: Node;
-  svgHtml: string;
+  svgXml: string;
   dataCsv: string;
 }
 
@@ -37,7 +37,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
     super(props);
     this.state = {
       modal: false,
-      svgHtml: "",
+      svgXml: "",
       chartDom: null,
       dataCsv: "",
     };
@@ -45,8 +45,8 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
     this.textareaElement = React.createRef();
     this.toggle = this.toggle.bind(this);
     this.onOpened = this.onOpened.bind(this);
-    this.copySvgToClipboard = this.copySvgToClipboard.bind(this);
-    this.downloadData = this.downloadData.bind(this);
+    this.onDownloadSvg = this.onDownloadSvg.bind(this);
+    this.onDownloadData = this.onDownloadData.bind(this);
     this.onClickTextarea = this.onClickTextarea.bind(this);
   }
 
@@ -62,11 +62,11 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
   /**
    * Updates the view state of the modal to true, and includes the data necessary for displaying the modal.
    */
-  public show(svgHTML: string, chartDOM: Node, dataCsv: string): void {
+  public show(svgXml: string, chartDom: Node, dataCsv: string): void {
     this.setState({
       modal: true,
-      svgHtml: svgHTML,
-      chartDom: chartDOM,
+      svgXml: svgXml,
+      chartDom: chartDom,
       dataCsv: dataCsv,
     });
   }
@@ -108,25 +108,14 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
   /**
    * On click handler for "Copy SVG to clipboard button".
    */
-  public copySvgToClipboard(): void {
-    const currentFocus = document.activeElement;
-    this.onClickTextarea();
-    document.execCommand("copy");
-
-    // restore original focus
-    if (
-      currentFocus &&
-      currentFocus instanceof HTMLElement &&
-      typeof currentFocus.focus === "function"
-    ) {
-      currentFocus.focus();
-    }
+  public onDownloadSvg(): void {
+    saveToFile("chart.svg", this.state.svgXml);
   }
 
   /**
    * On click handler for "Download Data" button.
    */
-  public downloadData(): void {
+  public onDownloadData(): void {
     saveToFile("export.csv", this.state.dataCsv);
   }
 
@@ -144,18 +133,18 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
           <div className="modal-chart-container"></div>
           <textarea
             className="copy-svg mt-3"
-            value={this.state.svgHtml}
+            value={this.state.svgXml}
             readOnly
             ref={this.textareaElement}
             onClick={this.onClickTextarea}
           ></textarea>
         </ModalBody>
         <ModalFooter>
-          <Button color="primary" onClick={this.copySvgToClipboard}>
-            Copy SVG to clipboard
+          <Button color="primary" onClick={this.onDownloadSvg}>
+            Download chart as SVG
           </Button>{" "}
-          <Button color="primary" onClick={this.downloadData}>
-            Download Data
+          <Button color="primary" onClick={this.onDownloadData}>
+            Download Data as CSV
           </Button>
         </ModalFooter>
       </Modal>

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -23,7 +23,7 @@ import * as d3 from "d3";
 const TITLE_HEIGHT = 20;
 const TITLE_MARGIN = 10;
 const SOURCES_HEIGHT = 10;
-const SOURCES_MARGIN = 10;
+const SOURCES_MARGIN = 30;
 const SVGNS = "http://www.w3.org/2000/svg";
 const XLINKNS = "http://www.w3.org/1999/xlink";
 

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -60,7 +60,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
       chartDate: "",
       sources: [],
     };
-    this.chartDownloadXml = '';
+    this.chartDownloadXml = "";
     this.modalId = randDomId();
     this.svgContainerElement = React.createRef();
     this.textareaElement = React.createRef();
@@ -182,8 +182,9 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
 
     this.chartDownloadXml = this.decorateSvgChart();
 
-    const imageElement =  document.createElement("img");
-    const chartBase64 = "data:image/svg+xml;base64," + btoa(this.chartDownloadXml);
+    const imageElement = document.createElement("img");
+    const chartBase64 =
+      "data:image/svg+xml;base64," + btoa(this.chartDownloadXml);
     imageElement.src = chartBase64;
     this.svgContainerElement.current.append(imageElement);
   }
@@ -214,7 +215,6 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
   }
 
   public render(): JSX.Element {
-    console.log("render");
     return (
       <Modal
         isOpen={this.state.modal}
@@ -223,7 +223,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
         onOpened={this.onOpened}
         id={this.modalId}
       >
-        <ModalHeader toggle={this.toggle}>Embed this chart</ModalHeader>
+        <ModalHeader toggle={this.toggle}>Export this chart</ModalHeader>
         <ModalBody>
           <div
             ref={this.svgContainerElement}

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -17,12 +17,25 @@
 import React from "react";
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from "reactstrap";
 import { randDomId, saveToFile } from "../shared/util";
+import * as d3 from "d3";
+
+// SVG adjustment related constants
+const TITLE_HEIGHT = 20;
+const TITLE_MARGIN = 10;
+const SOURCES_HEIGHT = 10;
+const SOURCES_MARGIN = 10;
+const SVGNS = "http://www.w3.org/2000/svg";
+const XLINKNS = "http://www.w3.org/1999/xlink";
 
 interface ChartEmbedStateType {
   modal: boolean;
-  chartDom: Node;
   svgXml: string;
   dataCsv: string;
+  chartWidth: number;
+  chartHeight: number;
+  chartTitle: string;
+  chartDate: string;
+  sources: string[];
 }
 
 /**
@@ -30,19 +43,28 @@ interface ChartEmbedStateType {
  * in a Modal
  */
 class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
-  private textareaElement: React.RefObject<HTMLTextAreaElement>;
+  private chartDownloadXml: string;
   private modalId: string;
+  private svgContainerElement: React.RefObject<HTMLDivElement>;
+  private textareaElement: React.RefObject<HTMLTextAreaElement>;
 
   constructor(props: unknown) {
     super(props);
     this.state = {
       modal: false,
       svgXml: "",
-      chartDom: null,
       dataCsv: "",
+      chartWidth: 0,
+      chartHeight: 0,
+      chartTitle: "",
+      chartDate: "",
+      sources: [],
     };
+    this.chartDownloadXml = '';
     this.modalId = randDomId();
+    this.svgContainerElement = React.createRef();
     this.textareaElement = React.createRef();
+
     this.toggle = this.toggle.bind(this);
     this.onOpened = this.onOpened.bind(this);
     this.onDownloadSvg = this.onDownloadSvg.bind(this);
@@ -62,36 +84,108 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
   /**
    * Updates the view state of the modal to true, and includes the data necessary for displaying the modal.
    */
-  public show(svgXml: string, chartDom: Node, dataCsv: string): void {
+  public show(
+    svgXml: string,
+    dataCsv: string,
+    chartWidth: number,
+    chartHeight: number,
+    chartTitle: string,
+    chartDate: string,
+    sources: string[]
+  ): void {
     this.setState({
       modal: true,
       svgXml: svgXml,
-      chartDom: chartDom,
       dataCsv: dataCsv,
+      chartWidth: chartWidth,
+      chartHeight: chartHeight,
+      chartTitle: chartTitle,
+      chartDate: chartDate ? "(" + chartDate + ")" : "",
+      sources: sources,
     });
+  }
+
+  /**
+   * Decorates svgXml with title and provenance information embeded in an enclosing
+   * SVG node. Returns the SVG contents as a string.
+   */
+  private decorateSvgChart(): string {
+    const container = this.svgContainerElement.current;
+    container.innerHTML = "";
+
+    // Decorate a hidden chart svg with title and provenance
+    const svg = d3
+      .select(container)
+      .append("svg")
+      .attr("xmlns", SVGNS)
+      .attr("xmlns:xlink", XLINKNS)
+      .attr("width", this.state.chartWidth)
+      .attr(
+        "height",
+        this.state.chartHeight +
+          TITLE_HEIGHT +
+          TITLE_MARGIN +
+          SOURCES_HEIGHT +
+          SOURCES_MARGIN
+      );
+
+    svg
+      .append("g")
+      .attr(
+        "transform",
+        `translate(${this.state.chartWidth / 2}, ${TITLE_HEIGHT})`
+      )
+      .append("text")
+      .style("font-family", "sans-serif")
+      .style("fill", "#3b3b3b")
+      .style("font-size", ".85rem")
+      .style("font-weight", "bold")
+      .style("text-anchor", "middle")
+      .text(`${this.state.chartTitle} ${this.state.chartDate}`);
+
+    svg
+      .append("g")
+      .attr("transform", `translate(0, ${TITLE_HEIGHT + TITLE_MARGIN})`)
+      .append("svg")
+      .html(this.state.svgXml);
+
+    svg
+      .append("g")
+      .attr(
+        "transform",
+        `translate(5, ${
+          TITLE_HEIGHT + TITLE_MARGIN + this.state.chartHeight + SOURCES_MARGIN
+        })`
+      )
+      .append("text")
+      .style("fill", "#3b3b3b")
+      .style("font-family", "sans-serif")
+      .style("font-size", ".7rem")
+      .text(`Data from ${this.state.sources.join(",")} via Data Commons`);
+
+    const svgXml = svg.node().outerHTML;
+    container.innerHTML = "";
+
+    return svgXml;
   }
 
   /**
    * Callback for after the modal has been rendered and added to the DOM.
    */
   public onOpened(): void {
-    const modalElement = document.getElementById(this.modalId);
-    if (!modalElement || !this.state.chartDom) {
+    if (!this.svgContainerElement.current) {
       return;
     }
-    // Append cloned chart DOM to the modal.
-    const containerElem = modalElement.querySelector(".modal-chart-container");
-    if (containerElem) {
-      containerElem.appendChild(this.state.chartDom);
-      const chartElem = containerElem.querySelector(".chart-container");
-      if (chartElem) {
-        // Update width of textarea to match the width of the chart.
-        const textarea = modalElement.querySelector("textarea");
-        if (textarea) {
-          textarea.style.width = chartElem.clientWidth + "px";
-        }
-      }
+    if (this.textareaElement.current) {
+      this.textareaElement.current.style.width = this.state.chartWidth + "px";
     }
+
+    this.chartDownloadXml = this.decorateSvgChart();
+
+    const imageElement =  document.createElement("img");
+    const chartBase64 = "data:image/svg+xml;base64," + btoa(this.chartDownloadXml);
+    imageElement.src = chartBase64;
+    this.svgContainerElement.current.append(imageElement);
   }
 
   /**
@@ -109,7 +203,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
    * On click handler for "Copy SVG to clipboard button".
    */
   public onDownloadSvg(): void {
-    saveToFile("chart.svg", this.state.svgXml);
+    saveToFile("chart.svg", this.chartDownloadXml);
   }
 
   /**
@@ -120,6 +214,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
   }
 
   public render(): JSX.Element {
+    console.log("render");
     return (
       <Modal
         isOpen={this.state.modal}
@@ -130,10 +225,13 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
       >
         <ModalHeader toggle={this.toggle}>Embed this chart</ModalHeader>
         <ModalBody>
-          <div className="modal-chart-container"></div>
+          <div
+            ref={this.svgContainerElement}
+            className="modal-chart-container"
+          ></div>
           <textarea
             className="copy-svg mt-3"
-            value={this.state.svgXml}
+            value={this.state.dataCsv}
             readOnly
             ref={this.textareaElement}
             onClick={this.onClickTextarea}
@@ -141,7 +239,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
         </ModalBody>
         <ModalFooter>
           <Button color="primary" onClick={this.onDownloadSvg}>
-            Download chart as SVG
+            Download Chart Image
           </Button>{" "}
           <Button color="primary" onClick={this.onDownloadData}>
             Download Data as CSV

--- a/static/js/shared/util.js
+++ b/static/js/shared/util.js
@@ -500,14 +500,21 @@ function randDomId() {
 /**
  * Saves csv to filename.
  * @param {filename} string
- * @param {csv} string
+ * @param {contents} string
+ * @param {=header} string optional file header to prepend to the file contents
  * @return void
  */
-function saveToFile(filename, csv) {
-  if (!csv.match(/^data:text\/csv/i)) {
-    csv = "data:text/csv;charset=utf-8," + csv;
+function saveToFile(filename, contents) {
+  if (filename.match(/\.csv$/i)) {
+    if (!contents.match(/^data:text\/csv/i)) {
+      contents = "data:text/csv;charset=utf-8," + contents;
+    }
+  } else if (filename.match(/\.svg$/i)) {
+    if (!contents.match(/^data:image\/svg/i)) {
+      contents = "data:image/svg+xml;charset=utf-8," + contents;
+    }
   }
-  const data = encodeURI(csv);
+  const data = encodeURI(contents);
   const link = document.createElement("a");
   link.setAttribute("href", data);
   link.setAttribute("download", filename);


### PR DESCRIPTION
* move svg chart styling inline from css (so that all styling information is self-contained in the svg)
* added xml namespace attributes to svg
* include title and provenance information into a hidden svg image, which is then used to get the final svg xml for download and embed
* svg chart is now embedded as an image so that it can be copied
* svg is now downloadable as a standalone image