### PR TITLE
Automate downloading latest version of Chrome Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,16 @@ If using Linux system, you can run the following commands to download Chrome bro
 ```bash
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 sudo dpkg -i google-chrome-stable_current_amd64.deb; sudo apt-get -fy install
-wget https://chromedriver.storage.googleapis.com/84.0.4147.30/chromedriver_linux64.zip
+LATESTCHROMEDRIVERVERSION=$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+wget https://chromedriver.storage.googleapis.com/${LATESTCHROMEDRIVERVERSION}/chromedriver_linux64.zip
+unset LATESTCHROMEDRIVERVERSION
 unzip chromedriver_linux64.zip
 sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver
 sudo chmod +x /usr/bin/chromedriver
 ```
 
-Note: You can change `84.0.4147.30`(version number) to the lastet version [here](https://chromedriver.storage.googleapis.com/LATEST_RELEASE).
+Note: You can change view the lastet ChromeDriver version version [here](https://chromedriver.storage.googleapis.com/LATEST_RELEASE).
 
 #### Run all tests
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ sudo chown root:root /usr/bin/chromedriver
 sudo chmod +x /usr/bin/chromedriver
 ```
 
-Note: You can change view the lastet ChromeDriver version [here](https://chromedriver.storage.googleapis.com/LATEST_RELEASE).
+Note: Make sure that your ChromeDriver version is compatible with your local Google Chrome version.
+You can change view the lastet ChromeDriver version [here](https://chromedriver.storage.googleapis.com/LATEST_RELEASE).
 
 #### Run all tests
 

--- a/README.md
+++ b/README.md
@@ -95,16 +95,16 @@ If using Linux system, you can run the following commands to download Chrome bro
 ```bash
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 sudo dpkg -i google-chrome-stable_current_amd64.deb; sudo apt-get -fy install
-LATESTCHROMEDRIVERVERSION=$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
-wget https://chromedriver.storage.googleapis.com/${LATESTCHROMEDRIVERVERSION}/chromedriver_linux64.zip
-unset LATESTCHROMEDRIVERVERSION
+CHROMEDRIVERV=$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+wget https://chromedriver.storage.googleapis.com/${CHROMEDRIVERV}/chromedriver_linux64.zip
+unset CHROMEDRIVERV
 unzip chromedriver_linux64.zip
 sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver
 sudo chmod +x /usr/bin/chromedriver
 ```
 
-Note: You can change view the lastet ChromeDriver version version [here](https://chromedriver.storage.googleapis.com/LATEST_RELEASE).
+Note: You can change view the lastet ChromeDriver version [here](https://chromedriver.storage.googleapis.com/LATEST_RELEASE).
 
 #### Run all tests
 


### PR DESCRIPTION
Not sure if you like this idea, but I thought I'd propose it.

Instead of manually downloading the latest Chrome Driver version.

1. Curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE
2. Store the response as **CHROMEDRIVERV**.
3. Download https://chromedriver.storage.googleapis.com/${**CHROMEDRIVERV**}/chromedriver_linux64.zip