### PR TITLE
base template cleanup

### DIFF
--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -67,7 +67,8 @@
                 </a>
                 <div class="dropdown-menu" aria-labelledby="nav-explore-dropdown">
                   <a class="dropdown-item" href="{{ url_for('place.place') }}">Place Explorer</a>
-                  <a class="dropdown-item" href="{{ url_for('browser.kg_main') }}">Data Commons Graph Browser</a>
+                  <a class="dropdown-item" href="{{ url_for('browser.kg_main') }}">Graph
+                    Browser</a>
                   <a class="dropdown-item" href="{{ url_for('tools.timeline') }}">Timelines Explorer</a>
                 </div>
               </li>
@@ -76,16 +77,11 @@
                   Documentation
                 </a>
                 <div class="dropdown-menu" aria-labelledby="nav-doc-dropdown">
-                  <a class="dropdown-item" href="{{
-		  url_for('static.datasets') }}">Data Sources</a>
-
-                  <a class="dropdown-item" href="http://docs.datacommons.org/api/python/">Python API</a>
-                  <a class="dropdown-item" href="http://docs.datacommons.org/api/rest/">REST API</a>
-                  <a class="dropdown-item"
-				    href="http://docs.datacommons.org/api/sheets/">Google
-				    Sheets API</a>
-
+                  <a class="dropdown-item" href="http://docs.datacommons.org">Documentation</a>
+                  <a class="dropdown-item" href="http://docs.datacommons.org/api">API's</a>
                   <a class="dropdown-item" href="http://docs.datacommons.org/tutorials.html">Tutorials</a>
+                  <a class="dropdown-item"
+                    href="https://docs.datacommons.org/contributing/">Contribute</a>
                 </div>
               </li>
               <li class="nav-item dropdown">
@@ -94,6 +90,8 @@
                 </a>
                 <div class="dropdown-menu" aria-labelledby="nav-about-dropdown">
                   <a class="dropdown-item" href="{{ url_for('static.about') }}">About Data Commons</a>
+                  <a class="dropdown-item" href="{{ url_for('static.datasets') }}">Data
+                    Sources</a>
                   <a class="dropdown-item" href="{{ url_for('static.faq') }}">FAQ</a>
                 </div>
               </li>
@@ -116,20 +114,20 @@
             <section class="col-12 col-sm-6 col-md-4">
               <h6>Explore</h6>
               <a href="{{ url_for('place.place') }}">Place Explorer</a>
-              <a href="{{ url_for('browser.kg_main') }}">Data Commons Graph Explorer</a>
+              <a href="{{ url_for('browser.kg_main') }}">Graph Explorer</a>
               <a href="{{ url_for('tools.timeline') }}">Timelines Explorer</a>
             </section>
             <section class="col-12 col-sm-6 col-md-4">
               <h6>Documentation</h6>
-              <a href="{{ url_for('static.datasets') }}">Datasets</a>
-              <a href="http://docs.datacommons.org/api/python/">Python API</a>
-              <a href="http://docs.datacommons.org/api/r/">R API</a>
-              <a href="http://docs.datacommons.org/api/rest/">REST API</a>
-              <a href="http://docs.datacommons.org/api/sheets/">Google Sheets API</a>
+              <a href="http://docs.datacommons.org">Documentation</a>
+              <a href="http://docs.datacommons.org/api">API's</a>
+              <a href="http://docs.datacommons.org/tutorials.html">Tutorials</a>
+              <a href="https://docs.datacommons.org/contributing/">Contribute</a>
             </section>
             <section class="col-12 col-sm-6 col-md-4">
               <h6>Data Commons</h6>
-              <a href="#">About Data Commons</a>
+              <a href="{{ url_for('static.about') }}">About Data Commons</a>
+              <a href="{{ url_for('static.datasets') }}">Data Sources</a>
               <a href="{{ url_for('static.faq') }}">Frequently Asked Questions</a>
               <a href="http://github.com/datacommonsorg">Github Repository</a>
             </section>

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -21,6 +21,7 @@
   Optional variables:
   is_hide_full_footer: boolean, if true, hides the full expanded footer. Default false
   subpage_title: string, if specified, will be displayed in the header next to Data Commons
+  hide_search: boolean, if true, will remove the nav header search box
 
   Blocks to override:
   head - additional head elements
@@ -96,7 +97,9 @@
                 </div>
               </li>
             </ul>
+            {%- if not hide_search -%}
             <div class="gcse-searchbox-only" data-resultsUrl="/search"></div>
+            {%- endif -%}
           </div>
         </div>
       </nav>
@@ -150,7 +153,9 @@
   {# Compile this down (or manually implement). Used only for nav bar so far #}
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+  {%- if not hide_search -%}
   <script async src="https://cse.google.com/cse.js?cx=010079880385165835740%3Aosnv3q-sw08"></script>
+  {%- endif -%}
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-117119267-1"></script>
   {%- if GA_ACCOUNT -%}
   <script>

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -149,7 +149,6 @@
   </div>
   {# Compile this down (or manually implement). Used only for nav bar so far #}
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
   <script async src="https://cse.google.com/cse.js?cx=010079880385165835740%3Aosnv3q-sw08"></script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-117119267-1"></script>

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -30,7 +30,7 @@
 
 <html lang="en">
 <head>
-  <title>{{ title }} | Data Commons</title>
+  <title>{{ title }} - Data Commons</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/server/templates/browser/kg_entity.html
+++ b/server/templates/browser/kg_entity.html
@@ -17,7 +17,7 @@
 {% extends 'base.html' %}
 
 {% set main_id = 'kg_entity' %}
-{% set title = 'Data Commons Graph Browser' %}
+{% set title = 'Graph Browser' %}
 {% set subpage_title = 'Graph Browser' %}
 {% set subpage_url = url_for('browser.kg_main') %}
 

--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -16,7 +16,7 @@
 {%- extends 'base.html' -%}
 
 {% set main_id = 'dc-places' %}
-{% set title = place_name + ' ' + topic + ' | Place Explorer' %}
+{% set title = place_name + ' ' + topic + ' - Place Explorer' %}
 {% set subpage_title = 'Place Explorer' %}
 
 {% block head %}

--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -18,6 +18,7 @@
 {% set main_id = 'dc-places' %}
 {% set title = place_name + ' ' + topic + ' - Place Explorer' %}
 {% set subpage_title = 'Place Explorer' %}
+{% set hide_search = True %}
 
 {% block head %}
 <link rel="stylesheet"

--- a/server/templates/ranking.html
+++ b/server/templates/ranking.html
@@ -15,7 +15,7 @@
 #}
 {%- extends 'base.html' -%}
 
-{% set title = place_name + ' | Place Rankings' %}
+{% set title = place_name + ' - Place Rankings' %}
 {% set subpage_title = 'Place Rankings' %}
 
 {% block head %}

--- a/server/templates/search.html
+++ b/server/templates/search.html
@@ -17,7 +17,7 @@
 
 {% set search_query = request.args.get('q') %}
 {% set main_id = 'search' %}
-{% set title = search_query + ' | Search Results' %}
+{% set title = search_query + ' - Search Results' %}
 
 {% block head %}
   <link rel="stylesheet" href={{url_for('static', filename='css/search.min.css', t=config['GAE_VERSION'])}} >

--- a/server/templates/search.html
+++ b/server/templates/search.html
@@ -18,6 +18,7 @@
 {% set search_query = request.args.get('q') %}
 {% set main_id = 'search' %}
 {% set title = search_query + ' - Search Results' %}
+{% set hide_search = True %}
 
 {% block head %}
   <link rel="stylesheet" href={{url_for('static', filename='css/search.min.css', t=config['GAE_VERSION'])}} >

--- a/server/templates/search_dc.html
+++ b/server/templates/search_dc.html
@@ -16,7 +16,7 @@
 {% extends 'base.html' %}
 
 {% set main_id = 'search' %}
-{% set title = query_text + ' | Search Results' %}
+{% set title = query_text + ' - Search Results' %}
 
 {% block head %}
   <link rel="stylesheet" href={{url_for('static', filename='css/search.min.css', t=config['GAE_VERSION'])}} >

--- a/server/templates/static/about.html
+++ b/server/templates/static/about.html
@@ -19,82 +19,88 @@
 {% set title = 'About Us' %}
 
 {% block head %}
-  <link rel="stylesheet" href={{url_for('static', filename='css/static.min.css', t=config['GAE_VERSION'])}} >
+<link rel="stylesheet"
+  href={{url_for('static', filename='css/static.min.css', t=config['GAE_VERSION'])}}>
 {% endblock %}
 
 {% block content %}
-  <div class="container">
+<div class="container">
+  <h1>About Data Commons</h1>
+  <section>
     <h2>Why Data Commons</h2>
     <p>
-      Publicly available data from open sources (census.gov, cdc.gov, data.gov,
-      etc.) are vital resources for students and researchers in a variety of
-      disciplines. Unfortunately, processing these datasets is often tedious
-      and cumbersome. Organizations follow distinctive practices for codifying
-      datasets. Combining data from different sources requires mapping common
-      entities (city, county, etc.) and resolving different types of
-      keys/identifiers. This process is time consuming, tedious and
-  done over and over.     Our goal with Data Commons is to address this problem.
+      Publicly available data from open sources (census.gov, cdc.gov,
+      data.gov, etc.) are vital resources for students and researchers in a
+      variety of disciplines. Unfortunately, processing these datasets is
+      often tedious and cumbersome. Organizations follow distinctive
+      practices for codifying datasets. Combining data from different sources
+      requires mapping common entities (city, county, etc.) and resolving
+      different types of keys/identifiers. This process is time consuming,
+      tedious and done over and over. Our goal with Data Commons is to
+      address this problem.
     </p>
-
     <p>
-      Data Commons synthesizes a single  graph from
-      these different data sources. It links references to the same entities (such
-      as cities, counties, organizations, etc.) across different datasets to nodes
+      Data Commons synthesizes a single graph from
+      these different data sources. It links references to the same entities
+      (such
+      as cities, counties, organizations, etc.) across different datasets to
+      nodes
       on the graph, so that users can access data about a particular entity
-      aggregated from different sources without data cleaning or joining. We hope the data
+      aggregated from different sources without data cleaning or joining. We
+      hope the data
       contained within Data Commons will be useful to students, researchers, and
-      enthusiasts across different disciplines. 
+      enthusiasts across different disciplines.
     </p>
-<br><br>
+  </section>
+  <section>
     <h2>Who can use it?</h2>
     <p>
-    Data Commons can be accessed by anyone via  the tools available on
-    datacommons.org. Students, researchers and developers can use the
-    REST and Python APIs, both of which are free for educational,
-    academic and journalistic research purposes. At this point, use of
-    these APIs does not require an API Key.
-</p>
-<p>
-    The data may also be accessed via the SPARQL query interface,
-    which requires an API Key.
+      Data Commons can be accessed by anyone via the tools available on
+      datacommons.org. Students, researchers and developers can use the
+      REST and Python APIs, both of which are free for educational,
+      academic and journalistic research purposes. At this point, use of
+      these APIs does not require an API Key.
     </p>
-    <br><br>
+    <p>
+      The data may also be accessed via the SPARQL query interface,
+      which requires an API Key.
+    </p>
+  </section>
+  <section>
     <h2>Collaborations</h2>
     <p>
-    Data Commons has benefited greatly from many collaborations. In
-    addition to help from US Department of Commerce (notably the
-    Census Bureau), we have received help from our many academic
-    collaborations, including, UC San Francisco, Stanford University,
-UC Berkeley and Harvard. 
-</p>
-<p>
-We are looking for more collaborators, both for adding new data to
-Data Commons and for building new and interesting applications of Data
+      Data Commons has benefited greatly from many collaborations. In
+      addition to help from US Department of Commerce (notably the
+      Census Bureau), we have received help from our many academic
+      collaborations, including, UC San Francisco, Stanford University,
+      UC Berkeley and Harvard.
+    </p>
+    <p>
+      We are looking for more collaborators, both for adding new data to
+      Data Commons and for building new and interesting applications of Data
       Commons. Contact us if you are interested in working with us.
-</p>
-
-<h2>Advisory Board</h2>
-
-   We are  fortunate to have the counsel of our Advisory Board,
-which includes:
-<ul>
-  <li> <a href="https://gking.harvard.edu/">Gary King</a>, Director
-   for the Institute for Quantitative Social Science at Harvard
-  University.</li>
-  <li> <a href="https://en.wikipedia.org/wiki/Hal_Varian">Hal
-   Varian</a>, Chief Economist, Google. </li>
-   <li><a href="https://energy.stanford.edu/people/arun-majumdar">Arun
-   Majumdar</a>, Director, Precourt Institute for Energy.
-   </ul>
-    
-    
-
-    <section>
-      <h3>See also</h3>
-      <ul>
-        <li><a href="{{ url_for('static.datasets') }}">Data Sources</a>
-        <li><a href="{{ url_for('static.disclaimers') }}">Disclaimers</a>
-        <li><a href="{{ url_for('static.faq') }}">Frequently Asked Questions</a>
-      </ul>
-    </section>
-{% endblock %}
+    </p>
+  </section>
+  <section>
+    <h2>Advisory Board</h2>
+    <p>We are fortunate to have the counsel of our Advisory Board,
+      which includes:</p>
+    <ul>
+      <li> <a href="https://gking.harvard.edu/">Gary King</a>, Director
+        for the Institute for Quantitative Social Science at Harvard
+        University.</li>
+      <li> <a href="https://https://en.wikipedia.org/wiki/Hal_Varian">Hal
+          Varian</a>, Chief Economist, Google. </li>
+      <li><a href="https://energy.stanford.edu/people/arun-majumdar">Arun
+          Majumdar</a>, Director, Precourt Institute for Energy.
+    </ul>
+  </section>
+  <section>
+    <h3>See also</h3>
+    <ul>
+      <li><a href="{{ url_for('static.datasets') }}">Data Sources</a>
+      <li><a href="{{ url_for('static.disclaimers') }}">Disclaimers</a>
+      <li><a href="{{ url_for('static.faq') }}">Frequently Asked Questions</a>
+    </ul>
+  </section>
+  {% endblock %}

--- a/server/templates/static/homepage.html
+++ b/server/templates/static/homepage.html
@@ -58,7 +58,7 @@
 <section class="container">
   <h2>Easy analysis</h2>
   <p>
-    Access and analyze the graph easily using API's in Python, R, or Google Sheets.
+    Access and analyze the graph easily using API's in Python or Google Sheets.
   </p>
   <a href="http://docs.datacommons.org/api/">See API documentation.</a>
   <a href="http://docs.datacommons.org/tutorials.html">See some sample Python notebooks.</a>
@@ -66,9 +66,11 @@
 
 <section class="container">
   <h2>Open</h2>
-  <p>
-    Built using <a href="http://schema.org">Schema.org</a>. <a href="http://github.com/datacommonsorg">Open sourced</a>.
-    Build applications powered by the graph using the <a href="http://docs.datacommons.org/api/rest/">REST API</a>.
+  <p>Build applications powered by the graph using the <a
+      href="http://docs.datacommons.org/api/rest/">REST API</a>.</p>
+  <p><a href="http://github.com/datacommonsorg">Open sourced</a>, built using <a
+      href="http://schema.org">Schema.org</a>.</p>
+  <a href="https://docs.datacommons.org/contribute">Contribute to the graph.</a>
   </p>
 </section>
 

--- a/server/templates/static/homepage.html
+++ b/server/templates/static/homepage.html
@@ -113,13 +113,4 @@
   </div>
 </section>
 
-<section class="container">
-  <h2>What's new</h2>
-    <dl>
-      <dt>April 8, 2020</dt>
-      <dd>Published feed of <a href="{{ url_for('static.special_announcement') }}">COVID-19 Special Announcement</a> markups created in the Google Search Console.</dd>
-    </dl>
-  </div>
-</section>
-
 {% endblock %}

--- a/server/templates/tools/timeline.html
+++ b/server/templates/tools/timeline.html
@@ -13,13 +13,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 #}
+{%- extends 'base.html' -%}
 
 {% set is_hide_full_footer = true %}
 {% set subpage_title = "Timelines" %}
 {% set subpage_url = url_for('tools.timeline') %}
 {% set title = "Timelines Explorer" %}
-
-{% extends 'base.html' %}
+{% set hide_search = True %}
 
 {% block head %}
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/server/tests/redirects_test.py
+++ b/server/tests/redirects_test.py
@@ -22,7 +22,7 @@ class TestRedirects(unittest.TestCase):
     def test_gni(self):
         response = app.test_client().get('/gni', follow_redirects=True)
         assert response.status_code == 200
-        assert b"Timelines Explorer | Data Commons" in response.data
+        assert b"Timelines Explorer - Data Commons" in response.data
 
     def test_scatter(self):
         response = app.test_client().get('/scatter', follow_redirects=True)

--- a/server/tests/tools_test.py
+++ b/server/tests/tools_test.py
@@ -22,7 +22,7 @@ class TestStaticPage(unittest.TestCase):
     def test_timeline(self):
         response = app.test_client().get('/tools/timeline')
         assert response.status_code == 200
-        assert b"Timelines Explorer | Data Commons" in response.data
+        assert b"Timelines Explorer - Data Commons" in response.data
 
     def test_scatter(self):
         response = app.test_client().get('/tools/scatter')

--- a/server/webdriver_tests/place_explorer_test.py
+++ b/server/webdriver_tests/place_explorer_test.py
@@ -39,7 +39,7 @@ class TestPlaceExplorer(WebdriverBaseTest):
         req = urllib.request.Request(self.url_ + "/place.js")
         with urllib.request.urlopen(req) as response:
             self.assertEqual(response.getcode(), 200)
-        self.assertEqual("United States | Place Explorer | Data Commons",
+        self.assertEqual("United States - Place Explorer - Data Commons",
                          self.driver.title)
         title = self.driver.find_element_by_id("place-name")
         self.assertEqual("United States", title.text)
@@ -50,7 +50,7 @@ class TestPlaceExplorer(WebdriverBaseTest):
         """Test the place explorer page for MTV can be loaded successfullly."""
         self.driver.get(self.url_ + MTV_URL)
         time.sleep(5)
-        self.assertEqual("Mountain View | Place Explorer | Data Commons",
+        self.assertEqual("Mountain View - Place Explorer - Data Commons",
                          self.driver.title)
         title = self.driver.find_element_by_id("place-name")
         self.assertEqual("Mountain View", title.text)
@@ -71,7 +71,7 @@ class TestPlaceExplorer(WebdriverBaseTest):
         ca_result = search_results[0]
         ca_result.click()
         time.sleep(3)
-        self.assertEqual("California | Place Explorer | Data Commons",
+        self.assertEqual("California - Place Explorer - Data Commons",
                          self.driver.title)
 
     def test_demographics_link(self):

--- a/server/webdriver_tests/scatter_test.py
+++ b/server/webdriver_tests/scatter_test.py
@@ -28,7 +28,7 @@ class TestScatter(WebdriverBaseTest):
         self.driver.get(self.url_ + SCATTER_URL)
         # Using implicit wait here to wait for loading page.
         self.driver.implicitly_wait(3)
-        self.assertEqual("Scatterplot tool | Data Commons", self.driver.title)
+        self.assertEqual("Scatterplot tool - Data Commons", self.driver.title)
 
     def test_choosing_ptpvs_and_parameters_to_draw(self):
         """Test the scatter plot tool."""

--- a/server/webdriver_tests/timeline_test.py
+++ b/server/webdriver_tests/timeline_test.py
@@ -41,7 +41,7 @@ class TestCharts(WebdriverBaseTest):
         req = urllib.request.Request(self.url_ + "/timeline.js")
         with urllib.request.urlopen(req) as response:
             self.assertEqual(response.getcode(), 200)
-        self.assertEqual("Timelines Explorer | Data Commons", self.driver.title)
+        self.assertEqual("Timelines Explorer - Data Commons", self.driver.title)
 
     def test_charts_original(self):
         """Test the original timeline page. No charts in this page."""

--- a/static/css/static.scss
+++ b/static/css/static.scss
@@ -54,7 +54,7 @@ h2 {
   padding-top: 3rem;
   padding-bottom: 3rem;
   margin-top: 6rem;
-  margin-bottom: 5rem;
+  margin-bottom: -6rem;
 }
 
 #homepage section.container {

--- a/static/css/static.scss
+++ b/static/css/static.scss
@@ -66,6 +66,7 @@ h2 {
   display: inline;
 }
 
+#homepage section p,
 #homepage section a {
   display: block;
   margin-bottom: .4rem;

--- a/static/js/browser/kg.js
+++ b/static/js/browser/kg.js
@@ -647,7 +647,7 @@ function renderKGPage(
   document.getElementById("toogle-chart").checked = !showText;
 
   // Set name
-  document.title = `${name} - DataCommons Knowledge Graph`;
+  document.title = `${name} - Graph Browser - Data Commons`;
   let nameElem = document.getElementById("bg-node-name");
   nameElem.textContent = name;
 

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -140,7 +140,7 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
           } of ${displayNameForPlaceType(
             this.props.placeType,
             true /* isPlural */
-          )} in ${this.props.placeName} | Place Rankings`;
+          )} in ${this.props.placeName} - Place Rankings`;
         }
         this.setState({
           data: respData,


### PR DESCRIPTION
* use dashes instead of pipe for page title separators
* rearrange some links on the nav menus
* remove unused popper.js
* hide nav search box on some pages to avoid confusion