### PR TITLE
Loading Indicator for Choropleth Tool

### DIFF
--- a/static/css/tools/choropleth.scss
+++ b/static/css/tools/choropleth.scss
@@ -115,3 +115,23 @@ button {
   color: #600;
   cursor: pointer;
 }
+
+#choropleth-section {
+  position: relative;
+}
+
+#loading-overlay {
+  position: absolute;
+  z-index: 10;
+  display: none;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.75);
+}
+
+#loading-text {
+  font-size: 1.4rem;
+}

--- a/static/js/tools/choropleth/choropleth_template.tsx
+++ b/static/js/tools/choropleth/choropleth_template.tsx
@@ -167,15 +167,20 @@ class MainPane extends Component {
             <div className="column" id="breadcrumbs"></div>
             <div id="heading">Loading...</div>
             <div id="error"></div>
-            <div>
-              <ChoroplethMap
-                ref={this.state && this.state["choroplethMap"]}
-              ></ChoroplethMap>
-            </div>
-            <div id="choropleth-footer">
-              <div id="legend-container">
-                <div id="date"></div>
-                <div id="legend"></div>
+            <div id="choropleth-section">
+              <div>
+                <ChoroplethMap
+                  ref={this.state && this.state["choroplethMap"]}
+                ></ChoroplethMap>
+              </div>
+              <div id="choropleth-footer">
+                <div id="legend-container">
+                  <div id="date"></div>
+                  <div id="legend"></div>
+                </div>
+              </div>
+              <div id="loading-overlay">
+                <div id="loading-text">Loading...</div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
When in the choropleth tool and switching stat vars or changing the current place, update the title and then show loading indicator. Loading indicator not shown when first navigating to the choropleth tool.

![test (16)](https://user-images.githubusercontent.com/69875368/98423415-5f60a900-2043-11eb-81cb-ad2f4306843d.gif)
