### PR TITLE
Squashed commit of the following:

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
-node_modules
-__pycache__
+**/node_modules
+
+**/dist
+**/__pycache__
+**/.pytest_cache
 .pytest_cache
-dist
+
+.git
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,14 @@ dist/
 tmp/
 
 .air.toml
+
+website-robot-key.json
+mixer-robot-key.json
+
+# Kubernetes
+**/deployment.yaml
+**/endpoints.yaml
+mci.yaml
+
+mixer-grpc.latest.pb
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,39 @@
-FROM node:12-slim
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Test, build client side code
-COPY static /website/static
+
+# Build client side code
+FROM node:15-slim AS node
+WORKDIR /website
+COPY go/ /website/go/
+COPY static/package.json /website/static/package.json
+COPY static/package-lock.json /website/static/package-lock.json
+
 WORKDIR /website/static
 RUN npm install
-RUN npm run lint
-RUN npm run-script test
+COPY static/ /website/static/
 RUN npm run-script build
 
-# Test and build server side code
-FROM python:3.7-slim
-COPY server /website/server
-WORKDIR /website/server
-RUN pip install -r requirements.txt
-ENV FLASK_ENV="test"
-RUN python -m pytest
+
+# Build server side code
+FROM python:3.7
+WORKDIR /website
+COPY --from=node /website/ /website/
+COPY server/requirements.txt /website/server/requirements.txt
+RUN pip3 install -r /website/server/requirements.txt
+COPY server/ /website/server/
 
 # Run the web service on container startup.
-ENV FLASK_ENV="production"
+WORKDIR /website/server
 CMD exec gunicorn --bind :8080 --workers 1 --threads 8 --timeout 0 main:app

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ sudo chmod +x /usr/bin/chromedriver
 
 Note: Make sure that your ChromeDriver version is compatible with your local Google Chrome version.
 You can change view the lastet ChromeDriver version [here](https://chromedriver.storage.googleapis.com/LATEST_RELEASE).
+Also make sure PATH is updated with ChromeDriver location.
 
 #### Run all tests
 
@@ -143,7 +144,21 @@ This will watch static files change and re-build on code edit.
 Start the flask webserver locally at localhost:8080
 
 ```bash
-./run_server.sh
+./run_flask.sh
+```
+
+#### Start the Go Server
+
+Install "Air" for Go server auto reload
+
+```bash
+go get -u github.com/cosmtrek/air
+```
+
+Start the Go webserver locally at localhost:7070
+
+```bash
+air
 ```
 
 #### Start the Go Server

--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -72,8 +72,8 @@ steps:
       - |
         set -e
 
-        gcloud source repos clone deployment --project=datcom-ci
-        cd deployment
+        gcloud source repos clone deployment /deployment --project=datcom-ci
+        cd /deployment
         # Configure Git to create commits with Cloud Build's service account
         git config user.email $(gcloud auth list --filter=status:ACTIVE --format='value(account)')
         git checkout master

--- a/deployment/config.yaml
+++ b/deployment/config.yaml
@@ -1,0 +1,142 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project:
+  dev: datcom-website-dev
+  staging: datcom-website-staging
+  prod: datcom-website-prod
+
+image:
+  mixer: gcr.io/datcom-ci/datacommons-mixer:latest
+  website:
+    dev: website:local
+    staging: gcr.io/datcom-ci/website:latest
+    prod: gcr.io/datcom-ci/website:latest
+
+pull_policy:
+  dev: Never
+  staging: Always
+  prod: Always
+
+args:
+  mixer:
+    bt_project: google.com:datcom-store-dev
+    bt_instance: prophet-cache
+    branch_folder:
+      dev: "blank_branch_cache" # Emtpy branch cache folder for faster loading
+      staging:
+      prod:
+  esp:
+    non_gcp:
+      dev: "--non_gcp"
+      staging:
+      prod:
+
+# Node of "1" (regional) corresponding to 3 physical nodes (zonal).
+# Each physical node of "4 vCPU and 32G memory" machine can allocate about 4 pods (0.85 vCPU and 10.5G memory, see below).
+# So here we are looking at 1 : 9 ratio from "node" to "pod".
+# To allow other resources and rollout buffer, use 1 : 6 ratio to give some buffer.
+#
+# Dev (Minikube) will always have 1 node and 1 pod.
+scaling:
+  nodes:
+    dev: 1
+    staging: 1
+    prod: 10
+  replicas:
+    dev: 1
+    staging: 6
+    prod: 60
+
+# Memory Request and Limit
+# https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+
+# Actual usage can be checked from GCP console: https://pantheon.corp.google.com/monitoring/dashboards/resourceList/kubernetes?project=datcom-mixer&pageState=(%22interval%22:(%22d%22:%22P7D%22),%22gkeTableState%22:(%22t%22:%22CONTAINER%22,%22vA%22:true),%22filter%22:(%22naF%22:(%22n%22:%22mixer%22,%22cF%22:(%22pN%22:%22projects%2Fdatcom-mixer%22,%22l%22:%22us-west2-c%22,%22n%22:%22mixer%22))))
+# In prod/staging env, total memory is 2 + 8 + 0.5 = 10.5G
+#
+# Note the majority of mixer usage is branch cache, which can be cut by a lot after moving it out of memory.
+# TODO(shifucun): understand website memory and cpu usage pattern and adjust accordingly.
+mem:
+  website:
+    req:
+      dev: 1G
+      staging: 2G
+      prod: 2G
+    limit:
+      dev: 1G
+      staging: 2G
+      prod: 2G
+  mixer:
+    req:
+      dev: 1G
+      staging: 8G
+      prod: 8G
+    limit:
+      dev: 1G
+      staging: 8G
+      prod: 8G
+  esp:
+    req:
+      dev: 0.1G
+      staging: 0.5G
+      prod: 0.5G
+    limit:
+      dev: 0.1G
+      staging: 0.5G
+      prod: 0.5G
+
+# CPU Request and Limit
+# https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+
+# Actual usage can be checked from GCP console: https://pantheon.corp.google.com/monitoring/dashboards/resourceList/kubernetes?project=datcom-mixer&pageState=(%22interval%22:(%22d%22:%22P7D%22),%22gkeTableState%22:(%22t%22:%22CONTAINER%22,%22vA%22:true),%22filter%22:(%22naF%22:(%22n%22:%22mixer%22,%22cF%22:(%22pN%22:%22projects%2Fdatcom-mixer%22,%22l%22:%22us-west2-c%22,%22n%22:%22mixer%22))))
+# In prod/staging env, total memory is 0.5 + 0.3 + 0.05 = 0.85
+cpu:
+  website:
+    req:
+      dev: 100m
+      staging: 500m
+      prod: 500m
+    limit:
+      dev: 100m
+      staging: 500m
+      prod: 500m
+  mixer:
+    req:
+      dev: 100m
+      staging: 300m
+      prod: 300m
+    limit:
+      dev: 100m
+      staging: 300m
+      prod: 300m
+  # From GCP dashboard, esp does not use that much of cpu.
+  esp:
+    req:
+      dev: 10m
+      staging: 50m
+      prod: 50m
+    limit:
+      dev: 10m
+      staging: 50m
+      prod: 50m
+
+bind_project:
+  bigquery: google.com:datcom-store-dev
+  bigtable: google.com:datcom-store-dev
+  branch_cache: google.com:datcom-store-dev
+
+gcs_bucket:
+  dev: datcom-website-staging-resources
+  staging: datcom-website-staging-resources
+  prod: datcom-website-prod-resources

--- a/deployment/generate_yaml.sh
+++ b/deployment/generate_yaml.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to generate deployment yaml files
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT="$(dirname "$DIR")"
+
+function create_deployment {
+  # Add esp deployment
+  yq merge -a=append \
+    $DIR/website.yaml.tmpl \
+    $ROOT/mixer/deployment/template/esp.yaml.tmpl \
+    > deployment.yaml
+  # Add mixer deployment
+  yq merge -i -a=append \
+    deployment.yaml \
+    $ROOT/mixer/deployment/template/mixer.yaml.tmpl
+}
+
+function set_replicas {
+  yq w -i deployment.yaml \
+    spec.replicas \
+    $(yq r $DIR/config.yaml scaling.replicas.$env)
+}
+
+function set_website {
+  # Website memory request
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[0].resources.requests.memory \
+    $(yq r $DIR/config.yaml mem.website.req.$env)
+  # Website memory limit
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[0].resources.limits.memory \
+    $(yq r $DIR/config.yaml mem.website.limit.$env)
+  # Website cpu request
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[0].resources.requests.cpu \
+    $(yq r $DIR/config.yaml cpu.website.req.$env)
+  # Website cpu limit
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[0].resources.limits.cpu \
+    $(yq r $DIR/config.yaml cpu.website.limit.$env)
+
+  # Website container
+  # TODO(shifucun): update this to use github commit hash for ci/cd
+  yq w -i deployment.yaml \
+    spec.template.spec.containers[0].image $(yq r $DIR/config.yaml image.website.$env)
+  # Pull policy, should be local docker image for deve env
+  yq w -i deployment.yaml \
+    spec.template.spec.containers[0].imagePullPolicy $(yq r $DIR/config.yaml pull_policy.$env)
+  # Set FLASK_ENV
+  yq w -i deployment.yaml \
+    spec.template.spec.containers[0].env[1].value "gke"
+  # Set GCS_BUCKET
+  yq w -i deployment.yaml \
+    spec.template.spec.containers[0].env[2].value $(yq r $DIR/config.yaml gcs_bucket.$env)
+  # Set SECRET_PROJECT (which is the hosting project)
+  yq w -i deployment.yaml \
+    spec.template.spec.containers[0].env[3].value $(yq r $DIR/config.yaml project.$env)
+}
+
+function set_esp {
+  project=$(yq r $DIR/config.yaml project.$env)
+  if [[ $env == "dev" ]]; then
+      email=$(git config user.email)
+      prefix="${email/@/.}.website-esp"
+  else
+      prefix="website-esp"
+  fi
+  service_name="$prefix.endpoints.$project.cloud.goog"
+
+  # ESP service name
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[1].args[1] \
+    $service_name
+  # ESP memory request
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[1].resources.requests.memory \
+    $(yq r $DIR/config.yaml mem.esp.req.$env)
+  # ESP memory limit
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[1].resources.limits.memory \
+    $(yq r $DIR/config.yaml mem.esp.limit.$env)
+  # ESP cpu request
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[1].resources.requests.cpu \
+    $(yq r $DIR/config.yaml cpu.esp.req.$env)
+  # ESP cpu limit
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[1].resources.limits.cpu \
+    $(yq r $DIR/config.yaml cpu.esp.limit.$env)
+  # Need to set "non_gcp" flag to make ESP working on Minikube
+  if [[ $env == "dev" ]]; then
+    yq w -i --style=double --inplace -- deployment.yaml \
+      spec.template.spec.containers[1].args[+] '--non_gcp'
+  fi
+  # ESP service configuration
+  yq w --style=double $ROOT/mixer/deployment/template/endpoints.yaml.tmpl \
+    name $service_name > endpoints.yaml
+  yq w -i endpoints.yaml title $service_name
+}
+
+function set_mixer {
+  # Mixer memory request
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].resources.requests.memory \
+    $(yq r $DIR/config.yaml mem.mixer.req.$env)
+  # Mixer memory limit
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].resources.limits.memory \
+    $(yq r $DIR/config.yaml mem.mixer.limit.$env)
+  # Mixer cpu request
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].resources.requests.cpu \
+    $(yq r $DIR/config.yaml cpu.mixer.req.$env)
+  # Mixer cpu limit
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].resources.limits.cpu \
+    $(yq r $DIR/config.yaml cpu.mixer.limit.$env)
+  # Mixer image
+  yq w -i deployment.yaml \
+    spec.template.spec.containers[2].image \
+    $(yq r $DIR/config.yaml image.mixer)
+  # Mixer pull policy
+  yq w -i deployment.yaml \
+    spec.template.spec.containers[2].imagePullPolicy \
+    "Always"
+  # Bigquery dataset
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].args[1] "$(head -1 $ROOT/mixer/deployment/bigquery.txt)"
+  # Bigtable table name
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].args[3] "$(head -1 $ROOT/mixer/deployment/bigtable.txt)"
+  # Bigtable project
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].args[5] "$(yq r $DIR/config.yaml args.mixer.bt_project)"
+  # Bigtable instance
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].args[7] "$(yq r $DIR/config.yaml args.mixer.bt_instance)"
+  # Bigquery billing project
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].args[9] "$(yq r $DIR/config.yaml project.$env)"
+  # Branch cache folder
+  yq w -i --style=double deployment.yaml \
+    spec.template.spec.containers[2].args[11] "$(yq r $DIR/config.yaml args.mixer.branch_folder.$env)"
+}
+
+
+# Valid argument would be: "dev", "staging", "prod"
+env=$1
+if [[ $env != "dev" ]] && [[ $env != "staging" ]] && [[ $env != "prod" ]]; then
+    echo "Invalid environment: $env"
+    exit
+fi
+
+create_deployment
+set_replicas
+set_website
+set_esp
+set_mixer

--- a/deployment/gke/README.md
+++ b/deployment/gke/README.md
@@ -1,0 +1,50 @@
+# Deploy Website to Multiple GKE Clusters
+
+You should have owner/editor role to perform the following tasks.
+
+## Prerequisites
+
+- [Create global static IP in GCP](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#reserve_new_static)
+- Update the IP address in cluster.yaml, `ip` field.
+- Update the domain in cluster.yaml `domain` field.
+- Create a GCS bucket, copy resource files (placeid2dcid.json, etc) to it and update config.yaml `gcs_bucket` field.
+- Create api key for "Maps API" and "Place API" and put them in GCP "Secret Manager" with name `maps-api-key`.
+
+## One Time Setup
+
+```bash
+./first_time_setup.sh < staging | prod>
+```
+
+**NOTE** In IAM, Give the robot account `website-robot@PROJECT_ID.iam.gserviceaccount.com` "GCE Storage Lister" role.
+TODO(shifucun): Figure out how to do this with gcloud, without giving "objectAdmin" role.
+
+This step creates clusters and runs all the one time tasks, including:
+
+- Enable API in the project.
+- Create service account, set up roles and create service account key.
+- Create a cluster in each region
+- Setup the config cluster
+
+Each cluster is a regional cluster with 3 zones.
+
+Each node is a configured to e2-highmem-4 machine type that has 4 vCPU and 32G memory.
+
+## DNS setup
+
+- Make sure the managed SSL certificate is "ACTIVE" by checking ["Load balancing" in GCP](https://pantheon.corp.google.com/net-services/loadbalancing/advanced/sslCertificates/list?project=PROJECT_ID&sslCertificateTablesize=50). This can take minutes up to hours.
+
+- [Configure the DNS in the domain registrar](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs#update-dns)).
+
+## Deploy website manually (not recommended)
+
+```bash
+./deploy.sh <staging | prod> region
+```
+
+## Add a new cluster
+
+```bash
+./create_cluster.sh <staging | prod> <region> <num_nodes>
+./setup_config_cluster.sh <staging | prod>
+```

--- a/deployment/gke/cluster.yaml
+++ b/deployment/gke/cluster.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+region:
+  staging:
+    primary: us-central1
+    others:
+      - europe-west2
+  prod:
+    primary: us-central1
+    others:
+      - europe-west2
+
+ip:
+  staging: 35.186.255.58
+  prod: 34.120.161.85
+
+domain:
+  # TODO(shifucun): for testing purpose, should change to "staging.datacomons.org" when ready.
+  staging: staging.dcdctest.com
+  prod: prod.dcdctest.com

--- a/deployment/gke/config_project.sh
+++ b/deployment/gke/config_project.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+PROJECT_ID=$1
+
+gcloud services enable --project=$PROJECT_ID \
+  anthos.googleapis.com \
+  multiclusteringress.googleapis.com \
+  container.googleapis.com \
+  gkeconnect.googleapis.com \
+  gkehub.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  servicecontrol.googleapis.com \
+  maps-backend.googleapis.com \
+  places-backend.googleapis.com \
+  secretmanager.googleapis.com

--- a/deployment/gke/config_robot_account.sh
+++ b/deployment/gke/config_robot_account.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+PROJECT_ID=$1
+NAME="website-robot"
+SERVICE_ACCOUNT="$NAME@$PROJECT_ID.iam.gserviceaccount.com"
+
+# Query BigQuery
+gcloud projects add-iam-policy-binding $(yq r ../config.yaml bind_project.bigquery) \
+  --member serviceAccount:$SERVICE_ACCOUNT \
+  --role roles/bigquery.user
+
+# Query Bigtable
+gcloud projects add-iam-policy-binding $(yq r ../config.yaml bind_project.bigtable) \
+  --member serviceAccount:$SERVICE_ACCOUNT \
+  --role roles/bigtable.reader
+
+# Branch Cache Read
+gcloud projects add-iam-policy-binding $(yq r ../config.yaml bind_project.branch_cache) \
+  --member serviceAccount:$SERVICE_ACCOUNT \
+  --role roles/storage.objectViewer
+
+# Branch Cache subscription
+gcloud projects add-iam-policy-binding $(yq r ../config.yaml bind_project.branch_cache) \
+  --member serviceAccount:$SERVICE_ACCOUNT \
+  --role roles/pubsub.editor
+
+# Self project roles
+declare -a roles=(
+   # service control report for endpoints.
+    "roles/endpoints.serviceAgent"
+    # Website resource: placeid2dcid.json, etc...
+    "roles/storage.objectViewer"
+    # Secret manager accessor
+    "roles/secretmanager.secretAccessor"
+    # Logging and monitoring
+    "roles/logging.logWriter"
+    "roles/monitoring.metricWriter"
+    "roles/stackdriver.resourceMetadata.writer"
+)
+for role in "${roles[@]}"
+do
+  gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member serviceAccount:$SERVICE_ACCOUNT \
+    --role $role
+done

--- a/deployment/gke/create_cluster.sh
+++ b/deployment/gke/create_cluster.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ENV=$1
+REGION=$2
+NODES=$3
+
+PROJECT_ID=$(yq r ../config.yaml project.$ENV)
+CLUSTER_NAME="website-$REGION"
+
+gcloud config set project $PROJECT_ID
+
+../generate_yaml.sh $ENV
+./download_robot_key.sh $PROJECT_ID
+
+gcloud container clusters create $CLUSTER_NAME \
+  --num-nodes=$NODES \
+  --region=$REGION \
+  --machine-type=e2-highmem-4 \
+  --enable-ip-alias # VPC native-cluster to enable Ingress for Anthos
+
+# Register cluster using Workload Identity ([Documentation](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster#register_cluster))
+gcloud beta container hub memberships register $CLUSTER_NAME \
+  --gke-uri=https://container.googleapis.com/v1/projects/$PROJECT_ID/locations/$REGION/clusters/$CLUSTER_NAME \
+  --enable-workload-identity
+
+# IAM for gke connect
+gcloud projects add-iam-policy-binding \
+  $PROJECT_ID \
+  --member "serviceAccount:$PROJECT_ID.hub.id.goog[gke-connect/connect-agent-sa]" \
+  --role "roles/gkehub.connect"
+
+gcloud container clusters get-credentials $CLUSTER_NAME --region=$REGION
+
+# Create namespace
+kubectl create namespace website
+# Website robot account
+kubectl create secret generic website-robot-key --from-file=website-robot-key.json --namespace=website
+# Mixer robot account
+kubectl create secret generic mixer-robot-key --from-file=mixer-robot-key.json --namespace=website
+# Mixer deployment
+kubectl apply -f deployment.yaml

--- a/deployment/gke/create_robot_account.sh
+++ b/deployment/gke/create_robot_account.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+PROJECT_ID=$1
+NAME="website-robot"
+SERVICE_ACCOUNT="$NAME@$PROJECT_ID.iam.gserviceaccount.com"
+
+# Create service account
+gcloud iam service-accounts create $NAME
+
+# Enable service account
+gcloud alpha iam service-accounts enable $SERVICE_ACCOUNT
+
+./download_robot_key.sh $PROJECT_ID

--- a/deployment/gke/deploy.sh
+++ b/deployment/gke/deploy.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+ENV=$1
+REGION=$2
+
+PROJECT_ID=$(yq r ../config.yaml project.$ENV)
+../generate_yaml.sh $ENV
+
+gcloud config set project $PROJECT_ID
+
+# Valid argument would be: "staging", "prod"
+if [[ $ENV != "staging" ]] && [[ $ENV != "prod" ]]; then
+    echo "Invalid environment: $ENV"
+    exit
+fi
+
+if [[ $REGION == "" ]]; then
+  echo "Second argument (region) is empty"
+  exit
+fi
+
+CLUSTER_NAME="website-$REGION"
+
+gcloud container clusters get-credentials $CLUSTER_NAME --region=$REGION
+
+kubectl apply -f deployment.yaml

--- a/deployment/gke/download_robot_key.sh
+++ b/deployment/gke/download_robot_key.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+PROJECT_ID=$1
+
+# Get the robot account key
+gcloud iam service-accounts keys create website-robot-key.json \
+    --iam-account website-robot@$PROJECT_ID.iam.gserviceaccount.com
+
+# Use the same robot account for website and mixer
+cp website-robot-key.json mixer-robot-key.json

--- a/deployment/gke/first_time_setup.sh
+++ b/deployment/gke/first_time_setup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Valid argument would be: "staging", "prod"
+ENV=$1
+if [[ $ENV != "staging" ]] && [[ $ENV != "prod" ]]; then
+    echo "Invalid environment: $ENV"
+    exit
+fi
+
+../generate_yaml.sh $ENV
+
+PROJECT_ID=$(yq r ../config.yaml project.$ENV)
+
+# Update gcloud
+gcloud components update
+
+# Auth
+gcloud auth login
+
+# Set project
+gcloud config set project $PROJECT_ID
+
+# Project level setup
+./config_project.sh $PROJECT_ID
+
+# Create robot account and download robot account key
+./create_robot_account.sh $PROJECT_ID
+
+# Config robot account IAM
+./config_robot_account.sh $PROJECT_ID
+
+# Create certificate
+# !! This is crucial to get the ingress external IP working.
+./setup_ssl.sh $(yq r cluster.yaml domain.$ENV)
+
+# Deploy esp service
+./setup_esp.sh $ENV
+
+# Setup cluster in primary region
+PRIMARY_REGION=$(yq r cluster.yaml region.$ENV.primary)
+./create_cluster.sh $ENV $PRIMARY_REGION $(yq r ../config.yaml scaling.nodes.$ENV)
+
+# Setup cluster in other regions
+len=$(yq r cluster.yaml --length region.$ENV.others)
+for index in $(seq 0 $(($len-1)));
+do
+  REGION=$(yq r cluster.yaml region.$ENV.others[$index])
+  ./create_cluster.sh $ENV $REGION $(yq r ../config.yaml scaling.nodes.$ENV)
+done
+
+./setup_config_cluster.sh $ENV

--- a/deployment/gke/mci.yaml.tmpl
+++ b/deployment/gke/mci.yaml.tmpl
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.gke.io/v1
+kind: MultiClusterIngress
+metadata:
+  name: website-mci
+  namespace: website
+  annotations:
+    networking.gke.io/pre-shared-certs: website-certificate
+    networking.gke.io/static-ip: <IP>
+spec:
+  template:
+    spec:
+      backend:
+        serviceName: website-mcs
+        servicePort: 8080

--- a/deployment/gke/mcs.yaml
+++ b/deployment/gke/mcs.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.gke.io/v1
+kind: MultiClusterService
+metadata:
+  name: website-mcs
+  namespace: website
+spec:
+  template:
+    spec:
+      selector:
+        app: website-app
+      ports:
+        - name: web
+          protocol: TCP
+          port: 8080
+          targetPort: 8080

--- a/deployment/gke/setup_config_cluster.sh
+++ b/deployment/gke/setup_config_cluster.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-for-anthos-setup
+
+ENV=$1
+
+PROJECT_ID=$(yq r ../config.yaml project.$ENV)
+REGION=$(yq r cluster.yaml region.$ENV.primary)
+CLUSTER_NAME="website-$REGION"
+
+gcloud container clusters get-credentials $CLUSTER_NAME --region $REGION
+gcloud alpha container hub ingress enable \
+  --config-membership=projects/$PROJECT_ID/locations/global/memberships/$CLUSTER_NAME
+
+yq w mci.yaml.tmpl \
+  metadata.annotations.[networking.gke.io/static-ip] \
+  $(yq r cluster.yaml ip.$ENV) \
+  > mci.yaml
+
+kubectl apply -f mci.yaml
+kubectl apply -f mcs.yaml
+
+# Check the status: `kubectl describe mci website -n website`

--- a/deployment/gke/setup_esp.sh
+++ b/deployment/gke/setup_esp.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+## Update endpoints.yaml
+../generate_yaml.sh $1
+
+## Deploy ESP configuration
+gsutil cp gs://artifacts.datcom-ci.appspot.com/mixer-grpc/mixer-grpc.latest.pb .
+gcloud endpoints services deploy mixer-grpc.latest.pb endpoints.yaml
+gcloud services enable $(yq r endpoints.yaml name)

--- a/deployment/gke/setup_ssl.sh
+++ b/deployment/gke/setup_ssl.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOMAIN=$1
+
+gcloud compute ssl-certificates create website-certificate \
+    --domains=$DOMAIN --global

--- a/deployment/minikube/README.md
+++ b/deployment/minikube/README.md
@@ -1,0 +1,61 @@
+# Bring up the Website App locally in Minikube
+
+Website can be deployed in Kubernetes cluster on [GKE](https://cloud.google.com/kubernetes-engine) or
+[MiniKube](https://minikube.sigs.k8s.io/docs/).
+
+This folder contains the config and script for local development with Minikube.
+
+## Prerequisites
+
+- Install [`Docker`](https://www.docker.com/products/docker-desktop).
+
+- Install [`Minikube`](https://minikube.sigs.k8s.io/docs/start/).
+
+- Install [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+
+- Install [`yq`](https://mikefarah.gitbook.io/yq/).
+
+## One time setup
+
+```bash
+./onetime_setup.sh
+```
+
+## Deploy endpoints configuration
+
+**Note** Need to run this regularly to keep track of the mixer service updates.
+Ideally, mixer-grpc.pb could be generated locally with protoc, or check the mixer.proto change and only deploy esp service when there is proto change.
+
+```bash
+./run_endponit_service.sh
+```
+
+## Run Minikube cluster
+
+This will bring up the minikube cluster and keep it running.
+You can keep it running in the background or stop it after development to save 4G of memory on you computer.
+
+After seeing the dashboard, type and pick the "website" namespace.
+
+```bash
+./run_cluster.sh
+```
+
+## Deployment to Minikube
+
+After code change, run the following command to deploy it locally.
+TODO(shifucun): Use [Scaffold](https://skaffold.dev/) to manage deployment.
+
+```bash
+./deploy_website.sh
+```
+
+## Access the service
+
+After successful deployment, use kubectl to forward the port:
+
+```bash
+kubectl port-forward service/website-service 8080:8080 -n website
+```
+
+Open browser to test out: `localhost:8080`

--- a/deployment/minikube/deploy_website.sh
+++ b/deployment/minikube/deploy_website.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Update Mixer Submodule
+git submodule foreach git pull origin master
+
+# Update yaml file
+../generate_yaml.sh dev
+
+# Use local docker image with Minikube.
+eval $(minikube docker-env)
+
+# Build Docker Image [Run after code change]
+# The build would take a few mintues the first time. Subsquent build should only take a few seconds with docker caching.
+cd ../../
+DOCKER_BUILDKIT=1 docker build --tag website:local .
+cd deployment/minikube
+
+# Apply deployment and service
+kubectl apply -f deployment.yaml -f service.yaml

--- a/deployment/minikube/onetime_setup.sh
+++ b/deployment/minikube/onetime_setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Dev project
+PROJECT_ID=$(yq r ../config.yaml project.dev)
+
+# Update gcloud
+gcloud components update
+
+# Auth
+gcloud auth login
+gcloud config set project $PROJECT_ID
+
+# Get the service account key
+# TODO(shifucun): update "mixer-robot" to "website-robot"
+gcloud iam service-accounts keys create website-robot-key.json \
+      --iam-account mixer-robot@$GCP_PROJECT.iam.gserviceaccount.com
+# Use the same robot account for website and mixer
+cp website-robot-key.json mixer-robot-key.json

--- a/deployment/minikube/run_cluster.sh
+++ b/deployment/minikube/run_cluster.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start Minikube dashboard
+minikube start --memory=4g
+# Create namespace
+kubectl create namespace website
+# Mount the GCP credential
+kubectl create secret generic website-robot-key --from-file=website-robot-key.json --namespace=website
+kubectl create secret generic mixer-robot-key --from-file=mixer-robot-key.json --namespace=website
+# Bring up dashboard
+minikube dashboard

--- a/deployment/minikube/run_endpoint_service.sh
+++ b/deployment/minikube/run_endpoint_service.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Generate the yaml files
+../generate_yaml.sh dev
+
+## Deploy ESP configuration
+gsutil cp gs://artifacts.datcom-ci.appspot.com/mixer-grpc/mixer-grpc.latest.pb .
+gcloud endpoints services deploy mixer-grpc.latest.pb endpoints.yaml
+gcloud services enable $(yq r endpoints.yaml name)

--- a/deployment/minikube/service.yaml
+++ b/deployment/minikube/service.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Kubernetes service to expose mixer gRPC.
+apiVersion: v1
+kind: Service
+metadata:
+  name: website-service
+  namespace: website
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: website-app

--- a/deployment/push_image.sh
+++ b/deployment/push_image.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Build Docker image and push to Cloud Container Registry
+
+cd ../
+gcloud auth login
+gcloud config set project datcom-ci
+export TAG="$(git rev-parse --short HEAD)"
+DOCKER_BUILDKIT=1 docker build --tag gcr.io/datcom-ci/website:$TAG .
+DOCKER_BUILDKIT=1 docker build --tag gcr.io/datcom-ci/website:latest .
+docker push gcr.io/datcom-ci/website:$TAG
+docker push gcr.io/datcom-ci/website:latest
+cd deployment

--- a/deployment/website.yaml.tmpl
+++ b/deployment/website.yaml.tmpl
@@ -1,0 +1,76 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mixer service backend
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: website-app
+  namespace: website
+  labels:
+    app: website-app
+spec:
+  replicas: <REPLICAS>
+  strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        # maximum number of Pods that can be created over the desired number of Pods
+        maxSurge: 1
+        # maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 25%
+  selector:
+    matchLabels:
+      app: website-app
+  template:
+    metadata:
+      labels:
+        app: website-app
+    spec:
+      volumes:
+        - name: website-robot-key
+          secret:
+            secretName: website-robot-key
+      containers:
+        - name: website
+          image: <WEBSITE_IMAGE>
+          imagePullPolicy: <WEBSITE_PULL_POLICY>
+          resources:
+            requests:
+              memory: <WEBSITE_MEM_REQ>
+              cpu: <WEBSITE_CPU_REQ>
+            limits:
+              memory: <WEBSITE_MEM_LIMIT>
+              cpu: <WEBSITE_CPU_LIMIT>
+          args: []
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            failureThreshold: 1
+            periodSeconds: 10
+          volumeMounts:
+            - name: website-robot-key
+              mountPath: /var/secrets/google
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secrets/google/website-robot-key.json
+            - name: FLASK_ENV
+              value: <FLASK_ENV>
+            - name: GCS_BUCKET
+              value: <GCS_BUCKET>
+            # This is the GCP project that holds the secrets: api key, etc...
+            - name: SECRET_PROJECT
+              value: <SECRET_PROJECT>

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -66,9 +66,18 @@ def create_app():
         cfg = import_string('configmodule.StagingConfig')()
     elif os.environ.get('FLASK_ENV') == 'development':
         cfg = import_string('configmodule.DevelopmentConfig')()
+    elif os.environ.get('FLASK_ENV') == 'minikube':
+        cfg = import_string('configmodule.MinikubeConfig')()
+        cfg.GCS_BUCKET = os.environ.get('GCS_BUCKET')
+        cfg.SECRET_PROJECT = os.environ.get('SECRET_PROJECT')
+    elif os.environ.get('FLASK_ENV') == 'gke':
+        cfg = import_string('configmodule.GKEConfig')()
+        cfg.GCS_BUCKET = os.environ.get('GCS_BUCKET')
+        cfg.SECRET_PROJECT = os.environ.get('SECRET_PROJECT')
     else:
         raise ValueError("No valid FLASK_ENV is specified: %s" %
                          os.environ.get('FLASK_ENV'))
+    cfg.MAPS_API_KEY = os.environ.get('MAPS_API_KEY')
     app.config.from_object(cfg)
 
     # Init extentions
@@ -104,15 +113,13 @@ def create_app():
         chart_config = json.load(f)
     app.config['CHART_CONFIG'] = chart_config
 
-    if cfg.WEBDRIVER or cfg.DEVELOPMENT:
+    if not cfg.TEST:
         secret_client = secretmanager.SecretManagerServiceClient()
-        secret_name = secret_client.secret_version_path(cfg.PROJECT,
+        secret_name = secret_client.secret_version_path(cfg.SECRET_PROJECT,
                                                         'maps-api-key', '1')
         secret_response = secret_client.access_secret_version(secret_name)
         app.config['MAPS_API_KEY'] = secret_response.payload.data.decode(
             'UTF-8')
-    else:
-        app.config['MAPS_API_KEY'] = "AIzaSyCi3WDvStkhQOBQRnV_4Fcuar7ZRteHgvU"
 
     if cfg.TEST or cfg.WEBDRIVER:
         app.config['PLACEID2DCID'] = {

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -12,10 +12,13 @@ class Config:
     CACHE_TYPE = 'simple'  # Flask-Caching related configs
     GAE_VERSION = (os.environ.get('GAE_VERSION') or
                    datetime.datetime.today().strftime("%m-%d-%H-%M"))
+    API_PROJECT = ''
+    GA_ACCOUNT = ''
+    MAPS_API_KEY = ''
 
 
 class ProductionConfig(Config):
-    PROJECT = 'factcheck-sandbox'
+    SECRET_PROJECT = 'factcheck-sandbox'
     API_PROJECT = 'datcom-mixer'
     API_ROOT = 'https://api.datacommons.org'
     GCS_BUCKET = 'datcom-browser-prod.appspot.com'
@@ -23,7 +26,7 @@ class ProductionConfig(Config):
 
 
 class StagingConfig(Config):
-    PROJECT = 'datcom-browser-staging'
+    SECRET_PROJECT = 'datcom-browser-staging'
     API_PROJECT = 'datcom-mixer-staging'
     API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
     GCS_BUCKET = 'datcom-browser-staging.appspot.com'
@@ -32,20 +35,27 @@ class StagingConfig(Config):
 
 class DevelopmentConfig(Config):
     DEVELOPMENT = True
-    PROJECT = 'datcom-browser-staging'
+    SECRET_PROJECT = 'datcom-website-dev'
     API_PROJECT = 'datcom-mixer-staging'
     API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
     GCS_BUCKET = 'datcom-browser-staging.appspot.com'
-    GA_ACCOUNT = 'UA-117119267-2'
+
+
+class MinikubeConfig(Config):
+    DEVELOPMENT = True
+    API_ROOT = 'http://127.0.0.1:8081'  # Port for Kubernetes ESP.
+
+
+class GKEConfig(Config):
+    API_ROOT = 'http://127.0.0.1:8081'  # Port for Kubernetes ESP.
 
 
 class WebdriverConfig(Config):
     WEBDRIVER = True
-    PROJECT = 'datcom-browser-staging'
+    SECRET_PROJECT = 'datcom-website-dev'
     API_PROJECT = 'datcom-mixer-staging'
     API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
     GCS_BUCKET = ''
-    GA_ACCOUNT = ''
 
 
 class TestConfig(Config):
@@ -53,4 +63,3 @@ class TestConfig(Config):
     API_PROJECT = 'api-project'
     API_ROOT = 'api-root'
     GCS_BUCKET = 'gcs-bucket'
-    GA_ACCOUNT = ''

--- a/server/main.py
+++ b/server/main.py
@@ -74,6 +74,11 @@ def search():
     return flask.render_template('search.html')
 
 
+@app.route('/healthz')
+def healthz():
+    return "very healthy"
+
+
 @app.route('/search_dc')
 def search_dc():
     """Add DC API powered search for non-place searches temporarily"""

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -106,6 +106,8 @@ def cached_name(dcids):
                           post=True)
     result = {}
     for dcid in dcids:
+        if not dcid:
+            continue
         values = response[dcid].get('out')
         result[dcid] = values[0]['value'] if values else ''
     return result
@@ -220,10 +222,8 @@ def api_i18n_name():
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def statsvars_route(dcid):
     """Get all the statistical variables that exist for a give place.
-
     Args:
       dcid: Place dcid.
-
     Returns:
       A list of statistical variable dcids.
     """
@@ -244,6 +244,40 @@ def statsvars(dcid):
                           post=False,
                           has_payload=False)
     return response['places'][dcid].get('statsVars', [])
+
+
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+def get_stat_vars_union(dcids):
+    """Get all the statistical variable dcids for some places.
+
+    Args:
+        dcids: Place DCIDs separated by "^" as a single string.
+
+    Returns:
+        List of unique statistical variable dcids each as a string.
+    """
+    dcids = dcids.split("^")
+    # The two indexings are due to how protobuf fields are converted to json
+    return fetch_data('/place/stat-vars/union', {
+        'dcids': dcids,
+    },
+                      compress=False,
+                      post=True,
+                      has_payload=False)['statVars']['statVars']
+
+
+@bp.route('/stat-vars/union', methods=['POST'])
+def get_stat_vars_union_route():
+    """Get all the statistical variables that exist for some places.
+
+    Returns:
+        List of unique statistical variable dcids each as a string.
+    """
+    dcids = sorted(request.json.get('dcids', []))
+
+    return Response(json.dumps(get_stat_vars_union("^".join(dcids))),
+                    200,
+                    mimetype='application/json')
 
 
 @bp.route('/child/<path:dcid>')
@@ -637,3 +671,37 @@ def api_display_name():
     locale = request.args.get('hl', default="en")
     result = get_display_name('^'.join((sorted(dcids))), locale)
     return Response(json.dumps(result), 200, mimetype='application/json')
+
+
+@bp.route('/places-in')
+@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+def get_places_in():
+    """Gets DCIDs of places of a certain type contained in some places.
+    
+    Sends the request to the Data Commons "/node/places-in" API.
+    See https://docs.datacommons.org/api/rest/place_in.html.
+
+    Returns:
+        Dict keyed by parent DCIDs with lists of child place DCIDs as values.
+    """
+    dcids = request.args.getlist("dcid")
+    place_type = request.args.get("placeType")
+    return Response(json.dumps(dc.get_places_in(dcids, place_type)),
+                    200,
+                    mimetype='application/json')
+
+
+@bp.route('/places-in-names')
+@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+def get_places_in_names():
+    """Gets names of places of a certain type contained in a place.
+
+    Returns:
+        Dicts keyed by child place DCIDs with their names as values.
+    """
+    dcid = request.args.get("dcid")
+    place_type = request.args.get("placeType")
+    child_places = dc.get_places_in([dcid], place_type)[dcid]
+    return Response(json.dumps(get_name(child_places)),
+                    200,
+                    mimetype='application/json')

--- a/server/routes/api/stats.py
+++ b/server/routes/api/stats.py
@@ -132,3 +132,51 @@ def stats_var_property_wrapper(dcids):
             'pvs': pvs,
         }
     return result
+
+
+@bp.route('/api/stats/value')
+@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+def get_stats_value():
+    """Returns a value for a place based on a statistical variable.
+
+    Sends the request to the Data Commons "/stat/value" API.
+    See https://docs.datacommons.org/api/rest/stat_value.html.
+
+    Returns:
+        Singleton dict with key "value".
+    """
+    place = request.args.get("place")
+    stat_var = request.args.get("stat_var")
+    date = request.args.get("date")
+    measurement_method = request.args.get("measurement_method")
+    observation_period = request.args.get("observation_period")
+    unit = request.args.get("unit")
+    scaling_factor = request.args.get("scaling_factor")
+    return Response(json.dumps(
+        dc.get_stats_value(place, stat_var, date, measurement_method,
+                           observation_period, unit, scaling_factor)),
+                    200,
+                    mimetype='application/json')
+
+
+@bp.route('/api/stats/collection')
+@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+def get_stats_collection():
+    """Gets the statistical variable values for child places of a certain place
+    type contained in a parent place at a given date.
+    
+    Returns:
+        Dict keyed by statvar DCIDs with dicts as values. See `SourceSeries` in
+        https://github.com/datacommonsorg/mixer/blob/master/proto/mixer.proto
+        for the definition of the inner dicts. In particular, the values for "val"
+        are dicts keyed by child place DCIDs with the statvar values as values.
+    """
+    parent_place = request.args.get("parent_place")
+    child_type = request.args.get("child_type")
+    date = request.args.get("date")
+    stat_vars = request.args.getlist("stat_vars")
+    return Response(json.dumps(
+        dc.get_stats_collection(parent_place, child_type, date,
+                                stat_vars)['data']),
+                    200,
+                    mimetype='application/json')

--- a/server/routes/dev.py
+++ b/server/routes/dev.py
@@ -58,8 +58,8 @@ def clearcacheaction():
         cfg = None
         flask.abort(500, 'clear cache not working for env %s' % env)
     secret_client = secretmanager.SecretManagerServiceClient()
-    secret_name = secret_client.secret_version_path(cfg.PROJECT, 'clearcache',
-                                                    '1')
+    secret_name = secret_client.secret_version_path(cfg.SECRET_PROJECT,
+                                                    'clearcache', '1')
     secret_response = secret_client.access_secret_version(secret_name)
     token = secret_response.payload.data.decode('UTF-8')
     if user_input == token:

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -32,23 +32,15 @@ elif os.environ.get('FLASK_ENV') == 'production':
     cfg = import_string('configmodule.ProductionConfig')()
 elif os.environ.get('FLASK_ENV') == 'staging':
     cfg = import_string('configmodule.StagingConfig')()
+elif os.environ.get('FLASK_ENV') == 'minikube':
+    cfg = import_string('configmodule.MinikubeConfig')()
+elif os.environ.get('FLASK_ENV') == 'gke':
+    cfg = import_string('configmodule.GKEConfig')()
 else:
     cfg = import_string('configmodule.DevelopmentConfig')()
 
 API_ROOT = cfg.API_ROOT
 API_PROJECT = cfg.API_PROJECT
-
-DC_API_KEY = 'api-key'
-# if (os.environ.get('FLASK_ENV') == 'test' or
-#         os.environ.get('FLASK_ENV') == 'webdriver'):
-#     DC_API_KEY = 'api-key'
-# else:
-#     # Read the api key from Google Cloud Secret Manager
-#     secret_client = secretmanager.SecretManagerServiceClient()
-#     secret_name = secret_client.secret_version_path(API_PROJECT,
-#                                                     'mixer-api-key', '1')
-#     secret_response = secret_client.access_secret_version(secret_name)
-#     DC_API_KEY = secret_response.payload.data.decode('UTF-8')
 
 # --------------------------------- CONSTANTS ---------------------------------
 
@@ -69,6 +61,8 @@ API_ENDPOINTS = {
     'get_chart_data': '/node/chart-data',
     'get_stats': '/bulk/stats',
     'get_stats_all': '/stat/all',
+    'get_stats_value': '/stat/value',
+    'get_stats_collection': '/stat/collection',
     # TODO(shifucun): switch back to /node/related-places after data switch.
     'get_related_places': '/node/related-locations',
     'get_interesting_places': '/node/interesting-place-aspects',
@@ -82,9 +76,8 @@ _MAX_LIMIT = 100
 
 def search(query_text, max_results):
     req_url = API_ROOT + API_ENDPOINTS['search']
-    req_url += '?key={}&query={}&max_results={}'.format(
-        DC_API_KEY, urllib.parse.quote(query_text.replace(',', ' ')),
-        max_results)
+    req_url += '?query={}&max_results={}'.format(
+        urllib.parse.quote(query_text.replace(',', ' ')), max_results)
     response = requests.get(req_url)
     if response.status_code != 200:
         raise ValueError(
@@ -116,6 +109,49 @@ def get_stats_all(place_dcids, stat_vars):
         'stat_vars': stat_vars,
     }
     return send_request(url, req_json=req_json, has_payload=False)
+
+
+def get_stats_value(place, stat_var, date, measurement_method,
+                    observation_period, unit, scaling_factor):
+    """See https://docs.datacommons.org/api/rest/stat_value.html."""
+    url = API_ROOT + API_ENDPOINTS['get_stats_value']
+    req_json = {
+        'place': place,
+        'stat_var': stat_var,
+        'date': date,
+        'measurement_method': measurement_method,
+        'observation_period': observation_period,
+        'unit': unit,
+        'scaling_factor': scaling_factor
+    }
+    return send_request(url, req_json=req_json, post=False, has_payload=False)
+
+
+def get_stats_collection(parent_place, child_type, date, stat_vars):
+    """Gets the statistical variable values for child places of a certain place
+    type contained in a parent place at a given date.
+
+    Args:
+        parent_place: Parent place DCID as a string.
+        child_type: Type of child places as a string.
+        date: Date as a string of the form YYYY-MM-DD (month and day are optional).
+        stat_vars: List of statistical variable DCIDs each as a string.
+
+    Returns:
+        Dict with a single key "data". The value is a dict keyed by statvar DCIDs,
+        with dicts as values. See `SourceSeries` in
+        https://github.com/datacommonsorg/mixer/blob/master/proto/mixer.proto
+        for the definition of the inner dicts. In particular, the values for "val"
+        are dicts keyed by child place DCIDs with the statvar values as values.
+    """
+    url = API_ROOT + API_ENDPOINTS['get_stats_collection']
+    req_json = {
+        'parent_place': parent_place,
+        'child_type': child_type,
+        'date': date,
+        'stat_vars': stat_vars
+    }
+    return send_request(url, req_json=req_json, post=False, has_payload=False)
 
 
 def get_chart_data(keys):
@@ -332,7 +368,7 @@ def get_place_obs(place_type,
 def query(query_string):
     # Get the API Key and perform the POST request.
     logging.info("[ Mixer Request ]: query")
-    headers = {'x-api-key': DC_API_KEY, 'Content-Type': 'application/json'}
+    headers = {'Content-Type': 'application/json'}
     req_url = API_ROOT + API_ENDPOINTS['query']
     response = requests.post(req_url,
                              json={'sparql': query_string},
@@ -376,7 +412,7 @@ def send_request(req_url,
     Returns:
       The payload returned by sending the POST/GET request formatted as a dict.
     """
-    headers = {'x-api-key': DC_API_KEY, 'Content-Type': 'application/json'}
+    headers = {'Content-Type': 'application/json'}
     logging.info("Send request to %s", req_url)
 
     # Send the request and verify the request succeeded

--- a/server/templates/tools/scatter2.html
+++ b/server/templates/tools/scatter2.html
@@ -13,29 +13,28 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  #}
+{% extends 'base.html' %}
 
- {% set is_hide_full_footer = true %}
- {% set subpage_title = "Scatter2" %}
- {% set subpage_url = url_for('tools.scatter2') %}
- {% set title = "Scatterplot Tool 2" %}
+{% set is_hide_full_footer = true %}
+{% set subpage_title = "Scatter2" %}
+{% set subpage_url = url_for('tools.scatter2') %}
+{% set title = "Scatterplot Tool 2" %}
+{% set hide_search = True %}
 
- {% extends 'base.html' %}
+{% block head %}
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+<link rel="stylesheet" href={{url_for('static', filename='css/scatter2.min.css', t=config['GAE_VERSION'])}}>
+{% endblock %}
 
- {% block head %}
- <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
- <link rel="stylesheet" href={{url_for('static', filename='css/scatter2.min.css', t=config['GAE_VERSION'])}}>
- {% endblock %}
+{% block content %}
+<div id="main-pane"></div>
+{% endblock %}
 
- {% block content %}
- <div id="main-pane"></div>
- {% endblock %}
+{% block footer %}
+<script src={{url_for('static', filename='scatter2.js', t=config['GAE_VERSION'])}}></script>
+<script src="https://maps.googleapis.com/maps/api/js?key={{maps_api_key}}&libraries=places" async defer></script>
+{% endblock %}
 
- {% block footer %}
- <script src={{url_for('static', filename='scatter2.js', t=config['GAE_VERSION'])}}></script>
- <script src="https://maps.googleapis.com/maps/api/js?key={{maps_api_key}}&libraries=places" async
-   defer></script>
- {% endblock %}
-
- {% block subfooter_extra %}
- <button id="download-link" class="btn-subfooter btn btn-dark" style="visibility: hidden">Download Data</button>
- {% endblock %}
+{% block subfooter_extra %}
+<button id="download-link" class="btn-subfooter btn btn-dark" style="visibility: hidden">Download Data</button>
+{% endblock %}

--- a/server/tests/api_place_test.py
+++ b/server/tests/api_place_test.py
@@ -17,6 +17,7 @@ import unittest
 from unittest.mock import patch
 
 from main import app
+from services import datacommons as dc
 
 
 class TestRoute(unittest.TestCase):
@@ -347,3 +348,195 @@ class TestApiDisplayName(unittest.TestCase):
             dcid2: dcid2,
             dcid3: dcid3
         }
+
+
+class TestApiGetPlacesIn(unittest.TestCase):
+
+    @patch('services.datacommons.send_request')
+    def test_api_get_places_in(self, send_request):
+
+        def side_effect(req_url,
+                        req_json={},
+                        compress=False,
+                        post=True,
+                        has_payload=True):
+            if req_url == dc.API_ROOT + "/node/places-in" and req_json == {
+                    'dcids': ['geoId/10', 'geoId/56'],
+                    'place_type': 'County'
+            } and not post:
+                return [{
+                    "dcid": "geoId/10",
+                    "place": "geoId/10001"
+                }, {
+                    "dcid": "geoId/10",
+                    "place": "geoId/10003"
+                }, {
+                    "dcid": "geoId/10",
+                    "place": "geoId/10005"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56001"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56003"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56005"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56007"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56009"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56011"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56013"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56015"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56017"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56019"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56021"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56023"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56025"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56027"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56029"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56031"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56033"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56035"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56037"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56039"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56041"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56043"
+                }, {
+                    "dcid": "geoId/56",
+                    "place": "geoId/56045"
+                }]
+
+        send_request.side_effect = side_effect
+        response = app.test_client().get(
+            '/api/place/places-in?dcid=geoId/10&dcid=geoId/56&placeType=County')
+        assert response.status_code == 200
+        assert json.loads(response.data) == {
+            "geoId/10": ["geoId/10001", "geoId/10003", "geoId/10005"],
+            "geoId/56": [
+                "geoId/56001", "geoId/56003", "geoId/56005", "geoId/56007",
+                "geoId/56009", "geoId/56011", "geoId/56013", "geoId/56015",
+                "geoId/56017", "geoId/56019", "geoId/56021", "geoId/56023",
+                "geoId/56025", "geoId/56027", "geoId/56029", "geoId/56031",
+                "geoId/56033", "geoId/56035", "geoId/56037", "geoId/56039",
+                "geoId/56041", "geoId/56043", "geoId/56045"
+            ]
+        }
+
+
+class TestApiGetPlacesInNames(unittest.TestCase):
+
+    @patch('services.datacommons.send_request')
+    def test_api_get_places_in_names(self, send_request):
+
+        def side_effect(req_url,
+                        req_json={},
+                        compress=False,
+                        post=True,
+                        has_payload=True):
+            if req_url == dc.API_ROOT + "/node/places-in" and req_json == {
+                    'dcids': ['geoId/10'],
+                    'place_type': 'County'
+            } and not post:
+                return [{
+                    "dcid": "geoId/10",
+                    "place": "geoId/10001"
+                }, {
+                    "dcid": "geoId/10",
+                    "place": "geoId/10003"
+                }, {
+                    "dcid": "geoId/10",
+                    "place": "geoId/10005"
+                }]
+            elif req_url == dc.API_ROOT + "/node/property-values" and req_json == {
+                    'dcids': ["geoId/10001", "geoId/10003", "geoId/10005"],
+                    'property': 'name',
+                    'direction': 'out'
+            } and post:
+                return {
+                    "geoId/10001": {
+                        'out': [{
+                            'value': "Kent County"
+                        }]
+                    },
+                    "geoId/10003": {
+                        'out': [{
+                            'value': "New Castle County"
+                        }]
+                    },
+                    "geoId/10005": {
+                        'out': [{
+                            'value': "Sussex County"
+                        }]
+                    },
+                }
+
+        send_request.side_effect = side_effect
+        response = app.test_client().get(
+            '/api/place/places-in-names?dcid=geoId/10&placeType=County')
+        assert response.status_code == 200
+        assert json.loads(response.data) == {
+            "geoId/10001": "Kent County",
+            "geoId/10003": "New Castle County",
+            "geoId/10005": "Sussex County",
+        }
+
+
+class TestApiGetStatVarsUnion(unittest.TestCase):
+
+    @patch('services.datacommons.send_request')
+    def test_api_get_stat_vars_union(self, send_request):
+        req = {'dcids': ['geoId/10001', 'geoId/10003', 'geoId/10005']}
+        result = ["sv1", "sv2", "sv3"]
+
+        def side_effect(req_url,
+                        req_json={},
+                        compress=False,
+                        post=True,
+                        has_payload=True):
+            if (req_url == dc.API_ROOT + "/place/stat-vars/union" and
+                    req_json == req and post and not has_payload):
+                return {'statVars': {'statVars': result}}
+
+        send_request.side_effect = side_effect
+        response = app.test_client().post('/api/place/stat-vars/union',
+                                          json=req)
+        assert response.status_code == 200
+        assert json.loads(response.data) == result

--- a/server/tests/api_stats_test.py
+++ b/server/tests/api_stats_test.py
@@ -1,0 +1,91 @@
+import json
+import unittest
+from unittest import mock
+
+from main import app
+from services import datacommons as dc
+
+
+class TestApiGetStatsValue(unittest.TestCase):
+
+    @mock.patch('services.datacommons.send_request')
+    def test_api_get_stats_value(self, send_request):
+
+        def side_effect(req_url,
+                        req_json={},
+                        compress=False,
+                        post=True,
+                        has_payload=True):
+            if req_url == dc.API_ROOT + "/stat/value" and req_json == {
+                    'place': 'geoId/06',
+                    'stat_var': 'Count_Person_Male',
+                    'date': None,
+                    'measurement_method': None,
+                    'observation_period': None,
+                    'unit': None,
+                    'scaling_factor': None
+            } and not post and not has_payload:
+                return {'value': 19640794}
+
+        send_request.side_effect = side_effect
+        response = app.test_client().get(
+            '/api/stats/value?place=geoId/06&stat_var=Count_Person_Male')
+        assert response.status_code == 200
+        assert json.loads(response.data) == {"value": 19640794}
+
+
+class TestApiGetStatsCollection(unittest.TestCase):
+
+    @mock.patch('services.datacommons.send_request')
+    def test_api_get_stats_collection(self, send_request):
+
+        result = {
+            "data": {
+                "Count_Person_Male": {
+                    "val": {
+                        "geoId/10001": 84271,
+                        "geoId/10003": 268870,
+                        "geoId/10005": 106429
+                    },
+                    "measurementMethod": "CensusACS5yrSurvey",
+                    "importName": "CensusACS5YearSurvey",
+                    "provenanceDomain": "census.gov",
+                    "provenanceUrl": "https://www.census.gov/"
+                },
+                "Count_Person": {
+                    "val": {
+                        "geoId/10001": 178540,
+                        "geoId/10003": 557550,
+                        "geoId/10005": 229389
+                    },
+                    "measurementMethod":
+                        "CensusPEPSurvey",
+                    "importName":
+                        "CensusPEP",
+                    "provenanceDomain":
+                        "census.gov",
+                    "provenanceUrl":
+                        "https://www.census.gov/programs-surveys/popest.html"
+                }
+            }
+        }
+
+        def side_effect(req_url,
+                        req_json={},
+                        compress=False,
+                        post=True,
+                        has_payload=True):
+            if req_url == dc.API_ROOT + "/stat/collection" and req_json == {
+                    'parent_place': 'geoId/10',
+                    'child_type': 'County',
+                    'date': '2018',
+                    'stat_vars': ['Count_Person', 'Count_Person_Male']
+            } and not post and not has_payload:
+                return result
+
+        send_request.side_effect = side_effect
+        response = app.test_client().get(
+            '/api/stats/collection?parent_place=geoId/10&child_type=County'
+            '&date=2018&stat_vars=Count_Person&stat_vars=Count_Person_Male')
+        assert response.status_code == 200
+        assert json.loads(response.data) == result['data']

--- a/server/webdriver_tests/screenshot/screenshot_test.py
+++ b/server/webdriver_tests/screenshot/screenshot_test.py
@@ -109,6 +109,15 @@ TEST_URLS = [
         'test_class': 'chart',
         'height': 2300
     },
+    {
+        'url':
+            '/tools/scatter2#&svx=Count_Person_Employed&svpx=3-0&svdx=Count_Person&svnx=Employed'
+            '&svy=Count_Establishment&svpy=9-2&svny=Number of Establishments&epd=geoId/10'
+            '&epn=Delaware&ept=County&y=2016',
+        'filename_suffix': 'scatter2_delaware_establishments_vs_employed.png',
+        'test_class': 'plot-title',
+        'height': 1000
+    }
 ]
 
 

--- a/server/webdriver_tests/timeline_test.py
+++ b/server/webdriver_tests/timeline_test.py
@@ -156,6 +156,7 @@ class TestCharts(WebdriverBaseTest):
         first_result.click()
 
         # Type USA into the search box.
+        search_box_input.clear()
         search_box_input.send_keys(PLACE_SEARCH_USA)
 
         # Wait until there is at least one result in autocomplete results.

--- a/static/css/_search_place.scss
+++ b/static/css/_search_place.scss
@@ -1,0 +1,176 @@
+@mixin search-place {
+  #search {
+    margin-bottom: 2rem;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4);
+    border-radius: 8px;
+    border: none;
+    overflow: hidden;
+  }
+  
+  #search #location-field {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    flex-direction: row;
+  }
+  
+  #search #location-field #prompt {
+    display: none;
+  }
+  
+  #search #location-field #place-list {
+    flex-shrink: 0;
+    margin-left: 32px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  
+  #search #location-field #search-icon {
+    width: 56px;
+    height: 56px;
+    margin-right: -32px;
+    background: url("../images/icon-pin.svg") no-repeat;
+    background-position: center;
+  }
+  
+  #location-field #ac {
+    display: flex;
+    flex-grow: 1;
+    height: 56px;
+    margin-left: 16px;
+    border: none;
+    box-sizing: border-box;
+    outline: none;
+    font-family: "Roboto";
+    font-size: 16px;
+    color: #202124;
+    letter-spacing: 0;
+    background: url("../images/icon-search.svg") no-repeat;
+    background-position: right 16px top 50%;
+  }
+  
+  #location-field #ac::-webkit-input-placeholder {
+    /* Chrome/Opera/Safari */
+    color: rgba(0, 0, 0, 0.25);
+  }
+  
+  .mdl-chip {
+    height: 32px;
+    line-height: 30px;
+    padding: 0 12px;
+    border: 0;
+    border-radius: 16px;
+    background-color: #dedede;
+    display: inline-block;
+    color: rgba(0, 0, 0, 0.87);
+    margin: 2px 0;
+    font-size: 0;
+    white-space: nowrap;
+  }
+  
+  #location-field .mdl-chip {
+    margin-right: 6px;
+    border: 0.5px solid #5384ec;
+    background: rgba(66, 133, 244, 0.08);
+  }
+  
+  .material-icons {
+    font-family: "Material Icons";
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    word-wrap: normal;
+    font-feature-settings: "liga";
+    -webkit-font-feature-settings: "liga";
+    -webkit-font-smoothing: antialiased;
+  }
+  
+  .mdl-chip__action .material-icons {
+    color: #3c4043;
+    font-size: 18px;
+  }
+  
+  /* Maps suggestion dropdown overrides */
+  .pac-container {
+    border: none;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12);
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+    transform: translateX(-16px);
+  }
+  
+  .pac-item {
+    padding: 4px 16px;
+  }
+  
+  .pac-icon {
+    display: none;
+  }
+  
+  .pac-logo:after {
+    display: none;
+  }
+  
+  .mdl-chip__text {
+    font-size: 13px;
+    vertical-align: middle;
+    display: inline-block;
+  }
+  
+  .mdl-chip__action {
+    height: 24px;
+    width: 24px;
+    line-height: 33px;
+    background: transparent;
+    opacity: 0.54;
+    display: inline-block;
+    cursor: pointer;
+    text-align: center;
+    vertical-align: middle;
+    padding: 0;
+    margin: 0;
+    margin-left: 4px;
+    font-size: 13px;
+    text-decoration: none;
+    color: rgba(0, 0, 0, 0.87);
+    border: none;
+    outline: none;
+    overflow: hidden;
+  }
+  
+  .mdl-chip__contact {
+    height: 32px;
+    width: 32px;
+    border-radius: 16px;
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 8px;
+    overflow: hidden;
+    text-align: center;
+    font-size: 18px;
+    line-height: 32px;
+  }
+  
+  .mdl-chip:focus {
+    outline: 0;
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
+      0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  }
+  
+  .mdl-chip:active {
+    background-color: #d6d6d6;
+  }
+  
+  .mdl-chip--deletable {
+    padding-right: 4px;
+  }
+  
+  .mdl-chip--contact {
+    padding-left: 0;
+  }
+}

--- a/static/css/timeline.scss
+++ b/static/css/timeline.scss
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+@use "search_place";
 @import "tools/base_tools";
 @import "tools/statvar_menu";
 @import "draw";
+
+@include search_place.search-place;
 
 #main-pane-download {
   margin: 64px auto;
@@ -58,199 +61,6 @@
 .mdc-top-app-bar button {
   border: none;
   background: none;
-}
-
-#search {
-  margin-bottom: 2rem;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4);
-  border-radius: 8px;
-  border: none;
-  overflow: hidden;
-}
-
-#search #location-field {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  flex-direction: row;
-}
-
-#search #location-field #prompt {
-  display: none;
-}
-
-#search #location-field #place-list {
-  flex-shrink: 0;
-  margin-left: 32px;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-#search #location-field #search-icon {
-  width: 56px;
-  height: 56px;
-  margin-right: -32px;
-  background: url("../images/icon-pin.svg") no-repeat;
-  background-position: center;
-}
-
-#location-field #ac {
-  display: flex;
-  flex-grow: 1;
-  height: 56px;
-  margin-left: 16px;
-  border: none;
-  box-sizing: border-box;
-  outline: none;
-  font-family: "Roboto";
-  font-size: 16px;
-  color: #202124;
-  letter-spacing: 0;
-  background: url("../images/icon-search.svg") no-repeat;
-  background-position: right 16px top 50%;
-}
-
-#location-field #ac::-webkit-input-placeholder {
-  /* Chrome/Opera/Safari */
-  color: rgba(0, 0, 0, 0.25);
-}
-
-.mdl-chip {
-  height: 32px;
-  line-height: 30px;
-  padding: 0 12px;
-  border: 0;
-  border-radius: 16px;
-  background-color: #dedede;
-  display: inline-block;
-  color: rgba(0, 0, 0, 0.87);
-  margin: 2px 0;
-  font-size: 0;
-  white-space: nowrap;
-}
-
-#location-field .mdl-chip {
-  margin-right: 6px;
-  border: 0.5px solid #5384ec;
-  background: rgba(66, 133, 244, 0.08);
-}
-
-.material-icons {
-  font-family: "Material Icons";
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  word-wrap: normal;
-  font-feature-settings: "liga";
-  -webkit-font-feature-settings: "liga";
-  -webkit-font-smoothing: antialiased;
-}
-
-.mdl-chip__action .material-icons {
-  color: #3c4043;
-  font-size: 18px;
-}
-
-/* Maps suggestion dropdown overrides */
-.pac-container {
-  border: none;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12);
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  transform: translateX(-16px);
-}
-.pac-item {
-  padding: 4px 16px;
-}
-.pac-icon {
-  display: none;
-}
-.pac-logo:after {
-  display: none;
-}
-
-#observation {
-  display: none;
-  width: 100%;
-  flex-grow: 1;
-  position: relative;
-}
-
-#main-pane-download #observation {
-  width: 800px;
-  display: block !important;
-}
-
-.pv-chip {
-  height: 36px;
-  line-height: 36px;
-  padding: 0 15px;
-  border: 20;
-  border-radius: 16px;
-  background-color: #999;
-  display: inline-block;
-  color: white;
-  margin: 2px 2px;
-  font-size: 0;
-  white-space: nowrap;
-  margin-right: 8px;
-}
-.mdl-chip__text {
-  font-size: 13px;
-  vertical-align: middle;
-  display: inline-block;
-}
-.mdl-chip__action {
-  height: 24px;
-  width: 24px;
-  line-height: 33px;
-  background: transparent;
-  opacity: 0.54;
-  display: inline-block;
-  cursor: pointer;
-  text-align: center;
-  vertical-align: middle;
-  padding: 0;
-  margin: 0;
-  margin-left: 4px;
-  font-size: 13px;
-  text-decoration: none;
-  color: rgba(0, 0, 0, 0.87);
-  border: none;
-  outline: none;
-  overflow: hidden;
-}
-.mdl-chip__contact {
-  height: 32px;
-  width: 32px;
-  border-radius: 16px;
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: 8px;
-  overflow: hidden;
-  text-align: center;
-  font-size: 18px;
-  line-height: 32px;
-}
-.mdl-chip:focus {
-  outline: 0;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
-    0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
-
-.mdl-chip:active {
-  background-color: #d6d6d6;
-}
-.mdl-chip--deletable {
-  padding-right: 4px;
-}
-.mdl-chip--contact {
-  padding-left: 0;
 }
 
 #placeholder-container li span {
@@ -328,4 +138,31 @@ sup {
   font-size: 14px;
   margin-bottom: 10px;
   margin-left: 5px;
+}
+
+#observation {
+  display: none;
+  width: 100%;
+  flex-grow: 1;
+  position: relative;
+}
+
+#main-pane-download #observation {
+  width: 800px;
+  display: block !important;
+}
+
+.pv-chip {
+  height: 36px;
+  line-height: 36px;
+  padding: 0 15px;
+  border: 20;
+  border-radius: 16px;
+  background-color: #999;
+  display: inline-block;
+  color: white;
+  margin: 2px 2px;
+  font-size: 0;
+  white-space: nowrap;
+  margin-right: 8px;
 }

--- a/static/css/tools/scatter2.scss
+++ b/static/css/tools/scatter2.scss
@@ -14,8 +14,91 @@
  * limitations under the License.
  */
 
+@use "../search_place";
 @import "base_tools";
 @import "statvar_menu";
-@import "../draw";
 
-// TODO(intrepiditee)
+
+@mixin scatter-search {
+  @include search_place.search-place;
+
+  #search {
+    margin-bottom: 0;
+  }
+
+  #search #location-field {
+    flex-wrap: nowrap;
+  }
+}
+
+@include scatter-search;
+
+#main-pane #plot-container {
+  direction: initial;
+  padding: 2rem;
+  overflow-y: scroll;
+}
+
+#chart-row {
+  display: block;
+}
+
+.no-padding {
+  padding: 0;
+}
+
+#stats {
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  white-space: pre;
+}
+
+.form-check {
+  padding-left: 0;
+}
+
+.form-group {
+  margin-bottom: 0;
+}
+
+#plot-options .collapse .row,
+#plot-options .collapsing .row {
+  margin-top: 10px;
+}
+
+.datepicker {
+  margin-right: 10px;
+}
+
+.card {
+  flex-grow: 1;
+  flex-shrink: 1;
+  margin-bottom: 15px;
+
+  // Copied from timeline.scss
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
+  padding: 15px;
+}
+
+.flex-container {
+  display: flex;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+#tooltip {
+  background-color: #f8f9fa;
+  font-size: 10pt;
+  padding: 10px;
+  border-radius: 8px;
+  opacity: 0.9;
+}
+
+#statvar-modal .row {
+  margin-left: 0;
+}
+
+#placeholder-container {
+  margin-top: 1rem;
+}

--- a/static/css/translator.scss
+++ b/static/css/translator.scss
@@ -19,6 +19,10 @@ h3 {
   color: #444;
 }
 
+#select-input {
+  margin: 20px 0;
+}
+
 #input-box {
   display: flex;
 }
@@ -27,7 +31,7 @@ h3 {
 #query {
   font-size: 15px;
   width: 100%;
-  height: 400px;
+  height: 500px;
   overflow: scroll;
   color: #444;
 }
@@ -93,7 +97,8 @@ table.translation-info-table td {
 }
 
 table.translation-info-table .sql-result {
-  color: #4285f4;
+  color: #333;
+  font-size: 16px;
 }
 
 .summary-title,

--- a/static/js/tools/__snapshots__/timeline_page.test.tsx.snap
+++ b/static/js/tools/__snapshots__/timeline_page.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Single place and single stats var 1`] = `
 "<div class=\\"card\\"><span class=\\"chartPerCapita\\">Per capita<button class=\\"perCapitaCheckbox\\"></button><a href=\\"/faq#perCapita\\"><span> *</span></a></span>
-  <div class=\\"chart-svg\\"></div>
+  <div class=\\"chart-svg\\"><svg width=\\"500\\" height=\\"500\\"><text>svg text</text></svg></div>
   <div class=\\"statsVarChipRegion\\">
     <div class=\\"pv-chip mdl-chip--deletable\\"><span class=\\"mdl-chip__text\\">Median age</span><button class=\\"mdl-chip__action\\"><i class=\\"material-icons\\">cancel</i></button></div>
   </div>
@@ -41,7 +41,7 @@ exports[`Single place and single stats var 3`] = `
 
 exports[`chart options 1`] = `
 "<div class=\\"card\\"><span class=\\"chartPerCapita\\">Per capita<button class=\\"perCapitaCheckbox checked\\"></button><a href=\\"/faq#perCapita\\"><span> *</span></a></span>
-  <div class=\\"chart-svg\\"></div>
+  <div class=\\"chart-svg\\"><svg width=\\"500\\" height=\\"500\\"><text>svg text</text></svg></div>
   <div class=\\"statsVarChipRegion\\">
     <div class=\\"pv-chip mdl-chip--deletable\\"><span class=\\"mdl-chip__text\\">Median age</span><button class=\\"mdl-chip__action\\"><i class=\\"material-icons\\">cancel</i></button></div>
   </div>

--- a/static/js/tools/mock_functions.tsx
+++ b/static/js/tools/mock_functions.tsx
@@ -25,6 +25,7 @@ import * as d3 from "d3";
 export function axios_mock(): void {
   // Mock all the async axios call.
   axios.get = jest.fn();
+  axios.post = jest.fn();
 
   // get hierachy.json
   when(axios.get)
@@ -61,8 +62,8 @@ export function axios_mock(): void {
     });
 
   // get place stats vars, geoId/05
-  when(axios.get)
-    .calledWith("/api/place/statsvars/geoId/05")
+  when(axios.post)
+    .calledWith("/api/place/stat-vars/union", { dcids: ["geoId/05"] })
     .mockResolvedValue({
       data: ["Count_Person", "Median_Age_Person", "NotInTheTree"],
     });

--- a/static/js/tools/scatter2/app.test.tsx
+++ b/static/js/tools/scatter2/app.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Enzyme, { mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import React, { useEffect } from "react";
+import Cheerio from "cheerio";
+import { when } from "jest-when";
+import axios from "axios";
+import { App } from "./app";
+import { Context, useContextStore } from "./context";
+
+import hierarchy from "../../../data/hierarchy_top.json";
+import { waitFor } from "@testing-library/react";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+function TestApp(): JSX.Element {
+  const context = useContextStore();
+  useEffect(() => {
+    context.place.setEnclosingPlace({ name: "Delaware", dcid: "geoId/10" });
+  }, []);
+  return (
+    <Context.Provider value={context}>
+      <App />
+    </Context.Provider>
+  );
+}
+
+function mockAxios(): () => void {
+  const get = axios.get;
+  axios.get = jest.fn();
+
+  // Counties in Delaware
+  when(axios.get)
+    .calledWith(`/api/place/places-in-names?dcid=geoId/10&placeType=County`)
+    .mockResolvedValue({
+      data: {
+        "geoId/10001": "Kent County",
+        "geoId/10003": "New Castle County",
+        "geoId/10005": "Sussex County",
+      },
+    });
+
+  // Population and statvar data
+  const data = {
+    Count_Person: {
+      val: {
+        "geoId/10001": 180786,
+        "geoId/10003": 558753,
+        "geoId/10005": 234225,
+      },
+      measurementMethod: "CensusPEPSurvey",
+      importName: "CensusPEP",
+      provenanceDomain: "census.gov",
+      provenanceUrl: "https://www.census.gov/programs-surveys/popest.html",
+    },
+    Count_Person_Employed: {
+      val: {
+        "geoId/10001": 76726,
+        "geoId/10003": 276517,
+        "geoId/10005": 104845,
+      },
+      measurementMethod: "BLSSeasonallyUnadjusted",
+      observationPeriod: "P1Y",
+      importName: "BLS_LAUS",
+      provenanceDomain: "bls.gov",
+      provenanceUrl: "https://www.bls.gov/lau/",
+    },
+    Count_Establishment: {
+      val: { "geoId/10001": 3422, "geoId/10003": 16056, "geoId/10005": 5601 },
+      measurementMethod: "CensusCBPSurvey",
+      importName: "CensusCountyBusinessPatterns",
+      provenanceDomain: "census.gov",
+      provenanceUrl: "https://www.census.gov/",
+    },
+    Count_HousingUnit: {
+      val: {
+        "geoId/10001": 70576,
+        "geoId/10003": 222146,
+        "geoId/10005": 135529,
+      },
+      measurementMethod: "CensusACS5yrSurvey",
+      importName: "CensusACS5YearSurvey",
+      provenanceDomain: "census.gov",
+      provenanceUrl: "https://www.census.gov/",
+    },
+  };
+  when(axios.get)
+    .calledWith(
+      "/api/stats/collection?parent_place=geoId/10&child_type=County&date=2016" +
+        "&stat_vars=Count_Person&stat_vars=Count_Person&stat_vars=Count_Person_Employed&" +
+        "stat_vars=Count_Establishment"
+    )
+    .mockResolvedValue({
+      data: {
+        Count_Person: data.Count_Person,
+        Count_Person_Employed: data.Count_Person_Employed,
+        Count_Establishment: data.Count_Establishment,
+      },
+    });
+  when(axios.get)
+    .calledWith(
+      "/api/stats/collection?parent_place=geoId/10&child_type=County&date=2016" +
+        "&stat_vars=Count_Person&stat_vars=Count_Person&stat_vars=Count_Person_Employed&" +
+        "stat_vars=Count_HousingUnit"
+    )
+    .mockResolvedValue({
+      data: {
+        Count_Person: data.Count_Person,
+        Count_Person_Employed: data.Count_Person_Employed,
+        Count_HousingUnit: data.Count_HousingUnit,
+      },
+    });
+
+  const post = axios.post;
+  axios.post = jest.fn();
+  when(axios.post)
+    .calledWith("/api/place/stat-vars/union", {
+      dcids: ["geoId/10001", "geoId/10003", "geoId/10005"],
+    })
+    .mockResolvedValue({
+      data: [
+        "Count_Person_Employed",
+        "Count_Establishment",
+        "Count_HousingUnit",
+      ],
+    });
+
+  // Statvar menu
+  when(axios.get)
+    .calledWith("../../data/hierarchy_statsvar.json")
+    .mockResolvedValue({ data: hierarchy });
+
+  return () => {
+    axios.get = get;
+    axios.post = post;
+  };
+}
+
+function expectCircles(n: number, app: Enzyme.ReactWrapper): void {
+  const $ = Cheerio.load(app.html());
+  expect($("circle").length).toEqual(n);
+}
+
+function expectInfo(
+  xMean: number,
+  yMean: number,
+  xStd: number,
+  yStd: number,
+  xProvenance: string,
+  yProvenance: string,
+  app: Enzyme.ReactWrapper
+): void {
+  const text = app.text();
+  expect(text).toContain(`X Mean: ${xMean}`);
+  expect(text).toContain(`Y Mean: ${yMean}`);
+  expect(text).toContain(`X Standard Deviation: ${xStd}`);
+  expect(text).toContain(`Y Standard Deviation: ${yStd}`);
+  expect(text).toContain(`X Data Source: ${xProvenance}`);
+  expect(text).toContain(`Y Data Source: ${yProvenance}`);
+}
+
+test("all functionalities", async (done) => {
+  const unmock = mockAxios();
+  const app = mount(<TestApp />);
+
+  // Expand these verticals
+  app.find("#Demographics a").simulate("click");
+  app.find("#Employment a").simulate("click");
+  app.find("#Economics a").simulate("click");
+  await waitFor(() => expect(app.text()).toContain("Population Density"));
+
+  // Select county as child place type
+  app
+    .find("#enclosed-place-type")
+    .at(0)
+    .simulate("change", { target: { value: "County" } });
+
+  // Population density should be filtered out
+  await waitFor(() => expect(app.text()).not.toContain("Population Density"));
+
+  // Choose 2016 for date
+  app
+    .find(`.datepicker`)
+    .at(0)
+    .simulate("change", { target: { value: 2016 } });
+
+  // Choose employed for x and establishments for y
+  app.find(`[id="Employed"] button`).simulate("click");
+  app.find(`[id="Number of Establishments"] button`).simulate("click");
+
+  await waitFor(() => {
+    // Title
+    expect(app.text()).toContain("Number Of Establishments vs Employed");
+    // Stats
+    expectInfo(
+      152696,
+      8359.667,
+      108149.894,
+      6753.678,
+      "bls.gov",
+      "census.gov",
+      app
+    );
+    // Points
+    expectCircles(3, app);
+  });
+
+  // Swap axes
+  app.find("#swap-axes").at(0).simulate("click");
+  const expectTitle = (title: string) => expect(app.text()).toContain(title);
+
+  expectTitle("Employed vs Number Of Establishments");
+  expectInfo(
+    8359.667,
+    152696,
+    6753.678,
+    108149.894,
+    "census.gov",
+    "bls.gov",
+    app
+  );
+  expectCircles(3, app);
+
+  // Per capita
+  app
+    .find("#per-capita-x")
+    .at(0)
+    .simulate("change", { target: { checked: true } });
+  app
+    .find("#per-capita-y")
+    .at(0)
+    .simulate("change", { target: { checked: true } });
+  expectTitle("Employed Per Capita vs Number Of Establishments Per Capita");
+  expectInfo(0.024, 0.456, 0.005, 0.036, "census.gov", "bls.gov", app);
+  expectCircles(3, app);
+
+  // Log
+  app
+    .find("#log-x")
+    .at(0)
+    .simulate("change", { target: { checked: true } });
+  app
+    .find("#log-y")
+    .at(0)
+    .simulate("change", { target: { checked: true } });
+  expectCircles(3, app);
+
+  // Choose a third statvar
+  app.find("#Housing a").simulate("click");
+  app.find(`[id="Housing Units"] button`).simulate("click");
+  await waitFor(() =>
+    expect(app.find(".modal-title").text()).toContain(
+      "Select two of the three statistical variables"
+    )
+  );
+
+  // Uncheck establishments and check housing
+  app
+    .find(`input[name="x"]`)
+    .simulate("change", { target: { name: "x", checked: false } });
+  app
+    .find(`input[name="third"]`)
+    .simulate("change", { target: { name: "third", checked: true } });
+  app.find(".modal-footer button").simulate("click");
+  await waitFor(() => {
+    expect(app.text()).toContain(
+      "Housing Units Per Capita vs Employed Per Capita"
+    );
+    expectInfo(0.456, 0.456, 0.036, 0.107, "bls.gov", "census.gov", app);
+    expectCircles(3, app);
+  });
+
+  unmock();
+  done();
+});

--- a/static/js/tools/scatter2/app.tsx
+++ b/static/js/tools/scatter2/app.tsx
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Main app component for scatter2.
+ */
+
+import React, { useContext, useEffect } from "react";
+import _ from "lodash";
+import { Container, Row } from "reactstrap";
+import { StatVarChooser } from "./statvar";
+import { PlaceOptions } from "./place_options";
+import { PlotOptions } from "./plot_options";
+import { ChartLoader } from "./chart_loader";
+import { Info } from "./info";
+import { Spinner } from "./spinner";
+import {
+  Context,
+  useContextStore,
+  Axis,
+  PlaceInfo,
+  IsLoadingWrapper,
+  DateInfo,
+} from "./context";
+import { isDateChosen, updateHash, applyHash } from "./util";
+
+function App(): JSX.Element {
+  const { x, y, place, date, isLoading } = useContext(Context);
+  const hideInfo = shouldHideInfo(x.value, y.value, place.value, date.value);
+  return (
+    <div>
+      <StatVarChooser />
+      <div id="plot-container">
+        <Container>
+          {!hideInfo && (
+            <Row>
+              <h1 className="mb-4">Scatter Plot Tool</h1>
+            </Row>
+          )}
+          <Row>
+            <PlaceOptions />
+          </Row>
+          <Row>
+            <PlotOptions />
+          </Row>
+          {hideInfo ? (
+            <Row id="chart-row">
+              <ChartLoader />
+            </Row>
+          ) : (
+            <Row>
+              <Info />
+            </Row>
+          )}
+        </Container>
+      </div>
+      <Spinner isOpen={shouldDisplaySpinner(isLoading)} />
+    </div>
+  );
+}
+
+function AppWithContext(): JSX.Element {
+  const store = useContextStore();
+
+  useEffect(() => applyHash(store), []);
+  useEffect(() => updateHash(store), [store]);
+  window.onhashchange = () => applyHash(store);
+
+  return (
+    <Context.Provider value={store}>
+      <App />
+    </Context.Provider>
+  );
+}
+
+/**
+ * Returns whether the spinner should be shown.
+ * @param isLoading
+ */
+function shouldDisplaySpinner(isLoading: IsLoadingWrapper): boolean {
+  return (
+    isLoading.arePlacesLoading ||
+    isLoading.areStatVarsLoading ||
+    isLoading.areDataLoading
+  );
+}
+
+/**
+ * Checks if the info page should be hidden to display the chart.
+ * Returns true if the enclosing place, child place type,
+ * statvars for the x and y axes are selected, and the date
+ * is chosen.
+ * @param x
+ * @param y
+ * @param place
+ */
+function shouldHideInfo(
+  x: Axis,
+  y: Axis,
+  place: PlaceInfo,
+  date: DateInfo
+): boolean {
+  return (
+    !_.isEmpty(place.enclosedPlaceType) &&
+    !_.isEmpty(place.enclosingPlace.dcid) &&
+    !_.isEmpty(x.statVar) &&
+    !_.isEmpty(y.statVar) &&
+    isDateChosen(date)
+  );
+}
+
+export { App, AppWithContext };

--- a/static/js/tools/scatter2/chart.tsx
+++ b/static/js/tools/scatter2/chart.tsx
@@ -1,0 +1,322 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chart component for plotting a scatter plot.
+ */
+
+import React, { useEffect, useRef } from "react";
+import _ from "lodash";
+import { Container, Row, Card, Badge } from "reactstrap";
+import * as d3 from "d3";
+import { Point } from "./chart_loader";
+
+interface ChartPropsType {
+  points: Array<Point>;
+  xLabel: string;
+  yLabel: string;
+  xLog: boolean;
+  yLog: boolean;
+  xPerCapita: boolean;
+  yPerCapita: boolean;
+  xProvenance: string;
+  yProvenance: string;
+}
+
+function Chart(props: ChartPropsType): JSX.Element {
+  const svg = useRef<SVGSVGElement>();
+  const tooltip = useRef<HTMLDivElement>();
+
+  // Replot when data changes.
+  useEffect(() => {
+    plot(svg, tooltip, props);
+  }, [props]);
+
+  return (
+    <Container id="chart">
+      <Row>
+        <Card id="no-padding">
+          <svg ref={svg} />
+          <div id="tooltip" ref={tooltip} />
+        </Card>
+      </Row>
+      <Row>
+        <Card id="stats">
+          <Badge color="light">X Data Source: {props.xProvenance}</Badge>
+          <Badge color="light">Y Data Source: {props.yProvenance}</Badge>
+          <Badge color="light">X Mean: {getXMean(props.points)}</Badge>
+          <Badge color="light">Y Mean: {getYMean(props.points)}</Badge>
+          <Badge color="light">
+            X Standard Deviation: {getXStd(props.points)}
+          </Badge>
+          <Badge color="light">
+            Y Standard Deviation: {getYStd(props.points)}
+          </Badge>
+        </Card>
+      </Row>
+    </Container>
+  );
+}
+
+/**
+ * Formats a number, or returns "N/A" if not an number.
+ * If the number is a float, keeps three decimal places.
+ * TODO: Need a utility determine decimals places based on value.
+ * @param num
+ */
+function getStringOrNA(num: number): string {
+  return _.isNil(num)
+    ? "N/A"
+    : Number.isInteger(num)
+    ? num.toString()
+    : num.toFixed(3);
+}
+
+/**
+ * Returns the mean for x axis.
+ * @param points
+ */
+function getXMean(points: Array<Point>): string {
+  return getStringOrNA(d3.mean(points.map((point) => point.xVal)));
+}
+
+/**
+ * Returns the mean for y axis.
+ * @param points
+ */
+function getYMean(points: Array<Point>): string {
+  return getStringOrNA(d3.mean(points.map((point) => point.yVal)));
+}
+
+/**
+ * Returns the stdev for x axis.
+ * @param points
+ */
+function getXStd(points: Array<Point>): string {
+  return getStringOrNA(d3.deviation(points.map((point) => point.xVal)));
+}
+
+/**
+ * Returns the stdev for y axis.
+ * @param points
+ */
+function getYStd(points: Array<Point>): string {
+  return getStringOrNA(d3.deviation(points.map((point) => point.yVal)));
+}
+
+/**
+ * Plots a scatter plot.
+ * @param svg
+ * @param tooltip
+ * @param props
+ */
+function plot(
+  svg: React.MutableRefObject<SVGElement>,
+  tooltip: React.MutableRefObject<HTMLDivElement>,
+  props: ChartPropsType
+): void {
+  d3.select(svg.current).selectAll("*").remove();
+
+  // TODO: Handle log domain 0.
+  const xMinMax = d3.extent(props.points, (point) => point.xVal);
+  const yMinMax = d3.extent(props.points, (point) => point.yVal);
+
+  const margin = {
+    top: 50,
+    right: 30,
+    bottom: 60,
+    left: 90,
+  };
+  const svgWidth = 1200;
+  const svgHeight = 430;
+  const width = svgWidth - margin.left - margin.right;
+  const height = svgHeight - margin.top - margin.bottom;
+
+  const g = d3
+    .select(svg.current)
+    .attr("id", "scatterplot")
+    .attr("width", "100%")
+    .attr("height", "100%")
+    // The following two lines make the plot responsive.
+    .attr("viewBox", `0 0 ${svgWidth} ${svgHeight}`)
+    .attr("preserveAspectRatio", "xMidYMid meet")
+    .append("g")
+    .attr("transform", `translate(${margin.left},${margin.top})`);
+
+  const xScale = addXAxis(
+    g,
+    props.xLog,
+    props.xPerCapita,
+    props.xLabel,
+    height,
+    width,
+    margin.bottom,
+    xMinMax[0],
+    xMinMax[1]
+  );
+  const yScale = addYAxis(
+    g,
+    props.yLog,
+    props.yPerCapita,
+    props.yLabel,
+    height,
+    margin.left,
+    yMinMax[0],
+    yMinMax[1]
+  );
+
+  g.append("text")
+    .attr("class", "plot-title")
+    .attr("transform", `translate(${width / 2},${-margin.top / 2})`)
+    .attr("text-anchor", "middle")
+    .style("font-size", "1.1em")
+    .text(`${props.yLabel} vs ${props.xLabel}`);
+
+  const dots = g
+    .selectAll("dot")
+    .data(props.points)
+    .enter()
+    .append("circle")
+    .attr("r", 5)
+    .attr("cx", (point) => xScale(point.xVal))
+    .attr("cy", (point) => yScale(point.yVal))
+    .attr("stroke", "rgb(147, 0, 0)")
+    .attr("stroke-width", 1.5)
+    .attr("fill", "#FFFFFF")
+    .style("opacity", "0.7");
+
+  addTooltip(tooltip, dots, props.xLabel, props.yLabel);
+}
+
+/**
+ * Adds the x axis to the plot.
+ * @param g plot container
+ * @param log
+ * @param perCapita
+ * @param xLabel
+ * @param height plot height
+ * @param width plot width
+ * @param marginBottom plot bottom margin
+ * @param min domain min
+ * @param max domain max
+ */
+function addXAxis(
+  g: d3.Selection<SVGGElement, unknown, HTMLElement, any>,
+  log: boolean,
+  perCapita: boolean,
+  xLabel: string,
+  height: number,
+  width: number,
+  marginBottom: number,
+  min: number,
+  max: number
+): d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number> {
+  const xScale = (log ? d3.scaleLog() : d3.scaleLinear())
+    .domain([min, max])
+    .range([0, width])
+    .nice();
+  g.append("g")
+    .attr("transform", `translate(0,${height})`)
+    .call(
+      d3
+        .axisBottom(xScale)
+        .ticks(log ? 5 : 10, d3.format(perCapita ? ".3f" : "d"))
+    );
+  g.append("text")
+    .attr("text-anchor", "middle")
+    .attr(
+      "transform",
+      `translate(${width / 2},${height + marginBottom / 2 + 10})`
+    )
+    .text(xLabel);
+  return xScale;
+}
+
+/**
+ * Adds the y axis to the plot.
+ * @param g plot container
+ * @param log
+ * @param perCapita
+ * @param yLabel
+ * @param height plot height
+ * @param marginLeft plot left margin
+ * @param min domain min
+ * @param max domain max
+ */
+function addYAxis(
+  g: d3.Selection<SVGGElement, unknown, HTMLElement, any>,
+  log: boolean,
+  perCapita: boolean,
+  yLabel: string,
+  height: number,
+  marginLeft: number,
+  min: number,
+  max: number
+): d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number> {
+  const yScale = (log ? d3.scaleLog() : d3.scaleLinear())
+    .domain([min, max])
+    .range([height, 0])
+    .nice();
+  g.append("g").call(
+    d3.axisLeft(yScale).ticks(log ? 5 : 10, d3.format(perCapita ? ".3f" : "d"))
+  );
+  g.append("text")
+    .attr("text-anchor", "middle")
+    .attr(
+      "transform",
+      `rotate(-90) translate(${-height / 2},${-(marginLeft / 2 + 5)})`
+    )
+    .text(yLabel);
+  return yScale;
+}
+
+/**
+ * Adds a hidden tooltip that becomse visible when hovering over a point
+ * describing the point.
+ * @param tooltip
+ * @param dots
+ * @param xLabel
+ * @param yLabel
+ */
+function addTooltip(
+  tooltip: React.MutableRefObject<HTMLDivElement>,
+  dots: d3.Selection<SVGCircleElement, Point, SVGGElement, unknown>,
+  xLabel: string,
+  yLabel: string
+): void {
+  const div = d3
+    .select(tooltip.current)
+    .style("visibility", "hidden")
+    .style("position", "fixed");
+
+  const onTooltipMouseover = (point: Point) => {
+    const html =
+      `${point.place.name || point.place.dcid}<br/>` +
+      `${xLabel}: ${getStringOrNA(point.xVal)}<br/>` +
+      `${yLabel}: ${getStringOrNA(point.yVal)}`;
+    div
+      .html(html)
+      .style("left", d3.event.pageX + 15 + "px")
+      .style("top", d3.event.pageY - 28 + "px")
+      .style("visibility", "visible");
+  };
+  const onTooltipMouseout = () => {
+    div.style("visibility", "hidden");
+  };
+  dots.on("mouseover", onTooltipMouseover).on("mouseout", onTooltipMouseout);
+}
+
+export { Chart, ChartPropsType };

--- a/static/js/tools/scatter2/chart_loader.tsx
+++ b/static/js/tools/scatter2/chart_loader.tsx
@@ -1,0 +1,419 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Component for retrieving and transforming data into a form ready for plotting
+ * and passing the data to a `Chart` component that plots the scatter plot.
+ */
+
+import React, { useContext, useEffect, useState } from "react";
+import _ from "lodash";
+import { saveToFile } from "../../shared/util";
+import {
+  getStatsCollection,
+  nodeGetStatVar,
+  isDateChosen,
+  SourceSeries,
+} from "./util";
+import { Chart } from "./chart";
+import {
+  Context,
+  NamedPlace,
+  Axis,
+  AxisWrapper,
+  PlaceInfo,
+  DateInfo,
+  IsLoadingWrapper,
+} from "./context";
+import { StatsVarNode } from "../timeline_util";
+
+/**
+ * Represents a point in the scatter plot.
+ */
+interface Point {
+  xVal: number;
+  yVal: number;
+  xPop: number;
+  yPop: number;
+  place: NamedPlace;
+}
+
+type Cache = Record<string, SourceSeries>;
+
+function ChartLoader(): JSX.Element {
+  const { x, y } = useContext(Context);
+  const cache = useCache();
+  const points = usePoints(cache);
+
+  const xVal = x.value;
+  const yVal = y.value;
+
+  return (
+    <div>
+      {areStatVarNamesLoaded(xVal, yVal) && (
+        <Chart
+          points={points}
+          xLabel={getLabel(xVal.name, xVal.perCapita)}
+          yLabel={getLabel(yVal.name, yVal.perCapita)}
+          xLog={xVal.log}
+          yLog={yVal.log}
+          xPerCapita={xVal.perCapita}
+          yPerCapita={yVal.perCapita}
+          xProvenance={getProvenance(cache, nodeGetStatVar(xVal.statVar))}
+          yProvenance={getProvenance(cache, nodeGetStatVar(yVal.statVar))}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Hook that returns a cache containing population and statvar data.
+ */
+function useCache(): Cache {
+  const { x, y, place, date, isLoading } = useContext(Context);
+
+  // From statvar DCIDs to `SourceSeries` data
+  const [cache, setCache] = useState({} as Cache);
+
+  const xVal = x.value;
+  const yVal = y.value;
+  const placeVal = place.value;
+  const dateVal = date.value;
+
+  /**
+   * When statvars, enclosing place, child place type, or any plot options change,
+   * re-retreive data.
+   */
+  useEffect(() => {
+    if (
+      !arePlacesLoaded(placeVal) ||
+      !areStatVarNamesLoaded(xVal, yVal) ||
+      !isDateChosen(date.value)
+    ) {
+      setCache({});
+      return;
+    }
+    if (!areDataLoaded(cache, xVal, yVal, dateVal)) {
+      loadData(x, y, placeVal, dateVal, isLoading, setCache);
+    }
+  }, [xVal, yVal, placeVal, dateVal]);
+
+  return cache;
+}
+
+/**
+ * Converts `DateInfo` to a string of the form YYYY-MM-DD,
+ * YYYY-MM, or YYYY, depending if month and day are chosen.
+ * @param date
+ */
+function formatDate(date: DateInfo) {
+  let str = date.year.toString();
+  if (date.month) {
+    str += `-${date.month < 10 ? "0" : ""}${date.month}`;
+    if (date.day) {
+      str += `-${date.day < 10 ? "0" : ""}${date.day}`;
+    }
+  }
+  return str;
+}
+
+/**
+ * Fills cache with population and statvar data.
+ * @param x
+ * @param y
+ * @param place
+ * @param date
+ * @param isLoading
+ * @param setCache
+ */
+async function loadData(
+  x: AxisWrapper,
+  y: AxisWrapper,
+  place: PlaceInfo,
+  date: DateInfo,
+  isLoading: IsLoadingWrapper,
+  setCache: (cache: Cache) => void
+) {
+  const dateString = formatDate(date);
+  isLoading.setAreDataLoading(true);
+  const data = await getStatsCollection(
+    place.enclosingPlace.dcid,
+    place.enclosedPlaceType,
+    dateString,
+    [
+      // Populations
+      getPopulationStatVar(x.value.statVar),
+      getPopulationStatVar(y.value.statVar),
+      // Statvars
+      nodeGetStatVar(x.value.statVar),
+      nodeGetStatVar(y.value.statVar),
+    ]
+  );
+  if (!areDataLoaded(data, x.value, y.value, date)) {
+    alert(
+      `Sorry, no data available for ${dateString}. Try picking another date.`
+    );
+  } else {
+    setCache(data);
+  }
+  isLoading.setAreDataLoading(false);
+}
+
+/**
+ * Gets the provenance for a statvar from the cache.
+ * Returns an empty string if the statvar is not in the
+ * cache.
+ * @param cache
+ * @param statVar
+ */
+function getProvenance(cache: Cache, statVar: string) {
+  if (statVar in cache) {
+    return cache[statVar].provenanceDomain;
+  }
+  return "";
+}
+
+/**
+ * Hook that returns an array of points for plotting.
+ * @param cache
+ */
+function usePoints(cache: Cache): Array<Point> {
+  const { x, y, place, date } = useContext(Context);
+  const [points, setPoints] = useState([] as Array<Point>);
+
+  const xVal = x.value;
+  const yVal = y.value;
+  const placeVal = place.value;
+  const dateVal = date.value;
+
+  /**
+   * Regenerates points after population and statvar data are retrieved
+   * and after plot options change.
+   */
+  useEffect(() => {
+    if (_.isEmpty(cache) || !areDataLoaded(cache, xVal, yVal, dateVal)) {
+      return;
+    }
+    const points = getPoints(xVal, yVal, placeVal, cache);
+    setPoints(computeCapita(points, xVal.perCapita, yVal.perCapita));
+
+    const downloadButton = document.getElementById("download-link");
+    if (downloadButton) {
+      downloadButton.style.visibility = "visible";
+      downloadButton.onclick = () =>
+        downloadData(xVal, yVal, placeVal, dateVal, points);
+    }
+  }, [cache, xVal, yVal, placeVal]);
+
+  return points;
+}
+
+/**
+ * Gets the DCID of the per capita denominator.
+ * @param node
+ */
+function getPopulationStatVar(node: StatsVarNode): string {
+  return Object.values(node)[0].denominators[0] || "Count_Person";
+}
+
+/**
+ * Divides `xVal` and `yVal` by `xPop` and `yPop` if per capita is
+ * selected for that axis.
+ * @param points
+ * @param xPerCapita
+ * @param yPerCapita
+ */
+function computeCapita(
+  points: Array<Point>,
+  xPerCapita: boolean,
+  yPerCapita: boolean
+) {
+  return points.map((point) => ({
+    ...point,
+    xVal: xPerCapita ? point.xVal / point.xPop : point.xVal,
+    yVal: yPerCapita ? point.yVal / point.yPop : point.yVal,
+  }));
+}
+
+/**
+ * Constructs an array of points for plotting.
+ * @param x
+ * @param y
+ * @param place
+ * @param cache
+ */
+function getPoints(
+  x: Axis,
+  y: Axis,
+  place: PlaceInfo,
+  cache: Cache
+): Array<Point> {
+  const xData = cache[nodeGetStatVar(x.statVar)];
+  const yData = cache[nodeGetStatVar(y.statVar)];
+  const xPops = cache[getPopulationStatVar(x.statVar)];
+  const yPops = cache[getPopulationStatVar(y.statVar)];
+  const lower = place.lowerBound;
+  const upper = place.upperBound;
+  return (
+    place.enclosedPlaces
+      // Map to `Point`s
+      .map((namedPlace) => ({
+        xVal: xData.val[namedPlace.dcid],
+        yVal: yData.val[namedPlace.dcid],
+        xPop: xPops.val[namedPlace.dcid],
+        yPop: yPops.val[namedPlace.dcid],
+        place: namedPlace,
+      }))
+      // Filter out unavailable data
+      .filter(
+        ({ xVal, yVal, xPop, yPop }) =>
+          !_.isNil(xVal) &&
+          !_.isNil(yVal) &&
+          // If not per capita, allow populations to be not available
+          (!_.isNil(xPop) || !x.perCapita) &&
+          (!_.isNil(yPop) || !y.perCapita) &&
+          isBetween(xPop, lower, upper) &&
+          isBetween(yPop, lower, upper)
+      )
+  );
+}
+
+/**
+ * Checks if the child places have been loaded.
+ * @param place
+ */
+function arePlacesLoaded(place: PlaceInfo): boolean {
+  return (
+    place.enclosedPlaceType &&
+    place.enclosingPlace.dcid &&
+    !_.isEmpty(place.enclosedPlaces)
+  );
+}
+
+/**
+ * Checks if the name of a statvar for an axis has been
+ * loaded from the statvar menu.
+ * @param axis
+ */
+function isStatVarNameLoaded(axis: Axis): boolean {
+  return !_.isEmpty(axis.name);
+}
+
+/**
+ * Checks if the names of the two statvars for both axes
+ * has been loaded from the statvar menu.
+ */
+function areStatVarNamesLoaded(x: Axis, y: Axis): boolean {
+  return isStatVarNameLoaded(x) && isStatVarNameLoaded(y);
+}
+
+/**
+ * Checks if the population (for per capita) and statvar data
+ * have been loaded for both axes.
+ * @param x
+ * @param y
+ */
+function areDataLoaded(
+  cache: Cache,
+  x: Axis,
+  y: Axis,
+  date: DateInfo
+): boolean {
+  const xStatVar = nodeGetStatVar(x.statVar);
+  const yStatVar = nodeGetStatVar(y.statVar);
+  const xPopStatVar = getPopulationStatVar(x.statVar);
+  const yPopStatVar = getPopulationStatVar(y.statVar);
+  return (
+    xStatVar in cache &&
+    !_.isEmpty(cache[xStatVar]) &&
+    yStatVar in cache &&
+    !_.isEmpty(cache[yStatVar]) &&
+    xPopStatVar in cache &&
+    !_.isEmpty(cache[xPopStatVar]) &&
+    yPopStatVar in cache &&
+    !_.isEmpty(cache[yPopStatVar]) &&
+    // Checking the date of one axis is enough because all
+    // statvars share the same date
+    formatDate(date) === cache[xStatVar].date
+  );
+}
+
+/**
+ * Saves data to a CSV file.
+ * @param points
+ */
+function downloadData(
+  x: Axis,
+  y: Axis,
+  place: PlaceInfo,
+  date: DateInfo,
+  points: Array<Point>
+): void {
+  const xStatVar = nodeGetStatVar(x.statVar);
+  const yStatVar = nodeGetStatVar(y.statVar);
+  const xPopStatVar = getPopulationStatVar(x.statVar);
+  const yPopStatVar = getPopulationStatVar(y.statVar);
+
+  // Headers
+  let csv =
+    "placeName," +
+    "placeDCID," +
+    `xValue-${xStatVar},` +
+    `yValue-${yStatVar},` +
+    `xPopulation-${xPopStatVar},` +
+    `yPopulation-${yPopStatVar}\n`;
+  // Data
+  for (const { xVal, yVal, xPop, yPop, place } of points) {
+    csv += `${place.name},${place.dcid},${xVal},${yVal},${xPop},${yPop}\n`;
+  }
+
+  saveToFile(
+    `${xStatVar}+` +
+      `${yStatVar}+` +
+      `${place.enclosingPlace.name}+` +
+      `${place.enclosedPlaceType}+` +
+      `${formatDate(date)}.csv`,
+    csv
+  );
+}
+
+/**
+ * Checks if a number is in an inclusive range.
+ * @param num
+ * @param lower
+ * @param upper
+ */
+function isBetween(num: number, lower: number, upper: number): boolean {
+  if (_.isNil(lower) || _.isNil(upper)) {
+    return true;
+  }
+  return lower <= num && num <= upper;
+}
+
+/**
+ * Formats a statvar name passed by the statvar menu to be an axis label.
+ * @param name
+ * @param perCapita
+ */
+function getLabel(name: string, perCapita: boolean): string {
+  if (!name.endsWith("$")) {
+    name = _.startCase(name);
+  }
+  return `${name}${perCapita ? " Per Capita" : ""}`;
+}
+
+export { ChartLoader, Point };

--- a/static/js/tools/scatter2/context.ts
+++ b/static/js/tools/scatter2/context.ts
@@ -1,0 +1,425 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Global app context.
+ */
+
+import { createContext, useState } from "react";
+import { StatsVarNode } from "../timeline_util";
+
+interface Axis {
+  // StatVar to plot for this axis
+  statVar: StatsVarNode;
+  // Human readable name of the StatVar
+  name: string;
+  // Whether to plot on log scale
+  log: boolean;
+  // Whether to plot per capita values
+  perCapita: boolean;
+}
+
+const EmptyAxis: Axis = Object.freeze({
+  statVar: {},
+  name: "",
+  log: false,
+  perCapita: false,
+});
+
+interface Setter<T> {
+  (value: T): void;
+}
+
+interface AxisWrapper {
+  value: Axis;
+
+  // Setters
+  set: Setter<Axis>;
+  setStatVar: Setter<StatsVarNode>;
+  unsetStatVar: Setter<void>;
+  setStatVarName: Setter<string>;
+  setLog: Setter<boolean>;
+  setPerCapita: Setter<boolean>;
+}
+
+interface NamedPlace {
+  name: string;
+  dcid: string;
+}
+
+interface PlaceInfo {
+  // Place that encloses the child places to plot
+  enclosingPlace: NamedPlace;
+  // Type of places to plot
+  enclosedPlaceType: string;
+  // Places to plot
+  enclosedPlaces: Array<NamedPlace>;
+  // Only plot places with populations between these
+  lowerBound: number;
+  upperBound: number;
+}
+
+interface PlaceInfoWrapper {
+  value: PlaceInfo;
+
+  // Setters
+  set: Setter<PlaceInfo>;
+  setEnclosingPlace: Setter<NamedPlace>;
+  setEnclosedPlaceType: Setter<string>;
+  setEnclosedPlaces: Setter<Array<NamedPlace>>;
+  setLowerBound: Setter<number>;
+  setUpperBound: Setter<number>;
+}
+
+const EmptyPlace: PlaceInfo = Object.freeze({
+  enclosingPlace: {
+    name: "",
+    dcid: "",
+  },
+  enclosedPlaceType: "",
+  enclosedPlaces: [],
+  lowerBound: 0,
+  upperBound: 1e10,
+});
+
+interface DateInfo {
+  year: number;
+  month: number;
+  day: number;
+}
+
+interface DateInfoWrapper {
+  value: DateInfo;
+
+  // Setters
+  set: Setter<DateInfo>;
+  setYear: Setter<number>;
+  setMonth: Setter<number>;
+  setDay: Setter<number>;
+}
+
+const EmptyDate: DateInfo = Object.freeze({
+  year: 0,
+  month: 0,
+  day: 0,
+});
+
+interface IsLoadingWrapper {
+  // Whether child places and their names are being retrieved
+  arePlacesLoading: boolean;
+  // Whether valid statvars are being retrieved for filtering the statvar menu
+  areStatVarsLoading: boolean;
+  // Whether population and statvar data are being retrieved for plotting
+  areDataLoading: boolean;
+
+  // Setters
+  setArePlacesLoading: Setter<boolean>;
+  setAreStatVarsLoading: Setter<boolean>;
+  setAreDataLoading: Setter<boolean>;
+}
+
+// Global app state
+interface ContextType {
+  // X axis
+  x: AxisWrapper;
+  // Y axis
+  y: AxisWrapper;
+  // Places to plot
+  place: PlaceInfoWrapper;
+  // Date of data to retrieve
+  date: DateInfoWrapper;
+  // Whether there are currently active network tasks
+  isLoading: IsLoadingWrapper;
+}
+
+const Context = createContext({} as ContextType);
+
+// For values are used as keys in URL hash
+const FieldToAbbreviation = {
+  // Axis fields
+  statVarDcid: "sv",
+  statVarPath: "svp",
+  statVarDenominator: "svd",
+  name: "svn",
+  log: "l",
+  perCapita: "pc",
+
+  // PlaceInfo fields
+  enclosingPlaceName: "epn",
+  enclosingPlaceDcid: "epd",
+  enclosedPlaceType: "ept",
+  lowerBound: "lb",
+  upperBound: "ub",
+
+  // DateInfo fields
+  year: "y",
+  month: "m",
+  day: "d",
+};
+
+/**
+ * Hook that constructs an initial context.
+ */
+function useContextStore(): ContextType {
+  const [x, setX] = useState(EmptyAxis);
+  const [y, setY] = useState(EmptyAxis);
+  const [place, setPlace] = useState(EmptyPlace);
+  const [date, setDate] = useState(EmptyDate);
+  const [arePlacesLoading, setArePlacesLoading] = useState(false);
+  const [areStatVarsLoading, setAreStatVarsLoading] = useState(false);
+  const [areDataLoading, setAreDataLoading] = useState(false);
+  return {
+    x: {
+      value: x,
+      set: (axis) => setX(axis),
+      setStatVar: getSetStatVar(x, setX),
+      unsetStatVar: getUnsetStatVar(x, setX),
+      setStatVarName: getSetStatVarName(x, setX),
+      setLog: getSetLog(x, setX),
+      setPerCapita: getSetPerCapita(x, setX),
+    },
+    y: {
+      value: y,
+      set: (axis) => setY(axis),
+      setStatVar: getSetStatVar(y, setY),
+      unsetStatVar: getUnsetStatVar(y, setY),
+      setStatVarName: getSetStatVarName(y, setY),
+      setLog: getSetLog(y, setY),
+      setPerCapita: getSetPerCapita(y, setY),
+    },
+    place: {
+      value: place,
+      set: (place) => setPlace(place),
+      setEnclosingPlace: getSetEnclosingPlace(place, setPlace),
+      setEnclosedPlaceType: getSetEnclosedPlaceType(place, setPlace),
+      setEnclosedPlaces: getSetEnclosedPlaces(place, setPlace),
+      setLowerBound: getSetLowerBound(place, setPlace),
+      setUpperBound: getSetUpperBound(place, setPlace),
+    },
+    date: {
+      value: date,
+      set: (date) => setDate(date),
+      setYear: getSetYear(date, setDate),
+      setMonth: getSetMonth(date, setDate),
+      setDay: getSetDay(date, setDate),
+    },
+    isLoading: {
+      arePlacesLoading: arePlacesLoading,
+      areStatVarsLoading: areStatVarsLoading,
+      areDataLoading: areDataLoading,
+      setArePlacesLoading: setArePlacesLoading,
+      setAreStatVarsLoading: setAreStatVarsLoading,
+      setAreDataLoading: setAreDataLoading,
+    },
+  };
+}
+
+/**
+ * Returns a setter for the parent place and additionally
+ * clearing the child places.
+ * @param place
+ * @param setPlace
+ */
+function getSetEnclosingPlace(
+  place: PlaceInfo,
+  setPlace: React.Dispatch<React.SetStateAction<PlaceInfo>>
+): Setter<NamedPlace> {
+  return (enclosingPlace) =>
+    setPlace({
+      ...place,
+      enclosedPlaces: [],
+      enclosingPlace: enclosingPlace,
+    });
+}
+
+/**
+ * Returns a setter for child place type and additionally
+ * clearing the child places.
+ * @param place
+ * @param setPlace
+ */
+function getSetEnclosedPlaceType(
+  place: PlaceInfo,
+  setPlace: React.Dispatch<React.SetStateAction<PlaceInfo>>
+): Setter<string> {
+  return (enclosedPlaceType) =>
+    setPlace({
+      ...place,
+      enclosedPlaceType: enclosedPlaceType,
+      enclosedPlaces: [],
+    });
+}
+
+function getSetEnclosedPlaces(
+  place: PlaceInfo,
+  setPlace: React.Dispatch<React.SetStateAction<PlaceInfo>>
+): Setter<Array<NamedPlace>> {
+  return (enclosedPlaces) =>
+    setPlace({
+      ...place,
+      enclosedPlaces: enclosedPlaces,
+    });
+}
+
+/**
+ * Returns a setter for the statvar for an axis and additionally
+ * clearing the name of the statvar.
+ * @param axis
+ * @param setAxis
+ */
+function getSetStatVar(
+  axis: Axis,
+  setAxis: React.Dispatch<React.SetStateAction<Axis>>
+): Setter<StatsVarNode> {
+  return (statVar) => {
+    setAxis({
+      ...axis,
+      statVar: statVar,
+      name: "",
+    });
+  };
+}
+
+/**
+ * Returns a setter for an axis that clears the statvar and the name
+ * of the statvar.
+ * @param axis
+ * @param setAxis
+ */
+function getUnsetStatVar(
+  axis: Axis,
+  setAxis: React.Dispatch<React.SetStateAction<Axis>>
+): Setter<void> {
+  return () => {
+    setAxis({
+      ...axis,
+      statVar: {},
+      name: "",
+    });
+  };
+}
+
+function getSetStatVarName(
+  axis: Axis,
+  setAxis: React.Dispatch<React.SetStateAction<Axis>>
+): Setter<string> {
+  return (name) => {
+    setAxis({
+      ...axis,
+      name: name,
+    });
+  };
+}
+
+function getSetLog(
+  axis: Axis,
+  setAxis: React.Dispatch<React.SetStateAction<Axis>>
+): Setter<boolean> {
+  return (log) => {
+    setAxis({
+      ...axis,
+      log: log,
+    });
+  };
+}
+
+function getSetPerCapita(
+  axis: Axis,
+  setAxis: React.Dispatch<React.SetStateAction<Axis>>
+): Setter<boolean> {
+  return (perCapita) => {
+    setAxis({
+      ...axis,
+      perCapita: perCapita,
+    });
+  };
+}
+
+function getSetLowerBound(
+  place: PlaceInfo,
+  setPlace: React.Dispatch<React.SetStateAction<PlaceInfo>>
+): Setter<number> {
+  return (lowerBound) =>
+    setPlace({
+      ...place,
+      lowerBound: lowerBound,
+    });
+}
+
+function getSetUpperBound(
+  place: PlaceInfo,
+  setPlace: React.Dispatch<React.SetStateAction<PlaceInfo>>
+): Setter<number> {
+  return (upperBound) =>
+    setPlace({
+      ...place,
+      upperBound: upperBound,
+    });
+}
+
+function getSetYear(
+  date: DateInfo,
+  setDate: React.Dispatch<React.SetStateAction<DateInfo>>
+): Setter<number> {
+  return (year) => {
+    setDate({
+      ...date,
+      year: year,
+    });
+  };
+}
+
+function getSetMonth(
+  date: DateInfo,
+  setDate: React.Dispatch<React.SetStateAction<DateInfo>>
+): Setter<number> {
+  return (month) => {
+    setDate({
+      ...date,
+      month: month,
+    });
+  };
+}
+
+function getSetDay(
+  date: DateInfo,
+  setDate: React.Dispatch<React.SetStateAction<DateInfo>>
+): Setter<number> {
+  return (day) => {
+    setDate({
+      ...date,
+      day: day,
+    });
+  };
+}
+
+export {
+  Context,
+  useContextStore,
+  ContextType,
+  Axis,
+  AxisWrapper,
+  NamedPlace,
+  PlaceInfo,
+  PlaceInfoWrapper,
+  DateInfo,
+  DateInfoWrapper,
+  IsLoadingWrapper,
+  EmptyAxis,
+  EmptyPlace,
+  EmptyDate,
+  FieldToAbbreviation,
+};

--- a/static/js/tools/scatter2/info.tsx
+++ b/static/js/tools/scatter2/info.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Info page before a chart is shown.
+ */
+
+import React from "react";
+
+function Info(): JSX.Element {
+  return (
+    <div id="placeholder-container">
+      <p>
+        The scatter plot tool helps you visualize the correlation between two
+        variables that appear in the pane to the left.
+      </p>
+      <ol>
+        <li>
+          Select the type of places you want to plot in the dropdown menu and
+          enter the containing place in the search box above.
+        </li>
+        <li>
+          Select the date of data to retrieve below the place options. For
+          monthly data, leave day empty. For quaterly data, select the start
+          month of the quarter.
+        </li>
+        <li>
+          Pick two variables in the left pane. There are thousands of variables
+          to choose from, arranged in a topical hierarchy.
+        </li>
+      </ol>
+
+      {/* TODO(intrepiditee): Add descriptions examples */}
+
+      <p>Take the data and use it on your site!</p>
+      <p>
+        <a href="mailto:collaborations@datacommons.org">Send</a> us your
+        discoveries!
+      </p>
+    </div>
+  );
+}
+
+export { Info };

--- a/static/js/tools/scatter2/place_options.tsx
+++ b/static/js/tools/scatter2/place_options.tsx
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Place options for selecting the child place type and the enclosing place.
+ */
+
+import React, { useContext, useEffect } from "react";
+import _ from "lodash";
+import { Card } from "reactstrap";
+import {
+  Context,
+  IsLoadingWrapper,
+  PlaceInfo,
+  PlaceInfoWrapper,
+} from "./context";
+import { SearchBar } from "../timeline_search";
+import { getPlaceNames } from "../timeline_util";
+import { getPlacesInNames } from "./util";
+
+import { Container, Row, Col, CustomInput } from "reactstrap";
+
+/**
+ * Possible child place types.
+ */
+const EnclosedTypes = [
+  // "Country", // TODO: Search bar should be able to search for "Earth".
+  "State",
+  "County",
+  "City",
+  "Town",
+  "Village",
+  "Borough",
+  "CensusZipCodeTabulationArea",
+  "EurostatNUTS1",
+  "EurostatNUTS2",
+  "EurostatNUTS3",
+  "AdministrativeArea1",
+  "AdministrativeArea2",
+  "AdministrativeArea3",
+  "AdministrativeArea4",
+  "AdministrativeArea5",
+];
+
+function PlaceOptions(): JSX.Element {
+  const { place, isLoading } = useContext(Context);
+
+  /**
+   * Reloads child places if the enclosing place or child place type changes.
+   */
+  useEffect(() => {
+    if (!shouldLoadPlaces(place.value)) {
+      return;
+    }
+    loadPlaces(place, isLoading);
+  }, [place.value]);
+
+  return (
+    <Card>
+      <Container>
+        <Row>
+          <Col xs="auto">Plot places of type</Col>
+          <Col xs="3">
+            <CustomInput
+              id="enclosed-place-type"
+              type="select"
+              value={place.value.enclosedPlaceType}
+              onChange={(e) => selectEnclosedPlaceType(place, e)}
+            >
+              <option value="">Select a place type</option>
+              {EnclosedTypes.map((type) => (
+                <option value={type} key={type}>
+                  {type}
+                </option>
+              ))}
+            </CustomInput>
+          </Col>
+          <Col xs="auto">in</Col>
+          <Col>
+            <div id="search">
+              <SearchBar
+                places={
+                  place.value.enclosingPlace.dcid
+                    ? {
+                        [place.value.enclosingPlace.dcid]:
+                          place.value.enclosingPlace.name,
+                      }
+                    : {}
+                }
+                addPlace={(e) => selectEnclosingPlace(place, e)}
+                removePlace={() => unselectEnclosingPlace(place)}
+                numPlacesLimit={1}
+              />
+            </div>
+          </Col>
+        </Row>
+      </Container>
+    </Card>
+  );
+}
+
+/**
+ * Checks if the child place type and the enclosing place have been selected but
+ * the child places are not.
+ * @param place
+ */
+function shouldLoadPlaces(place: PlaceInfo): boolean {
+  return (
+    place.enclosedPlaceType &&
+    place.enclosingPlace.dcid &&
+    _.isEmpty(place.enclosedPlaces)
+  );
+}
+
+/**
+ * Loads child places.
+ * @param place
+ * @param isLoading
+ */
+async function loadPlaces(
+  place: PlaceInfoWrapper,
+  isLoading: IsLoadingWrapper
+): Promise<void> {
+  let dcidToName: Record<string, string>;
+  isLoading.setArePlacesLoading(true);
+  try {
+    dcidToName = await getPlacesInNames(
+      place.value.enclosingPlace.dcid,
+      place.value.enclosedPlaceType
+    );
+  } catch (err) {
+    dcidToName = {};
+  }
+  if (!_.isEmpty(dcidToName)) {
+    place.setEnclosedPlaces(
+      _.keys(dcidToName).map((dcid) => ({
+        dcid: dcid,
+        name: dcidToName[dcid] || dcid,
+      }))
+    );
+  } else {
+    alert(
+      `Sorry, ${place.value.enclosingPlace.name} does not contain places of type ` +
+        `${place.value.enclosedPlaceType}. Try picking another type or place.`
+    );
+  }
+  isLoading.setArePlacesLoading(false);
+}
+
+/**
+ * Selects child place type.
+ * @param place
+ * @param event
+ */
+function selectEnclosedPlaceType(
+  place: PlaceInfoWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+) {
+  place.setEnclosedPlaceType(event.target.value);
+}
+
+/**
+ * Selects the enclosing place.
+ * @param place
+ * @param dcid
+ */
+async function selectEnclosingPlace(place: PlaceInfoWrapper, dcid: string) {
+  const dcidToName = await getPlaceNames([dcid]);
+  place.setEnclosingPlace({ dcid: dcid, name: dcidToName[dcid] });
+}
+
+/**
+ * Removes the enclosing place
+ * @param place
+ */
+function unselectEnclosingPlace(place: PlaceInfoWrapper) {
+  place.setEnclosingPlace({ dcid: "", name: "" });
+}
+
+export { PlaceOptions };

--- a/static/js/tools/scatter2/plot_options.tsx
+++ b/static/js/tools/scatter2/plot_options.tsx
@@ -1,0 +1,338 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Plot options for log scale, per capita, swapping axes, and
+ * lower and upper bounds for populations.
+ */
+
+import React, { useContext, useState } from "react";
+import { FormGroup, Label, Input, Card, Button, Collapse } from "reactstrap";
+import {
+  AxisWrapper,
+  Context,
+  DateInfoWrapper,
+  PlaceInfoWrapper,
+} from "./context";
+
+import { Container, Row, Col } from "reactstrap";
+
+// TODO: Add a new API that given a statvar, a parent place, and a child type,
+// returns the available dates for the statvar. Then, fill the datapicker with
+// the dates.
+function PlotOptions(): JSX.Element {
+  const { place, date, x, y } = useContext(Context);
+
+  const [open, setOpen] = useState(false);
+
+  const { year, month, day } = date.value;
+
+  return (
+    <Card>
+      <Container id="plot-options">
+        <Row>
+          <Col xs="auto">Date</Col>
+          <Col xs="5">
+            <FormGroup className="flex-container">
+              <Input
+                type="select"
+                onChange={(event) => selectYear(date, event)}
+                className="datepicker"
+                value={year}
+              >
+                <option value={0}>Year</option>
+                {getYears().map((year) => (
+                  <option value={year} key={year}>
+                    {year}
+                  </option>
+                ))}
+              </Input>
+              <Input
+                type="select"
+                onChange={(event) => selectMonth(date, event)}
+                className="datepicker"
+                value={month}
+              >
+                <option value={0}>Month</option>
+                {getMonths().map((month) => (
+                  <option value={month} key={month}>
+                    {month}
+                  </option>
+                ))}
+              </Input>
+              <Input
+                type="select"
+                onChange={(event) => selectDay(date, event)}
+                className="datepicker"
+                value={day}
+              >
+                <option value={0}>Day</option>
+                {getDays().map((day) => (
+                  <option value={day} key={day}>
+                    {day}
+                  </option>
+                ))}
+              </Input>
+            </FormGroup>
+          </Col>
+          <Col xs="auto">
+            <Button
+              className="flex-container"
+              color="light"
+              size="sm"
+              onClick={() => setOpen(!open)}
+            >
+              <i className="material-icons">
+                {open ? "expand_less" : "expand_more"}
+              </i>
+              More Options
+            </Button>
+          </Col>
+        </Row>
+        <Row>
+          <Collapse isOpen={open} className="flex-container">
+            <Container>
+              <Row>
+                <Col xs="3">Only plot places of this size</Col>
+                <Col>
+                  <FormGroup check>
+                    <Input
+                      type="number"
+                      onChange={(e) => selectLowerBound(place, e)}
+                      value={place.value.lowerBound}
+                    />
+                  </FormGroup>
+                </Col>
+                <Col xs="auto">to</Col>
+                <Col>
+                  <FormGroup check>
+                    <Input
+                      type="number"
+                      onChange={(e) => selectUpperBound(place, e)}
+                      value={
+                        place.value.upperBound === Number.POSITIVE_INFINITY
+                          ? 1e10
+                          : place.value.upperBound
+                      }
+                    />
+                  </FormGroup>
+                </Col>
+              </Row>
+              <Row>
+                <Col xs="3">Plot Options</Col>
+                <Col>
+                  <Button
+                    id="swap-axes"
+                    size="sm"
+                    color="light"
+                    onClick={() => swapAxes(x, y)}
+                  >
+                    Swap X and Y axes
+                  </Button>
+                </Col>
+                <Col>
+                  <FormGroup check>
+                    <Label check>
+                      <Input
+                        id="per-capita-x"
+                        type="checkbox"
+                        checked={x.value.perCapita}
+                        onChange={(e) => checkPerCapita(x, e)}
+                      />
+                      Plot X-axis per capita
+                    </Label>
+                  </FormGroup>
+                  <FormGroup check>
+                    <Label check>
+                      <Input
+                        id="per-capita-y"
+                        type="checkbox"
+                        checked={y.value.perCapita}
+                        onChange={(e) => checkPerCapita(y, e)}
+                      />
+                      Plot Y-axis per capita
+                    </Label>
+                  </FormGroup>
+                </Col>
+                <Col>
+                  <FormGroup check>
+                    <Label check>
+                      <Input
+                        id="log-x"
+                        type="checkbox"
+                        checked={x.value.log}
+                        onChange={(e) => checkLog(x, e)}
+                      />
+                      Plot X-axis on log scale
+                    </Label>
+                  </FormGroup>
+                  <FormGroup check>
+                    <Label check>
+                      <Input
+                        id="log-y"
+                        type="checkbox"
+                        checked={y.value.log}
+                        onChange={(e) => checkLog(y, e)}
+                      />
+                      Plot Y-axis on log scale
+                    </Label>
+                  </FormGroup>
+                </Col>
+              </Row>
+            </Container>
+          </Collapse>
+        </Row>
+      </Container>
+    </Card>
+  );
+}
+
+/**
+ * Returns current year using local date.
+ */
+function getCurrentYear(): number {
+  return new Date().getFullYear();
+}
+
+/**
+ * Returns a sorted array of numbers from `n` to `m`.
+ * @param n
+ * @param m
+ * @param descending
+ */
+function getNToM(n: number, m: number, descending = false): Array<number> {
+  const nums = [];
+  for (let i = n; i <= m; i++) {
+    nums.push(i);
+  }
+  return descending ? nums.sort((a, b) => b - a) : nums;
+}
+
+/**
+ * Returns possible years for the datepicker.
+ */
+function getYears(): Array<number> {
+  return getNToM(1900, getCurrentYear(), true);
+}
+
+/**
+ * Returns possible months for the datepicker.
+ */
+function getMonths(): Array<number> {
+  return getNToM(1, 12, true);
+}
+
+/**
+ * Returns possible days for the datepicker.
+ */
+function getDays(): Array<number> {
+  return getNToM(1, 31, true);
+}
+
+/**
+ * Selects a year for the datepicker.
+ * @param date
+ * @param event
+ */
+function selectYear(
+  date: DateInfoWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+) {
+  date.setYear(Number.parseInt(event.target.value));
+}
+
+/**
+ * Selects a month for the datepicker.
+ * @param date
+ * @param event
+ */
+function selectMonth(
+  date: DateInfoWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+) {
+  date.setMonth(Number.parseInt(event.target.value));
+}
+
+/**
+ * Selects a day for the datepicker.
+ */
+function selectDay(
+  date: DateInfoWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+) {
+  date.setDay(Number.parseInt(event.target.value));
+}
+
+/**
+ * Swaps the axes.
+ * @param x
+ * @param y
+ */
+function swapAxes(x: AxisWrapper, y: AxisWrapper): void {
+  const [xValue, yValue] = [x.value, y.value];
+  x.set(yValue);
+  y.set(xValue);
+}
+
+/**
+ * Toggles whether to plot per capita values for an axis.
+ * @param axis
+ * @param event
+ */
+function checkPerCapita(
+  axis: AxisWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+): void {
+  axis.setPerCapita(event.target.checked);
+}
+
+/**
+ * Toggles whether to plot an axis on log scale.
+ * @param axis
+ * @param event
+ */
+function checkLog(
+  axis: AxisWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+): void {
+  axis.setLog(event.target.checked);
+}
+
+/**
+ * Sets the lower bound for populations.
+ * @param place
+ * @param event
+ */
+function selectLowerBound(
+  place: PlaceInfoWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+): void {
+  place.setLowerBound(parseInt(event.target.value) || 0);
+}
+
+/**
+ * Sets the upper bound for populations.
+ * @param place
+ * @param event
+ */
+function selectUpperBound(
+  place: PlaceInfoWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+): void {
+  place.setUpperBound(parseInt(event.target.value) || 1e10);
+}
+
+export { PlotOptions };

--- a/static/js/tools/scatter2/scatter2.ts
+++ b/static/js/tools/scatter2/scatter2.ts
@@ -14,5 +14,13 @@
  * limitations under the License.
  */
 
-// TODO(intrepiditee)
-alert("Not implemented!");
+import React from "react";
+import ReactDOM from "react-dom";
+import { AppWithContext } from "./app";
+
+window.onload = () => {
+  ReactDOM.render(
+    React.createElement(AppWithContext),
+    document.getElementById("main-pane")
+  );
+};

--- a/static/js/tools/scatter2/spinner.tsx
+++ b/static/js/tools/scatter2/spinner.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+interface SpinnerProps {
+  isOpen: boolean;
+}
+
+function Spinner(props: SpinnerProps): JSX.Element {
+  return (
+    <div id="screen" style={{ display: props.isOpen ? "block" : "none" }}>
+      <div id="spinner" />
+    </div>
+  );
+}
+
+export { Spinner };

--- a/static/js/tools/scatter2/statvar.tsx
+++ b/static/js/tools/scatter2/statvar.tsx
@@ -1,0 +1,459 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Wrapper around the statvar menu. We only want the user to choose two statvars.
+ * Pops up a modal if three statvars are selected and forces the user to choose
+ * two of the three.
+ */
+
+import React, { useContext, useEffect, useState } from "react";
+import _ from "lodash";
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Container,
+  FormGroup,
+  Label,
+  Input,
+} from "reactstrap";
+import { Menu } from "../statsvar_menu";
+import { NoopStatsVarFilter, TimelineStatsVarFilter } from "../commons";
+import { StatsVarNode, getStatsVar } from "../timeline_util";
+import {
+  Context,
+  EmptyAxis,
+  Axis,
+  AxisWrapper,
+  NamedPlace,
+  IsLoadingWrapper,
+} from "./context";
+import { nodeGetStatVar } from "./util";
+
+interface NamedStatVar {
+  // Always contains a single statvar.
+  statVar: StatsVarNode;
+  name: string;
+}
+
+const emptyStatVar: NamedStatVar = Object.freeze({
+  statVar: {},
+  name: "",
+});
+
+interface ModalSelected {
+  x: boolean;
+  y: boolean;
+  third: boolean;
+}
+
+const defaultModalSelected: ModalSelected = Object.freeze({
+  x: true,
+  y: true,
+  third: false,
+});
+
+function StatVarChooser(): JSX.Element {
+  const { x, y } = useContext(Context);
+
+  // Temporary variable for storing an extra statvar.
+  const [thirdStatVar, setThirdStatVar] = useState(emptyStatVar);
+  // Records which two of the three statvars are wanted if a third statvar is selected.
+  const [modalSelected, setModalSelected] = useState(defaultModalSelected);
+  // Passed to the statvar menu.
+  const menuSelected = {
+    ...x.value.statVar,
+    ...y.value.statVar,
+    ...thirdStatVar.statVar,
+  };
+  // Filtered statvar DCIDs.
+  const validStatVars = useValidStatVars();
+
+  return (
+    <div className="explore-menu-container" id="explore">
+      <div id="drill-scroll-container">
+        <div className="title">Select variables:</div>
+        <Menu
+          selectedNodes={menuSelected}
+          statsVarFilter={
+            _.isEmpty(validStatVars)
+              ? new NoopStatsVarFilter()
+              : new TimelineStatsVarFilter(validStatVars)
+          }
+          setStatsVarTitle={(statsVarId2Title) =>
+            setStatsVarTitle(
+              x,
+              y,
+              statsVarId2Title,
+              thirdStatVar,
+              setThirdStatVar
+            )
+          }
+          addStatsVar={(statsVar, nodePath, denominators) =>
+            addStatVar(x, y, statsVar, nodePath, denominators, setThirdStatVar)
+          }
+          removeStatsVar={(statsVar, nodePath) =>
+            removeStatVar(x, y, statsVar, nodePath)
+          }
+        ></Menu>
+      </div>
+      <Modal
+        isOpen={!_.isEmpty(thirdStatVar.statVar)}
+        backdrop="static"
+        id="statvar-modal"
+      >
+        <ModalHeader close={null}>
+          Select two of the three statistical variables
+        </ModalHeader>
+        <ModalBody>
+          <Container>
+            <FormGroup check row>
+              <Label check>
+                <Input
+                  type="checkbox"
+                  checked={modalSelected.x}
+                  onChange={(e) =>
+                    selectStatVar(modalSelected, setModalSelected, e)
+                  }
+                  name="x"
+                />
+                {x.value.name}
+              </Label>
+            </FormGroup>
+            <FormGroup check row>
+              <Label check>
+                <Input
+                  type="checkbox"
+                  checked={modalSelected.y}
+                  onChange={(e) =>
+                    selectStatVar(modalSelected, setModalSelected, e)
+                  }
+                  name="y"
+                />
+                {y.value.name}
+              </Label>
+            </FormGroup>
+            <FormGroup check row>
+              <Label check>
+                <Input
+                  type="checkbox"
+                  checked={modalSelected.third}
+                  onChange={(e) =>
+                    selectStatVar(modalSelected, setModalSelected, e)
+                  }
+                  name="third"
+                />
+                {thirdStatVar.name}
+              </Label>
+            </FormGroup>
+          </Container>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            color="primary"
+            onClick={() =>
+              confirmStatVars(
+                x,
+                y,
+                thirdStatVar,
+                setThirdStatVar,
+                modalSelected,
+                setModalSelected
+              )
+            }
+          >
+            Confirm
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </div>
+  );
+}
+
+/**
+ * Hook that returns a set of statvars available for the child places.
+ */
+function useValidStatVars(): Set<string> {
+  const { place, x, y, isLoading } = useContext(Context);
+
+  // Stores filtered statvar DCIDs.
+  const [validStatVars, setValidStatVars] = useState(new Set<string>());
+
+  // When child places change, refilter the statvars.
+  useEffect(() => {
+    if (_.isEmpty(place.value.enclosedPlaces)) {
+      setValidStatVars(new Set<string>());
+      return;
+    }
+    filterStatVars(
+      x,
+      y,
+      place.value.enclosedPlaces,
+      isLoading,
+      setValidStatVars
+    );
+  }, [place.value.enclosedPlaces]);
+
+  return validStatVars;
+}
+
+/**
+ * Retrieves and sets statvars shown in the statvar menu.
+ * A statvar is kept if it is available for at least one of the child places.
+ * Throws an alert if a currently selected statvar is filtered out.
+ * @param x
+ * @param y
+ * @param enclosedPlaces
+ * @param isLoading
+ * @param setValidStatVars
+ */
+async function filterStatVars(
+  x: AxisWrapper,
+  y: AxisWrapper,
+  enclosedPlaces: Array<NamedPlace>,
+  isLoading: IsLoadingWrapper,
+  setValidStatVars: (statVars: Set<string>) => void
+): Promise<void> {
+  isLoading.setAreStatVarsLoading(true);
+  const statVars = await getStatsVar(
+    enclosedPlaces.map((namedPlace) => namedPlace.dcid),
+    true
+  );
+  setValidStatVars(statVars);
+  isLoading.setAreStatVarsLoading(false);
+  alertIfStatVarsUnavailable(x, y, statVars);
+}
+
+/**
+ * Throws an alert if a currently selected statvar is not available.
+ * @param x
+ * @param y
+ * @param statVars Set of available statvars
+ */
+function alertIfStatVarsUnavailable(
+  x: AxisWrapper,
+  y: AxisWrapper,
+  statVars: Set<string>
+) {
+  let message = "";
+  const statVarX = nodeGetStatVar(x.value.statVar);
+  const statVarY = nodeGetStatVar(y.value.statVar);
+  if (statVarX && !statVars.has(statVarX)) {
+    x.unsetStatVar();
+    message += `Sorry, no data available for ${statVarX}`;
+  }
+  if (statVarY && !statVars.has(statVarY)) {
+    y.unsetStatVar();
+    message += message.length
+      ? ` or ${statVarY}`
+      : `Sorry, no data available for ${statVarY}`;
+  }
+  if (message) {
+    alert(`${message}. Try picking other variables.`);
+  }
+}
+
+/**
+ * Adds a statvar.
+ * If either x or y axis does not yet have a statvar selected, assign the new
+ * statvar to that axis. Otherwise, set the new statvar as the third, extra statvar.
+ * @param x
+ * @param y
+ * @param statVar
+ * @param nodePath
+ * @param denominators
+ * @param setThirdStatVar
+ */
+function addStatVar(
+  x: AxisWrapper,
+  y: AxisWrapper,
+  statVar: string,
+  nodePath: string[],
+  denominators: string[],
+  setThirdStatVar: (statVar: NamedStatVar) => void
+) {
+  const node = {
+    [statVar]: { paths: [nodePath], denominators: denominators },
+  };
+  if (_.isEmpty(x.value.statVar)) {
+    x.setStatVar(node);
+  } else if (_.isEmpty(y.value.statVar)) {
+    y.setStatVar(node);
+  } else {
+    setThirdStatVar({ statVar: node, name: "" });
+  }
+}
+
+/**
+ * Removes a selected statvar.
+ * @param x
+ * @param y
+ * @param statVar
+ * @param nodePath
+ */
+function removeStatVar(
+  x: AxisWrapper,
+  y: AxisWrapper,
+  statVar: string,
+  nodePath?: string[]
+) {
+  const statVarX = _.keys(x.value.statVar)[0];
+  const statVarY = _.keys(y.value.statVar)[0];
+  const path = [nodePath];
+  if (
+    statVarX === statVar &&
+    (!nodePath || _.isEqual(x.value.statVar[statVarX].paths, path))
+  ) {
+    x.unsetStatVar();
+  } else if (
+    statVarY === statVar &&
+    (!nodePath || _.isEqual(y.value.statVar[statVarY].paths, path))
+  ) {
+    y.unsetStatVar();
+  }
+}
+
+/**
+ * Sets the title of a statvar.
+ * The title could be for the statvar for the x axis,
+ * the statvar for the y axis, or the third, extra statvar.
+ * @param x
+ * @param y
+ * @param statsVarId2Title
+ * @param thirdStatVar
+ * @param setThirdStatVar
+ */
+function setStatsVarTitle(
+  x: AxisWrapper,
+  y: AxisWrapper,
+  statsVarId2Title: Record<string, string>,
+  thirdStatVar: NamedStatVar,
+  setThirdStatVar: (statVar: NamedStatVar) => void
+): void {
+  const statVarX = nodeGetStatVar(x.value.statVar);
+  if (statVarX && statVarX in statsVarId2Title) {
+    x.setStatVarName(statsVarId2Title[statVarX]);
+  }
+  const statVarY = nodeGetStatVar(y.value.statVar);
+  if (statVarY && statVarY in statsVarId2Title) {
+    y.setStatVarName(statsVarId2Title[statVarY]);
+  }
+  const statVarThird = nodeGetStatVar(thirdStatVar.statVar);
+  if (statVarThird && statVarThird in statsVarId2Title) {
+    setThirdStatVar({ ...thirdStatVar, name: statsVarId2Title[statVarThird] });
+  }
+}
+
+/**
+ * Selects or unselects one of the three statvars displayed in the modal.
+ * @param modalSelected
+ * @param setModalSelected
+ * @param event
+ */
+function selectStatVar(
+  modalSelected: ModalSelected,
+  setModalSelected: (modalSelected: ModalSelected) => void,
+  event: React.ChangeEvent<HTMLInputElement>
+): void {
+  switch (event.target.name) {
+    case "x":
+      setModalSelected({ ...modalSelected, x: event.target.checked });
+      break;
+    case "y":
+      setModalSelected({ ...modalSelected, y: event.target.checked });
+      break;
+    case "third":
+      setModalSelected({ ...modalSelected, third: event.target.checked });
+      break;
+  }
+}
+
+/**
+ * Confirms the statvar selections in the modal.
+ * No-op if all three statvars are selected.
+ * Clears the third, extra statvar and the modal selections.
+ * @param x
+ * @param y
+ * @param thirdStatVar
+ * @param setThirdStatVar
+ * @param modalSelected
+ * @param setModalSelected
+ */
+function confirmStatVars(
+  x: AxisWrapper,
+  y: AxisWrapper,
+  thirdStatVar: NamedStatVar,
+  setThirdStatVar: (statVar: NamedStatVar) => void,
+  modalSelected: ModalSelected,
+  setModalSelected: (modalSelected: ModalSelected) => void
+): void {
+  if (modalSelected.x && modalSelected.y && modalSelected.third) {
+    // TODO: Maybe display an error message.
+    return;
+  }
+  const values: Array<Axis> = [];
+  const axes = [x, y];
+
+  if (modalSelected.x) {
+    values.push(x.value);
+  } else {
+    assignAxes([x], [EmptyAxis]);
+  }
+  if (modalSelected.y) {
+    values.push(y.value);
+  } else {
+    assignAxes([y], [EmptyAxis]);
+  }
+  values.push({
+    ...EmptyAxis,
+    statVar: thirdStatVar.statVar,
+    name: thirdStatVar.name,
+  });
+
+  if (modalSelected.x) {
+    assignAxes(axes, values);
+  }
+  if (modalSelected.y) {
+    assignAxes(axes, values);
+  }
+  if (modalSelected.third) {
+    assignAxes(axes, values);
+  }
+
+  setThirdStatVar(emptyStatVar);
+  setModalSelected(defaultModalSelected);
+}
+
+/**
+ * Assigns the first `Axis` in `values` to the first `AxisWrapper` in axes while
+ * keeping the log and per capita options in the original `AxisWrapper`.
+ * The `Axis` and `AxisWrapper` involved are removed from the arrays.
+ * @param axes
+ * @param values
+ */
+function assignAxes(axes: Array<AxisWrapper>, values: Array<Axis>) {
+  const axis = axes.shift();
+  axis.set({
+    ...values.shift(),
+    log: axis.value.log,
+    perCapita: axis.value.perCapita,
+  });
+}
+
+export { StatVarChooser };

--- a/static/js/tools/scatter2/util.test.ts
+++ b/static/js/tools/scatter2/util.test.ts
@@ -1,0 +1,114 @@
+import { ContextType } from "./context";
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { updateHash, applyHash } from "./util";
+
+const TestContext = ({
+  x: {
+    value: {
+      statVar: {
+        Count_Person: {
+          paths: [["0", "1"]],
+          denominators: ["Count_Person_Female", "Count_Person_Male"],
+        },
+      },
+      name: "People",
+      log: true,
+      perCapita: false,
+    },
+  },
+  y: {
+    value: {
+      statVar: {
+        Count_HousingUnit: {
+          paths: [["5", "6"]],
+          denominators: [],
+        },
+      },
+      name: "Housing Units",
+      log: false,
+      perCapita: true,
+    },
+  },
+  place: {
+    value: {
+      enclosingPlace: {
+        name: "Delaware",
+        dcid: "geoId/10",
+      },
+      enclosedPlaceType: "County",
+      enclosedPlaces: [
+        {
+          name: "a county",
+          dcid: "geoId/10003",
+        },
+        {
+          name: "another county",
+          dcid: "geoId/10005",
+        },
+      ],
+      lowerBound: 0,
+      upperBound: 99999,
+    },
+  },
+  date: {
+    value: {
+      year: 2016,
+      month: 0,
+      day: 0,
+    },
+  },
+} as unknown) as ContextType;
+const Hash =
+  "#%26svx%3DCount_Person%26svpx%3D0-1%26svdx%3DCount_Person_Female%26svnx%3DPeople" +
+  "%26lx%3D1%26svy%3DCount_HousingUnit%26svpy%3D5-6%26svny%3DHousing%20Units%26pcy%3D1" +
+  "%26epd%3DgeoId%2F10%26epn%3DDelaware%26ept%3DCounty%26ub%3D99999%26y%3D2016";
+
+test("updateHash", () => {
+  history.pushState = jest.fn();
+  updateHash(TestContext);
+  expect(history.pushState).toHaveBeenCalledWith(
+    {},
+    "",
+    `/tools/scatter2${Hash}`
+  );
+});
+
+test("applyHash", () => {
+  const context = { x: {}, y: {}, place: {}, date: {} } as ContextType;
+  context.x.set = (value) => (context.x.value = value);
+  context.y.set = (value) => (context.y.value = value);
+  context.place.set = (value) => (context.place.value = value);
+  context.date.set = (value) => (context.date.value = value);
+  location.hash = Hash;
+  applyHash(context);
+  expect(context.x.value).toEqual({
+    ...TestContext.x.value,
+    statVar: {
+      Count_Person: {
+        paths: [["0", "1"]],
+        denominators: ["Count_Person_Female"],
+      },
+    },
+  });
+  expect(context.y.value).toEqual(TestContext.y.value);
+  expect(context.place.value).toEqual({
+    ...TestContext.place.value,
+    enclosedPlaces: [],
+  });
+  expect(context.date.value).toEqual(TestContext.date.value);
+});

--- a/static/js/tools/scatter2/util.ts
+++ b/static/js/tools/scatter2/util.ts
@@ -1,0 +1,339 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Functions for making API calls and updating and applying URL hash.
+ */
+
+import axios from "axios";
+import _ from "lodash";
+import { StatsVarNode } from "../timeline_util";
+import {
+  ContextType,
+  Axis,
+  PlaceInfo,
+  EmptyAxis,
+  EmptyPlace,
+  EmptyDate,
+  FieldToAbbreviation,
+  DateInfo,
+} from "./context";
+
+interface SourceSeries {
+  val: Record<string, number>;
+  measurementMethod: string;
+  importName: string;
+  provenanceDomain: string;
+  provenanceUrl: string;
+  observationPeriod: string;
+  unit: string;
+  scalingFactor: string;
+  isDcAggregate: boolean;
+  date: string;
+}
+
+async function getPlacesInNames(
+  dcid: string,
+  type: string
+): Promise<Record<string, string>> {
+  const resp = await axios.get(
+    `/api/place/places-in-names?dcid=${dcid}&placeType=${type}`
+  );
+  return resp.data;
+}
+
+async function getStatsCollection(
+  parent_place: string,
+  child_type: string,
+  date: string,
+  statVars: Array<string>
+): Promise<Record<string, SourceSeries>> {
+  let statVarParams = "";
+  for (const statVar of statVars) {
+    statVarParams += `&stat_vars=${statVar}`;
+  }
+  const resp = await axios.get(
+    `/api/stats/collection?parent_place=${parent_place}&child_type=${child_type}&date=${date}${statVarParams}`
+  );
+  // Tag `SourceSeries`'s with the requested date
+  const data = resp.data;
+  for (const dcid in data) {
+    const sourceSeries = data[dcid];
+    if (_.isEmpty(sourceSeries)) {
+      continue;
+    }
+    sourceSeries["date"] = date;
+  }
+  return data;
+}
+
+/**
+ * Given a `StatsVarNode` that only has one key,
+ * return the key.
+ * @param node
+ */
+function nodeGetStatVar(node: StatsVarNode): string {
+  return _.findKey(node);
+}
+
+/**
+ * Checks if the date of data to retrieve is chosen.
+ * Returns true if year is chosen, or year and month are chosen,
+ * or year, month, and day are chosen.
+ * @param date
+ */
+function isDateChosen(date: DateInfo): boolean {
+  return (
+    (date.year > 0 && !date.month && !date.day) ||
+    (date.year > 0 && date.month > 0 && !date.day) ||
+    (date.year > 0 && date.month > 0 && date.day > 0)
+  );
+}
+
+/**
+ * Parses the hash and updates the context accordingly.
+ * @param context
+ */
+function applyHash(context: ContextType): void {
+  const params = new URLSearchParams(
+    decodeURIComponent(location.hash).replace("#", "?")
+  );
+  context.x.set(applyHashAxis(params, true));
+  context.y.set(applyHashAxis(params, false));
+  context.place.set(applyHashPlace(params));
+  context.date.set(applyHashDate(params));
+}
+
+/**
+ * Appends "x" or "y" to the key based on `isX`.
+ * @param key
+ * @param isX
+ */
+function addSuffix(key: string, isX: boolean) {
+  return `${key}${isX ? "x" : "y"}`;
+}
+
+/**
+ * Uses the parsed hash to produce an `Axis`.
+ * @param params
+ * @param isX
+ */
+function applyHashAxis(params: URLSearchParams, isX: boolean): Axis {
+  const dcid = params.get(addSuffix(FieldToAbbreviation.statVarDcid, isX));
+  if (!dcid) {
+    return EmptyAxis;
+  }
+  const axis = _.cloneDeep(EmptyAxis);
+
+  const node: StatsVarNode = {
+    [dcid]: {
+      paths: [],
+      denominators: [],
+    },
+  };
+  const path = params.get(addSuffix(FieldToAbbreviation.statVarPath, isX));
+  if (path) {
+    node[dcid].paths = [path.split("-")];
+  }
+  const denominator = params.get(
+    addSuffix(FieldToAbbreviation.statVarDenominator, isX)
+  );
+  if (denominator) {
+    node[dcid].denominators = [denominator];
+  }
+  axis.statVar = node;
+
+  for (const key of ["name", "log", "perCapita"]) {
+    const value = params.get(addSuffix(FieldToAbbreviation[key], isX));
+    if (value) {
+      axis[key] = value === "1" ? true : value;
+    }
+  }
+
+  return axis;
+}
+
+/**
+ * Uses the parsed hash to produce a `PlaceInfo`.
+ * @param params
+ */
+function applyHashPlace(params: URLSearchParams): PlaceInfo {
+  const place = _.cloneDeep(EmptyPlace);
+  const dcid = params.get(FieldToAbbreviation.enclosingPlaceDcid);
+  if (dcid) {
+    place.enclosingPlace = {
+      dcid: dcid,
+      name: params.get(FieldToAbbreviation.enclosingPlaceName),
+    };
+  }
+  const type = params.get(FieldToAbbreviation.enclosedPlaceType);
+  if (type) {
+    place.enclosedPlaceType = type;
+  }
+  for (const key of ["lowerBound", "upperBound"]) {
+    const value = params.get(FieldToAbbreviation[key]);
+    if (value) {
+      place[key] = Number.parseInt(value);
+    }
+  }
+  return place;
+}
+
+/**
+ * Uses the parsed hash to produce a `DateInfo`.
+ * @param params
+ */
+function applyHashDate(params: URLSearchParams): DateInfo {
+  const date = _.cloneDeep(EmptyDate);
+  for (const key of ["year", "month", "day"]) {
+    const value = params.get(FieldToAbbreviation[key]);
+    if (value) {
+      date[key] = Number.parseInt(value);
+    }
+  }
+  return date;
+}
+
+/**
+ * Updates the hash based on the context and returns the new hash.
+ * If there are multiple denominators for a statvar, only the first
+ * one is stored in the hash.
+ * @param context
+ */
+function updateHash(context: ContextType): void {
+  const x = context.x.value;
+  const y = context.y.value;
+  const place = context.place.value;
+  const date = context.date.value;
+  let hash = updateHashAxis("", x, true);
+  hash = updateHashAxis(hash, y, false);
+  hash = updateHashPlace(hash, place);
+  hash = updateHashDate(hash, date);
+  if (hash) {
+    history.pushState({}, "", `/tools/scatter2#${encodeURIComponent(hash)}`);
+  }
+}
+
+/**
+ * Appends a key-value mapping to the hash.
+ * @param hash
+ * @param key
+ * @param value
+ */
+function appendEntry(hash: string, key: string, value: string): string {
+  return `${hash}&${key}=${value}`;
+}
+
+/**
+ * Updates the hash based on the axis and returns the new hash.
+ * @param hash
+ * @param axis
+ * @param isX
+ */
+function updateHashAxis(hash: string, axis: Axis, isX: boolean): string {
+  if (_.isEqual(axis, EmptyAxis)) {
+    return hash;
+  }
+  const statVarDcid = nodeGetStatVar(axis.statVar);
+  if (statVarDcid) {
+    hash = appendEntry(
+      hash,
+      addSuffix(FieldToAbbreviation.statVarDcid, isX),
+      statVarDcid
+    );
+    const node = axis.statVar[statVarDcid];
+    if (!_.isEmpty(node.paths)) {
+      hash = appendEntry(
+        hash,
+        addSuffix(FieldToAbbreviation.statVarPath, isX),
+        node.paths[0].join("-")
+      );
+    }
+    if (!_.isEmpty(node.denominators)) {
+      hash = appendEntry(
+        hash,
+        addSuffix(FieldToAbbreviation.statVarDenominator, isX),
+        node.denominators[0]
+      );
+    }
+    for (const key of ["name", "log", "perCapita"]) {
+      if (axis[key]) {
+        hash = appendEntry(
+          hash,
+          addSuffix(FieldToAbbreviation[key], isX),
+          axis[key] === true ? "1" : axis[key]
+        );
+      }
+    }
+  }
+  return hash;
+}
+
+/**
+ * Updates the hash based on the `PlaceInfo` and returns the new hash.
+ * @param hash
+ * @param place
+ */
+function updateHashPlace(hash: string, place: PlaceInfo): string {
+  if (_.isEqual(place, EmptyPlace)) {
+    return hash;
+  }
+  if (place.enclosingPlace.dcid) {
+    hash = appendEntry(
+      hash,
+      FieldToAbbreviation.enclosingPlaceDcid,
+      place.enclosingPlace.dcid
+    );
+    hash = appendEntry(
+      hash,
+      FieldToAbbreviation.enclosingPlaceName,
+      place.enclosingPlace.name
+    );
+  }
+  for (const key of ["enclosedPlaceType", "lowerBound", "upperBound"]) {
+    if (place[key] !== EmptyPlace[key]) {
+      hash = appendEntry(hash, FieldToAbbreviation[key], place[key].toString());
+    }
+  }
+  return hash;
+}
+
+/**
+ * Updates the hash based on the `DateInfo` and returns the new hash.
+ * @param hash
+ * @param date
+ */
+function updateHashDate(hash: string, date: DateInfo) {
+  if (_.isEqual(date, EmptyDate)) {
+    return hash;
+  }
+  for (const key of ["year", "month", "day"]) {
+    if (date[key]) {
+      hash = appendEntry(hash, FieldToAbbreviation[key], date[key].toString());
+    }
+  }
+  return hash;
+}
+
+export {
+  getPlacesInNames,
+  getStatsCollection,
+  nodeGetStatVar,
+  isDateChosen,
+  updateHash,
+  applyHash,
+  SourceSeries,
+};

--- a/static/js/tools/timeline_info.tsx
+++ b/static/js/tools/timeline_info.tsx
@@ -21,7 +21,7 @@ class Info extends Component {
     return (
       <div id="placeholder-container">
         <p>
-          The timelines tool help you explore trends for the variables that
+          The timelines tool helps you explore trends for the variables that
           appear in the pane to the left. Enter a place --- city, state, zip,
           county, country --- in the search box above and then pick one or more
           variables in the pane. There are thousands of variables to choose

--- a/static/js/tools/timeline_search.tsx
+++ b/static/js/tools/timeline_search.tsx
@@ -50,6 +50,7 @@ interface SearchBarPropType {
   places: Record<string, string>;
   addPlace: (place: string) => void;
   removePlace: (place: string) => void;
+  numPlacesLimit?: number; // Maximum number of places allowed
 }
 
 class SearchBar extends Component<SearchBarPropType> {
@@ -102,6 +103,11 @@ class SearchBar extends Component<SearchBarPropType> {
       );
       this.ac.addListener("place_changed", this.getPlaceAndRender);
     }
+    this.setPlaceholder();
+  }
+
+  componentDidUpdate(): void {
+    this.setPlaceholder();
   }
 
   private getPlaceAndRender() {
@@ -113,18 +119,27 @@ class SearchBar extends Component<SearchBarPropType> {
         this.props.addPlace(resp.data);
       })
       .catch(() => {
-        alert("Sorry, but we don't have any data about " + name);
+        alert("Sorry, but we don't have any data about " + place.name);
       });
-    this.setPlaceholder();
   }
 
   private setPlaceholder() {
     this.inputElem.current.value = "";
-    if (Object.keys(this.props.places).length > 0) {
-      this.inputElem.current.placeholder = "Add another place";
+    const numPlaces = Object.keys(this.props.places).length;
+    this.inputElem.current.disabled = false;
+    if (numPlaces > 0) {
+      if (
+        this.props.numPlacesLimit !== undefined &&
+        numPlaces >= this.props.numPlacesLimit
+      ) {
+        this.inputElem.current.placeholder = "";
+        this.inputElem.current.disabled = true;
+      } else {
+        this.inputElem.current.placeholder = "Add another place";
+      }
     } else {
       this.inputElem.current.placeholder =
-        "Enter a country, state, county or city to get started";
+        "Enter a country, state, county, or city to get started";
     }
   }
 }

--- a/static/js/tools/timeline_util.ts
+++ b/static/js/tools/timeline_util.ts
@@ -51,26 +51,25 @@ function getStatsVarInfo(
   });
 }
 
-function getStatsVar(dcids: string[]): Promise<Set<string>> {
+/**
+ * Returns the union of all statvars available for the given places.
+ * @param dcids
+ * @param sample Whether to sample `sampleSize` places from the given places, and only
+ * get the statvars for them.
+ * @param sampleSize
+ */
+async function getStatsVar(
+  dcids: string[],
+  sample = false,
+  sampleSize = 50
+): Promise<Set<string>> {
   if (dcids.length === 0) {
     return Promise.resolve(new Set<string>());
   }
-  const promises = [];
-  // ToDo: read the set of statsVars available for multiple dcids from server side
-  for (const dcid of dcids) {
-    promises.push(
-      axios.get("/api/place/statsvars/" + dcid).then((resp) => {
-        return resp.data;
-      })
-    );
-  }
-  return Promise.all(promises).then((values) => {
-    let statsVars = new Set();
-    for (const value of values) {
-      statsVars = new Set([...Array.from(statsVars), ...value]);
-    }
-    return statsVars;
-  }) as Promise<Set<string>>;
+  const resp = await axios.post("/api/place/stat-vars/union", {
+    dcids: sample ? _.sampleSize(dcids, sampleSize).sort() : dcids,
+  });
+  return new Set<string>(resp.data);
 }
 
 const placeSep = ",";

--- a/static/js/translator/constants.ts
+++ b/static/js/translator/constants.ts
@@ -14,7 +14,67 @@
  * limitations under the License.
  */
 
-export const SCHEMA_MAPPING = `
+export const input = {
+  place: {
+    mapping: `
+Node: E:Place->E1
+typeOf: Place
+subType: C:Place->type
+dcid: C:Place->id
+name: C:Place->name
+functionalDeps: dcid
+
+Node: E:Observation->E1
+typeOf: Observation
+dcid: C:Observation->id
+measuredProperty: C:Observation->measured_prop
+observationDate: C:Observation->observation_date
+measuredValue: C:Observation->measured_value
+observedNode: E:Observation->E2
+functionalDeps: dcid
+
+Node: E:Observation->E2
+typeOf: Place
+dcid: C:Observation->observed_node_key
+functionalDeps: dcid
+    `,
+    sparql: `
+SELECT ?name ?date ?value
+WHERE {
+  ?o typeOf Observation .
+  ?p typeOf State .
+  ?o observedNode ?p .
+  ?p name ?name .
+  ?o measuredProperty Count_EarthquakeEvent_M3To4 .
+  ?o observationDate ?date .
+  ?o measuredValue ?value .
+}
+    `,
+  },
+  sv: {
+    mapping: `
+Node: E:Triple->E1
+dcid: C:Triple->subject_id
+provenance: E:Triple->E2
+C:Triple->predicate: C:Triple->object_value
+functionalDeps: dcid
+
+Node: E:Triple->E2
+typeOf: Provenance
+dcid: C:Triple->prov_id
+functionalDeps: dcid
+    `,
+    sparql: `
+SELECT ?sv
+WHERE {
+  ?sv typeOf StatisticalVariable .
+  ?sv measuredProperty count .
+  ?sv populationType Person .
+}
+    `,
+  },
+  all: {
+    mapping: `
 Node: E:StatisticalPopulation->E1
 typeOf: StatisticalPopulation
 dcid: C:StatisticalPopulation->id
@@ -265,9 +325,8 @@ Node: E:Triple->E2
 typeOf: Provenance
 dcid: C:Triple->prov_id
 functionalDeps: dcid
-`;
-
-export const SAMPLE_QUERY = `
+`,
+    sparql: `
 SELECT ?node ?freelunch_percent ?unemploy_rate
 WHERE {
   ?node typeOf State .
@@ -295,4 +354,6 @@ WHERE {
   ?obs2 observationDate "2018" .
   ?obs2 measuredValue ?unemploy_rate .
 }
-`;
+`,
+  },
+};

--- a/static/js/translator/page.tsx
+++ b/static/js/translator/page.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import axios from "axios";
 
 import { Binding, Constraint, Translation } from "./translation";
+import { input } from "./constants";
 
 interface PagePropType {
   mapping: string;
@@ -32,15 +33,24 @@ interface PageStateType {
 }
 
 export class Page extends React.Component<PagePropType, PageStateType> {
-  sparql: string;
-  mapping: string;
-  delayTimer: NodeJS.Timeout;
+  private sparql: string;
+  private mapping: string;
+  private delayTimer: NodeJS.Timeout;
+  private mappingInputElem: React.RefObject<HTMLTextAreaElement>;
+  private sparqlInputElem: React.RefObject<HTMLTextAreaElement>;
+  private defaultRadioElem: React.RefObject<HTMLInputElement>;
+
   constructor(props: PagePropType) {
     super(props);
     this.handleSparqlChange = this.handleSparqlChange.bind(this);
     this.handleMappingChange = this.handleMappingChange.bind(this);
+    this.onModeChange = this.onModeChange.bind(this);
     this.sparql = this.props.sparql;
     this.mapping = this.props.mapping;
+    this.mappingInputElem = React.createRef();
+    this.sparqlInputElem = React.createRef();
+    this.defaultRadioElem = React.createRef();
+
     this.state = {
       sql: "",
       bindings: [],
@@ -60,8 +70,17 @@ export class Page extends React.Component<PagePropType, PageStateType> {
     this.delayTimer = setTimeout(this.updateTranslation.bind(this), 1000);
   }
 
+  onModeChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    this.mappingInputElem.current.value = input[event.target.value].mapping;
+    this.sparqlInputElem.current.value = input[event.target.value].sparql;
+    this.mapping = input[event.target.value].mapping;
+    this.sparql = input[event.target.value].sparql;
+    this.updateTranslation();
+  }
+
   componentDidMount(): void {
     this.updateTranslation();
+    this.defaultRadioElem.current.checked = true;
   }
 
   render(): JSX.Element {
@@ -69,10 +88,39 @@ export class Page extends React.Component<PagePropType, PageStateType> {
       <div className="container">
         <h1>Schema Translator</h1>
         <h5>Enter Schema Mapping and Graph Query</h5>
-        <div id="input-box" className="row mt-5">
+        <form>
+          <label id="select-input">
+            <input
+              type="radio"
+              value="place"
+              name="mode"
+              onChange={this.onModeChange}
+              ref={this.defaultRadioElem}
+            />
+            Place Observation
+            <br />
+            <input
+              type="radio"
+              value="sv"
+              name="mode"
+              onChange={this.onModeChange}
+            />
+            Statistical Variable
+            <br />
+            <input
+              type="radio"
+              value="all"
+              name="mode"
+              onChange={this.onModeChange}
+            />{" "}
+            All
+          </label>
+        </form>
+        <div id="input-box" className="row">
           <div className="input-box-content col-6">
             <h6>Schema Mapping</h6>
             <textarea
+              ref={this.mappingInputElem}
               id="mapping"
               onChange={this.handleMappingChange}
               defaultValue={this.props.mapping}
@@ -81,6 +129,7 @@ export class Page extends React.Component<PagePropType, PageStateType> {
           <div className="input-box-content col-6">
             <h6>Graph Query</h6>
             <textarea
+              ref={this.sparqlInputElem}
               id="query"
               onChange={this.handleSparqlChange}
               defaultValue={this.props.sparql}

--- a/static/js/translator/translation.tsx
+++ b/static/js/translator/translation.tsx
@@ -41,6 +41,13 @@ interface TranslationPropType {
 }
 
 export class Translation extends React.Component<TranslationPropType> {
+  formatSql(sql: string): string {
+    return sql
+      .replace(/ FROM/g, "\n    FROM")
+      .replace(/ JOIN/g, "\nJOIN")
+      .replace(/ AND/g, "\n    AND")
+      .replace(/ WHERE/g, "\nWHERE");
+  }
   render(): JSX.Element {
     return (
       <>
@@ -68,11 +75,9 @@ export class Translation extends React.Component<TranslationPropType> {
           <table className="translation-info-table">
             <tbody>
               <tr className="header">
-                <td className="sql">SQL</td>
                 <td className="constraints">Constraints</td>
               </tr>
               <tr>
-                <td className="sql-result">{this.props.sql}</td>
                 <td>
                   <ul>
                     {this.props.constraints.map((c, index) => {
@@ -84,6 +89,16 @@ export class Translation extends React.Component<TranslationPropType> {
                     })}
                   </ul>
                 </td>
+              </tr>
+            </tbody>
+          </table>
+          <table className="translation-info-table">
+            <tbody>
+              <tr className="header">
+                <td className="sql">SQL</td>
+              </tr>
+              <tr>
+                <td className="sql-result">{this.formatSql(this.props.sql)}</td>
               </tr>
             </tbody>
           </table>

--- a/static/js/translator/translator.ts
+++ b/static/js/translator/translator.ts
@@ -22,7 +22,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { Page } from "./page";
-import { SCHEMA_MAPPING, SAMPLE_QUERY } from "./constants";
+import { input } from "./constants";
 
 /**
  * Update translation results when schema mapping or query changes.
@@ -30,8 +30,8 @@ import { SCHEMA_MAPPING, SAMPLE_QUERY } from "./constants";
 window.onload = function () {
   ReactDOM.render(
     React.createElement(Page, {
-      sparql: SAMPLE_QUERY,
-      mapping: SCHEMA_MAPPING,
+      mapping: input.place.mapping,
+      sparql: input.place.sparql,
     }),
     document.getElementById("translator")
   );

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -15916,8 +15916,7 @@
     "webpack-shell-plugin": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/webpack-shell-plugin/-/webpack-shell-plugin-0.5.0.tgz",
-      "integrity": "sha1-Kbih2A3erg3bEOcpZn9yhlPCx0I=",
-      "dev": true
+      "integrity": "sha1-Kbih2A3erg3bEOcpZn9yhlPCx0I="
     },
     "webpack-sources": {
       "version": "1.4.3",

--- a/static/package.json
+++ b/static/package.json
@@ -54,7 +54,8 @@
     "typescript": "^3.9.7",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
-    "webpack-fix-style-only-entries": "^0.5.1"
+    "webpack-fix-style-only-entries": "^0.5.1",
+    "webpack-shell-plugin": "^0.5.0"
   },
   "devDependencies": {
     "@babel/polyfill": "^7.11.5",

--- a/static/webpack.config.js
+++ b/static/webpack.config.js
@@ -23,7 +23,7 @@ const config = {
   entry: {
     // TODO(intrepiditee): Rename to scatter when ready.
     scatter2: [
-      __dirname + "/js/tools/scatter2/scatter2.tsx",
+      __dirname + "/js/tools/scatter2/scatter2.ts",
       __dirname + "/css/tools/scatter2.scss",
     ],
     choropleth: [

--- a/tools/pv_tree_generator/dc_request.py
+++ b/tools/pv_tree_generator/dc_request.py
@@ -21,19 +21,10 @@ from google.cloud import secretmanager
 API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
 
 
-def get_api_key():
-    secret_client = secretmanager.SecretManagerServiceClient()
-    secret_name = secret_client.secret_version_path('datcom-mixer-staging',
-                                                    'mixer-api-key', '1')
-    secret_response = secret_client.access_secret_version(secret_name)
-    DC_API_KEY = secret_response.payload.data.decode('UTF-8')
-    return DC_API_KEY
-
-
 def get_sv_dcids():
     req_url = API_ROOT + "/query"
     query_str = "SELECT ?a WHERE {?a typeOf StatisticalVariable}"
-    headers = {'x-api-key': get_api_key(), 'Content-Type': 'application/json'}
+    headers = {'Content-Type': 'application/json'}
     response = requests.post(req_url,
                              json={'sparql': query_str},
                              headers=headers,
@@ -68,7 +59,7 @@ def send_request(req_url, req_json={}, compress=False, post=True):
     Returns:
       The payload returned by sending the POST/GET request formatted as a dict.
     """
-    headers = {'x-api-key': get_api_key(), 'Content-Type': 'application/json'}
+    headers = {'Content-Type': 'application/json'}
 
     # Send the request and verify the request succeeded
     if post:


### PR DESCRIPTION
commit 3b88d00059b46ff65f0fff5a18a527594c63fdb8
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Tue Jan 5 10:20:29 2021 -0800

    Update staging mixer endpoints (#736)

commit 92aaa2c1ffdb801a403b0d8a7cf548954068b446
Author: hanlu09205 <59888187+hanlu09205@users.noreply.github.com>
Date:   Wed Dec 30 11:28:21 2020 -0800

    remind people to update chromedriver path (#734)

    * remind people to update chromedriver path

    * reword

commit 037c58f53625ae3a08e9f25ada6d38cd0ea15dfc
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Wed Dec 16 19:49:01 2020 -0800

    Fix cloudbulid error: 'deployment' folder already exists (#730)

    * Fix cloudbulid deployment error:  already exists

    * update

commit 142074e67e76cee9f3f4b6c25b9dfda7f7e3ff76
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Wed Dec 16 17:54:02 2020 -0800

    [MAPS_API_KEY] Use distinct keys from GCP projects corresponding to the  environment (#727)

    * [MAPS_API_KEY] Use distinct keys from GCP projects corresponding to the  environment

    * update README

    * Put all api key in secret manager

    * fix test

    * naming

commit 929d410a5b832889246c5e7859b5d46287736206
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Wed Dec 16 17:08:29 2020 -0800

    Fix the steps for create standalone cluster (#723)

    * Fix the steps for create standalone cluster

    * Add more fix

    * order

commit 602fea6e40e0cac1cdcf8a34b33d586eabdde823
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Wed Dec 16 16:50:24 2020 -0800

    Remove API_KEY related code since it's not needed (#729)

commit ceefd68a2d09acc43de6691645d0faac0babd842
Author: Prashanth R <shanth@google.com>
Date:   Tue Dec 15 12:33:40 2020 -0800

    Trim values for "nameWithLanguage" predicate on browser (#722)

commit 68fb35d019b9f54e6d58b3648efed823702874bc
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Mon Dec 14 10:44:00 2020 -0800

    [Translator] Add more default inputs; Format SQL (#721)

commit e5c3873dec12b73687f1d17212ba86b23a7c03a7
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Mon Dec 14 10:38:33 2020 -0800

    Various fixes and updates for website GKE deployment process (#720)

    * Various fixes and updates for website gke deployment process

    * finish up prod setup

    * update and fix

    * fix number

commit f306a7a519b2f4e48cfef7a946a71b6b297cba83
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Fri Dec 11 16:59:52 2020 -0800

    GKE does not support startupProbe yyet,so only keep readiness probe (#719)

commit 04899bb0aade094635aa5497b3660840867f70d5
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Fri Dec 11 15:44:03 2020 -0800

    Update resource allocation based on actual usage from GCP dashboard (#718)

    * Update cpu and resource allocation based on actual usage from gcp dashboard

    * Update deployment/config.yaml

    Co-authored-by: beets <beets@users.noreply.github.com>

    Co-authored-by: beets <beets@users.noreply.github.com>

commit c889d422ffabfd09c1e2dd41b1487752bd3a7b8e
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Fri Dec 11 11:17:57 2020 -0800

    website app /healthz endpoints used for kubernetes health check (#717)

    * website app /healthz endpoints used for kubernetes health check

    * Add startup and liveness probe

commit 3e2041b2c53af6f74ec8e10148f54dcf4bd2eaa0
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Fri Dec 11 10:05:57 2020 -0800

    Update GKE deployment steps: this is a working version on a brand new GCP project (#716)

    * Update gke deployment steps

    * update regions

    * fix typo

    * todo

commit 6b437b4ba37fbe2e08849f7eb8ecb13786e11bcd
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Thu Dec 10 11:44:35 2020 -0800

    Deploy website + mixer + esp on Kubernetes (#698)

    * Kubenetes deployment of website + mixer + esp, working on Minikube

    * Fix app selector

    * update

    * consolidate minikube and gke

    * more update

    * clean up minikube steps

    * update gke steps

    * resolve comments

    * more fix

    * typos

    * use us-central1, update staging ip and domain

commit 1bb4c6d1262eb31ecd8afba6ef7772bb32495210
Author: intrepiditee <31870027+intrepiditee@users.noreply.github.com>
Date:   Thu Dec 10 13:12:18 2020 -0600

    [Scatter2] Fix formatDate and isDateChosen (#707)

    Fix formatDate not adding extra zeros before single digit months and days
    Fix isDateChosen not checking if month or day is not set

commit 0f467203f19589077acb63f699675c5c2e8c624b
Author: intrepiditee <31870027+intrepiditee@users.noreply.github.com>
Date:   Wed Dec 9 16:57:47 2020 -0600

    [Scatter2] APIs, provenance, shorter URL (#699)

    Use /stat/collection for getting date and /place/stat-vars/union for getting available statvars
    Show provenance #702
    Create shorter URL hash
    Clear hash after resetting #704

commit 65bf4feb0d67e00ad8688389f331186b6eaf3836
Author: intrepiditee <31870027+intrepiditee@users.noreply.github.com>
Date:   Thu Dec 3 19:24:05 2020 -0600

    [Scatter2] Rewrite scatter plot tool in React (#668)

    * basic flow

    * switch to global state

    * add untracked

    * works for median age and income

    * functional

    * fix ticks and labels

    * move stats below chart

    * collapse plot options

    * place search bar same row

    * add loading spinner

    * factor out search bar css

    * spinner for statvar menu

    * capitalize labels

    * listen to hash change

    * move some functions out of components

    * expand options if any option is checked

    * fix y label

    * doc and refactor

    * use refs for d3

    * add tests

    * use spinner from base_tools.scss

    * use spinner from base_tools.scss

    * reduce plot height

    * fix search bar alert message

    * add screenshot test

    * lint

    * only plot after statvar names are loaded

    * fix for beets

    * partial fix for shifucun

    * move api calls to server side

    * atach setters to context

    * fix doc

    * add headline and info

    * add files

    * newline

    * revert shouldHideInfo

    * add test for places-in

    * add test for stats/value

    * fix search box test

    * test third statvar

    * remove log

    * update child place types

    * fixed doc

    * remove country from child place types

commit 1bed4d30de00643a0f8c6d8b63b731cfbec657b3
Author: Eduardo Morales <edumorales@google.com>
Date:   Mon Nov 30 17:46:39 2020 -0500

    Webdriver tests in parallel (#695)

    * Initial commit for webdriver tests in parallel

    * fix linting'

    * fixes to doc

commit 0a4d41f157632324437305ba66b4f0ee8e54df00
Author: beets <beets@users.noreply.github.com>
Date:   Wed Nov 25 14:27:27 2020 -0800

    fix truncated downloads (#691)

commit 0d5b3cb42d5e80979680ec9cf9a6981500d0bf29
Author: beets <beets@users.noreply.github.com>
Date:   Wed Nov 25 13:56:28 2020 -0800

    [place] UI fixes (#690)

    - Fix overflowing feedback links under each chart
    - Fix extraneous scrollbar on the left nav as you scroll
    - Fix potential overflow issue with the left nav scroll #632
    - Update text used to sort rankings #625

commit 409d3740bedf3ff58cf8a39eca8520a9f8cef7c9
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Wed Nov 25 13:40:00 2020 -0800

    Add mixer repo as a submodule of website repo (#689)

    * Add mixer repo as a submodule of website repo

    * README

    * typo

commit f29a6be840de6882142cffa1b9ca9302af519cb0
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Tue Nov 24 13:40:56 2020 -0800

    clear cache only for production (#688)

commit 9fb5d739f346f4c0326bbae6cf18828e606adfa3
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Tue Nov 24 11:15:42 2020 -0800

    Move all the client side api call to server side (#685)

    * Move all the client side api call to server side

    * clean up

    * lint

commit acb8f69110cdc2ae17b63d143ae8beee5d6638a5
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Mon Nov 23 17:11:09 2020 -0800

    Remove deprecated/initial implementation of place page in side graph browser (#686)

commit 551ea0baa6cd8c214f6865994b14c9ffa77910dc
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Wed Nov 18 15:05:37 2020 -0800

    Refactor translator into react component (#678)

    * Refactor translator into react componenet

    * Fix lint

    * resolve comments

commit adc4bfa60cd3109a640bae3aa0e7e11a3f4aa8d9
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Wed Nov 18 10:30:32 2020 -0800

    Update view library to typescript (#680)

commit 4974a7bba03bb63b1a72f1ed4b3eeed7fea314be
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Wed Nov 18 10:13:11 2020 -0800

    Various fix for Go service (#682)

    * Fix port and comment issue

    * Update comment

    * use gohtml extension

    * include dist in go service

commit 36f84ad9837c3d7fe671fae1ec15296ef2027d60
Author: Eduardo Morales <edumorales@google.com>
Date:   Wed Nov 18 11:55:07 2020 -0500

    Increase Timeout to 25 secs (#683)

    * increase sleep time to 25 secs

    * Adds timeout_sec to base_test

    * lint fix

commit 49abdf5ca0386612efde70e5009d5755d80acb93
Author: Bo Xu <shifucun@users.noreply.github.com>
Date:   Tue Nov 17 16:30:21 2020 -0800

    Migrate /dev page to go server and the base html template ready for other pages (#661)

    * Proof concept to add GO backend and co-exist with Flask

    * Migrate /dev to go backend

    * add back /dev

    * Use {# #} for html comments

commit 9b6b295c8c691c25d1c3cdbe040a5b97d5f8c197
Author: Eduardo Morales <edumorales@google.com>
Date:   Mon Nov 16 16:16:16 2020 -0500

    move webdriver test to screenshot test (#674)

    Co-authored-by: Bo Xu <shifucun@users.noreply.github.com>

commit 3eabbe857eb520e810dda0365ad8080af0ea9132
Author: Eduardo Morales <edumorales@google.com>
Date:   Mon Nov 16 14:43:38 2020 -0500

    small fix in time waiting (#675)

commit 80ce25d30178af64bf82e387426100b4f11513f3
Author: beets <beets@users.noreply.github.com>
Date:   Thu Nov 12 11:19:14 2020 -0800

    Revert i18n changes from master branch (#673)

    Change still lives on in i18n branch