### PR TITLE
[Scatter2] Fix formatDate and isDateChosen

### DIFF
--- a/static/js/tools/scatter2/chart_loader.tsx
+++ b/static/js/tools/scatter2/chart_loader.tsx
@@ -123,9 +123,9 @@ function useCache(): Cache {
 function formatDate(date: DateInfo) {
   let str = date.year.toString();
   if (date.month) {
-    str += `-${date.month}`;
+    str += `-${date.month < 10 ? "0" : ""}${date.month}`;
     if (date.day) {
-      str += `-${date.day}`;
+      str += `-${date.day < 10 ? "0" : ""}${date.day}`;
     }
   }
   return str;

--- a/static/js/tools/scatter2/util.ts
+++ b/static/js/tools/scatter2/util.ts
@@ -97,8 +97,8 @@ function nodeGetStatVar(node: StatsVarNode): string {
  */
 function isDateChosen(date: DateInfo): boolean {
   return (
-    date.year > 0 ||
-    (date.year > 0 && date.month > 0) ||
+    (date.year > 0 && !date.month && !date.day) ||
+    (date.year > 0 && date.month > 0 && !date.day) ||
     (date.year > 0 && date.month > 0 && date.day > 0)
   );
 }


### PR DESCRIPTION
1. Fix `formatDate` not adding extra zeros before single digit months and days
2. Fix `isDateChosen` not checking if month or day is not set