### PR TITLE
Link per capita charts to equivalent in timelines tool

### DIFF
--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -52,9 +52,11 @@ def get_landing_page_data(dcid, stat_vars):
     return response
 
 
-def build_url(dcids, stats_vars):
+def build_url(dcids, stats_vars, is_scaled=False):
     anchor = '&place={}&statsVar={}'.format(','.join(dcids),
                                             '__'.join(stats_vars))
+    if is_scaled:
+        anchor = anchor + '&pc=1'
     return urllib.parse.unquote(url_for('tools.timeline', _anchor=anchor))
 
 
@@ -173,7 +175,10 @@ def get_bar(cc, data, places):
     # so client won't draw chart.
     if len(result['data']) <= 1:
         return {}
-    result['exploreUrl'] = build_url(places, cc['statsVars'])
+    is_scaled = (('relatedChart' in cc and
+                  cc['relatedChart'].get('scale', False)) or
+                 ('denominator' in cc))
+    result['exploreUrl'] = build_url(places, cc['statsVars'], is_scaled)
     return result
 
 
@@ -211,10 +216,12 @@ def get_trend(cc, data, place):
             del series[stat_var]
     if not series:
         return {}
+
+    is_scaled = ('denominator' in cc)
     return {
         'series': series,
         'sources': list(sources),
-        'exploreUrl': build_url([place], cc['statsVars'])
+        'exploreUrl': build_url([place], cc['statsVars'], is_scaled)
     }
 
 

--- a/static/js/tools/timeline_chart_region.tsx
+++ b/static/js/tools/timeline_chart_region.tsx
@@ -28,6 +28,7 @@ interface ChartRegionPropsType {
   removeStatsVar: (statsVar: string, nodePath?: string[]) => void;
   chartOptions: ChartOptions;
   setPC: (mprop: string, pc: boolean) => void;
+  initialPC: boolean;
 }
 
 class ChartRegion extends Component<ChartRegionPropsType, unknown> {
@@ -44,6 +45,12 @@ class ChartRegion extends Component<ChartRegionPropsType, unknown> {
       this.downloadLink.onclick = () => {
         saveToFile("export.csv", this.createDataCsv());
       };
+    }
+    if (this.props.initialPC) {
+      const groups = this.groupStatsVars(this.props.statsVars);
+      for (const groupId in groups) {
+        this.props.setPC(groupId, true);
+      }
     }
   }
 

--- a/static/js/tools/timeline_page.test.tsx
+++ b/static/js/tools/timeline_page.test.tsx
@@ -189,7 +189,7 @@ test("chart options", () => {
         .then(() => {
           wrapper.update();
           expect(window.location.hash).toBe(
-            "place=geoId%2F05&statsVar=Median_Age_Person&chart=%257B%2522age%2522%253A%257B%2522pc%2522%253Atrue%257D%257D"
+            "place=geoId%2F05&statsVar=Median_Age_Person&chart=%7B%22age%22%3A%7B%22pc%22%3Atrue%7D%7D"
           );
           expect(
             pretty(wrapper.find("#chart-region").getDOMNode().innerHTML)
@@ -199,7 +199,7 @@ test("chart options", () => {
           wrapper.find("#drill .checkbox.checked").simulate("click");
           expect(wrapper.find("#chart-region").length).toBe(0); // chart deleted
           expect(window.location.hash).toBe(
-            "place=geoId%2F05&statsVar=&chart=%257B%2522age%2522%253A%257B%2522pc%2522%253Afalse%257D%257D"
+            "place=geoId%2F05&statsVar=&chart=%7B%22age%22%3A%7B%22pc%22%3Afalse%7D%7D"
           );
 
           // TODO: look into the mock functions
@@ -211,7 +211,7 @@ test("chart options", () => {
             "/api/stats/stats-var-property?dcid=Median_Age_Person"
           );
           expect(window.location.hash).toBe(
-            "place=geoId%2F05&statsVar=Median_Age_Person%2C0%2C2&chart=%257B%2522age%2522%253A%257B%2522pc%2522%253Afalse%257D%257D"
+            "place=geoId%2F05&statsVar=Median_Age_Person%2C0%2C2&chart=%7B%22age%22%3A%7B%22pc%22%3Afalse%7D%7D"
           );
 
           Promise.resolve(wrapper)

--- a/static/js/tools/timeline_page.test.tsx
+++ b/static/js/tools/timeline_page.test.tsx
@@ -154,6 +154,8 @@ test("statsVar not in PV-tree", () => {
     });
 });
 
+// TODO: Add test that loading from URL with these options works as expected
+// TODO: Add test that URL with &pc=1 set works as expected, and is cleared after the option is set.
 test("chart options", () => {
   // test if the chart options are correctly set
   Object.defineProperty(window, "location", {

--- a/static/js/tools/timeline_page.tsx
+++ b/static/js/tools/timeline_page.tsx
@@ -245,6 +245,7 @@ class Page extends Component<Record<string, unknown>, PageStateType> {
                     removeStatsVar={this.removeStatsVar.bind(this)}
                     chartOptions={this.state.chartOptions}
                     setPC={this.setChartPerCapita.bind(this)}
+                    initialPC={this.params.allPerCapita}
                   ></ChartRegion>
                 </div>
               )}

--- a/static/js/tools/timeline_util.ts
+++ b/static/js/tools/timeline_util.ts
@@ -95,6 +95,7 @@ class TimelineParams {
   urlParams: URLSearchParams;
   listenHashChange: boolean;
   chartOptions: ChartOptions;
+  allPerCapita: boolean;
 
   constructor() {
     this.statsVarNodes = {};
@@ -109,7 +110,7 @@ class TimelineParams {
     this.chartOptions = {};
   }
 
-  // set PerCaptia for a chart
+  // set PerCapita for a chart
   public setChartPC(groupId: string, pc: boolean): boolean {
     if (!this.chartOptions || !(groupId in this.chartOptions)) {
       this.chartOptions[groupId] = { pc: pc };
@@ -203,8 +204,9 @@ class TimelineParams {
 
   // set chartOptions in url
   public setUrlChartOptions(): void {
-    const chartOptions = encodeURIComponent(JSON.stringify(this.chartOptions));
+    const chartOptions = JSON.stringify(this.chartOptions);
     this.urlParams.set("chart", chartOptions);
+    this.urlParams.delete("pc");
     this.listenHashChange = false;
     window.location.hash = this.urlParams.toString();
   }
@@ -245,7 +247,7 @@ class TimelineParams {
     if (statsVars) {
       for (const statsVarString of statsVars.split(statsVarSep)) {
         const statsVarInfo = statsVarString.split(nodePathSep);
-        // if statsVar path is not include in url
+        // if statsVar path is not included in url
         // load the path from pre-built map
         if (statsVarInfo.length === 1) {
           if (statsVarInfo[0] in statsVarPathMap) {
@@ -261,9 +263,11 @@ class TimelineParams {
         }
       }
     }
-    const chartOptions = JSON.parse(
-      decodeURIComponent(this.urlParams.get("chart"))
-    );
+
+    // set per-capita for links from place-explorer
+    const pc = this.urlParams.get("pc");
+    this.allPerCapita = pc !== null && pc !== "0";
+    const chartOptions = JSON.parse(this.urlParams.get("chart"));
     if (chartOptions) {
       this.chartOptions = chartOptions;
     } else {


### PR DESCRIPTION
* Added support for specifying per capita from a general get param (as opposed to the chart config which requires knowledge of mprop). if &pc=1, enable per capita for all charts specified
* Updated explore links for scaled charts to specify per capita 