### PR TITLE
Some chart rendering fixes

### DIFF
--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -66,6 +66,20 @@
     </div>
   </div>
   <div id="modal"></div>
+  {#- Add an SVG filter to lighten bars for comparison places -#}
+  <style>
+    g rect.g-bar[data-dcid="{{ place_dcid }}"] {
+      filter: url(#lighten);
+    }
+  </style>
+  <svg width=0 height=0>
+    <filter id="lighten">
+      <feColorMatrix type="matrix" values="1.25  0     0    0  0
+                                           0     1.25  0    0  0
+                                           0     0     1.25 0  0
+                                           0     0     0    1  0" />
+    </filter>
+  </svg>
 {% endblock %}
 
 {% block footer %}

--- a/static/js/chart/base.ts
+++ b/static/js/chart/base.ts
@@ -21,9 +21,12 @@ const DEFAULT_COLOR = "#000";
 class DataPoint {
   value: number;
   label: string;
-  constructor(label: string, value: number) {
+  // Optional DCID to add to a chart as a data atttribute
+  dcid?: string;
+  constructor(label: string, value: number, dcid?: string) {
     this.value = value;
     this.label = label;
+    this.dcid = dcid;
   }
 }
 

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -106,6 +106,7 @@ function wrap(
     let word: string;
     word = words.pop();
     while (word) {
+      word = word.trim();
       let separator = getWrapLineSeparator(line);
       line.push(word);
       tspan.text(line.join(separator));
@@ -380,6 +381,11 @@ function drawStackBarChart(
   dataGroups: DataGroup[],
   unit?: string
 ): void {
+  const labelToLink = {};
+  for (const dataGroup of dataGroups) {
+    labelToLink[dataGroup.label] = dataGroup.link;
+  }
+
   const keys = dataGroups[0].value.map((dp) => dp.label);
 
   const data = [];
@@ -439,6 +445,20 @@ function drawStackBarChart(
     .attr("height", (d) => (Number.isNaN(d[1]) ? 0 : y(d[0]) - y(d[1])));
 
   appendLegendElem(id, color, keys);
+
+  // Add link to place name labels.
+  svg
+    .select(".x.axis")
+    .selectAll(".tick text")
+    .filter(function (this) {
+      return !!labelToLink[d3.select(this).text()];
+    })
+    .attr("class", "place-tick")
+    .style("cursor", "pointer")
+    .style("text-decoration", "underline")
+    .on("click", function (this) {
+      window.open(labelToLink[d3.select(this).text()], "_blank");
+    });
 }
 
 /**

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -355,6 +355,8 @@ function drawSingleBarChart(
     .selectAll("rect")
     .data(dataPoints)
     .join("rect")
+    .classed("g-bar", true)
+    .attr("data-dcid", (d) => d.dcid)
     .attr("x", (d) => x(d.label))
     .attr("y", (d) => y(d.value))
     .attr("width", x.bandwidth())
@@ -385,6 +387,7 @@ function drawStackBarChart(
     const curr: { [property: string]: any } = { label: dataGroup.label };
     for (const dataPoint of dataGroup.value) {
       curr[dataPoint.label] = dataPoint.value;
+      curr.dcid = dataPoint.dcid;
     }
     data.push(curr);
   }
@@ -428,6 +431,8 @@ function drawStackBarChart(
     .selectAll("rect")
     .data((d) => d)
     .join("rect")
+    .classed("g-bar", true)
+    .attr("data-dcid", (d) => d.data.dcid)
     .attr("x", (d) => x(String(d.data.label)))
     .attr("y", (d) => (Number.isNaN(d[1]) ? y(d[0]) : y(d[1])))
     .attr("width", x.bandwidth())
@@ -498,8 +503,12 @@ function drawGroupBarChart(
     .join("g")
     .attr("transform", (dg) => `translate(${x0(dg.label)},0)`)
     .selectAll("rect")
-    .data((dg) => dg.value.map((dp) => ({ key: dp.label, value: dp.value })))
+    .data((dg) =>
+      dg.value.map((dp) => ({ key: dp.label, value: dp.value, dcid: dp.dcid }))
+    )
     .join("rect")
+    .classed("g-bar", true)
+    .attr("data-dcid", (d) => d.dcid)
     .attr("x", (d) => x1(d.key))
     .attr("y", (d) => y(d.value))
     .attr("width", x1.bandwidth())

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -157,16 +157,21 @@ function addXAxis(
     .append("g")
     .attr("class", "x axis")
     .attr("transform", `translate(0, ${chartHeight - MARGIN.bottom})`)
-    .style("stroke", AXIS_GRID_FILL)
-    .style("stroke-width", "0.5px")
     .call(d3Axis)
-    .call((g) => g.select(".domain").remove());
+    .call((g) => g.select(".domain").remove())
+    .call((g) =>
+      g
+        .selectAll("line")
+        .attr("stroke", AXIS_GRID_FILL)
+        .attr("stroke-width", "0.5")
+    );
 
   if (shouldRotate) {
     axis
       .attr("transform", `translate(0, ${chartHeight - ROTATE_MARGIN_BOTTOM})`)
       .selectAll("text")
       .style("text-anchor", "end")
+      .style("text-rendering", "optimizedLegibility")
       .attr("dx", "-.8em")
       .attr("dy", ".15em")
       .attr("transform", "rotate(-35)");
@@ -175,7 +180,7 @@ function addXAxis(
       .selectAll(".tick text")
       .style("fill", AXIS_TEXT_FILL)
       .style("font-family", TEXT_FONT_FAMILY)
-      .style("shape-rendering", "crispEdges")
+      .style("text-rendering", "optimizedLegibility")
       .call(wrap, xScale.bandwidth());
   }
 
@@ -774,6 +779,7 @@ function drawGroupLineChart(
     .attr("text-anchor", "start")
     .attr("transform", `translate(${MARGIN.grid}, ${YLABEL.topMargin})`)
     .style("font-size", "12px")
+    .style("text-rendering", "optimizedLegibility")
     .text(ylabel);
 
   for (const place in dataGroupsDict) {
@@ -794,10 +800,11 @@ function drawGroupLineChart(
         .append("path")
         .datum(dataset)
         .attr("class", "line")
-        .style("stroke", lineStyle.color)
         .attr("d", line)
-        .attr("stroke-width", "1")
-        .attr("stroke-dasharray", lineStyle.dash);
+        .style("fill", "none")
+        .style("stroke", lineStyle.color)
+        .style("stroke-width", "2px")
+        .style("stroke-dasharray", lineStyle.dash);
     }
   }
   // add source info to the chart
@@ -806,12 +813,14 @@ function drawGroupLineChart(
     svg
       .append("text")
       .attr("class", "label")
-      .attr("text-anchor", "start")
       .attr(
         "transform",
         `translate(${MARGIN.grid}, ${height + SOURCE.topMargin})`
       )
-      .attr("fill", "#808080")
+      .style("fill", "#808080")
+      .style("font-size", "12px")
+      .style("text-anchor", "start")
+      .style("text-rendering", "optimizedLegibility")
       .text(sourceText);
   }
 
@@ -853,8 +862,8 @@ function buildInChartLegend(
         .attr("class", "legend-line")
         .attr("x1", "0")
         .attr("x2", `${LEGEND.dashWidth - 3}`)
-        .attr("stroke", LEGEND.defaultColor)
-        .attr("stroke-dasharray", `${legendStyle.dash}`);
+        .style("stroke", LEGEND.defaultColor)
+        .style("stroke-dasharray", `${legendStyle.dash}`);
       dashWidth = LEGEND.dashWidth;
     }
     // Draw the text.
@@ -865,7 +874,8 @@ function buildInChartLegend(
       .attr("y", "0.3em")
       .attr("dy", "0")
       .text(label)
-      .attr("fill", `${legendStyle.color}`)
+      .style("text-rendering", "optimizedLegibility")
+      .style("fill", `${legendStyle.color}`)
       .call(wrap, legendTextdWidth);
     yOffset += lgGroup.node().getBBox().height + LEGEND.lineMargin;
   }

--- a/static/js/dev.ts
+++ b/static/js/dev.ts
@@ -72,24 +72,24 @@ window.onload = () => {
       new DataPoint("2013", 24000),
     ]),
     new DataGroup("San Francisco", [
-      new DataPoint("2011", 21000),
+      new DataPoint("2011", null),
       new DataPoint("2012", 25000),
       new DataPoint("2013", 22000),
     ]),
     new DataGroup("Mountain View", [
-      new DataPoint("2011", 1000),
+      new DataPoint("2011", null),
       new DataPoint("2012", 5000),
       new DataPoint("2013", 2000),
     ]),
     new DataGroup("Very-Long-City-Name", [
       new DataPoint("2011", 1000),
       new DataPoint("2012", 5000),
-      new DataPoint("2013", 2000),
+      new DataPoint("2013", null),
     ]),
     new DataGroup("Multi several very long city name long", [
       new DataPoint("2011", 1000),
       new DataPoint("2012", 5000),
-      new DataPoint("2013", 2000),
+      new DataPoint("2013", null),
     ]),
   ];
 

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -329,10 +329,12 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         });
         break;
       case chartTypeEnum.SINGLE_BAR:
-        for (const statVar in this.props.snapshot.data[0].data) {
+        const snapshotData = this.props.snapshot.data[0];
+        for (const statVar in snapshotData.data) {
           dataPoints.push({
             label: STATS_VAR_LABEL[statVar],
-            value: this.props.snapshot.data[0].data[statVar] * scaling,
+            value: snapshotData.data[statVar] * scaling,
+            dcid: snapshotData.dcid,
           });
         }
         this.setState({
@@ -349,6 +351,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
             dataPoints.push({
               label: STATS_VAR_LABEL[statVar],
               value: val ? val * scaling : null,
+              dcid: placeData.dcid,
             });
           }
           dataGroups.push(

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -70,6 +70,10 @@ interface ChartPropType {
    * Scale number
    */
   scaling?: number;
+  /**
+   * All stats vars for this chart
+   */
+  statsVars: string[];
 }
 
 interface ChartStateType {
@@ -340,10 +344,11 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       case chartTypeEnum.STACK_BAR:
         for (const placeData of this.props.snapshot.data) {
           const dataPoints: DataPoint[] = [];
-          for (const statVar in placeData.data) {
+          for (const statVar of this.props.statsVars) {
+            const val = placeData.data[statVar];
             dataPoints.push({
               label: STATS_VAR_LABEL[statVar],
-              value: placeData.data[statVar] * scaling,
+              value: val ? val * scaling : null,
             });
           }
           dataGroups.push(

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -355,7 +355,11 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
             });
           }
           dataGroups.push(
-            new DataGroup(this.props.names[placeData.dcid], dataPoints)
+            new DataGroup(
+              this.props.names[placeData.dcid],
+              dataPoints,
+              `/place?dcid=${placeData.dcid}`
+            )
           );
         }
         this.setState({

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -329,13 +329,15 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         });
         break;
       case chartTypeEnum.SINGLE_BAR:
-        const snapshotData = this.props.snapshot.data[0];
-        for (const statVar in snapshotData.data) {
-          dataPoints.push({
-            label: STATS_VAR_LABEL[statVar],
-            value: snapshotData.data[statVar] * scaling,
-            dcid: snapshotData.dcid,
-          });
+        {
+          const snapshotData = this.props.snapshot.data[0];
+          for (const statVar in snapshotData.data) {
+            dataPoints.push({
+              label: STATS_VAR_LABEL[statVar],
+              value: snapshotData.data[statVar] * scaling,
+              dcid: snapshotData.dcid,
+            });
+          }
         }
         this.setState({
           dataPoints,

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -74,6 +74,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
           unit={this.props.data.unit}
           names={this.props.names}
           scaling={this.props.data.scaling}
+          statsVars={this.props.data.statsVars}
         ></Chart>
       );
     }
@@ -109,6 +110,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
         unit: unit,
         names: this.props.names,
         scaling: scaling,
+        statsVars: this.props.data.statsVars,
       };
       if (this.props.isOverview) {
         // Show child place(state) chart for USA page, otherwise show nearby


### PR DESCRIPTION
* Fix overlapping stack bar charts when there is incomplete stat var data
* Highlight the SVG rect of the current place (it's quite subtle so we might want to tweak it)
* Make place labels clickable again (also applied to stack bar charts)
* Fix label rendering crispness and timelines tool (regression from #472)

![image](https://user-images.githubusercontent.com/6052978/94985029-7887ae80-0507-11eb-8577-315b852b6b6e.png)
