### PR TITLE
Add topic to click url

### DIFF
--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -46,7 +46,8 @@ function drawChoropleth(
     [placeDcid: string]: number;
   },
   unit: string,
-  statVar: string
+  statVar: string,
+  urlSuffix: string
 ): void {
   const label = STATS_VAR_LABEL[statVar];
   const maxColor = d3.color(getColorFn([label])(label));
@@ -105,7 +106,7 @@ function drawChoropleth(
     .on("mouseover", onMouseOver(domContainerId))
     .on("mouseout", onMouseOut(domContainerId))
     .on("mousemove", onMouseMove(domContainerId, dataValues, unit))
-    .on("click", onMapClick(domContainerId));
+    .on("click", onMapClick(domContainerId, urlSuffix));
 
   generateLegend(svg, chartWidth, chartHeight, colorScale, unit);
   addTooltip(domContainerId);
@@ -152,11 +153,14 @@ const onMouseMove = (
     .style("top", d3.event.offsetY + topOffset + "px");
 };
 
-const onMapClick = (domContainerId: string) => (
+const onMapClick = (domContainerId: string, urlSuffix: string) => (
   geo: { properties: { geoDcid: string } },
   index
 ) => {
-  window.open(REDIRECT_BASE_URL + geo.properties.geoDcid, "_blank");
+  window.open(
+    `${REDIRECT_BASE_URL}${geo.properties.geoDcid}${urlSuffix}`,
+    "_blank"
+  );
   mouseOutAction(domContainerId, index);
 };
 

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -95,6 +95,10 @@ interface ChartPropType {
    * Template to create links to place rankings (replace _sv_ with a StatVar)
    */
   rankingTemplateUrl: string;
+  /**
+   * The topic of the page the chart is in
+   */
+  topic: string;
 }
 
 interface ChartStateType {
@@ -342,6 +346,8 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       chartType === chartTypeEnum.CHOROPLETH &&
       this.state.choroplethDataGroup
     ) {
+      const urlSuffix =
+        this.props.topic === "Overview" ? "" : "?topic=" + this.props.topic;
       drawChoropleth(
         this.props.id,
         this.state.geoJson,
@@ -349,7 +355,8 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         elem.offsetWidth,
         this.state.choroplethDataGroup.data,
         this.props.unit,
-        this.props.statsVars[0]
+        this.props.statsVars[0],
+        urlSuffix
       );
     }
   }
@@ -379,6 +386,8 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
     const dataPoints: DataPoint[] = [];
     const allDates = new Set<string>();
     const scaling = this.props.scaling ? this.props.scaling : 1;
+    const linkSuffix =
+      this.props.topic === "Overview" ? "" : "?topic=" + this.props.topic;
     switch (this.props.chartType) {
       case chartTypeEnum.LINE:
         for (const statVar in this.props.trend.series) {
@@ -441,7 +450,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
             new DataGroup(
               this.props.names[placeData.dcid],
               dataPoints,
-              `/place/${placeData.dcid}`
+              `/place/${placeData.dcid}${linkSuffix}`
             )
           );
         }

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -66,6 +66,10 @@ interface ChartBlockPropType {
    * DCIDs of parent places
    */
   parentPlaces: string[];
+  /**
+   * The topic of the page the chart block is in
+   */
+  topic: string;
 }
 
 class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
@@ -112,6 +116,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
           rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${
             this.parentPlaceDcid
           }?${rankingParam.toString()}`}
+          topic={this.props.topic}
         ></Chart>
       );
     }
@@ -146,6 +151,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
       names: this.props.names,
       scaling: scaling,
       statsVars: this.props.data.statsVars,
+      topic: this.props.topic,
     };
     const rankingParam = new URLSearchParams(`h=${this.props.dcid}`);
     if (
@@ -310,6 +316,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
             choroplethData={this.props.choroplethData}
             statsVars={this.props.data.statsVars}
             rankingTemplateUrl={`/ranking/_sv_/${this.props.placeType}/${this.props.dcid}${rankingArg}`}
+            topic={this.props.topic}
           ></Chart>
         );
       }

--- a/static/js/place/main.tsx
+++ b/static/js/place/main.tsx
@@ -32,9 +32,9 @@ interface MainPanePropType {
    */
   placeType: string;
   /**
-   * The category of the current page.
+   * The topic of the current page.
    */
-  category: string;
+  topic: string;
   /**
    * The config and stat data.
    */
@@ -73,9 +73,9 @@ class MainPane extends React.Component<MainPanePropType, unknown> {
   }
 
   render(): JSX.Element {
-    const topicData = this.props.pageChart[this.props.category];
-    const category = this.props.category;
-    const isOverview = category === "Overview";
+    const topicData = this.props.pageChart[this.props.topic];
+    const currentPageTopic = this.props.topic;
+    const isOverview = currentPageTopic === "Overview";
     return (
       <>
         {this.props.isUsaPlace &&
@@ -119,6 +119,7 @@ class MainPane extends React.Component<MainPanePropType, unknown> {
                       choroplethData={this.props.choroplethData}
                       childPlaceType={this.props.childPlacesType}
                       parentPlaces={this.props.parentPlaces}
+                      topic={currentPageTopic}
                     />
                   );
                 })}

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -213,7 +213,7 @@ function renderPage(): void {
 
       ReactDOM.render(
         React.createElement(MainPane, {
-          category: topic,
+          topic,
           dcid,
           isUsaPlace,
           names: data.names,


### PR DESCRIPTION
- When clicking on a place in the bar charts or choropleth and opening a new tab for the clicked place, go to the same topic page as the current one

![clickTargetWithTopic](https://user-images.githubusercontent.com/69875368/96197213-3a768b80-0f06-11eb-9f9b-dd2cf160f085.gif)
