### PR TITLE
Api i18n name

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This will watch static files change and re-build on code edit.
 Start the flask webserver locally at localhost:8080
 
 ```bash
-./run_flask.sh
+./run_server.sh
 ```
 
 #### Start the Go Server

--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -25,7 +25,7 @@ import routes.api.choropleth as choropleth_api
 import routes.api.landing_page as landing_page_api
 
 from cache import cache
-from flask import Blueprint, current_app, Response
+from flask import Blueprint, current_app, request, Response
 from routes.api.place import EQUIVALENT_PLACE_TYPES
 # Define blueprint
 bp = Blueprint("api_chart", __name__, url_prefix='/api/chart')
@@ -110,7 +110,8 @@ def geojson(dcid):
     if not geos:
         return Response(json.dumps({}), 200, mimetype='application/json')
 
-    names_by_geo = place_api.get_display_name('^'.join(geos))
+    locale = request.args.get('hl', default="en")
+    names_by_geo = place_api.get_display_name('^'.join(geos), locale)
     geojson_by_geo = dc_service.get_property_values(geos, geojson_prop)
     features = []
     for geo_id, json_text in geojson_by_geo.items():

--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -24,7 +24,7 @@ import json
 import logging
 import urllib
 
-from flask import Blueprint, current_app, Response, url_for
+from flask import Blueprint, current_app, request, Response, url_for
 from collections import defaultdict
 
 from cache import cache
@@ -357,6 +357,7 @@ def data(dcid):
     """
     logging.info("Landing Page: cache miss for %s, fetch and process data ...",
                  dcid)
+    locale = request.args.get('hl', default="en")
     spec_and_stat, stat_vars = build_spec(current_app.config['CHART_CONFIG'])
     raw_page_data = get_landing_page_data(dcid, stat_vars)
 
@@ -474,7 +475,7 @@ def data(dcid):
     all_places = [dcid]
     for t in BAR_CHART_TYPES:
         all_places.extend(raw_page_data.get(t + 'Places', []))
-    names = place_api.get_display_name('^'.join(sorted(all_places)))
+    names = place_api.get_display_name('^'.join(sorted(all_places)), locale)
 
     # Pick data to highlight - only population for now
     population, statvar_denom = get_snapshot_across_places(

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -151,9 +151,9 @@ def cached_i18n_name(dcids, locale):
                           compress=False,
                           post=True)
     result = {}
-    # When there is no locale, fall back to default en. 
-    # When there is no exact match of locale, and locale can be broken into parts: language - region, fall back to use language part. 
-    # If there still isn't a match, fall back to use en. 
+    # When there is no locale, fall back to default en.
+    # When there is no exact match of locale, and locale can be broken into parts: language - region, fall back to use language part.
+    # If there still isn't a match, fall back to use en.
     if not locale:
         locale = ENGLISH_LANG
     fallback_lang = locale.split('-')[0] if locale.find('-') != -1 else ''

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -150,42 +150,31 @@ def cached_i18n_name(dcids, locale):
                           compress=False,
                           post=True)
     result = {}
-    if not locale:
-        locale = 'en'
-    fallback_locale = locale.split('-')[0] if locale.find('-') != -1 else ''
+    # When there is no locale, fall back to default en. 
+    # When there is no exact match of locale, and locale can be broken into parts: language - region, fall back to use language par. 
+    # If there still isn't a match, fall back to use en. 
     english_local = 'en'
-    second_choice = ''
-    last_choice = ''
+    if not locale:
+        locale = english_local
+    fallback_locale = locale.split('-')[0] if locale.find('-') != -1 else ''
     for dcid in dcids:
         values = response[dcid].get('out')
         name_in_en = ''
         result[dcid] = ''
-        print('locale = ' + locale)
+        fallback_choice = ''
+        english_choice = ''
         for entry in values:
-            print(entry)
             if (has_locale_name(entry, locale)):
                 result[dcid] = extract_locale_name(entry, locale)
+                # Find the exact matches, no need to fall back.
                 break
-            # if entry['value'].endswith('@' + locale.lower()):
-            #     i18nname_end_index = len(entry['value']) - len(locale) - 1
-            #     result[dcid] = entry['value'][:i18nname_end_index]
-            # if result[dcid]:
-            # Already found best match, break out of the loop
-            # break
             else:
                 if (has_locale_name(entry, fallback_locale)):
-                    second_choice = extract_locale_name(entry, fallback_locale)
+                    fallback_choice = extract_locale_name(entry, fallback_locale)
                 if (has_locale_name(entry, english_local)):
-                    last_choice = extract_locale_name(entry, english_local)
-                # if entry['value'].endswith('@' + fallbacl_locale):
-                # if entry['value'].endswith('@en'):
-                #     name_in_en = entry['value'][:(len(entry['value']) -
-                #                                   len('en') - 1)]
-        # When there isn't a name in required language code, falls back to
-        # English name if exists.
+                    english_choice = extract_locale_name(entry, english_local)
         if not result[dcid]:
-            print('if not result[dcid]:')
-            result[dcid] = second_choice if second_choice else last_choice
+            result[dcid] = fallback_choice if fallback_choice else english_choice
     return result
 
 
@@ -197,9 +186,8 @@ def extract_locale_name(entry, locale):
     if entry['value'].endswith('@' + locale.lower()):
         locale_index = len(entry['value']) - len(locale) - 1
         return entry['value'][:locale_index]
-    else:
+    else :
         return ''
-
 
 def get_i18n_name(dcids, locale):
     """"Returns localization names for set of dcids.

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -62,6 +62,7 @@ RANKING_STATS = {
 
 STATE_EQUIVALENTS = {"State", "AdministrativeArea1"}
 US_ISO_CODE_PREFIX = 'US'
+ENGLISH_LANG = 'en'
 
 # Define blueprint
 bp = Blueprint("api.place", __name__, url_prefix='/api/place')
@@ -150,13 +151,12 @@ def cached_i18n_name(dcids, locale):
                           compress=False,
                           post=True)
     result = {}
-    # When there is no locale, fall back to default en. 
-    # When there is no exact match of locale, and locale can be broken into parts: language - region, fall back to use language par. 
-    # If there still isn't a match, fall back to use en. 
-    english_local = 'en'
+    # When there is no locale, fall back to default en.
+    # When there is no exact match of locale, and locale can be broken into parts: language - region, fall back to use language part.
+    # If there still isn't a match, fall back to use en.
     if not locale:
-        locale = english_local
-    fallback_locale = locale.split('-')[0] if locale.find('-') != -1 else ''
+        locale = ENGLISH_LANG
+    fallback_lang = locale.split('-')[0] if locale.find('-') != -1 else ''
     for dcid in dcids:
         values = response[dcid].get('out')
         result[dcid] = ''
@@ -165,15 +165,16 @@ def cached_i18n_name(dcids, locale):
         for entry in values:
             if (has_locale_name(entry, locale)):
                 result[dcid] = extract_locale_name(entry, locale)
-                # Find the exact matches, no need to fall back.
+                # Found the exact match, no need to fall back.
                 break
             else:
-                if (has_locale_name(entry, fallback_locale)):
-                    fallback_choice = extract_locale_name(entry, fallback_locale)
-                if (has_locale_name(entry, english_local)):
-                    english_choice = extract_locale_name(entry, english_local)
+                if (has_locale_name(entry, fallback_lang)):
+                    fallback_choice = extract_locale_name(entry, fallback_lang)
+                if (has_locale_name(entry, ENGLISH_LANG)):
+                    english_choice = extract_locale_name(entry, ENGLISH_LANG)
         if not result[dcid]:
-            result[dcid] = fallback_choice if fallback_choice else english_choice
+            result[
+                dcid] = fallback_choice if fallback_choice else english_choice
     return result
 
 
@@ -185,8 +186,9 @@ def extract_locale_name(entry, locale):
     if entry['value'].endswith('@' + locale.lower()):
         locale_index = len(entry['value']) - len(locale) - 1
         return entry['value'][:locale_index]
-    else :
+    else:
         return ''
+
 
 def get_i18n_name(dcids, locale):
     """"Returns localization names for set of dcids.

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -132,7 +132,7 @@ def api_name():
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def cached_i18n_name(dcids, locale):
-    """Returns localination names for set of dcids.
+    """Returns localization names for set of dcids.
 
     Args:
         dcids: ^ separated string of dcids. It must be a single string for the cache.
@@ -155,14 +155,14 @@ def cached_i18n_name(dcids, locale):
         name_in_en = ''
         result[dcid] = ''
         for entry in values:
-            if entry['value'].endswith(locale):
+            if entry['value'].endswith(locale.lower()):
                 i18nname_end_index = len(entry['value']) - len(locale) - 1
                 result[dcid] = entry['value'][:i18nname_end_index]
             else:
                 if entry['value'].endswith('en'):
                     name_in_en = entry['value'][:(len(entry['value']) -
                                                   len('en') - 1)]
-        # With there isn't a name in required language code, falls back to 
+        # When there isn't a name in required language code, falls back to
         # English name if exists.
         if not result[dcid]:
             result[dcid] = name_in_en
@@ -182,7 +182,7 @@ def get_i18n_name(dcids, locale):
     return cached_i18n_name('^'.join((sorted(dcids))), locale)
 
 
-@bp.route('/i18nname')
+@bp.route('/name/i18n')
 def api_i18n_name():
     """Get place i18n names."""
     dcids = request.args.getlist('dcid')

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -150,23 +150,55 @@ def cached_i18n_name(dcids, locale):
                           compress=False,
                           post=True)
     result = {}
+    if not locale:
+        locale = 'en'
+    fallback_locale = locale.split('-')[0] if locale.find('-') != -1 else ''
+    english_local = 'en'
+    second_choice = ''
+    last_choice = ''
     for dcid in dcids:
         values = response[dcid].get('out')
         name_in_en = ''
         result[dcid] = ''
+        print('locale = ' + locale)
         for entry in values:
-            if entry['value'].endswith(locale.lower()):
-                i18nname_end_index = len(entry['value']) - len(locale) - 1
-                result[dcid] = entry['value'][:i18nname_end_index]
+            print(entry)
+            if (has_locale_name(entry, locale)):
+                result[dcid] = extract_locale_name(entry, locale)
+                break
+            # if entry['value'].endswith('@' + locale.lower()):
+            #     i18nname_end_index = len(entry['value']) - len(locale) - 1
+            #     result[dcid] = entry['value'][:i18nname_end_index]
+            # if result[dcid]:
+            # Already found best match, break out of the loop
+            # break
             else:
-                if entry['value'].endswith('en'):
-                    name_in_en = entry['value'][:(len(entry['value']) -
-                                                  len('en') - 1)]
+                if (has_locale_name(entry, fallback_locale)):
+                    second_choice = extract_locale_name(entry, fallback_locale)
+                if (has_locale_name(entry, english_local)):
+                    last_choice = extract_locale_name(entry, english_local)
+                # if entry['value'].endswith('@' + fallbacl_locale):
+                # if entry['value'].endswith('@en'):
+                #     name_in_en = entry['value'][:(len(entry['value']) -
+                #                                   len('en') - 1)]
         # When there isn't a name in required language code, falls back to
         # English name if exists.
         if not result[dcid]:
-            result[dcid] = name_in_en
+            print('if not result[dcid]:')
+            result[dcid] = second_choice if second_choice else last_choice
     return result
+
+
+def has_locale_name(entry, locale):
+    return entry['value'].endswith('@' + locale.lower())
+
+
+def extract_locale_name(entry, locale):
+    if entry['value'].endswith('@' + locale.lower()):
+        locale_index = len(entry['value']) - len(locale) - 1
+        return entry['value'][:locale_index]
+    else:
+        return ''
 
 
 def get_i18n_name(dcids, locale):

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -159,7 +159,6 @@ def cached_i18n_name(dcids, locale):
     fallback_locale = locale.split('-')[0] if locale.find('-') != -1 else ''
     for dcid in dcids:
         values = response[dcid].get('out')
-        name_in_en = ''
         result[dcid] = ''
         fallback_choice = ''
         english_choice = ''

--- a/server/routes/api/ranking.py
+++ b/server/routes/api/ranking.py
@@ -40,6 +40,7 @@ def ranking_api(stat_var, place_type, place=None):
         pc (per capita - the presence of the key enables it)
         bottom (show bottom ranking instead - the presence of the key enables it)
     """
+    locale = flask.request.args.get('hl', default="en")
     is_per_capita = flask.request.args.get('pc', False) != False
     is_show_bottom = flask.request.args.get('bottom', False) != False
     rank_keys = BOTTOM_KEYS_KEEP if is_show_bottom else TOP_KEYS_KEEP
@@ -82,7 +83,8 @@ def ranking_api(stat_var, place_type, place=None):
                 dcids.add(r['placeDcid'])
             payload[stat_var][k]['info'] = info
             # payload[stat_var][k]['count'] = count
-    place_names = place_api.get_display_name('^'.join(sorted(list(dcids))))
+    place_names = place_api.get_display_name('^'.join(sorted(list(dcids))),
+                                             locale)
     for k in rank_keys:
         if k in payload[stat_var] and 'info' in payload[stat_var][k]:
             for r in payload[stat_var][k]['info']:

--- a/server/routes/ranking.py
+++ b/server/routes/ranking.py
@@ -16,6 +16,8 @@
 import flask
 import routes.api.place as place_api
 
+from flask import request
+
 bp = flask.Blueprint('ranking', __name__, url_prefix='/ranking')
 
 
@@ -24,7 +26,7 @@ bp = flask.Blueprint('ranking', __name__, url_prefix='/ranking')
 def ranking(stat_var, place_type, place_dcid=''):
     place_name = ''
     if place_dcid:
-        place_names = place_api.get_name([place_dcid])
+        place_names = place_api.get_i18n_name([place_dcid])
         place_name = place_names[place_dcid]
         if place_name == '':
             place_name = place_dcid

--- a/server/tests/api_place_test.py
+++ b/server/tests/api_place_test.py
@@ -187,7 +187,7 @@ class TestApiPlaceI18nName(unittest.TestCase):
 
         # There is no hl parameter, use default en.
         response = app.test_client().get(
-            '/api/place/i18nname?dcid=geoId/05&dcid=geoId/06')
+            '/api/place/name/i18n?dcid=geoId/05&dcid=geoId/06')
         assert response.status_code == 200
         assert json.loads(response.data) == {
             'geoId/05': 'ArkansasEn',
@@ -199,11 +199,20 @@ class TestApiPlaceI18nName(unittest.TestCase):
 
         # Arkansas doesn't have name in @it, fall back to @en instead.
         response = app.test_client().get(
-            '/api/place/i18nname?dcid=geoId/05&dcid=geoId/06&hl=it')
+            '/api/place/name/i18n?dcid=geoId/05&dcid=geoId/06&hl=it')
         assert response.status_code == 200
         assert json.loads(response.data) == {
             'geoId/05': 'ArkansasEn',
             'geoId/06': 'CaliforniaIT'
+        }
+
+        # Lower case language code.
+        response = app.test_client().get(
+            '/api/place/name/i18n?dcid=geoId/05&dcid=geoId/06&hl=LA')
+        assert response.status_code == 200
+        assert json.loads(response.data) == {
+            'geoId/05': 'ArkansasEn',
+            'geoId/06': 'CaliforniaLA'
         }
 
 

--- a/server/tests/api_place_test.py
+++ b/server/tests/api_place_test.py
@@ -170,6 +170,9 @@ class TestApiPlaceI18nName(unittest.TestCase):
                 }, {
                     'value': 'ArkansasIO@io',
                     'provenance': 'prov1'
+                }, {
+                    'value': 'ArkansasLA-RU@la-ru',
+                    'provenance': 'prov1'
                 }]
             },
             'geoId/06': {
@@ -212,6 +215,21 @@ class TestApiPlaceI18nName(unittest.TestCase):
         assert response.status_code == 200
         assert json.loads(response.data) == {
             'geoId/05': 'ArkansasEn',
+            'geoId/06': 'CaliforniaLA'
+        }
+
+        # Verify language code parsing correct, not using la-ru.
+        response = app.test_client().get(
+            '/api/place/name/i18n?dcid=geoId/05&hl=ru')
+        assert response.status_code == 200
+        assert json.loads(response.data) == {'geoId/05': 'ArkansasEn'}
+
+        # Verify fall back to the first part of locale, la-ru to la.
+        response = app.test_client().get(
+            '/api/place/name/i18n?dcid=geoId/05&dcid=geoId/06&hl=la-ru')
+        assert response.status_code == 200
+        assert json.loads(response.data) == {
+            'geoId/05': 'ArkansasLA-RU',
             'geoId/06': 'CaliforniaLA'
         }
 

--- a/server/tests/api_place_test.py
+++ b/server/tests/api_place_test.py
@@ -233,6 +233,29 @@ class TestApiPlaceI18nName(unittest.TestCase):
             'geoId/06': 'CaliforniaLA'
         }
 
+        # Verify when there is no nameWithLanguage, fall back to name
+        def side_effect(url, req, compress, post):
+            if 'name' == req['property']:
+                return {
+                    'geoId/08': {
+                        'out': [{
+                            'value': 'Colorado',
+                            'provenance': 'prov2'
+                        }]
+                    }
+                }
+            elif 'nameWithLanguage' == req['property']:
+                return {"geoId/08": {}}
+            else:
+                return {req['dcids'][0]: {}}
+
+        mock_fetch_data.side_effect = side_effect
+        response = app.test_client().get('/api/place/name/i18n?dcid=geoId/08')
+        assert response.status_code == 200
+        assert json.loads(response.data) == {
+            'geoId/08': 'Colorado',
+        }
+
 
 class TestApiDisplayName(unittest.TestCase):
 
@@ -245,6 +268,9 @@ class TestApiDisplayName(unittest.TestCase):
         us_state_parent = 'parent1'
         us_country_parent = 'parent2'
         cad_state_parent = 'parent3'
+        dcid1_en = 'dcid1@en'
+        dcid2_en = 'dcid2@en'
+        dcid3_en = 'dcid3@en'
 
         def side_effect(url, req, compress, post):
             if 'containedInPlace' == req['property']:
@@ -287,21 +313,21 @@ class TestApiDisplayName(unittest.TestCase):
                         'out': []
                     }
                 }
-            elif 'name' == req['property']:
+            elif 'nameWithLanguage' == req['property']:
                 return {
                     dcid1: {
                         'out': [{
-                            'value': dcid1
+                            'value': dcid1_en
                         }]
                     },
                     dcid2: {
                         'out': [{
-                            'value': dcid2
+                            'value': dcid2_en
                         }]
                     },
                     dcid3: {
                         'out': [{
-                            'value': dcid3
+                            'value': dcid3_en
                         }]
                     },
                 }

--- a/static/js/i18n/stats_var_labels.json
+++ b/static/js/i18n/stats_var_labels.json
@@ -1,0 +1,942 @@
+{
+  "Amount_Consumption_Alcohol_15OrMoreYears_AsFractionOf_Count_Person_15OrMoreYears": {
+    "defaultMessage": "Pure Alcohol Consumption",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes amount of pure alcohol consumed as a fraction of people of age."
+  },
+  "Amount_Consumption_Electricity_PerCapita": {
+    "defaultMessage": "Electricity Consumption",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes amount of electricity consumed per capita."
+  },
+  "Amount_Consumption_Energy_PerCapita": {
+    "defaultMessage": "Energy Consumption",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes amount of energy consumed per capita."
+  },
+  "Amount_Debt_Government": {
+    "defaultMessage": "Government Debt",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes total amount of government debt."
+  },
+  "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_ExpenditureActivity_Government": {
+    "defaultMessage": "Government Expenditures on Education (% of Government Expenditures)",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes amount spent by a government on education as a percentage of total expenditure."
+  },
+  "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal": {
+    "defaultMessage": "Government Expenditures on Education (% of GDP)",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes amount spent by a government on education as a percentage of GDP."
+  },
+  "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government": {
+    "defaultMessage": "Government Expenditures on Military",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes amount spent by a government on the military."
+  },
+  "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal": {
+    "defaultMessage": "Government Expenditures on Military (% of GDP)",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes amount spent by a govnerment on the military as a percentage of GDP."
+  },
+  "Amount_EconomicActivity_GrossDomesticProduction_Nominal": {
+    "defaultMessage": "GDP",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes nominal gross domestic production."
+  },
+  "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita": {
+    "defaultMessage": "GDP Per Capita",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes nominal gross domestic production, per capita."
+  },
+  "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity": {
+    "defaultMessage": "GNI PPP",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes gross national income, using purchasing power parity."
+  },
+  "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity_PerCapita": {
+    "defaultMessage": "GNI PPP Per Capita",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes gross national income, using purchasing power parity on a per capita basis."
+  },
+  "Amount_Emissions_CarbonDioxide_PerCapita": {
+    "defaultMessage": "CO2 Emissions",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes amount of Carbon Dioxide emissions, per capita."
+  },
+  "Amount_Remittance_InwardRemittance": {
+    "defaultMessage": "Inward Remittance",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the total amount of inward remittance into a place."
+  },
+  "Amount_Remittance_InwardRemittance_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal": {
+    "defaultMessage": "Inward Remittance (% of GDP)",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the total amount of inward remittance into a place (as a percentage of GDP)."
+  },
+  "Amount_Remittance_OutwardRemittance": {
+    "defaultMessage": "Outward Remittance",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the total amount of outward remittance from a place."
+  },
+  "Amount_Stock": {
+    "defaultMessage": "Market Capitalization of Domestic Companies",
+    "description": "Label used to describe statistical variables in chart legends, string should be short."
+  },
+  "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal": {
+    "defaultMessage": "Market Capitalization of Domestic Companies (% of GDP)",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the market capitalization of domestic companies, as a fraction of GDP."
+  },
+  "Count_CriminalActivities_Arson": {
+    "defaultMessage": "Arson",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the total number of arson incidents."
+  },
+  "Count_CriminalActivities_CombinedCrime": {
+    "defaultMessage": "Combined Crimes",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the total number of crimes (of all types)."
+  },
+  "Count_CriminalActivities_PropertyCrime": {
+    "defaultMessage": "Property Crimes",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the total number of property crimes."
+  },
+  "Count_CriminalActivities_ViolentCrime": {
+    "defaultMessage": "Violent Crimes",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the total number of violent crimes."
+  },
+  "Count_CycloneEvent": {
+    "defaultMessage": "Cyclone",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the number of cyclone events."
+  },
+  "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth": {
+    "defaultMessage": "Infant Mortality Rate",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the number of infant deaths as a percentage of all births."
+  },
+  "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the infant mortality rate for females."
+  },
+  "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the infant mortality rate for males."
+  },
+  "Count_Death_DiseasesOfTheCirculatorySystem": {
+    "defaultMessage": "Circulatory System",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes diseases of the circulatory system in a chart about mortality events."
+  },
+  "Count_Death_DiseasesOfTheNervousSystem": {
+    "defaultMessage": "Nervous System",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes diseases of the nervous system in a chart about mortality events."
+  },
+  "Count_Death_DiseasesOfTheRespiratorySystem": {
+    "defaultMessage": "Respiratory System",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes diseases of the respiratory system in a chart about mortality events."
+  },
+  "Count_Death_ExternalCauses": {
+    "defaultMessage": "External Causes",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes deaths caused by external causes in a chart about mortality events."
+  },
+  "Count_Death_Neoplasms": {
+    "defaultMessage": "Neoplasms",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes deaths caused by neoplasms in a chart about mortality events."
+  },
+  "Count_DroughtEvent": {
+    "defaultMessage": "Drought",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the number of drought events."
+  },
+  "Count_EarthquakeEvent": {
+    "defaultMessage": "Earthquake",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the number of earthquake events."
+  },
+  "Count_FloodEvent": {
+    "defaultMessage": "Flood",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the number of flood events."
+  },
+  "Count_Household_IncomeOf100000To124999USDollar": {
+    "defaultMessage": "$100K to $125K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf10000To14999USDollar": {
+    "defaultMessage": "$10K to $15K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf125000To149999USDollar": {
+    "defaultMessage": "$125K to $150K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf150000To199999USDollar": {
+    "defaultMessage": "$150K to $200K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf200000OrMoreUSDollar": {
+    "defaultMessage": "Over $200K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf20000To24999USDollar": {
+    "defaultMessage": "$20K to $25K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf30000To34999USDollar": {
+    "defaultMessage": "$30K to $35K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf40000To44999USDollar": {
+    "defaultMessage": "$40K to $45K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf50000To59999USDollar": {
+    "defaultMessage": "$50K to $60K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf60000To74999USDollar": {
+    "defaultMessage": "$60K to $75K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOf75000To99999USDollar": {
+    "defaultMessage": "$75K to $100K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_Household_IncomeOfUpto10000USDollar": {
+    "defaultMessage": "Under $10K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of household income in US Dollars."
+  },
+  "Count_HousingUnit": {
+    "defaultMessage": "Housing Units",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the number of housing units available."
+  },
+  "Count_HousingUnit_1940To1949DateBuilt": {
+    "defaultMessage": "1940 - 1949",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of dates in which homes were built."
+  },
+  "Count_HousingUnit_1950To1959DateBuilt": {
+    "defaultMessage": "1950 - 1959",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of dates in which homes were built."
+  },
+  "Count_HousingUnit_1960To1969DateBuilt": {
+    "defaultMessage": "1960 - 1969",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of dates in which homes were built."
+  },
+  "Count_HousingUnit_1970To1979DateBuilt": {
+    "defaultMessage": "1970 - 1979",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of dates in which homes were built."
+  },
+  "Count_HousingUnit_1980To1989DateBuilt": {
+    "defaultMessage": "1980 - 1989",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of dates in which homes were built."
+  },
+  "Count_HousingUnit_1990To1999DateBuilt": {
+    "defaultMessage": "1990 - 1999",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of dates in which homes were built."
+  },
+  "Count_HousingUnit_2000To2009DateBuilt": {
+    "defaultMessage": "2000 - 2009",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of dates in which homes were built."
+  },
+  "Count_HousingUnit_2010OrLaterDateBuilt": {
+    "defaultMessage": "After 2010",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of dates in which homes were built."
+  },
+  "Count_HousingUnit_Before1939DateBuilt": {
+    "defaultMessage": "Before 1939",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of dates in which homes were built."
+  },
+  "Count_HousingUnit_HomeValue1000000To1499999USDollar": {
+    "defaultMessage": "$1M - $1.5M",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of home values, in US Dollars."
+  },
+  "Count_HousingUnit_HomeValue100000To199999USDollar": {
+    "defaultMessage": "$100K - $200K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of home values, in US Dollars."
+  },
+  "Count_HousingUnit_HomeValue1500000To1999999USDollar": {
+    "defaultMessage": "$1.5M - $2M",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of home values, in US Dollars."
+  },
+  "Count_HousingUnit_HomeValue2000000OrMoreUSDollar": {
+    "defaultMessage": "$2M+",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of home values, in US Dollars."
+  },
+  "Count_HousingUnit_HomeValue200000To299999USDollar": {
+    "defaultMessage": "$200K - $300K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of home values, in US Dollars."
+  },
+  "Count_HousingUnit_HomeValue300000To499999USDollar": {
+    "defaultMessage": "$300K - $500K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of home values, in US Dollars."
+  },
+  "Count_HousingUnit_HomeValue500000To999999USDollar": {
+    "defaultMessage": "$500K - $1M",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of home values, in US Dollars."
+  },
+  "Count_HousingUnit_HomeValue50000To99999USDollar": {
+    "defaultMessage": "$50K - $100K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of home values, in US Dollars."
+  },
+  "Count_HousingUnit_HomeValueUpto49999USDollar": {
+    "defaultMessage": "0 - $50K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of home values, in US Dollars."
+  },
+  "Count_HousingUnit_HouseholderRaceAmericanIndianOrAlaskaNativeAlone": {
+    "defaultMessage": "American Indian or Alaska Native",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a household."
+  },
+  "Count_HousingUnit_HouseholderRaceAsianAlone": {
+    "defaultMessage": "Asian Alone",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a household."
+  },
+  "Count_HousingUnit_HouseholderRaceBlackOrAfricanAmericanAlone": {
+    "defaultMessage": "Black or African American",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a household."
+  },
+  "Count_HousingUnit_HouseholderRaceHispanicOrLatino": {
+    "defaultMessage": "Hispanic or Latino",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a household."
+  },
+  "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone": {
+    "defaultMessage": "Native Hawaiian or Pacific Islander",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a household."
+  },
+  "Count_HousingUnit_HouseholderRaceSomeOtherRaceAlone": {
+    "defaultMessage": "Some Other Race",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a household."
+  },
+  "Count_HousingUnit_HouseholderRaceTwoOrMoreRaces": {
+    "defaultMessage": "Two or More Races",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a household."
+  },
+  "Count_HousingUnit_HouseholderRaceWhiteAlone": {
+    "defaultMessage": "White Alone",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a household."
+  },
+  "Count_HousingUnit_OwnerOccupied": {
+    "defaultMessage": "Owner",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe owner occupied homes."
+  },
+  "Count_HousingUnit_RenterOccupied": {
+    "defaultMessage": "Renter",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe renter occupied homes."
+  },
+  "Count_Person": {
+    "defaultMessage": "Total Population",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the total population of a place."
+  },
+  "Count_Person_10To14Years": {
+    "defaultMessage": "10-14",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_10To19Years": {
+    "defaultMessage": "10-19",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_15OrMoreYears": {
+    "defaultMessage": "15+",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_15To19Years": {
+    "defaultMessage": "15-19",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_15To64Years_InLaborForce_AsFractionOf_Count_Person_15To64Years": {
+    "defaultMessage": "People in Labor Force",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe people in the labor force as a fraction of people of age to work."
+  },
+  "Count_Person_16OrMoreYears": {
+    "defaultMessage": "16+",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_18To24Years": {
+    "defaultMessage": "18-24",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_20To24Years": {
+    "defaultMessage": "20-24",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_20To29Years": {
+    "defaultMessage": "20-29",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_25To29Years": {
+    "defaultMessage": "25-29",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_25To34Years": {
+    "defaultMessage": "25-34",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_25To34Years_EducationalAttainmentAssociatesDegree_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to distinguish between genders of associates degree holders."
+  },
+  "Count_Person_25To34Years_EducationalAttainmentAssociatesDegree_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to distinguish between genders of associates degree holders."
+  },
+  "Count_Person_25To34Years_EducationalAttainmentBachelorsDegree_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to distinguish between genders of bachelors degree holders."
+  },
+  "Count_Person_25To34Years_EducationalAttainmentBachelorsDegree_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to distinguish between genders of bachelors degree holders."
+  },
+  "Count_Person_25To34Years_EducationalAttainmentGraduateOrProfessionalDegree_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to distinguish between genders of graduate or professional degree holders."
+  },
+  "Count_Person_25To34Years_EducationalAttainmentGraduateOrProfessionalDegree_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to distinguish between genders of graduate or professional degree holders."
+  },
+  "Count_Person_30To34Years": {
+    "defaultMessage": "30-34",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_30To39Years": {
+    "defaultMessage": "30-39",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_35To39Years": {
+    "defaultMessage": "35-39",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_35To44Years": {
+    "defaultMessage": "35-44",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_40To44Years": {
+    "defaultMessage": "40-44",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_40To49Years": {
+    "defaultMessage": "40-49",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_45To49Years": {
+    "defaultMessage": "45-49",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_45To54Years": {
+    "defaultMessage": "45-54",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_50To54Years": {
+    "defaultMessage": "50-54",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_50To59Years": {
+    "defaultMessage": "50-59",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_55To59Years": {
+    "defaultMessage": "55-59",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_55To64Years": {
+    "defaultMessage": "55-64",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_5To17Years": {
+    "defaultMessage": "5-17",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_5To9Years": {
+    "defaultMessage": "5-9",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_60To61Years": {
+    "defaultMessage": "60-61",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_60To64Years": {
+    "defaultMessage": "60-64",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_60To69Years": {
+    "defaultMessage": "60-69",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_62To64Years": {
+    "defaultMessage": "62-64",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_65To69Years": {
+    "defaultMessage": "65-69",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_65To74Years": {
+    "defaultMessage": "65-74",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_70OrMoreYears": {
+    "defaultMessage": "70+",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_70To74Years": {
+    "defaultMessage": "70-74",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_70To79Years": {
+    "defaultMessage": "70-79",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_75OrMoreYears": {
+    "defaultMessage": "75+",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_75To79Years": {
+    "defaultMessage": "75-79",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_7To14Years_Employed_AsFractionOf_Count_Person_7To14Years": {
+    "defaultMessage": "Children in Employment",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the percentage of children who are employed."
+  },
+  "Count_Person_7To14Years_Female_Employed_AsFractionOf_Count_Person_7To14Years_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the percentage of female children who are employed."
+  },
+  "Count_Person_7To14Years_Male_Employed_AsFractionOf_Count_Person_7To14Years_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the percentage of male children who are employed."
+  },
+  "Count_Person_80OrMoreYears": {
+    "defaultMessage": "80+",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_80To84Years": {
+    "defaultMessage": "80-84",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages in a population."
+  },
+  "Count_Person_AmericanIndianOrAlaskaNativeAlone": {
+    "defaultMessage": "American Indian or Alaska Native",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population."
+  },
+  "Count_Person_AsianAlone": {
+    "defaultMessage": "Asian Alone",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population."
+  },
+  "Count_Person_BelowPovertyLevelInThePast12Months": {
+    "defaultMessage": "Poverty",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the number of poeple living below the poverty level."
+  },
+  "Count_Person_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone": {
+    "defaultMessage": "American Indian or Alaska Native",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population living below the poverty level."
+  },
+  "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone": {
+    "defaultMessage": "Asian",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population living below the poverty level."
+  },
+  "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone": {
+    "defaultMessage": "Black or African American",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population living below the poverty level."
+  },
+  "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino": {
+    "defaultMessage": "Hispanic or Latino",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population living below the poverty level."
+  },
+  "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone": {
+    "defaultMessage": "Native Hawaiian or Pacific Islander",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population living below the poverty level."
+  },
+  "Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone": {
+    "defaultMessage": "White",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population living below the poverty level."
+  },
+  "Count_Person_BlackOrAfricanAmericanAlone": {
+    "defaultMessage": "Black or African American",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population."
+  },
+  "Count_Person_Divorced": {
+    "defaultMessage": "Divorced",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the marital status of a population."
+  },
+  "Count_Person_EducationalAttainmentBachelorsDegree": {
+    "defaultMessage": "Bachelors",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the educational attainment of a population."
+  },
+  "Count_Person_EducationalAttainmentDoctorateDegree": {
+    "defaultMessage": "Doctorate",
+    "description": "Label used to describe statistical variables in chart legends, string should be short Used to describe the educational attainment of a population.."
+  },
+  "Count_Person_EducationalAttainmentMastersDegree": {
+    "defaultMessage": "Masters",
+    "description": "Label used to describe statistical variables in chart legends, string should be short Used to describe the educational attainment of a population.."
+  },
+  "Count_Person_EducationalAttainmentNoSchoolingCompleted": {
+    "defaultMessage": "No Schooling",
+    "description": "Label used to describe statistical variables in chart legends, string should be short Used to describe the educational attainment of a population.."
+  },
+  "Count_Person_EducationalAttainmentRegularHighSchoolDiploma": {
+    "defaultMessage": "High School",
+    "description": "Label used to describe statistical variables in chart legends, string should be short Used to describe the educational attainment of a population.."
+  },
+  "Count_Person_Employed": {
+    "defaultMessage": "Employed People",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the employment status of a population."
+  },
+  "Count_Person_EnrolledInSchool": {
+    "defaultMessage": "Enrolled in School",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe school enrollment of a population."
+  },
+  "Count_Person_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a gender of the population."
+  },
+  "Count_Person_Female_BelowPovertyLevelInThePast12Months": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the gender of a population below the poverty level."
+  },
+  "Count_Person_HispanicOrLatino": {
+    "defaultMessage": "Hispanic or Latino",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population."
+  },
+  "Count_Person_InLaborForce": {
+    "defaultMessage": "People in Labor Force",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the number of people in the labor force."
+  },
+  "Count_Person_IncomeOf10000To14999USDollar": {
+    "defaultMessage": "$10K to $15K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of indvidiual income, in US Dollars."
+  },
+  "Count_Person_IncomeOf15000To24999USDollar": {
+    "defaultMessage": "$15K to $25K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of indvidiual income, in US Dollars."
+  },
+  "Count_Person_IncomeOf25000To34999USDollar": {
+    "defaultMessage": "$25K to $35K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of indvidiual income, in US Dollars."
+  },
+  "Count_Person_IncomeOf35000To49999USDollar": {
+    "defaultMessage": "$35K to $50K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of indvidiual income, in US Dollars."
+  },
+  "Count_Person_IncomeOf50000To64999USDollar": {
+    "defaultMessage": "$50K to $65K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of indvidiual income, in US Dollars."
+  },
+  "Count_Person_IncomeOf65000To74999USDollar": {
+    "defaultMessage": "$65K to $75K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of indvidiual income, in US Dollars."
+  },
+  "Count_Person_IncomeOf75000OrMoreUSDollar": {
+    "defaultMessage": "Over $75K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of indvidiual income, in US Dollars."
+  },
+  "Count_Person_IncomeOfUpto9999USDollar": {
+    "defaultMessage": "Under $10K",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of indvidiual income, in US Dollars."
+  },
+  "Count_Person_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a gender of the population."
+  },
+  "Count_Person_Male_BelowPovertyLevelInThePast12Months": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the gender of a population below the poverty level."
+  },
+  "Count_Person_MarriedAndNotSeparated": {
+    "defaultMessage": "Married",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the marital status of a population."
+  },
+  "Count_Person_NativeHawaiianOrOtherPacificIslanderAlone": {
+    "defaultMessage": "Native Hawaiian or Pacific Islander",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population."
+  },
+  "Count_Person_NeverMarried": {
+    "defaultMessage": "Never Married",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the marital status of a population."
+  },
+  "Count_Person_NotAUSCitizen": {
+    "defaultMessage": "Not a Citizen",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the citizenship of a population."
+  },
+  "Count_Person_NotEnrolledInSchool": {
+    "defaultMessage": "Not Enrolled in School",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the school enrollment status of a population."
+  },
+  "Count_Person_PerArea": {
+    "defaultMessage": "Population Density",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the population size per area."
+  },
+  "Count_Person_Rural": {
+    "defaultMessage": "Rural Population",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the size of the population living in urban areas."
+  },
+  "Count_Person_Separated": {
+    "defaultMessage": "Separated",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the marital status of a population."
+  },
+  "Count_Person_SomeOtherRaceAlone": {
+    "defaultMessage": "Some Other Race",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population."
+  },
+  "Count_Person_TwoOrMoreRaces": {
+    "defaultMessage": "Two or More Races",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population."
+  },
+  "Count_Person_USCitizenBornAbroadOfAmericanParents": {
+    "defaultMessage": "Born Abroad",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the citizenship status of a population."
+  },
+  "Count_Person_USCitizenBornInTheUnitedStates": {
+    "defaultMessage": "Born in USA",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the citizenship status of a population."
+  },
+  "Count_Person_USCitizenByNaturalization": {
+    "defaultMessage": "Citizen by Naturalization",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the citizenship status of a population."
+  },
+  "Count_Person_Upto4Years": {
+    "defaultMessage": "0-4",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages of a population."
+  },
+  "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the gender of children affected by severe wasting."
+  },
+  "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the gender of children affected by wasting."
+  },
+  "Count_Person_Upto4Years_Male_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the gender of children affected by severe wasting."
+  },
+  "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the gender of children affected by wasting."
+  },
+  "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years": {
+    "defaultMessage": "Severely Wasted Children under 5",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the gender of children affected by severe wasting."
+  },
+  "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years": {
+    "defaultMessage": "Wasted Children under 5",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the gender of children affected by wasting."
+  },
+  "Count_Person_Upto9Years": {
+    "defaultMessage": "0-9",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a range of ages of a population."
+  },
+  "Count_Person_Urban": {
+    "defaultMessage": "Urban Population",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the size of the population living in urban areas."
+  },
+  "Count_Person_WhiteAlone": {
+    "defaultMessage": "White Alone",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the race of a population."
+  },
+  "Count_Person_Widowed": {
+    "defaultMessage": "Widowed",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the marital status of a population."
+  },
+  "Count_StormSurgeTideEvent": {
+    "defaultMessage": "Storm Surge Tide",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a type of natural disaster."
+  },
+  "Count_ThunderstormWindEvent": {
+    "defaultMessage": "Thunderstorm",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a type of natural disaster."
+  },
+  "Count_TornadoEvent": {
+    "defaultMessage": "Tornado",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a type of natural disaster."
+  },
+  "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance": {
+    "defaultMessage": "Unemployment Insurance Claims",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the number of unemployement insurance claims."
+  },
+  "Count_WildlandFireEvent": {
+    "defaultMessage": "Wildland Fire",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a type of natural disaster."
+  },
+  "CumulativeCount_MedicalConditionIncident_COVID_19_ConfirmedOrProbableCase": {
+    "defaultMessage": "COVID-19 Cumulative Cases",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the cumulative number of COVID-19 cases."
+  },
+  "CumulativeCount_MedicalConditionIncident_COVID_19_PatientDeceased": {
+    "defaultMessage": "COVID-19 Cumulative Deaths",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe the cumulative number of COVID-19 deaths."
+  },
+  "FertilityRate_Person_Female": {
+    "defaultMessage": "Fertility Rate",
+    "description": "Label used to describe statistical variables in chart legends, string should be short."
+  },
+  "GiniIndex_EconomicActivity": {
+    "defaultMessage": "Gini Index",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Used to describe a measure of inequality, see https://stats.oecd.org/glossary/detail.asp?ID=4842"
+  },
+  "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction": {
+    "defaultMessage": "GDP Growth Rate",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes annual percentage growth rate of GDP at market prices based on constant local currency."
+  },
+  "GrowthRate_Count_Person": {
+    "defaultMessage": "Population Growth Rate",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes increase in the number of individuals in a population."
+  },
+  "LifeExpectancy_Person": {
+    "defaultMessage": "Life Expectancy",
+    "description": "Label used to describe statistical variables in chart legends, string should be short."
+  },
+  "Median_Age_Person": {
+    "defaultMessage": "Median Age",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the median age of a population."
+  },
+  "Median_Age_Person_AmericanIndianOrAlaskaNativeAlone": {
+    "defaultMessage": "American Indian or Alaska Native",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median age across races."
+  },
+  "Median_Age_Person_AsianAlone": {
+    "defaultMessage": "Asian Alone",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median age across races."
+  },
+  "Median_Age_Person_BlackOrAfricanAmericanAlone": {
+    "defaultMessage": "Black or African American",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median age across races."
+  },
+  "Median_Age_Person_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the gender of a group, in a chart describing the median age across genders."
+  },
+  "Median_Age_Person_HispanicOrLatino": {
+    "defaultMessage": "Hispanic or Latino",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median age across races."
+  },
+  "Median_Age_Person_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the gender of a group, in a chart describing the median age across genders."
+  },
+  "Median_Age_Person_NativeHawaiianOrOtherPacificIslanderAlone": {
+    "defaultMessage": "Native Hawaiian or Pacific Islander",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median age across races."
+  },
+  "Median_Age_Person_SomeOtherRaceAlone": {
+    "defaultMessage": "Some Other Race",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median age across races."
+  },
+  "Median_Age_Person_TwoOrMoreRaces": {
+    "defaultMessage": "Two or More Races",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median age across races."
+  },
+  "Median_Age_Person_WhiteAlone": {
+    "defaultMessage": "White Alone",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median age across races."
+  },
+  "Median_Income_Household": {
+    "defaultMessage": "Median Household Income",
+    "description": "Label used to describe statistical variables in chart legends, string should be short."
+  },
+  "Median_Income_Household_HouseholderRaceAmericanIndianOrAlaskaNativeAlone": {
+    "defaultMessage": "American Indian or Alaska Native",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median age across races."
+  },
+  "Median_Income_Household_HouseholderRaceAsianAlone": {
+    "defaultMessage": "Asian",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median household income across races."
+  },
+  "Median_Income_Household_HouseholderRaceBlackOrAfricanAmericanAlone": {
+    "defaultMessage": "Black or African American",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median household income across races."
+  },
+  "Median_Income_Household_HouseholderRaceHispanicOrLatino": {
+    "defaultMessage": "Hispanic or Latino",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median household income across races."
+  },
+  "Median_Income_Household_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone": {
+    "defaultMessage": "Native Hawaiian or Pacific Islander",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median household income across races."
+  },
+  "Median_Income_Household_HouseholderRaceWhiteAlone": {
+    "defaultMessage": "White",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a group, in a chart describing the median household income across races."
+  },
+  "Median_Income_Person": {
+    "defaultMessage": "Median Income",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes median individual income."
+  },
+  "Median_Income_Person_15OrMoreYears_Female_WithIncome": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes gender, in a chart describing median incomes across genders."
+  },
+  "Median_Income_Person_15OrMoreYears_Male_WithIncome": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes gender, in a chart describing median incomes across genders."
+  },
+  "Percent_Person_18To64Years_Female_NoHealthInsurance": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes gender, in a chart describing portions of the population without health insurance."
+  },
+  "Percent_Person_18To64Years_Male_NoHealthInsurance": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes gender, in a chart describing portions of the population without health insurance."
+  },
+  "Percent_Person_18To64Years_NoHealthInsurance_BlackOrAfricanAmericanAlone": {
+    "defaultMessage": "Black Or African American",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a population without health insurance."
+  },
+  "Percent_Person_18To64Years_NoHealthInsurance_HispanicOrLatino": {
+    "defaultMessage": "Hispanic or Latino",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a population without health insurance."
+  },
+  "Percent_Person_18To64Years_NoHealthInsurance_WhiteAlone": {
+    "defaultMessage": "White",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the race of a population without health insurance."
+  },
+  "Percent_Person_BingeDrinking": {
+    "defaultMessage": "Binge Drinking",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "Percent_Person_Obesity": {
+    "defaultMessage": "Obesity",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "Percent_Person_PhysicalInactivity": {
+    "defaultMessage": "Physical Inactivity",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "Percent_Person_SleepLessThan7Hours": {
+    "defaultMessage": "Sleep Less Than 7 Hours",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "Percent_Person_Smoking": {
+    "defaultMessage": "Smoking",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "Percent_Person_WithArthritis": {
+    "defaultMessage": "Arthritis",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "Percent_Person_WithHighBloodPressure": {
+    "defaultMessage": "High Blood Pressure",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "Percent_Person_WithHighCholesterol": {
+    "defaultMessage": "High Cholesterol",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "Percent_Person_WithMentalHealthNotGood": {
+    "defaultMessage": "Mental Health Not Good",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "Percent_Person_WithPhysicalHealthNotGood": {
+    "defaultMessage": "Physical Health Not Good",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the percentage of people who have a negative health behavior."
+  },
+  "RetailDrugDistribution_DrugDistribution_Amphetamine": {
+    "defaultMessage": "Amphetamine",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes a retail prescription drug."
+  },
+  "RetailDrugDistribution_DrugDistribution_Codeine": {
+    "defaultMessage": "Codeine",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes a retail prescription drug."
+  },
+  "RetailDrugDistribution_DrugDistribution_Hydrocodone": {
+    "defaultMessage": "Hydrocodone",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes a retail prescription drug."
+  },
+  "RetailDrugDistribution_DrugDistribution_Morphine": {
+    "defaultMessage": "Morphine",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes a retail prescription drug."
+  },
+  "RetailDrugDistribution_DrugDistribution_Oxycodone": {
+    "defaultMessage": "Oxycodone",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes a retail prescription drug."
+  },
+  "UnemploymentRate_Person": {
+    "defaultMessage": "Unemployment Rate",
+    "description": "Label used to describe statistical variables in chart legends, string should be short."
+  },
+  "UnemploymentRate_Person_Female": {
+    "defaultMessage": "Female",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the gender of a population who are unemployed."
+  },
+  "UnemploymentRate_Person_Male": {
+    "defaultMessage": "Male",
+    "description": "Label used to describe statistical variables in chart legends, string should be short. Describes the gender of a population who are unemployed."
+  }
+}


### PR DESCRIPTION
1) Make locale a default value in cached_i18n_name, get_i18n_name in case upstream missing it.
2) Update cached_i18n_name to fall back to name, if there is no nameWithLanguage, which is legitimate for some places.
3) Switch to use cached_i18n_name or get_i18n_name and have caller pass in locale.

Added unit test 

Tested 
ranking.py 
http://127.0.0.1:8080/api/ranking/Count_Person/Place/geoId/06?hl=zh https://screenshot.googleplex.com/PA4xj69AY3R7b9p
landing_page.py
http://127.0.0.1:8080/api/landingpage/data/geoId/17043 https://screenshot.googleplex.com/5r7C3B2JavYMXDU

Failed to test chart.py. Any suggestion on the URL for /geojson/?
http://127.0.0.1:8080/api/chart/geojson/geoId/0667000 doesn't work.