### PR TITLE
Proof concept to add GO backend and co-exist with Flask

### DIFF
--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 steps:
   - id: package_js
     name: "node"
@@ -24,11 +38,20 @@ steps:
       - -c
       - |
         set -x
-        cd server
+
+        # Set project
         gcloud config set project datcom-browser-staging
-        # bdist_wheel for grpcio takes a long time, setting timeout to be 1200s
+
+        # Deploy dispatch.yaml
+        gclodu app deploy dispatch.yaml
+
+        # Deploy the go service
+        gcloud app deploy go/go.yaml
+
+        # Deploy flask app service
         gcloud config set app/cloud_build_timeout 1200
-        gcloud app deploy app_staging.yaml -q --version=$SHORT_SHA
+        gcloud app deploy server/app_staging.yaml -q --version=$SHORT_SHA
+
         # Keep at most 5 recent versions
         if [[ "$(gcloud app versions list | wc -l)" -gt 6 ]]; then
           echo "Remove the oldest version..."

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dispatch:
+  # Send all mobile traffic to the mobile frontend.
+  - url: "*/"
+    service: default
+
+  # Send all work to the one static backend.
+  - url: "*/go/"
+    service: go

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 dispatch:
-  # Send all mobile traffic to the mobile frontend.
+  # Send all traffic to the Flask server.
   - url: "*/"
     service: default
 
-  # Send all work to the one static backend.
+  # Send specific service to go server.
   - url: "*/go/"
     service: go

--- a/go/.gcloudignore
+++ b/go/.gcloudignore
@@ -1,0 +1,25 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with `go test -c`
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/go/go.yaml
+++ b/go/go.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runtime: go114
+# env: flex
+
+service: go
+
+manual_scaling:
+  instances: 2
+resources:
+  cpu: 1
+  memory_gb: 1
+  disk_size_gb: 10

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	http.HandleFunc("/go/", handle)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Printf("Listening on port %s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handle(w http.ResponseWriter, r *http.Request) {
+	log.Println(r.URL.Path)
+	fmt.Fprint(w, "Hello Data Commons!")
+}


### PR DESCRIPTION
This is a proof of concept to use go backend together with the current Flask server. This goal is to:
- write new endpoint in golang
- gradually migrate python to golang
- finally deprecate the flask server.

I have done the gcloud app deploy locally and can see the response from go service: https://staging.datacommons.org/go/