### PR TITLE
GKE does not support startupProbe yet, so only keep readiness probe

### DIFF
--- a/deployment/config.yaml
+++ b/deployment/config.yaml
@@ -121,7 +121,7 @@ cpu:
       dev: 100m
       staging: 300m
       prod: 300m
-  # From GCP dashboard, esp does not use that much of memory.
+  # From GCP dashboard, esp does not use that much of cpu.
   esp:
     req:
       dev: 10m

--- a/deployment/website.yaml.tmpl
+++ b/deployment/website.yaml.tmpl
@@ -55,22 +55,11 @@ spec:
           args: []
           ports:
             - containerPort: 8080
-          startupProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            failureThreshold: 30
-            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /healthz
               port: 8000
             failureThreshold: 1
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
             periodSeconds: 10
           volumeMounts:
             - name: website-robot-key


### PR DESCRIPTION
See discussion: https://stackoverflow.com/a/61936155.

Basically without startupProbe, the liveness probe can timeout if server starts slow and restart it, making it an infinite loop.