### PR TITLE
Add links to ranking pages from stat var chips

### DIFF
--- a/server/routes/api/ranking.py
+++ b/server/routes/api/ranking.py
@@ -82,7 +82,7 @@ def ranking_api(stat_var, place_type, place=None):
                 dcids.add(r['placeDcid'])
             payload[stat_var][k]['info'] = info
             # payload[stat_var][k]['count'] = count
-    place_names = place_api.get_name(list(dcids))
+    place_names = place_api.get_display_name('^'.join(sorted(list(dcids))))
     for k in rank_keys:
         if k in payload[stat_var] and 'info' in payload[stat_var][k]:
             for r in payload[stat_var][k]['info']:

--- a/server/templates/ranking.html
+++ b/server/templates/ranking.html
@@ -20,6 +20,11 @@
 
 {% block head %}
 <link rel="stylesheet" href={{url_for('static', filename='css/ranking.min.css', t=config['GAE_VERSION'])}}>
+<style>
+  tr[data-dcid="{{ request.args.get('h') }}"] {
+    background: #fffdd0;
+  }
+</style>
 {% endblock %}
 
 {% block content %}

--- a/static/css/ranking.scss
+++ b/static/css/ranking.scss
@@ -47,3 +47,9 @@ h3 a {
   font-size: 1rem;
   padding: 0.5rem;
 }
+
+td .num-value {
+  display: inline-block;
+  width: 140px;
+  text-align: right;
+}

--- a/static/js/chart/base.ts
+++ b/static/js/chart/base.ts
@@ -23,10 +23,13 @@ class DataPoint {
   label: string;
   // Optional DCID to add to a chart as a data atttribute
   dcid?: string;
-  constructor(label: string, value: number, dcid?: string) {
+  // Optional Label link to show on UI element
+  link?: string;
+  constructor(label: string, value: number, dcid?: string, link?: string) {
     this.value = value;
     this.label = label;
     this.dcid = dcid;
+    this.link = link;
   }
 }
 
@@ -36,7 +39,7 @@ class DataGroup {
   // For example, the label of a data point could be date string, while the
   // label of the DataGroup is a place name.
   label: string;
-  // Label link to show on UI element (optional)
+  // Optional label link to show on UI element
   link?: string;
   constructor(label: string, value: DataPoint[], link?: string) {
     this.value = value;

--- a/static/js/chart/draw.test.ts
+++ b/static/js/chart/draw.test.ts
@@ -20,14 +20,18 @@ import { appendLegendElem } from "./draw";
 
 test("svg test", () => {
   document.body.innerHTML = '<div id="chart"></div>';
-  const keys = ["San Jose", "Palo Alto"];
+  const data = [
+    { label: "San Jose", link: "about:blank" },
+    { label: "Palo Alto", link: "/foo/bar" },
+  ];
+  const keys = data.map((d) => d.label);
   const color = getColorFn(keys);
-  appendLegendElem("chart", color, keys);
+  appendLegendElem("chart", color, data);
 
   expect(document.getElementById("chart").innerHTML).toEqual(
     '<div class="legend">' +
-      '<div style="background: rgb(147, 0, 0)"><span>San Jose</span></div>' +
-      '<div style="background: rgb(94, 79, 162)"><span>Palo Alto</span></div>' +
+      '<div style="background: rgb(147, 0, 0)"><a href="about:blank">San Jose</a></div>' +
+      '<div style="background: rgb(94, 79, 162)"><a href="/foo/bar">Palo Alto</a></div>' +
       "</div>"
   );
 });

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -278,21 +278,6 @@ function drawHistogram(
   const textList = dataPoints.map((dataPoint) => dataPoint.label);
   const values = dataPoints.map((dataPoint) => dataPoint.value);
 
-  const x = d3
-    .scaleBand()
-    .domain(textList)
-    .rangeRound([MARGIN.left, width - MARGIN.right])
-    .paddingInner(0.1)
-    .paddingOuter(0.1);
-
-  const y = d3
-    .scaleLinear()
-    .domain([0, d3.max(values)])
-    .nice()
-    .rangeRound([height - ROTATE_MARGIN_BOTTOM, MARGIN.top]);
-
-  const color = getColorFn(["A"])("A"); // we only need one color
-
   const svg = d3
     .select("#" + id)
     .append("svg")
@@ -301,7 +286,23 @@ function drawHistogram(
     .attr("width", width)
     .attr("height", height);
 
-  addXAxis(svg, height, x, true);
+  const x = d3
+    .scaleBand()
+    .domain(textList)
+    .rangeRound([MARGIN.left, width - MARGIN.right])
+    .paddingInner(0.1)
+    .paddingOuter(0.1);
+
+  const bottomHeight = addXAxis(svg, height, x, true);
+
+  const y = d3
+    .scaleLinear()
+    .domain([0, d3.max(values)])
+    .nice()
+    .rangeRound([height - bottomHeight, MARGIN.top]);
+
+  const color = getColorFn(["A"])("A"); // we only need one color
+
   addYAxis(svg, width, y, unit);
 
   svg

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -56,7 +56,10 @@ const AXIS_GRID_FILL = "#999";
 function appendLegendElem(
   elem: string,
   color: d3.ScaleOrdinal<string, string>,
-  keys: string[]
+  keys: {
+    label: string;
+    link?: string;
+  }[]
 ): void {
   d3.select("#" + elem)
     .append("div")
@@ -64,9 +67,10 @@ function appendLegendElem(
     .selectAll("div")
     .data(keys)
     .join("div")
-    .attr("style", (d) => `background: ${color(d)}`)
-    .append("span")
-    .text((d) => d);
+    .attr("style", (d) => `background: ${color(d.label)}`)
+    .append("a")
+    .text((d) => d.label)
+    .attr("href", (d) => d.link || null);
 }
 
 function getWrapLineSeparator(line: string[]): string {
@@ -449,7 +453,14 @@ function drawStackBarChart(
     .attr("width", x.bandwidth())
     .attr("height", (d) => (Number.isNaN(d[1]) ? 0 : y(d[0]) - y(d[1])));
 
-  appendLegendElem(id, color, keys);
+  appendLegendElem(
+    id,
+    color,
+    dataGroups[0].value.map((dp) => ({
+      label: dp.label,
+      link: dp.link,
+    }))
+  );
 
   // Add link to place name labels.
   svg
@@ -540,7 +551,14 @@ function drawGroupBarChart(
     .attr("height", (d) => y(0) - y(d.value))
     .attr("fill", (d) => colorFn(d.key));
 
-  appendLegendElem(id, colorFn, keys);
+  appendLegendElem(
+    id,
+    colorFn,
+    dataGroups[0].value.map((dp) => ({
+      label: dp.label,
+      link: dp.link,
+    }))
+  );
 
   // Add link to place name labels.
   svg
@@ -663,7 +681,16 @@ function drawLineChart(
     }
   }
 
-  appendLegendElem(id, colorFn, legendText);
+  // appendLegendElem(id, colorFn, legendText);
+
+  appendLegendElem(
+    id,
+    colorFn,
+    dataGroups.map((dg) => ({
+      label: dg.label,
+      link: dg.link,
+    }))
+  );
   return !hasFilledInValues;
 }
 

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -89,6 +89,10 @@ interface ChartPropType {
    * All stats vars for this chart
    */
   statsVars: string[];
+  /**
+   * Template to create links to place rankings (replace _sv_ with a StatVar)
+   */
+  rankingTemplateUrl: string;
 }
 
 interface ChartStateType {
@@ -105,6 +109,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
   svgContainerElement: React.RefObject<HTMLDivElement>;
   embedModalElement: React.RefObject<ChartEmbed>;
   dcid: string;
+  rankingUrlByStatVar: { [statVar: string]: string };
 
   constructor(props: ChartPropType) {
     super(props);
@@ -121,6 +126,15 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
     // small screen sizes
     this._handleWindowResize = this._handleWindowResize.bind(this);
     this._handleEmbed = this._handleEmbed.bind(this);
+
+    this.rankingUrlByStatVar = {};
+    for (const statVar of this.props.statsVars) {
+      this.rankingUrlByStatVar[statVar] = this.props.rankingTemplateUrl.replace(
+        "_sv_",
+
+        statVar
+      );
+    }
   }
 
   render(): JSX.Element {
@@ -360,7 +374,13 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
               value: this.props.trend.series[statVar][date] * scaling,
             });
           }
-          dataGroups.push(new DataGroup(STATS_VAR_LABEL[statVar], dataPoints));
+          dataGroups.push(
+            new DataGroup(
+              STATS_VAR_LABEL[statVar],
+              dataPoints,
+              this.rankingUrlByStatVar[statVar]
+            )
+          );
         }
         for (let i = 0; i < dataGroups.length; i++) {
           dataGroups[i].value = this.expandDataPoints(
@@ -398,6 +418,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
               label: STATS_VAR_LABEL[statVar],
               value: val ? val * scaling : null,
               dcid: placeData.dcid,
+              link: this.rankingUrlByStatVar[statVar],
             });
           }
           dataGroups.push(

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -72,7 +72,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
     // Plot trend data in overview and topic page.
     if (!_.isEmpty(this.props.data.trend)) {
       const id = randDomId();
-      let rankingParam = new URLSearchParams(`h=${this.props.dcid}`);
+      const rankingParam = new URLSearchParams(`h=${this.props.dcid}`);
       this.props.data.denominator && rankingParam.set("pc", "1");
       this.props.data.scaling && rankingParam.set("scaling", "100");
       this.props.data.unit && rankingParam.set("unit", this.props.data.unit);
@@ -129,7 +129,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
         scaling: scaling,
         statsVars: this.props.data.statsVars,
       };
-      let rankingParam = new URLSearchParams(`h=${this.props.dcid}`);
+      const rankingParam = new URLSearchParams(`h=${this.props.dcid}`);
       if (
         this.props.data.denominator ||
         (!!this.props.data.relatedChart && this.props.data.relatedChart.scale)
@@ -138,7 +138,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
       }
       scaling && rankingParam.set("scaling", String(scaling));
       unit && rankingParam.set("unit", unit);
-      let rankingArg = `?${rankingParam.toString()}`;
+      const rankingArg = `?${rankingParam.toString()}`;
 
       if (this.props.isOverview) {
         // Show child place(state) chart for USA page, otherwise show nearby

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -58,6 +58,8 @@ interface ChartBlockPropType {
    * Values of statvar/denominator combinations for places one level down of current dcid
    */
   choroplethData: CachedChoroplethData;
+  childPlaceType: string;
+  parentPlaceDcid: string;
 }
 
 class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
@@ -70,6 +72,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
     // Plot trend data in overview and topic page.
     if (!_.isEmpty(this.props.data.trend)) {
       const id = randDomId();
+      const perCapitaArg = this.props.data.denominator ? "?pc" : "";
       chartElements.push(
         <Chart
           key={id}
@@ -83,6 +86,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
           names={this.props.names}
           scaling={this.props.data.scaling}
           statsVars={this.props.data.statsVars}
+          rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.parentPlaceDcid}${perCapitaArg}`}
         ></Chart>
       );
     }
@@ -120,6 +124,12 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
         scaling: scaling,
         statsVars: this.props.data.statsVars,
       };
+
+      const perCapitaArg =
+        this.props.data.denominator ||
+        (!!this.props.data.relatedChart && this.props.data.relatedChart.scale)
+          ? "?pc"
+          : "";
       if (this.props.isOverview) {
         // Show child place(state) chart for USA page, otherwise show nearby
         // places.
@@ -132,6 +142,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.child}
                 title={`${relatedChartTitle}: states within ${this.props.placeName}`}
+                rankingTemplateUrl={`/ranking/_sv_/State/country/USA${perCapitaArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -144,6 +155,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.nearby}
                 title={`${relatedChartTitle}: ${displayPlaceType} near ${this.props.placeName}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.parentPlaceDcid}${perCapitaArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -154,12 +166,14 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.child}
                 title={`${relatedChartTitle}: places within ${this.props.placeName}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.childPlaceType}/${this.props.dcid}${perCapitaArg}`}
                 {...sharedProps}
               ></Chart>
             );
           }
         }
       } else {
+        // Topic page
         if (this.props.dcid !== "country/USA") {
           if (!_.isEmpty(this.props.data.nearby)) {
             const id = randDomId();
@@ -169,6 +183,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.nearby}
                 title={`${relatedChartTitle}: ${displayPlaceType} near ${this.props.placeName}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.parentPlaceDcid}${perCapitaArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -181,6 +196,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.similar}
                 title={`${relatedChartTitle}: other ${displayPlaceType}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/country/USA${perCapitaArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -196,6 +212,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.child}
                 title={`${relatedChartTitle}: places within ${this.props.placeName}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.childPlaceType}/${this.props.dcid}${perCapitaArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -210,6 +227,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.parent}
                 title={`${relatedChartTitle}: places that contain ${this.props.placeName}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/country/USA${perCapitaArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -240,6 +258,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 geoJsonData={this.props.geoJsonData}
                 choroplethData={svChoroplethData}
                 statsVars={this.props.data.statsVars}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.dcid}${perCapitaArg}`}
               ></Chart>
             );
           }

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -72,7 +72,10 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
     // Plot trend data in overview and topic page.
     if (!_.isEmpty(this.props.data.trend)) {
       const id = randDomId();
-      const perCapitaArg = this.props.data.denominator ? "?pc" : "";
+      let rankingParam = new URLSearchParams(`h=${this.props.dcid}`);
+      this.props.data.denominator && rankingParam.set("pc", "1");
+      this.props.data.scaling && rankingParam.set("scaling", "100");
+      this.props.data.unit && rankingParam.set("unit", this.props.data.unit);
       chartElements.push(
         <Chart
           key={id}
@@ -86,7 +89,9 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
           names={this.props.names}
           scaling={this.props.data.scaling}
           statsVars={this.props.data.statsVars}
-          rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.parentPlaceDcid}${perCapitaArg}`}
+          rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${
+            this.props.parentPlaceDcid
+          }?${rankingParam.toString()}`}
         ></Chart>
       );
     }
@@ -124,12 +129,17 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
         scaling: scaling,
         statsVars: this.props.data.statsVars,
       };
-
-      const perCapitaArg =
+      let rankingParam = new URLSearchParams(`h=${this.props.dcid}`);
+      if (
         this.props.data.denominator ||
         (!!this.props.data.relatedChart && this.props.data.relatedChart.scale)
-          ? "?pc"
-          : "";
+      ) {
+        rankingParam.set("pc", "1");
+      }
+      scaling && rankingParam.set("scaling", String(scaling));
+      unit && rankingParam.set("unit", unit);
+      let rankingArg = `?${rankingParam.toString()}`;
+
       if (this.props.isOverview) {
         // Show child place(state) chart for USA page, otherwise show nearby
         // places.
@@ -142,7 +152,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.child}
                 title={`${relatedChartTitle}: states within ${this.props.placeName}`}
-                rankingTemplateUrl={`/ranking/_sv_/State/country/USA${perCapitaArg}`}
+                rankingTemplateUrl={`/ranking/_sv_/State/country/USA${rankingArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -155,7 +165,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.nearby}
                 title={`${relatedChartTitle}: ${displayPlaceType} near ${this.props.placeName}`}
-                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.parentPlaceDcid}${perCapitaArg}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.parentPlaceDcid}${rankingArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -166,7 +176,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.child}
                 title={`${relatedChartTitle}: places within ${this.props.placeName}`}
-                rankingTemplateUrl={`/ranking/_sv_/${this.props.childPlaceType}/${this.props.dcid}${perCapitaArg}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.childPlaceType}/${this.props.dcid}${rankingArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -183,7 +193,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.nearby}
                 title={`${relatedChartTitle}: ${displayPlaceType} near ${this.props.placeName}`}
-                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.parentPlaceDcid}${perCapitaArg}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.parentPlaceDcid}${rankingArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -196,7 +206,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.similar}
                 title={`${relatedChartTitle}: other ${displayPlaceType}`}
-                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/country/USA${perCapitaArg}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/country/USA${rankingArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -212,7 +222,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.child}
                 title={`${relatedChartTitle}: places within ${this.props.placeName}`}
-                rankingTemplateUrl={`/ranking/_sv_/${this.props.childPlaceType}/${this.props.dcid}${perCapitaArg}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.childPlaceType}/${this.props.dcid}${rankingArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -227,7 +237,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 id={id}
                 snapshot={this.props.data.parent}
                 title={`${relatedChartTitle}: places that contain ${this.props.placeName}`}
-                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/country/USA${perCapitaArg}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/country/USA${rankingArg}`}
                 {...sharedProps}
               ></Chart>
             );
@@ -258,7 +268,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
                 geoJsonData={this.props.geoJsonData}
                 choroplethData={svChoroplethData}
                 statsVars={this.props.data.statsVars}
-                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.dcid}${perCapitaArg}`}
+                rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.dcid}${rankingArg}`}
               ></Chart>
             );
           }

--- a/static/js/place/main.tsx
+++ b/static/js/place/main.tsx
@@ -57,6 +57,8 @@ interface MainPanePropType {
    * Values of statvar/denominator combinations for places one level down of current dcid
    */
   choroplethData: CachedChoroplethData;
+  childPlaceType: string;
+  parentPlaceDcid: string;
 }
 
 class MainPane extends React.Component<MainPanePropType, unknown> {
@@ -111,6 +113,8 @@ class MainPane extends React.Component<MainPanePropType, unknown> {
                       data={data}
                       geoJsonData={this.props.geoJsonData}
                       choroplethData={this.props.choroplethData}
+                      childPlaceType={this.props.childPlaceType}
+                      parentPlaceDcid={this.props.parentPlaceDcid}
                     />
                   );
                 })}

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -184,6 +184,7 @@ function renderPage(dcid: string) {
       data.allChildPlaces[placeType].sort((a, b) =>
         a.name < b.name ? -1 : a.name > b.name ? 1 : 0
       );
+      // TODO(beets): Remove this logic after we add this to the mixer response.
       const numChildren = data.allChildPlaces[placeType].length;
       if (numChildren > childPlaceTypeCount) {
         childPlaceTypeCount = numChildren;

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -178,10 +178,17 @@ function renderPage(dcid: string) {
     updatePageLayoutState();
 
     // Display child places alphabetically
+    let childPlaceType: string;
+    let childPlaceTypeCount = 0;
     for (const placeType in data.allChildPlaces) {
       data.allChildPlaces[placeType].sort((a, b) =>
         a.name < b.name ? -1 : a.name > b.name ? 1 : 0
       );
+      const numChildren = data.allChildPlaces[placeType].length;
+      if (numChildren > childPlaceTypeCount) {
+        childPlaceTypeCount = numChildren;
+        childPlaceType = placeType;
+      }
     }
     ReactDOM.render(
       React.createElement(ChildPlace, {
@@ -210,6 +217,9 @@ function renderPage(dcid: string) {
         placeType,
         geoJsonData,
         choroplethData,
+        childPlaceType,
+        parentPlaceDcid:
+          data.parentPlaces.length > 0 ? data.parentPlaces[0] : null,
       }),
       document.getElementById("main-pane")
     );

--- a/static/js/place/types.ts
+++ b/static/js/place/types.ts
@@ -46,6 +46,7 @@ export interface SnapshotData {
 export interface ChartBlockData {
   title: string;
   statsVars: string[];
+  denominator?: string[];
   unit: string;
   trend: TrendData;
   parent: SnapshotData;

--- a/static/js/ranking/ranking.ts
+++ b/static/js/ranking/ranking.ts
@@ -1,3 +1,4 @@
+import { PageHighlight } from "./../place/types";
 /**
  * Copyright 2020 Google LLC
  *

--- a/static/js/ranking/ranking.ts
+++ b/static/js/ranking/ranking.ts
@@ -30,6 +30,10 @@ window.onload = () => {
   const isPerCapita = JSON.parse(
     document.getElementById("per-capita").dataset.pc.toLowerCase()
   );
+  const urlParams = new URLSearchParams(window.location.search);
+  const unit = urlParams.get("unit");
+  let scaling = Number(urlParams.get("scaling"));
+  scaling = isNaN(scaling) || scaling == 0 ? 1 : scaling;
   ReactDOM.render(
     React.createElement(Page, {
       placeName,
@@ -37,6 +41,8 @@ window.onload = () => {
       withinPlace,
       statVar,
       isPerCapita,
+      unit,
+      scaling,
     }),
     document.getElementById("main-pane")
   );

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -22,6 +22,8 @@ import { drawHistogram } from "../chart/draw";
 interface RankingHistogramPropType {
   ranking: Ranking;
   id: string;
+  scaling: number;
+  unit: string;
 }
 
 interface RankingHistogramStateType {
@@ -65,14 +67,17 @@ class RankingHistogram extends React.Component<
 
   drawChart(): void {
     const rankList = this.props.ranking.info;
-    const dataPoints = rankList.map((d) => new DataPoint(d.placeName, d.value));
+    const dataPoints = rankList.map(
+      (d) => new DataPoint(d.placeName, d.value * this.props.scaling)
+    );
 
     this.chartElementRef.current.innerHTML = "";
     drawHistogram(
       this.props.id,
       this.chartElementRef.current.offsetWidth,
       this.chartElementRef.current.offsetHeight,
-      dataPoints
+      dataPoints,
+      this.props.unit
     );
   }
 

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -31,6 +31,8 @@ interface RankingPagePropType {
   withinPlace: string;
   statVar: string;
   isPerCapita: boolean;
+  scaling: number;
+  unit: string;
 }
 
 interface RankingPageStateType {
@@ -101,12 +103,17 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
           {subtitle}
           {this.renderToggle()}
         </h3>
-        <RankingHistogram ranking={ranking} id={"ranking-chart"} />
+        <RankingHistogram ranking={ranking} id={"ranking-chart"}
+          scaling={this.props.scaling}
+          unit={this.props.unit}
+          />
         <RankingTable
           ranking={ranking}
           id={"ranking-table"}
           placeType={this.props.placeType}
           sortAscending={!isBottom}
+          scaling={this.props.scaling}
+          unit={this.props.unit}
         />
       </div>
     );

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -103,10 +103,12 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
           {subtitle}
           {this.renderToggle()}
         </h3>
-        <RankingHistogram ranking={ranking} id={"ranking-chart"}
+        <RankingHistogram
+          ranking={ranking}
+          id={"ranking-chart"}
           scaling={this.props.scaling}
           unit={this.props.unit}
-          />
+        />
         <RankingTable
           ranking={ranking}
           id={"ranking-table"}

--- a/static/js/ranking/ranking_table.tsx
+++ b/static/js/ranking/ranking_table.tsx
@@ -47,7 +47,7 @@ class RankingTable extends React.Component<RankingTablePropType> {
       let value = rankInfo.value ? rankInfo.value : 0;
       value = value * scaling;
       return (
-        <tr key={rankInfo.rank}>
+        <tr key={rankInfo.rank} data-dcid={rankInfo.placeDcid}>
           <td>{rankInfo.rank ? rankInfo.rank : 0}</td>
           <td>
             <a href={`/place?dcid=${rankInfo.placeDcid}`}>
@@ -57,6 +57,7 @@ class RankingTable extends React.Component<RankingTablePropType> {
           <td className="text-right">
             {value.toLocaleString(undefined, {
               maximumFractionDigits: 1,
+              minimumFractionDigits: 1,
             })}
           </td>
         </tr>

--- a/static/js/ranking/ranking_table.tsx
+++ b/static/js/ranking/ranking_table.tsx
@@ -22,6 +22,8 @@ interface RankingTablePropType {
   id: string;
   placeType: string;
   sortAscending: boolean;
+  scaling: number;
+  unit: string;
 }
 
 class RankingTable extends React.Component<RankingTablePropType> {
@@ -41,7 +43,9 @@ class RankingTable extends React.Component<RankingTablePropType> {
   }
 
   render(): JSX.Element {
-    function renderRankInfo(rankInfo) {
+    function renderRankInfo(rankInfo: RankInfo, scaling: number) {
+      let value = rankInfo.value ? rankInfo.value : 0;
+      value = value * scaling;
       return (
         <tr key={rankInfo.rank}>
           <td>{rankInfo.rank ? rankInfo.rank : 0}</td>
@@ -51,7 +55,9 @@ class RankingTable extends React.Component<RankingTablePropType> {
             </a>
           </td>
           <td className="text-right">
-            {rankInfo.value ? rankInfo.value.toLocaleString() : "0"}
+            {value.toLocaleString(undefined, {
+              maximumFractionDigits: 1,
+            })}
           </td>
         </tr>
       );
@@ -64,14 +70,14 @@ class RankingTable extends React.Component<RankingTablePropType> {
             <th scope="col">Rank</th>
             <th scope="col">{this.props.placeType}</th>
             <th scope="col" className="text-center">
-              Value
+              {this.props.unit ? this.props.unit : "Value"}
             </th>
           </tr>
         </thead>
         <tbody>
           {this.info &&
             this.info.map((rankInfo) => {
-              return renderRankInfo(rankInfo);
+              return renderRankInfo(rankInfo, this.props.scaling);
             })}
         </tbody>
       </table>

--- a/static/js/ranking/ranking_table.tsx
+++ b/static/js/ranking/ranking_table.tsx
@@ -56,10 +56,10 @@ class RankingTable extends React.Component<RankingTablePropType> {
           </td>
           <td className="text-center">
             <span className="num-value">
-                {value.toLocaleString(undefined, {
-                  maximumFractionDigits: 1,
-                  minimumFractionDigits: 1,
-                })}
+              {value.toLocaleString(undefined, {
+                maximumFractionDigits: 1,
+                minimumFractionDigits: 1,
+              })}
             </span>
           </td>
         </tr>

--- a/static/js/ranking/ranking_table.tsx
+++ b/static/js/ranking/ranking_table.tsx
@@ -54,11 +54,13 @@ class RankingTable extends React.Component<RankingTablePropType> {
               {rankInfo.placeName || rankInfo.placeDcid}
             </a>
           </td>
-          <td className="text-right">
-            {value.toLocaleString(undefined, {
-              maximumFractionDigits: 1,
-              minimumFractionDigits: 1,
-            })}
+          <td className="text-center">
+            <span className="num-value">
+                {value.toLocaleString(undefined, {
+                  maximumFractionDigits: 1,
+                  minimumFractionDigits: 1,
+                })}
+            </span>
           </td>
         </tr>
       );

--- a/static/js/shared/stats_var_titles.ts
+++ b/static/js/shared/stats_var_titles.ts
@@ -198,7 +198,7 @@ const STATS_VAR_TITLES: { [key: string]: string } = {
     "Deaths Caused By Diseases of the Respiratory System",
   Count_Death_ExternalCauses: "Deaths Caused By External Causes",
   Count_Death_DiseasesOfTheNervousSystem:
-    "Deaths Caused By Diseases of the jNervous System",
+    "Deaths Caused By Diseases of the Nervous System",
 
   // Outcomes
   Percent_Person_WithHighCholesterol:


### PR DESCRIPTION
Also carry over params so the per capita, unit and scaling match the original charts.

![image](https://user-images.githubusercontent.com/6052978/95163065-ef1cea00-075b-11eb-8503-492d217fce9b.png)
