### PR TITLE
Update staging mixer endpoints

### DIFF
--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -28,7 +28,7 @@ class ProductionConfig(Config):
 class StagingConfig(Config):
     SECRET_PROJECT = 'datcom-browser-staging'
     API_PROJECT = 'datcom-mixer-staging'
-    API_ROOT = 'https://datacommons.endpoints.datcom-mixer-staging.cloud.goog'
+    API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
     GCS_BUCKET = 'datcom-browser-staging.appspot.com'
     GA_ACCOUNT = 'UA-117119267-2'
 
@@ -37,7 +37,7 @@ class DevelopmentConfig(Config):
     DEVELOPMENT = True
     SECRET_PROJECT = 'datcom-website-dev'
     API_PROJECT = 'datcom-mixer-staging'
-    API_ROOT = 'https://datacommons.endpoints.datcom-mixer-staging.cloud.goog'
+    API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
     GCS_BUCKET = 'datcom-browser-staging.appspot.com'
 
 
@@ -54,7 +54,7 @@ class WebdriverConfig(Config):
     WEBDRIVER = True
     SECRET_PROJECT = 'datcom-website-dev'
     API_PROJECT = 'datcom-mixer-staging'
-    API_ROOT = 'https://datacommons.endpoints.datcom-mixer-staging.cloud.goog'
+    API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
     GCS_BUCKET = ''
 
 

--- a/static/js/shared/util.js
+++ b/static/js/shared/util.js
@@ -65,7 +65,7 @@ const API_DATA = {
     key: "AIzaSyCJXDc2HxXL3u76PqQfYXuT1oGB-f4uC1I",
   },
   staging: {
-    root: "https://datacommons.endpoints.datcom-mixer-staging.cloud.goog",
+    root: "https://mixer.endpoints.datcom-mixer-staging.cloud.goog",
     key: "AIzaSyDffCx9SDfXDJ-lZdsCsYO4296UOH25oz8",
   },
 };

--- a/tools/pv_tree_generator/dc_request.py
+++ b/tools/pv_tree_generator/dc_request.py
@@ -18,7 +18,7 @@ import json
 import collections
 from google.cloud import secretmanager
 
-API_ROOT = 'https://datacommons.endpoints.datcom-mixer-staging.cloud.goog'
+API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
 
 
 def get_sv_dcids():


### PR DESCRIPTION
The staging mixer is re-deployed in a new cluster based on new process: https://github.com/datacommonsorg/mixer/pull/423.

This is to migrate the website to use the new mixer endpoints. Once this is checked in, can remove the old staging mixer cluster.