### PR TITLE
Switch to i18n name

### DIFF
--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -101,7 +101,8 @@ def get_choropleth_places(geoDcid):
 
 
 @bp.route('/geojson/<path:dcid>')
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+# TODO(hanlu): pasrse locale once from global context instead.
 def geojson(dcid):
     """
     Get geoJson data for a given place

--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -25,7 +25,7 @@ import routes.api.choropleth as choropleth_api
 import routes.api.landing_page as landing_page_api
 
 from cache import cache
-from flask import Blueprint, current_app, Response
+from flask import Blueprint, current_app, request, Response
 from routes.api.place import EQUIVALENT_PLACE_TYPES
 # Define blueprint
 bp = Blueprint("api_chart", __name__, url_prefix='/api/chart')
@@ -110,7 +110,8 @@ def geojson(dcid):
     if not geos:
         return Response(json.dumps({}), 200, mimetype='application/json')
 
-    names_by_geo = place_api.get_display_name('^'.join(geos))
+    locale = request.args.get('hl', default="en")
+    names_by_geo = place_api.get_display_name('^'.join(geos), locale)
     geojson_by_geo = dc_service.get_property_values(geos, geojson_prop)
     features = []
     for geo_id, json_text in geojson_by_geo.items():

--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -24,7 +24,7 @@ import json
 import logging
 import urllib
 
-from flask import Blueprint, current_app, Response, url_for
+from flask import Blueprint, current_app, request, Response, url_for
 from collections import defaultdict
 
 from cache import cache
@@ -357,6 +357,7 @@ def data(dcid):
     """
     logging.info("Landing Page: cache miss for %s, fetch and process data ...",
                  dcid)
+    locale = request.args.get('hl', default="en")
     spec_and_stat, stat_vars = build_spec(current_app.config['CHART_CONFIG'])
     raw_page_data = get_landing_page_data(dcid, stat_vars)
 
@@ -474,7 +475,7 @@ def data(dcid):
     all_places = [dcid]
     for t in BAR_CHART_TYPES:
         all_places.extend(raw_page_data.get(t + 'Places', []))
-    names = place_api.get_display_name('^'.join(sorted(all_places)))
+    names = place_api.get_display_name('^'.join(sorted(all_places)), locale)
 
     # Pick data to highlight - only population for now
     population, statvar_denom = get_snapshot_across_places(

--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -350,7 +350,7 @@ def scale_series(numerator, denominator):
 
 
 @bp.route('/data/<path:dcid>')
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
 def data(dcid):
     """
     Get chart spec and stats data of the landing page for a given place.

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -132,7 +132,7 @@ def api_name():
 
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def cached_i18n_name(dcids, locale):
+def cached_i18n_name(dcids, locale="en"):
     """Returns localization names for set of dcids.
 
     Args:
@@ -159,6 +159,10 @@ def cached_i18n_name(dcids, locale):
     fallback_lang = locale.split('-')[0] if locale.find('-') != -1 else ''
     for dcid in dcids:
         values = response[dcid].get('out')
+        # If there is no nameWithLanguage for this dcid, fall back to name.
+        if not values:
+            result[dcid] = cached_name(dcid)[dcid]
+            continue
         result[dcid] = ''
         fallback_choice = ''
         english_choice = ''
@@ -190,7 +194,7 @@ def extract_locale_name(entry, locale):
         return ''
 
 
-def get_i18n_name(dcids, locale):
+def get_i18n_name(dcids, locale="en"):
     """"Returns localization names for set of dcids.
 
     Args:
@@ -255,7 +259,8 @@ def child(dcid):
     return Response(json.dumps(child_places), 200, mimetype='application/json')
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+# TODO(hanlu): get nameWithLanguage instead of using name.
+# @cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def child_fetch(dcid):
     contained_response = fetch_data('/node/property-values', {
         'dcids': [dcid],
@@ -580,17 +585,18 @@ def get_state_code(dcids):
 
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def get_display_name(dcids):
+def get_display_name(dcids, locale="en"):
     """ Get display names for a list of places. Display name is place name with state code
     if it has a parent place that is a state.
 
     Args:
         dcids: ^ separated string of dcids. It must be a single string for the cache.
+        locale: the desired localization language code.
 
     Returns:
         A dictionary of display names, keyed by dcid.
     """
-    place_names = cached_name(dcids)
+    place_names = cached_i18n_name(dcids, locale)
     parents = parent_places(dcids)
     dcids = dcids.split('^')
     result = {}
@@ -620,5 +626,6 @@ def api_display_name():
     Get display names for a list of places.
     """
     dcids = request.args.getlist('dcid')
-    result = get_display_name('^'.join((sorted(dcids))))
+    locale = request.args.get('hl', default="en")
+    result = get_display_name('^'.join((sorted(dcids))), locale)
     return Response(json.dumps(result), 200, mimetype='application/json')

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -131,7 +131,7 @@ def api_name():
     return Response(json.dumps(result), 200, mimetype='application/json')
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
 def cached_i18n_name(dcids, locale="en"):
     """Returns localization names for set of dcids.
 
@@ -260,7 +260,7 @@ def child(dcid):
 
 
 # TODO(hanlu): get nameWithLanguage instead of using name.
-# @cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def child_fetch(dcid):
     contained_response = fetch_data('/node/property-values', {
         'dcids': [dcid],

--- a/server/routes/api/ranking.py
+++ b/server/routes/api/ranking.py
@@ -40,6 +40,7 @@ def ranking_api(stat_var, place_type, place=None):
         pc (per capita - the presence of the key enables it)
         bottom (show bottom ranking instead - the presence of the key enables it)
     """
+    locale = flask.request.args.get('hl', default="en")
     is_per_capita = flask.request.args.get('pc', False) != False
     is_show_bottom = flask.request.args.get('bottom', False) != False
     rank_keys = BOTTOM_KEYS_KEEP if is_show_bottom else TOP_KEYS_KEEP
@@ -82,7 +83,8 @@ def ranking_api(stat_var, place_type, place=None):
                 dcids.add(r['placeDcid'])
             payload[stat_var][k]['info'] = info
             # payload[stat_var][k]['count'] = count
-    place_names = place_api.get_display_name('^'.join(sorted(list(dcids))))
+    place_names = place_api.get_display_name('^'.join(sorted(list(dcids))),
+                                             locale)
     for k in rank_keys:
         if k in payload[stat_var] and 'info' in payload[stat_var][k]:
             for r in payload[stat_var][k]['info']:

--- a/server/routes/ranking.py
+++ b/server/routes/ranking.py
@@ -16,15 +16,18 @@
 import flask
 import routes.api.place as place_api
 
+from flask import request
+
 bp = flask.Blueprint('ranking', __name__, url_prefix='/ranking')
 
 
 @bp.route('/<stat_var>/<place_type>', strict_slashes=False)
 @bp.route('/<stat_var>/<place_type>/<path:place_dcid>')
 def ranking(stat_var, place_type, place_dcid=''):
+    locale = request.args.get('hl', default="en")
     place_name = ''
     if place_dcid:
-        place_names = place_api.get_name([place_dcid])
+        place_names = place_api.get_i18n_name([place_dcid], locale)
         place_name = place_names[place_dcid]
         if place_name == '':
             place_name = place_dcid

--- a/server/tests/api_place_test.py
+++ b/server/tests/api_place_test.py
@@ -233,6 +233,29 @@ class TestApiPlaceI18nName(unittest.TestCase):
             'geoId/06': 'CaliforniaLA'
         }
 
+        # Verify when there is no nameWithLanguage, fall back to name
+        def side_effect(url, req, compress, post):
+            if 'name' == req['property']:
+                return {
+                    'geoId/08': {
+                        'out': [{
+                            'value': 'Colorado',
+                            'provenance': 'prov2'
+                        }]
+                    }
+                }
+            elif 'nameWithLanguage' == req['property']:
+                return {"geoId/08": {}}
+            else:
+                return {req['dcids'][0]: {}}
+
+        mock_fetch_data.side_effect = side_effect
+        response = app.test_client().get('/api/place/name/i18n?dcid=geoId/08')
+        assert response.status_code == 200
+        assert json.loads(response.data) == {
+            'geoId/08': 'Colorado',
+        }
+
 
 class TestApiDisplayName(unittest.TestCase):
 
@@ -245,6 +268,9 @@ class TestApiDisplayName(unittest.TestCase):
         us_state_parent = 'parent1'
         us_country_parent = 'parent2'
         cad_state_parent = 'parent3'
+        dcid1_en = 'dcid1@en'
+        dcid2_en = 'dcid2@en'
+        dcid3_en = 'dcid3@en'
 
         def side_effect(url, req, compress, post):
             if 'containedInPlace' == req['property']:
@@ -287,21 +313,21 @@ class TestApiDisplayName(unittest.TestCase):
                         'out': []
                     }
                 }
-            elif 'name' == req['property']:
+            elif 'nameWithLanguage' == req['property']:
                 return {
                     dcid1: {
                         'out': [{
-                            'value': dcid1
+                            'value': dcid1_en
                         }]
                     },
                     dcid2: {
                         'out': [{
-                            'value': dcid2
+                            'value': dcid2_en
                         }]
                     },
                     dcid3: {
                         'out': [{
-                            'value': dcid3
+                            'value': dcid3_en
                         }]
                     },
                 }

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -2255,9 +2255,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
-      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
+      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -2273,9 +2273,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -2285,12 +2285,12 @@
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "globals": {
@@ -7200,26 +7200,26 @@
       }
     },
     "eslint": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
-      "integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.15.0.tgz",
+      "integrity": "sha512-Vr64xFDT8w30wFll643e7cGrIkPEU50yIiI36OdSIDoSGguIeaLzBo0vpGvzo9RECUqq7htURfwEtKqwytkqzA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.1.3",
+        "@eslint/eslintrc": "^0.2.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
-        "eslint-scope": "^5.1.0",
+        "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^1.3.0",
-        "espree": "^7.3.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
         "esquery": "^1.2.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
+        "file-entry-cache": "^6.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
@@ -7245,12 +7245,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -7291,13 +7290,19 @@
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+          "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+          "dev": true
         },
         "glob-parent": {
           "version": "5.1.1",
@@ -7323,6 +7328,15 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7336,10 +7350,13 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "shebang-command": {
           "version": "2.0.0",
@@ -7364,6 +7381,12 @@
           "requires": {
             "isexe": "^2.0.0"
           }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -7450,13 +7473,13 @@
       "dev": true
     },
     "espree": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
-      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
       "requires": {
         "acorn": "^7.4.0",
-        "acorn-jsx": "^5.2.0",
+        "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^1.3.0"
       }
     },
@@ -7845,12 +7868,12 @@
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
     },
     "file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
+      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
       "dev": true,
       "requires": {
-        "flat-cache": "^2.0.1"
+        "flat-cache": "^3.0.4"
       }
     },
     "file-loader": {
@@ -7965,20 +7988,19 @@
       }
     },
     "flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
       },
       "dependencies": {
         "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -7987,9 +8009,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
+      "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
       "dev": true
     },
     "flush-write-stream": {
@@ -9054,9 +9076,9 @@
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -16031,15 +16053,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1"
-      }
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/static/package.json
+++ b/static/package.json
@@ -71,7 +71,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.4",
     "enzyme-to-json": "^3.5.0",
-    "eslint": "^7.9.0",
+    "eslint": "^7.15.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",


### PR DESCRIPTION
Make locale a default value in cached_i18n_name, get_i18n_name in case upstream missing it.
Update cached_i18n_name to fall back to name, if there is no nameWithLanguage, which is legitimate for some places.
Switch to use cached_i18n_name or get_i18n_name and have caller pass in locale.
Added unit test

Tested
ranking.py
http://127.0.0.1:8080/api/ranking/Count_Person/Place/geoId/06?hl=zh https://screenshot.googleplex.com/PA4xj69AY3R7b9p
landing_page.py
http://127.0.0.1:8080/api/landingpage/data/geoId/17043 https://screenshot.googleplex.com/5r7C3B2JavYMXDU
chart.py http://127.0.0.1:8080/api/chart/geojson/geoId/06 https://screenshot.googleplex.com/Aa7CqX28LuiLAAj

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacommonsorg/website/728)
<!-- Reviewable:end -->
