### PR TITLE
draw choropleth for puerto rico

### DIFF
--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -88,6 +88,7 @@ def get_choropleth_places(geoDcid):
                                                           display_level).get(
                                                               parent_dcid, [])
                     geo_prop = CHOROPLETH_GEOJSON_PROPERTY_MAP[display_level]
+                    # Puerto Rico (geoId/72) requires higher resolution geoJson
                     if parent_dcid == 'geoId/72':
                         geo_prop = 'geoJsonCoordinatesDP1'
                     return place_list, geo_prop
@@ -96,6 +97,7 @@ def get_choropleth_places(geoDcid):
         place_list = dc_service.get_places_in([geoDcid],
                                               display_level).get(geoDcid, [])
         geo_prop = CHOROPLETH_GEOJSON_PROPERTY_MAP[display_level]
+        # Puerto Rico (geoId/72) requires higher resolution geoJson
         if geoDcid == 'geoId/72':
             geo_prop = 'geoJsonCoordinatesDP1'
         return place_list, geo_prop

--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -88,12 +88,16 @@ def get_choropleth_places(geoDcid):
                                                           display_level).get(
                                                               parent_dcid, [])
                     geo_prop = CHOROPLETH_GEOJSON_PROPERTY_MAP[display_level]
+                    if parent_dcid == 'geoId/72':
+                        geo_prop = 'geoJsonCoordinatesDP1'
                     return place_list, geo_prop
         return place_list
     else:
         place_list = dc_service.get_places_in([geoDcid],
                                               display_level).get(geoDcid, [])
         geo_prop = CHOROPLETH_GEOJSON_PROPERTY_MAP[display_level]
+        if geoDcid == 'geoId/72':
+            geo_prop = 'geoJsonCoordinatesDP1'
         return place_list, geo_prop
 
 

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -20,6 +20,7 @@
 
 import * as d3 from "d3";
 import * as geo from "geo-albers-usa-territories";
+import { GeoJsonData, GeoJsonFeature } from "../place/types";
 import { STATS_VAR_LABEL } from "../shared/stats_var_labels";
 import { getColorFn, formatYAxisTicks } from "./base";
 
@@ -45,24 +46,22 @@ const REDIRECT_BASE_URL = `/place/`;
 function fitSize(
   width: number,
   height: number,
-  object: any,
-  projection: any,
+  object: GeoJsonData,
+  projection: d3.GeoProjection,
   path: d3.GeoPath<any, d3.GeoPermissibleObjects>
 ): void {
   projection.scale(1).translate([0, 0]);
   const b = path.bounds(object);
   const s =
     1 / Math.max((b[1][0] - b[0][0]) / width, (b[1][1] - b[0][1]) / height);
-  const t = [
-    (width - s * (b[1][0] + b[0][0])) / 2,
-    (height - s * (b[1][1] + b[0][1])) / 2,
-  ];
-  projection.scale(s).translate(t);
+  const translateX = (width - s * (b[1][0] + b[0][0])) / 2;
+  const translateY = (height - s * (b[1][1] + b[0][1])) / 2;
+  projection.scale(s).translate([translateX, translateY]);
 }
 
 function drawChoropleth(
   containerId: string,
-  geoJson: any,
+  geoJson: GeoJsonData,
   chartHeight: number,
   chartWidth: number,
   dataValues: {
@@ -110,7 +109,7 @@ function drawChoropleth(
     .append("path")
     .attr("d", geomap)
     .attr("class", "border")
-    .attr("fill", (d: { properties: { geoDcid: string } }) => {
+    .attr("fill", (d: GeoJsonFeature) => {
       if (
         d.properties.geoDcid in dataValues &&
         dataValues[d.properties.geoDcid]
@@ -177,7 +176,7 @@ const onMouseMove = (
 };
 
 const onMapClick = (domContainerId: string, urlSuffix: string) => (
-  geo: { properties: { geoDcid: string } },
+  geo: GeoJsonFeature,
   index
 ) => {
   window.open(

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -295,12 +295,7 @@ class ChartBlock extends React.Component<ChartBlockPropType, unknown> {
           );
         }
       }
-      if (
-        !!this.props.data.isChoropleth &&
-        this.props.isUsaPlace &&
-        // d3 can't draw choropleth for Puerto Rico (geoId/72)
-        this.props.dcid !== "geoId/72"
-      ) {
+      if (!!this.props.data.isChoropleth && this.props.isUsaPlace) {
         const id = randDomId();
         const chartTitle =
           this.props.placeType === "County"

--- a/static/js/place/types.ts
+++ b/static/js/place/types.ts
@@ -103,27 +103,21 @@ export interface ChoroplethDataGroup {
   sources: string[];
 }
 
-export interface GeoJsonData {
-  type: string;
-  features: GeoJsonFeature[];
+export interface GeoJsonFeatureProperties {
+  name: string;
+  hasSublevel: boolean;
+  geoDcid: string;
+}
+
+export type GeoJsonFeature = GeoJSON.Feature<
+  GeoJSON.MultiPolygon,
+  GeoJsonFeatureProperties
+>;
+
+export interface GeoJsonData extends GeoJSON.FeatureCollection {
+  type: "FeatureCollection";
+  features: Array<GeoJsonFeature>;
   properties: {
     current_geo: string;
   };
 }
-
-export interface GeoJsonFeature {
-  type: string;
-  geometry: {
-    // Geojson features will always be MultiPolygons
-    type: string;
-    coordinates: Polygon[];
-  };
-  id: string;
-  properties: {
-    name: string;
-    hasSublevel: boolean;
-    geoDcid: string;
-  };
-}
-
-type Polygon = number[][][];

--- a/static/package.json
+++ b/static/package.json
@@ -57,7 +57,8 @@
     "typescript": "^3.9.7",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
-    "webpack-fix-style-only-entries": "^0.5.1"
+    "webpack-fix-style-only-entries": "^0.5.1",
+    "geo-albers-usa-territories": "0.1.0"
   },
   "dependencies": {
     "@babel/polyfill": "^7.11.5",


### PR DESCRIPTION
- use package "geo-albers-usa-territories" so puerto rico choropleth charts can be drawn
- use fitSize method from https://bl.ocks.org/HarryStevens/0e440b73fbd88df7c6538417481c9065 for fitting and centering the map
- when getting geoJson for puerto rico, use the highest resolution version of simplified geojsons because lower resolutions will look like a mosaic

![image](https://user-images.githubusercontent.com/69875368/96523301-3a3dff00-122a-11eb-897c-7e5ff853264c.png)
![image](https://user-images.githubusercontent.com/69875368/96523367-5d68ae80-122a-11eb-899e-587954b2bae9.png)


