### PR TITLE
[PV Tree Generator] restrict mprop to count for denominators

### DIFF
--- a/static/data/statsvar_path.json
+++ b/static/data/statsvar_path.json
@@ -2709,14 +2709,14 @@
   8,
   0,
   1,
-  5
+  4
  ],
  "dc/qhwj3qx90h4pd": [
   0,
   8,
   0,
   1,
-  5,
+  4,
   0,
   0
  ],
@@ -2725,7 +2725,7 @@
   8,
   0,
   1,
-  5,
+  4,
   0,
   1
  ],
@@ -2734,7 +2734,7 @@
   8,
   0,
   1,
-  5,
+  4,
   0,
   2
  ],
@@ -2743,7 +2743,7 @@
   8,
   0,
   1,
-  5,
+  4,
   0,
   3
  ],
@@ -2752,7 +2752,7 @@
   8,
   0,
   1,
-  5,
+  4,
   0,
   4
  ],
@@ -2761,7 +2761,7 @@
   8,
   0,
   1,
-  5,
+  4,
   0,
   5
  ],
@@ -4114,7 +4114,7 @@
   8,
   0,
   1,
-  4
+  5
  ],
  "Count_Person_45To64Years_EducationalAttainmentHighSchoolGraduateIncludesEquivalency_Female": [
   0,
@@ -29123,127 +29123,127 @@
   1,
   1
  ],
- "dc/32wz78p01jzng": [
+ "Count_HousingUnit_WithRent_Upto100USDollar": [
   6,
   2,
   0
  ],
- "dc/kyeqbevv1sm81": [
+ "Count_HousingUnit_WithRent_100To149USDollar": [
   6,
   2,
   1
  ],
- "dc/g9kdm6qtpmlr9": [
+ "Count_HousingUnit_WithRent_150To199USDollar": [
   6,
   2,
   2
  ],
- "dc/qhwefl16c41bd": [
+ "Count_HousingUnit_WithRent_200To249USDollar": [
   6,
   2,
   3
  ],
- "dc/sqqy03m22nyjb": [
+ "Count_HousingUnit_WithRent_250To299USDollar": [
   6,
   2,
   4
  ],
- "dc/7mt9llfdtpwfc": [
+ "Count_HousingUnit_WithRent_300To349USDollar": [
   6,
   2,
   5
  ],
- "dc/53q4prfptqbrc": [
+ "Count_HousingUnit_WithRent_350To399USDollar": [
   6,
   2,
   6
  ],
- "dc/02jzwq9z4qwp9": [
+ "Count_HousingUnit_WithRent_400To449USDollar": [
   6,
   2,
   7
  ],
- "dc/76y4ekvgmbmfg": [
+ "Count_HousingUnit_WithRent_450To499USDollar": [
   6,
   2,
   8
  ],
- "dc/zfxlht3tze97b": [
+ "Count_HousingUnit_WithRent_500To549USDollar": [
   6,
   2,
   9
  ],
- "dc/jp73mr7vpdgq": [
+ "Count_HousingUnit_WithRent_550To599USDollar": [
   6,
   2,
   10
  ],
- "dc/1lm619q2bsqh": [
+ "Count_HousingUnit_WithRent_600To649USDollar": [
   6,
   2,
   11
  ],
- "dc/c7dsklk9ffw07": [
+ "Count_HousingUnit_WithRent_650To699USDollar": [
   6,
   2,
   12
  ],
- "dc/3e1l7ddy6981f": [
+ "Count_HousingUnit_WithRent_700To749USDollar": [
   6,
   2,
   13
  ],
- "dc/1v5v92e7nc231": [
+ "Count_HousingUnit_WithRent_750To799USDollar": [
   6,
   2,
   14
  ],
- "dc/4jplkk8t30k5c": [
+ "Count_HousingUnit_WithRent_800To899USDollar": [
   6,
   2,
   15
  ],
- "dc/nm90w7gjnj558": [
+ "Count_HousingUnit_WithRent_900To999USDollar": [
   6,
   2,
   16
  ],
- "dc/v0zqzzbqglbg9": [
+ "Count_HousingUnit_WithRent_1000To1249USDollar": [
   6,
   2,
   17
  ],
- "dc/bb37z1pqxq695": [
+ "Count_HousingUnit_WithRent_1250To1499USDollar": [
   6,
   2,
   18
  ],
- "dc/dcxwcgnec87l7": [
+ "Count_HousingUnit_WithRent_1500To1999USDollar": [
   6,
   2,
   19
  ],
- "dc/e5cs7fm74cdnd": [
+ "Count_HousingUnit_WithRent_2000To2499USDollar": [
   6,
   2,
   20
  ],
- "dc/xywgpkqpl0f56": [
+ "Count_HousingUnit_WithRent_2000OrMoreUSDollar": [
   6,
   2,
   21
  ],
- "dc/h83w8tdeffz7c": [
+ "Count_HousingUnit_WithRent_2500To2999USDollar": [
   6,
   2,
   22
  ],
- "dc/8eb17sesktv9h": [
+ "Count_HousingUnit_WithRent_3000To3499USDollar": [
   6,
   2,
   23
  ],
- "dc/w8wj03vyy1wvf": [
+ "Count_HousingUnit_WithRent_3500OrMoreUSDollar": [
   6,
   2,
   24
@@ -29363,12 +29363,12 @@
   3,
   22
  ],
- "Count_HousingUnit_HomeValue1000000To1499999USDollar": [
+ "Count_HousingUnit_HomeValue1000000OrMoreUSDollar": [
   6,
   3,
   23
  ],
- "Count_HousingUnit_HomeValue1000000OrMoreUSDollar": [
+ "Count_HousingUnit_HomeValue1000000To1499999USDollar": [
   6,
   3,
   24

--- a/tools/pv_tree_generator/build_tree.py
+++ b/tools/pv_tree_generator/build_tree.py
@@ -164,7 +164,7 @@ def find_denominators(pop_obs: PopObsSpec, cpvs: Dict[str, str],
             key = (pop_obs.pop_type,) + obs_prop.key + subset
             matching_statvars += tuple(stats_vars_all.get(key, ()))
         for sv in matching_statvars:
-            if sv.dcid in stats_vars_to_exclude:
+            if sv.mprop != 'count' or sv.dcid in stats_vars_to_exclude:
                 continue
             sv_entries = set(sv.pv.items())
             if sv_entries == dpv_entries:


### PR DESCRIPTION
Only StatVars with an mprop of "count" can be used as denominators. (The diff for `hierarchy_statsvar.json ` can be loaded)

Thanks for reviewing.