### PR TITLE
ssl fix take 3

### DIFF
--- a/server/app_staging.yaml
+++ b/server/app_staging.yaml
@@ -31,14 +31,12 @@ handlers:
   # directory.
   - url: /static
     static_dir: dist
-    secure: always
 
     # This handler routes all requests not caught above to your main app. It is
     # required when static routes are defined, but can be omitted (along with
     # the entire handlers section) when there are no static files defined.
   - url: /.*
     script: auto
-    secure: always
 
 env_variables:
   FLASK_ENV: staging

--- a/server/main.py
+++ b/server/main.py
@@ -38,6 +38,15 @@ GCS_BUCKET = app.config['GCS_BUCKET']
 _MAX_SEARCH_RESULTS = 1000
 
 
+@app.before_request
+def before_request():
+    scheme = request.headers.get('X-Forwarded-Proto')
+    if scheme and scheme == 'http' and request.url.startswith('http://'):
+        url = request.url.replace('http://', 'https://', 1)
+        code = 301
+        return flask.redirect(url, code=code)
+
+
 @cache.cached(timeout=3600 * 24)
 @app.route('/api/placeid2dcid/<path:placeid>')
 def api_placeid2dcid(placeid):


### PR DESCRIPTION
Check x-forwarded-proto headers instead for ssl, and use a pre-request handler to redirect if non-ssl
https://stackoverflow.com/questions/32237379/python-flask-redirect-to-https-from-http

secure: always in the yaml file does not work for app engine flex