### PR TITLE
fix tooltip positioning

### DIFF
--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -138,8 +138,9 @@ const onMouseMove = (
   const tooltipHeight = document
     .getElementById(containerId)
     .querySelector(`[id=${TOOLTIP_ID}]`).clientHeight;
-  const leftOffset = 5;
-  const topOffset = -tooltipHeight - 5;
+  const offset = 5;
+  const leftOffset = offset;
+  const topOffset = -tooltipHeight - offset;
   d3.select("#" + containerId + " #tooltip")
     .text(text)
     .style("left", d3.event.offsetX + leftOffset + "px")

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -135,8 +135,9 @@ const onMouseMove = (
     }
   }
   const text = placeName + ": " + value;
-  const leftOffset = 3;
-  const topOffset = -3;
+  const tooltipHeight = document.getElementById(containerId).querySelector(`[id=${TOOLTIP_ID}]`).clientHeight;
+  const leftOffset = 5;
+  const topOffset = -tooltipHeight - 5;
   d3.select("#" + containerId + " #tooltip")
     .text(text)
     .style("left", d3.event.offsetX + leftOffset + "px")
@@ -169,6 +170,7 @@ function determineColorPalette(dataValues: {
 
 function addTooltip(containerId: string) {
   d3.select("#" + containerId)
+    .attr("style", "position: relative")
     .append("div")
     .attr("id", TOOLTIP_ID)
     .attr("style", "position: absolute; display: none; z-index: 10");


### PR DESCRIPTION
This change should make sure that the tooltip is always above and to the right of the mouse pointer, so it won't get in the way of hovering over the current area