### PR TITLE
Allow per chart stats vars to accommodate aggregation

### DIFF
--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -359,6 +359,9 @@ def data(dcid):
             for chart in spec_and_stat[category][topic]:
                 # Trend data
                 chart['trend'] = get_trend(chart, all_stat, dcid)
+                if 'aggregate' in chart:
+                    chart['trend']['statsVars'] = list(chart['trend'].get(
+                        'series', {}).keys())
                 # Bar data
                 for t in chart_types:
                     chart[t] = get_bar(chart, all_stat, [dcid] +
@@ -373,15 +376,15 @@ def data(dcid):
                                 break
                         if not keep_chart:
                             chart[t] = {}
-                # Update stat vars for aggregated stats
-                if 'aggregate' in chart:
-                    chart['statsVars'] = list(chart['trend'].get('series',
-                                                                 {}).keys())
-                    for t in chart_types:
+                    # Update stat vars for aggregated stats
+                    if 'aggregate' in chart and chart[t]:
+                        chart[t]['statsVars'] = []
                         for place_data in chart[t].get('data', []):
                             stat_vars = list(place_data['data'].keys())
-                            if len(stat_vars) > len(chart['statsVars']):
-                                chart['statsVars'] = stat_vars
+                            if len(stat_vars) > len(chart[t]['statsVars']):
+                                chart[t]['statsVars'] = stat_vars
+                if 'aggregate' in chart:
+                    chart['statsVars'] = []
 
     # Remove empty category and topics
     for category in list(spec_and_stat.keys()):

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -109,7 +109,8 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
   svgContainerElement: React.RefObject<HTMLDivElement>;
   embedModalElement: React.RefObject<ChartEmbed>;
   dcid: string;
-  rankingUrlByStatVar: { [statVar: string]: string };
+  rankingUrlByStatVar: { [key: string]: string };
+  statsVars: string[];
 
   constructor(props: ChartPropType) {
     super(props);
@@ -127,11 +128,21 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
     this._handleWindowResize = this._handleWindowResize.bind(this);
     this._handleEmbed = this._handleEmbed.bind(this);
 
+    // For aggregated stats vars, the per chart stats vars are availabe in
+    // chart level not chart block level.
+    if (this.props.statsVars.length > 0) {
+      this.statsVars = this.props.statsVars;
+    } else if (this.props.trend) {
+      this.statsVars = this.props.trend.statsVars;
+    } else if (this.props.snapshot) {
+      this.statsVars = this.props.snapshot.statsVars;
+    } else {
+      this.statsVars = [];
+    }
     this.rankingUrlByStatVar = {};
-    for (const statVar of this.props.statsVars) {
+    for (const statVar of this.statsVars) {
       this.rankingUrlByStatVar[statVar] = this.props.rankingTemplateUrl.replace(
         "_sv_",
-
         statVar
       );
     }
@@ -399,7 +410,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       case chartTypeEnum.STACK_BAR:
         for (const placeData of this.props.snapshot.data) {
           const dataPoints: DataPoint[] = [];
-          for (const statVar of this.props.statsVars) {
+          for (const statVar of this.statsVars) {
             const val = placeData.data[statVar];
             dataPoints.push({
               label: STATS_VAR_LABEL[statVar],

--- a/static/js/place/types.ts
+++ b/static/js/place/types.ts
@@ -30,6 +30,7 @@ export interface TrendData {
   series: { string: Series };
   sources: string[];
   exploreUrl: string;
+  statsVars?: string[];
 }
 
 export interface SnapshotData {
@@ -41,6 +42,7 @@ export interface SnapshotData {
   }[];
   sources: string[];
   exploreUrl: string;
+  statsVars?: string[];
 }
 
 export interface ChartBlockData {


### PR DESCRIPTION
Previously the statsVars are at Chart Block level. 

In age aggregation, then US age trend chart and US similar places charts could use different aggregated age buckets.

![image](https://user-images.githubusercontent.com/5951856/95802864-74038880-0cb3-11eb-9520-b3e5fd9d8829.png)
