### PR TITLE
get explore url for choropleth charts

### DIFF
--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -25,6 +25,7 @@ import services.datacommons as dc_service
 import routes.api.place as place_api
 import os
 import routes.api.choropleth as choropleth_api
+import routes.api.landing_page as landing_page_api
 
 from cache import cache
 from flask import Blueprint, current_app, Response, url_for, jsonify
@@ -541,12 +542,17 @@ def choropleth_data(dcid):
                 else:
                     geo_data[geo] = sv_data[geo][sv_date]
                     num_data_points += 1
+            exploreUrl = None
+            if denom_data:
+                exploreUrl = landing_page_api.build_url([dcid], [sv], True)
+            else:
+                exploreUrl = landing_page_api.build_url([dcid], [sv])
             sv_denom_result = {
                 'date': sv_date,
                 'data': geo_data,
                 'numDataPoints': num_data_points,
                 # TODO (chejennifer): exploreUrl should link to choropleth tool once the tool is ready
-                'exploreUrl': build_url(dcid, [sv])
+                'exploreUrl': exploreUrl
             }
             result[key] = sv_denom_result
     return Response(json.dumps(result), 200, mimetype='application/json')

--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -544,7 +544,9 @@ def choropleth_data(dcid):
             sv_denom_result = {
                 'date': sv_date,
                 'data': geo_data,
-                'numDataPoints': num_data_points
+                'numDataPoints': num_data_points,
+                # TODO (chejennifer): exploreUrl should link to choropleth tool once the tool is ready
+                'exploreUrl': build_url(dcid, [sv])
             }
             result[key] = sv_denom_result
     return Response(json.dumps(result), 200, mimetype='application/json')

--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -542,11 +542,8 @@ def choropleth_data(dcid):
                 else:
                     geo_data[geo] = sv_data[geo][sv_date]
                     num_data_points += 1
-            exploreUrl = None
-            if denom_data:
-                exploreUrl = landing_page_api.build_url([dcid], [sv], True)
-            else:
-                exploreUrl = landing_page_api.build_url([dcid], [sv])
+            exploreUrl = landing_page_api.build_url([dcid], [sv],
+                                                    bool(denom_data))
             sv_denom_result = {
                 'date': sv_date,
                 'data': geo_data,

--- a/server/tests/chart_test.py
+++ b/server/tests/chart_test.py
@@ -368,7 +368,7 @@ class TestChoroplethDataHelpers(unittest.TestCase):
 
 class TestChoroplethData(unittest.TestCase):
 
-    @patch('routes.api.chart.build_url')
+    @patch('routes.api.chart.landing_page_api.build_url')
     @patch('routes.api.chart.get_latest_common_date_for_sv')
     @patch('routes.api.chart.get_data_for_statvar')
     @patch('routes.api.chart.dc_service.get_stats_all')
@@ -440,9 +440,10 @@ class TestChoroplethData(unittest.TestCase):
         test_url2 = 'test/url/2'
 
         def build_url_side_effect(*args):
-            if args[0] == test_dcid and args[1] == ['StatVar1']:
+            if args[0] == [test_dcid] and args[1] == ['StatVar1']:
                 return test_url
-            elif args[0] == test_dcid and args[1] == ['StatVar3']:
+            elif args[0] == [test_dcid] and args[1] == ['StatVar3'
+                                                       ] and args[2] == True:
                 return test_url2
             else:
                 return None

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -137,13 +137,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         ? this.props.trend.sources
         : this.props.snapshot.sources;
     }
-    // TODO(chejennifer): get exploreURL for choropleth charts
-    let exploreUrl = "";
-    if (this.props.chartType !== chartTypeEnum.CHOROPLETH) {
-      exploreUrl = this.props.trend
-        ? this.props.trend.exploreUrl
-        : this.props.snapshot.exploreUrl;
-    }
+    const exploreUrl = this.getExploreUrl();
     if (
       this.props.chartType === chartTypeEnum.CHOROPLETH &&
       (!this.state.choroplethDataGroup ||
@@ -421,6 +415,18 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         break;
       default:
         break;
+    }
+  }
+
+  private getExploreUrl(): string {
+    if (this.props.chartType === chartTypeEnum.CHOROPLETH) {
+      return this.props.choroplethData
+        ? this.props.choroplethData.exploreUrl
+        : "";
+    } else {
+      return this.props.trend
+        ? this.props.trend.exploreUrl
+        : this.props.snapshot.exploreUrl;
     }
   }
 }

--- a/static/js/place/types.ts
+++ b/static/js/place/types.ts
@@ -95,4 +95,5 @@ export interface ChoroplethDataGroup {
     [placeDcid: string]: number;
   };
   numDataPoints: number;
+  exploreUrl: string;
 }


### PR DESCRIPTION
add explore url for choropleth charts which will redirect to timeline tool for the stat var for the current place

Changes:
- updated api/chart/choroplethdata/<dcid> to return the explore url for each stat var
- updated chart.tsx to get explore url for choropleth charts