### PR TITLE
Use first autocomplete result when pressing enter in search

### DIFF
--- a/static/js/place/search.ts
+++ b/static/js/place/search.ts
@@ -44,6 +44,7 @@ function initSearchAutocomplete(): void {
 function placeChangedCallback(): void {
   // Get the place details from the autocomplete object.
   const place = ac.getPlace();
+  // place won't have place_id information if no autocomplete object has been selected (ie. user did not select any of the autocomplete suggestions)
   if (!place.place_id) {
     queryAutocompleteService(place.name);
   } else {

--- a/static/js/place/search.ts
+++ b/static/js/place/search.ts
@@ -17,6 +17,7 @@
 import axios from "axios";
 
 let ac: google.maps.places.Autocomplete;
+let acs: google.maps.places.AutocompleteService;
 
 /**
  * Setup search input autocomplete
@@ -32,30 +33,60 @@ function initSearchAutocomplete(): void {
     "place-autocomplete"
   ) as HTMLInputElement;
   ac = new google.maps.places.Autocomplete(acElem, options);
-  ac.addListener("place_changed", getPlaceAndRender);
+  ac.addListener("place_changed", placeChangedCallback);
+  // Create the autocomplete service.
+  acs = new google.maps.places.AutocompleteService();
 }
 
 /*
- * Get place from autocomplete object and update url
+ * If the autocomplete object does not have a place_id, query the autocomplete service. Otherwise, get url for the place.
  */
-function getPlaceAndRender(): void {
+function placeChangedCallback(): void {
   // Get the place details from the autocomplete object.
   const place = ac.getPlace();
+  if (!place.place_id) {
+    queryAutocompleteService(place.name);
+  } else {
+    getPlaceAndRender(place.place_id, place.name);
+  }
+}
+
+function queryAutocompleteService(place_name): void {
+  acs.getPlacePredictions({
+      input: place_name,
+      types: ["(regions)"],
+  }, queryAutocompleteCallback(place_name));
+}
+
+let queryAutocompleteCallback = (place_name) => (predictions, status) => {
+  if (status === google.maps.places.PlacesServiceStatus.OK) {
+    getPlaceAndRender(predictions[0].place_id, place_name);
+  } else {
+    placeNotFoundAlert(place_name);
+  }
+}
+
+// Get url for a given place_id if we have data for the place. Otherwise, alert that the place is not found.
+function getPlaceAndRender(place_id, place_name): void {
   axios
-    .get(`/api/placeid2dcid/${place.place_id}`)
+    .get(`/api/placeid2dcid/${place_id}`)
     .then((resp) => {
       const urlParams = new URLSearchParams(window.location.search);
       urlParams.set("dcid", resp.data);
       window.location.search = urlParams.toString();
     })
     .catch(() => {
-      alert("Sorry, but we don't have any data about " + place.name);
-      const acElem = document.getElementById(
-        "place-autocomplete"
-      ) as HTMLInputElement;
-      acElem.value = "";
-      acElem.setAttribute("placeholder", "Search for another place");
+      placeNotFoundAlert(place_name);
     });
+}
+
+function placeNotFoundAlert(place_name): void {
+  alert("Sorry, but we don't have any data about " + place_name);
+  const acElem = document.getElementById(
+    "place-autocomplete"
+  ) as HTMLInputElement;
+  acElem.value = "";
+  acElem.setAttribute("placeholder", "Search for another place");
 }
 
 export { initSearchAutocomplete };

--- a/static/js/place/search.ts
+++ b/static/js/place/search.ts
@@ -52,19 +52,22 @@ function placeChangedCallback(): void {
 }
 
 function queryAutocompleteService(place_name): void {
-  acs.getPlacePredictions({
+  acs.getPlacePredictions(
+    {
       input: place_name,
       types: ["(regions)"],
-  }, queryAutocompleteCallback(place_name));
+    },
+    queryAutocompleteCallback(place_name)
+  );
 }
 
-let queryAutocompleteCallback = (place_name) => (predictions, status) => {
+const queryAutocompleteCallback = (place_name) => (predictions, status) => {
   if (status === google.maps.places.PlacesServiceStatus.OK) {
     getPlaceAndRender(predictions[0].place_id, place_name);
   } else {
     placeNotFoundAlert(place_name);
   }
-}
+};
 
 // Get url for a given place_id if we have data for the place. Otherwise, alert that the place is not found.
 function getPlaceAndRender(place_id, place_name): void {


### PR DESCRIPTION
fixes #522 
changes:
- if autocomplete object isn't selected (aka user isn't on one of the autocomplete suggestions), get the list of autocomplete predictions for what the user has entered and redirect according to the first prediction in the list.  
![searchFix](https://user-images.githubusercontent.com/69875368/96055112-16e50f80-0e38-11eb-95d9-8e666f6bcea7.gif)
