### PR TITLE
Replace GDP chart with GDP per capita.

### DIFF
--- a/server/chart_config.json
+++ b/server/chart_config.json
@@ -86,8 +86,10 @@
   },
   {
     "category": "Economics",
-    "title": "Gross Domestic Product",
-    "statsVars": ["Amount_EconomicActivity_GrossDomesticProduction_Nominal"],
+    "title": "Gross Domestic Product Per Capita",
+    "statsVars": [
+      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+    ],
     "unit": "$",
     "isOverview": true,
     "relatedChart": {


### PR DESCRIPTION
Use the WDI stat var "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita" instead. That is USD and only for country level.
Can revisit on using the Amount_EconomicActivity_GrossDomesticProduction_Nominal_AsAFractionOf_Count_Person version instead after some other work.


<img width="2240" alt="Screen Shot 2020-10-14 at 12 29 27 PM" src="https://user-images.githubusercontent.com/18621425/96036306-21dc7780-0e19-11eb-90a1-0973640aee2e.png">

<img width="2460" alt="Screen Shot 2020-10-14 at 12 30 50 PM" src="https://user-images.githubusercontent.com/18621425/96036320-256ffe80-0e19-11eb-81b3-e7c77991bc42.png">
