### PR TITLE
Parallelizes Testing Steps

### DIFF
--- a/cloudbuild.py.yaml
+++ b/cloudbuild.py.yaml
@@ -17,6 +17,7 @@ steps:
   - id: flask_test
     name: python:3.7
     entrypoint: /bin/sh
+    waitFor: ['-']
     args:
       - -c
       - |
@@ -25,6 +26,7 @@ steps:
   - id: package_js
     name: "node"
     entrypoint: /bin/bash
+    waitFor: ['-']
     args:
       - -c
       - |
@@ -35,6 +37,8 @@ steps:
   - id: flask_webdriver_test
     name: gcr.io/datcom-ci/webdriver-chrome:2020-10-21
     entrypoint: /bin/sh
+    waitFor:
+      - package_js
     args:
       - -c
       - |
@@ -43,6 +47,7 @@ steps:
   - id: pv_tree_generator
     name: python:3.7-slim
     entrypoint: /bin/sh
+    waitFor: ['-']
     args:
       - -c
       - set -e


### PR DESCRIPTION
I have made flask_test, package_js , and pv_tree_generator run in parallel from the beginning.
flask_webdriver_test will run after package_js has completed.

<img width="568" alt="Screen Shot 2020-10-28 at 2 31 34 PM" src="https://user-images.githubusercontent.com/11444894/97489316-cc828900-1935-11eb-9fb5-1f1b61f665eb.png">


Times:
Current Behavior Run 1: 324 secs
Current Behavior Run 2: 306 secs
Current Behavior Run 3: 314 secs

Parallel Run 1: 256 secs
Parallel Run 2: 245 secs
Parallel Run 3: 278 secs