### PR TITLE
Improve Test Waiting Time

### DIFF
--- a/server/webdriver_tests/README.md
+++ b/server/webdriver_tests/README.md
@@ -1,0 +1,53 @@
+# Data Commons WebDriver Unit Tests
+
+## How To Run the Data Commons WebDriver Unit Tests
+
+Run the following command from the parent directory:
+
+    ./run_tests.sh -w
+
+## Things To Note
+
+Data Commons sites can take up to a few seconds to load; thus, WebDriver needs to be told what elements to wait for to know that the page has finished loading/rendering.
+
+- `SLEEP_SEC` represents the maximum time to wait. If this time is exceeded, the test will fail with a `TimeoutException`. By default, the test cases use 15 seconds.
+- WebDriver allows to select HTML elements using `By.ID, By.CSS_SELECTOR, By.CLASS_NAME, By.XPATH`.
+- Sometimes, it is more convenient to use CSS_SELECTOR or XPATH.
+  - `By.CSS_SELECTOR('.myclass:nth-element(3)')`
+  - `By.XPATH('//*[@id="my-id"]/span/button')`
+
+### 1. Wait Until HTML Element is Present in DOM
+
+WebDriver can wait for an element to be present in the DOM using `presence_of_element_located`. An example would be to wait for "my-button" to appear after an event has triggered.
+    element_present = EC.presence_of_element_located(
+    (By.ID, 'my-button'))
+    WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
+### 2. Wait Until HTML Element Contains Desired Text
+
+There are some cases where the element is already part of the DOM, but that element's content is still loading. For example, a chart title might initially be `""` but then change to `"Poverty In the USA"` after an API request has finished loading. If this is the case, we have to tell WebDriver to wait until the text completes loading.
+
+In the example below, WebDriver will wait until the element contains `"Mountain View"` as part of the place-name text.
+
+    element_present = EC.text_to_be_present_in_element(
+    (By.ID, 'my-id'),
+    'Mountain View')
+    WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
+### 3. Wait Until HTML Element Disappears
+
+If you want to wait until an element disappears from the DOM, use `invisibility_of_element_located`.
+
+For example, in the Data Commons Timeline Tool, when a place is de-selected, some HTML elements have to be removed from the DOM.
+
+WebDriver can wait for the 2nd element to disappear as follows:
+
+    element_present = EC.invisibility_of_element_located(
+    (By.CSS_SELECTOR,'.my-class:nth-child(2)'))
+    WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
+### 4. Wait Until Page Title Changes
+
+If you want to make sure that the site's title is correct, wait until the title contains your desired text. This can be used to check to see if an on-click event works as expected.
+
+    WebDriverWait(self.driver, SLEEP_SEC).until(EC.title_contains(TITLE_TEXT)

--- a/server/webdriver_tests/place_explorer_test.py
+++ b/server/webdriver_tests/place_explorer_test.py
@@ -15,7 +15,10 @@
 import unittest
 import urllib
 from webdriver_tests.base_test import WebdriverBaseTest
-import time
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support import expected_conditions as EC
 
 MTV_URL = '/place/geoId/0649670'
 USA_URL = '/place/country/USA'
@@ -29,85 +32,165 @@ class TestPlaceExplorer(WebdriverBaseTest):
 
     def test_page_serve_usa(self):
         """Test the place explorer page for USA can be loaded successfullly."""
+        TITLE_TEXT = "United States - Place Explorer - Data Commons"
+        PLACE_TYPE_TEXT = "A Country in North America"
+
+        # Load USA page.
         self.driver.get(self.url_ + USA_URL)
-        # Wait for the XHR's to complete.
-        time.sleep(SLEEP_SEC)
+
+        # Wait until the place-type is correct.
+        element_present = EC.text_to_be_present_in_element(
+            (By.ID, 'place-type'), PLACE_TYPE_TEXT)
+        WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
+        # Assert 200 HTTP code: successful page load.
         req = urllib.request.Request(self.driver.current_url)
         with urllib.request.urlopen(req) as response:
             self.assertEqual(response.getcode(), 200)
-        # Assert the js files are generated successfully.
+
+        # Assert 200 HTTP code: successful JS generation.
         req = urllib.request.Request(self.url_ + "/place.js")
         with urllib.request.urlopen(req) as response:
             self.assertEqual(response.getcode(), 200)
-        self.assertEqual("United States - Place Explorer - Data Commons",
-                         self.driver.title)
+
+        # Wait until the page loads and the title is correct.
+        WebDriverWait(self.driver,
+                      SLEEP_SEC).until(EC.title_contains(TITLE_TEXT))
+        self.assertEqual(TITLE_TEXT, self.driver.title)
+
+        # Assert place title is correct.
         title = self.driver.find_element_by_id("place-name")
         self.assertEqual("United States", title.text)
+
+        # Assert place type is correct.
         subtitle = self.driver.find_element_by_id("place-type")
         self.assertEqual("A Country in North America", subtitle.text)
 
     def test_page_serve_mtv(self):
         """Test the place explorer page for MTV can be loaded successfullly."""
+        PLACE_TYPE_TITLE = "A City in Santa Clara County, California, United States of America, North America"
+        TITLE_TEXT = "Mountain View - Place Explorer - Data Commons"
+
+        # Load Mountain View Page.
         self.driver.get(self.url_ + MTV_URL)
-        time.sleep(SLEEP_SEC)
-        self.assertEqual("Mountain View - Place Explorer - Data Commons",
-                         self.driver.title)
-        title = self.driver.find_element_by_id("place-name")
-        self.assertEqual("Mountain View", title.text)
-        subtitle = self.driver.find_element_by_id("place-type")
-        self.assertEqual(
-            "A City in Santa Clara County, California, United States of America, North America",
-            subtitle.text)
+
+        # Wait until the page loads and the title is correct.
+        WebDriverWait(self.driver,
+                      SLEEP_SEC).until(EC.title_contains(TITLE_TEXT))
+
+        # Assert title is correct.
+        self.assertEqual(TITLE_TEXT, self.driver.title)
+
+        # Wait until the place name has loaded.
+        element_present = EC.text_to_be_present_in_element(
+            (By.ID, 'place-name'), "Mountain View")
+        WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+        place_name = self.driver.find_element_by_id("place-name").text
+
+        # Assert place name is correct.
+        self.assertEqual("Mountain View", place_name)
+
+        # Wait until the place type has loaded.
+        element_present = EC.text_to_be_present_in_element(
+            (By.ID, 'place-type'), PLACE_TYPE_TITLE)
+        WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
+        # Assert place type is correct.
+        place_type = self.driver.find_element_by_id("place-type").text
+        self.assertEqual(PLACE_TYPE_TITLE, place_type)
 
     def test_place_search(self):
         """Test the place search box can work correctly."""
+        CALIFORNIA_TITLE = "California - Place Explorer - Data Commons"
+        # Load USA page.
         self.driver.get(self.url_ + USA_URL)
-        # Using implicit wait here to wait for loading page.
-        self.driver.implicitly_wait(10)
+
+        # Wait until the place name has loaded.
+        element_present = EC.presence_of_element_located(
+            (By.CLASS_NAME, 'pac-target-input'))
+        WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
         search_box = self.driver.find_element_by_class_name("pac-target-input")
+
         search_box.send_keys(PLACE_SEARCH)
-        self.driver.implicitly_wait(10)
-        search_results = self.driver.find_elements_by_class_name("pac-item")
-        ca_result = search_results[0]
-        ca_result.click()
-        time.sleep(3)
-        self.assertEqual("California - Place Explorer - Data Commons",
-                         self.driver.title)
+
+        # Wait until the place name has loaded.
+        element_present = EC.presence_of_element_located(
+            (By.CSS_SELECTOR, '.pac-item:nth-child(1)'))
+        WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
+        # Select the first result from the list and click on it.
+        first_result = self.driver.find_element_by_css_selector(
+            '.pac-item:nth-child(1)')
+        first_result.click()
+
+        # Wait until the page loads and the title is correct.
+        WebDriverWait(self.driver,
+                      SLEEP_SEC).until(EC.title_contains(CALIFORNIA_TITLE))
+
+        # Assert page title is correct.
+        self.assertEqual(CALIFORNIA_TITLE, self.driver.title)
 
     def test_demographics_link(self):
         """
         Test the demographics link can work correctly.
         """
+        CHART_TITLE = "Gender distribution: states near California(2018)"
+        # Load California page.
         self.driver.get(self.url_ + CA_URL)
-        time.sleep(SLEEP_SEC)
-        demographics = self.driver.find_element_by_id("Demographics")
-        demographics.find_element_by_tag_name('a').click()
-        time.sleep(SLEEP_SEC)
-        self.assertTrue("Demographics" in self.driver.current_url)
-        subtopics = self.driver.find_elements_by_class_name("subtopic")
-        age_topic = subtopics[3]
-        age_charts = age_topic.find_elements_by_class_name("col")
-        age_across_places_chart = age_charts[1]
-        chart_title = age_across_places_chart.find_element_by_tag_name(
-            "h4").text
-        self.assertEqual("Gender distribution: states near California(2018)",
-                         chart_title, chart_title)
 
-    # TODO(beets): Re-enable this test when feasible (without sacrificing
-    #              potential ssl downgrade)
+        # Wait until the Demographics link is present.
+        element_present = EC.presence_of_element_located(
+            (By.XPATH, '//*[@id="Demographics"]/a'))
+        WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
+        # Find and click on the Demographics URL.
+        demographics = self.driver.find_element_by_xpath(
+            '//*[@id="Demographics"]/a')
+        demographics.click()
+
+        # Wait until the new page has loaded.
+        element_present = EC.presence_of_element_located(
+            (By.XPATH, '//*[@id="main-pane"]/section[4]/div/div[2]/div/h4'))
+        WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
+        # Assert that Demographics is part of the new url.
+        self.assertTrue("Demographics" in self.driver.current_url)
+
+        # Get the chart_title text.
+        chart_title = self.driver.find_element_by_xpath(
+            '//*[@id="main-pane"]/section[4]/div/div[2]/div/h4').text
+
+        # Assert chart title is correct.
+        self.assertEqual(CHART_TITLE, chart_title)
+
+    ## TODO(beets): Re-enable this test when feasible (without sacrificing potential ssl downgrade)
+    ## NOTE: Test case was re-designed but was not tested due to SSL issues. Possibly failing.
     # def test_demographics_redirect_link(self):
     #     """
     #     Test a place page with demographics after a redirect.
     #     """
+    #     # Load California's Demographics page.
     #     self.driver.get(self.url_ + '/place?dcid=geoId/06&topic=Demographics')
-    #     time.sleep(10)
+
+    #     # Wait until the page has loaded.
+    #     element_present = EC.presence_of_element_located(
+    #         (By.CSS_SELECTOR, '.subtopic:nth-node(4)'))
+    #     WebDriverWait(self.driver, SLEEP_SEC).until(element_present)
+
+    #     # Assert "Demographics" is part of the URL.
     #     self.assertTrue("Demographics" in self.driver.current_url)
-    #     subtopics = self.driver.find_elements_by_class_name("subtopic")
-    #     age_topic = subtopics[3]
-    #     age_charts = age_topic.find_elements_by_class_name("col")
-    #     age_across_places_chart = age_charts[1]
+
+    #     # Get the Age topic from the list of topics.
+    #     age_topic = self.driver.find_element_by_css_selector(
+    #         ".subtopic:nth-child(4)")
+    #     age_across_places_chart = age_topic.find_element_by_css_selector(
+    #         ".col:nth-child(2)")
+
     #     chart_title = age_across_places_chart.find_element_by_tag_name(
     #         "h4").text
+
+    #     # Assert chart title is correct.
     #     self.assertEqual(
     #         "Population by Gender Per Capita: states near California(2018)",
     #         chart_title, chart_title)


### PR DESCRIPTION
**Only Testing WebDriver tests total time.**
Current Behavior with time.sleep():
Run 1: 124secs
Run 2: 119secs
Run 3: 118secs
Run 4: 117secs


New Behavior with WebDriverWait:
Run 1: 55 secs
Run 2: 69 secs
Run 3: 67secs
Run 4: 61secs

Improvement of 1 minute 👍 

I wrote a README for anyone who wishes to maintain the tests.