### PR TITLE
Fix a bug that same chart reference in overview and topic page

### DIFF
--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -73,7 +73,7 @@ def build_spec(chart_config):
             del config['isOverview']
         del config['category']
         if is_overview:
-            spec[OVERVIEW][category].append(config)
+            spec[OVERVIEW][category].append(copy.deepcopy(config))
         spec[category][config['title']].append(config)
         stat_vars.extend(config['statsVars'])
         stat_vars.extend(config.get('denominator', []))


### PR DESCRIPTION
Overview chart data is filled with "parent" data but is not rendered, thus leaving a sub title only.