### PR TITLE
Add k8s Kustomize config and Skaffold config dev/staging

### DIFF
--- a/build/ci/cloudbuild.deploy.yaml
+++ b/build/ci/cloudbuild.deploy.yaml
@@ -82,4 +82,19 @@ steps:
         git commit -m "Deployed website to staging at commit https://github.com/datacommonsorg/website/commit/$SHORT_SHA"
         git push origin master
 
+  # Push website image to container registry
+  - id: push-image
+    name: gcr.io/cloud-builders/docker
+    entrypoint: "bash"
+    args:
+      - -c
+      - |
+        set -e
+        docker build -f build/Dockerfile \
+          -t gcr.io/datcom-ci/datacommons-website:$SHORT_SHA \
+          -t gcr.io/datcom-ci/datacommons-website:latest \
+          .
+        docker push gcr.io/datcom-ci/datacommons-website:$SHORT_SHA
+        docker push gcr.io/datcom-ci/datacommons-website:latest
+
 timeout: 3600s

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Mixer Kubernetes Deployment config. (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+# Website App Kubernetes Deployment config. (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
 # This is to be extended by the dev/staging/prod overlay.
-# The deployment contains grpc mixer container and esp container that transcodes grpc to JSON.
+# The deployment contains Flask web server container , gRPC mixer container and ESP container that transcodes grpc to JSON.
 
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -1,0 +1,159 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mixer Kubernetes Deployment config. (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+# This is to be extended by the dev/staging/prod overlay.
+# The deployment contains grpc mixer container and esp container that transcodes grpc to JSON.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: website-app
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # maximum number of Pods that can be created over the desired number of Pods
+      maxSurge: 1
+      # maximum number of Pods that can be unavailable during the update process
+      maxUnavailable: 25%
+  selector:
+    matchLabels:
+      app: website-app
+  template:
+    metadata:
+      labels:
+        app: website-app
+    spec:
+      # This k8s service account binds to the GCP service account, and used
+      # for GKE Workload Identity: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+      serviceAccountName: website-ksa
+      containers:
+        - name: website
+          image: gcr.io/datcom-ci/datacommons-website:latest
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "1G"
+              cpu: "500m"
+          args: []
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            failureThreshold: 1
+            periodSeconds: 10
+          env:
+            - name: FLASK_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: website-configmap
+                  key: flaskEnv
+            - name: GCS_BUCKET
+              valueFrom:
+                configMapKeyRef:
+                  name: website-configmap
+                  key: gcsBucket
+            # This is the GCP project that holds the secrets: api key, etc...
+            - name: SECRET_PROJECT
+              valueFrom:
+                configMapKeyRef:
+                  name: website-configmap
+                  key: secretProject
+        - name: mixer
+          image: gcr.io/datcom-ci/datacommons-mixer:latest
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "1G"
+              cpu: "500m"
+          args:
+            - --bq_dataset
+            - "$(BIG_QUERY)"
+            - --bt_table
+            - "$(BIG_TABLE)"
+            - --bt_project
+            - "google.com:datcom-store-dev"
+            - --bt_instance
+            - "prophet-cache"
+            - --project_id
+            - $(PROJECT_ID)
+          env:
+            - name: PROJECT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: mixer-configmap
+                  key: projectId
+            - name: BIG_QUERY
+              valueFrom:
+                configMapKeyRef:
+                  name: store-configmap
+                  key: bigquery.version
+            - name: BIG_TABLE
+              valueFrom:
+                configMapKeyRef:
+                  name: store-configmap
+                  key: bigtable.version
+          ports:
+            - containerPort: 12345
+          readinessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:12345"]
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:12345"]
+            periodSeconds: 5
+            initialDelaySeconds: 10
+        - name: esp
+          image: gcr.io/endpoints-release/endpoints-runtime:1
+          args:
+            - --service
+            - $(SERVICE_NAME)
+            - --rollout_strategy
+            - "managed"
+            - --http_port
+            - "8081"
+            - --backend
+            - "grpc://127.0.0.1:12345"
+            - --cors_preset
+            - "basic"
+            - --healthz
+            - "healthz"
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: mixer-configmap
+                  key: serviceName
+          resources:
+            limits:
+              memory: "0.3G"
+              cpu: "100m"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            periodSeconds: 5
+            initialDelaySeconds: 5
+          ports:
+            - containerPort: 8081

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,25 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Kustomization configuration for base yaml files.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: website
+
+resources:
+  - ../../mixer/deploy/storage
+  - deployment.yaml
+  - namespace.yaml

--- a/deploy/base/namespace.yaml
+++ b/deploy/base/namespace.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Mixer resources are always in the "mixer" namespace.
+# Mixer resources are always in the "website" namespace.
 
 apiVersion: v1
 kind: Namespace

--- a/deploy/base/namespace.yaml
+++ b/deploy/base/namespace.yaml
@@ -1,0 +1,20 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mixer resources are always in the "mixer" namespace.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: website-namespace

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Kustomization for dev mixer in local Minikube environment.
+# Kustomization for dev website in local Minikube environment.
 # - Adds "dev" suffix to all the resources
 # - Use "serviceaccount.yaml" to create service account explicitly.
 #   Note the GKE cluster service account is created once at cluster creation time.

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -1,0 +1,60 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Kustomization for dev mixer in local Minikube environment.
+# - Adds "dev" suffix to all the resources
+# - Use "serviceaccount.yaml" to create service account explicitly.
+#   Note the GKE cluster service account is created once at cluster creation time.
+# - Patch deployment with "api-compiler" image that can updates the gRPC config on code change.
+# - Update the esp startup options for local container.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -dev
+namespace: website
+
+bases:
+  - ../../base
+
+resources:
+  - service.yaml
+  - serviceaccount.yaml
+
+configMapGenerator:
+  - name: website-configmap
+    behavior: create
+    literals:
+      - flaskEnv=minikube
+      - gcsBucket=datcom-website-staging-resources
+      - secretProject=datcom-website-dev
+  - name: mixer-configmap
+    behavior: create
+    literals:
+      - projectId=datcom-mixer-dev
+      - serviceName=
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patchesStrategicMerge:
+  - patch_deployment.yaml
+
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: website-app
+    path: patch_esp.yaml

--- a/deploy/overlays/dev/patch_deployment.yaml
+++ b/deploy/overlays/dev/patch_deployment.yaml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Deployment patches that
+# - Use local container image
+# - Use api-compiler to create service config
+# - Make shared volume for api-compiler and ESP container
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/overlays/dev/patch_deployment.yaml
+++ b/deploy/overlays/dev/patch_deployment.yaml
@@ -1,0 +1,57 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: website-app
+spec:
+  selector:
+    matchLabels:
+      app: website-app
+  template:
+    spec:
+      volumes:
+        - name: mixer-grpc-json
+          emptyDir: {}
+      containers:
+        - name: website
+          image: datacommons/website
+          imagePullPolicy: Never
+        - name: mixer
+          image: datacommons/mixer
+          imagePullPolicy: Never
+        - name: esp
+          volumeMounts:
+            - mountPath: /esp
+              name: mixer-grpc-json
+        - name: api-compiler
+          image: datacommons/api-compiler
+          imagePullPolicy: Never
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - >
+              cp /output/mixer-grpc.json /esp/ &&
+              while true; do
+                echo "api-compiler running"
+                sleep 10;
+              done
+          volumeMounts:
+            - name: mixer-grpc-json
+              mountPath: /esp
+          readinessProbe:
+            exec:
+              command: ["ls", "/esp/mixer-grpc.json"]
+            periodSeconds: 1

--- a/deploy/overlays/dev/patch_esp.yaml
+++ b/deploy/overlays/dev/patch_esp.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Update ESP container startup options to work locally without talking to GCP.
+
 - op: remove
   path: /spec/template/spec/containers/2/args/0
 - op: remove

--- a/deploy/overlays/dev/patch_esp.yaml
+++ b/deploy/overlays/dev/patch_esp.yaml
@@ -1,0 +1,36 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- op: remove
+  path: /spec/template/spec/containers/2/args/0
+- op: remove
+  path: /spec/template/spec/containers/2/args/0
+- op: replace
+  path: /spec/template/spec/containers/2/args/1
+  value: fixed
+- op: add
+  path: /spec/template/spec/containers/2/args/0
+  value: --service_json_path
+- op: add
+  path: /spec/template/spec/containers/2/args/1
+  value: /esp/mixer-grpc.json
+- op: add
+  path: /spec/template/spec/containers/2/args/2
+  value: --non_gcp
+- op: add
+  path: /spec/template/spec/containers/2/args/2
+  value: --disable_cloud_trace_auto_sampling
+- op: add
+  path: /spec/template/spec/containers/2/args/2
+  value: --enable_debug

--- a/deploy/overlays/dev/patch_esp.yaml
+++ b/deploy/overlays/dev/patch_esp.yaml
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 # Update ESP container startup options to work locally without talking to GCP.
+# The dev ESP args are quite different comparing with GCP args as it does not
+# talk to GCP at all. This
+# 1. remove "--service"
+# 2. change "--rollout_strategy" to be fixed
+# 3. add "--service_json_path" to use json service config
+# 4. add a bunch of other dev only args
 
 - op: remove
   path: /spec/template/spec/containers/2/args/0

--- a/deploy/overlays/dev/service.yaml
+++ b/deploy/overlays/dev/service.yaml
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Mixer Kubernetes Service config. (https://kubernetes.io/docs/concepts/services-networking/service/)
-# The service exposes the esp (on port 8081) to port 80 via NodePort.
+# Website Kubernetes Service config. (https://kubernetes.io/docs/concepts/services-networking/service/)
+# The service exposes the website port 8080 via NodePort.
+# Note this is only needed for dev environment since the staging/production uses multi-cluster service.
 
 apiVersion: v1
 kind: Service

--- a/deploy/overlays/dev/service.yaml
+++ b/deploy/overlays/dev/service.yaml
@@ -1,0 +1,31 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mixer Kubernetes Service config. (https://kubernetes.io/docs/concepts/services-networking/service/)
+# The service exposes the esp (on port 8081) to port 80 via NodePort.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: website-service
+  namespace: website
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: website-app

--- a/deploy/overlays/dev/serviceaccount.yaml
+++ b/deploy/overlays/dev/serviceaccount.yaml
@@ -1,0 +1,18 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: website-ksa

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Kustomization for prod website runnign on GCP `datcom-website-prod` project.
+# Kustomization for prod website running on GCP `datcom-website-prod` project.
 # - Adds "prod" suffix to all the resources.
 # - Set environmnet variables.
 # - Update replicas.

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -1,0 +1,49 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Kustomization for staging website runnign on GCP `datcom-website-staging` project.
+# - Adds "staging" suffix to all the resources.
+# - Set environmnet variables.
+# - Update replicas.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -prod
+namespace: website
+
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: website-configmap
+    behavior: create
+    literals:
+      - flaskEnv=gke
+      - gcsBucket=datcom-website-prod-resources
+      - secretProject=datcom-website-prod
+  - name: mixer-configmap
+    behavior: create
+    literals:
+      - projectId=datcom-website-prod
+      - serviceName=website-esp.endpoints.datcom-website-prod.cloud.goog
+
+patchesStrategicMerge:
+  - |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: website-app
+    spec:
+      replicas: 60

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Kustomization for staging website runnign on GCP `datcom-website-staging` project.
-# - Adds "staging" suffix to all the resources.
+# Kustomization for prod website runnign on GCP `datcom-website-prod` project.
+# - Adds "prod" suffix to all the resources.
 # - Set environmnet variables.
 # - Update replicas.
 

--- a/deploy/overlays/staging/kustomization.yaml
+++ b/deploy/overlays/staging/kustomization.yaml
@@ -1,0 +1,49 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Kustomization for staging website runnign on GCP `datcom-website-staging` project.
+# - Adds "staging" suffix to all the resources.
+# - Set environmnet variables.
+# - Update replicas.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -staging
+namespace: website
+
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: website-configmap
+    behavior: create
+    literals:
+      - flaskEnv=gke
+      - gcsBucket=datcom-website-staging-resources
+      - secretProject=datcom-website-staging
+  - name: mixer-configmap
+    behavior: create
+    literals:
+      - projectId=datcom-website-staging
+      - serviceName=website-esp.endpoints.datcom-website-staging.cloud.goog
+
+patchesStrategicMerge:
+  - |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: website-app
+    spec:
+      replicas: 12

--- a/deploy/overlays/staging/kustomization.yaml
+++ b/deploy/overlays/staging/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Kustomization for staging website runnign on GCP `datcom-website-staging` project.
+# Kustomization for staging website running on GCP `datcom-website-staging` project.
 # - Adds "staging" suffix to all the resources.
 # - Set environmnet variables.
 # - Update replicas.

--- a/script/deploy_gke.sh
+++ b/script/deploy_gke.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Script to deploy website to a GKE cluster.
+#
+# Usage:
+#
+# ./deploy_key.sh <"prod"|"staging">
+#
+# First argument is either "prod" or "staging".
+#
+# !!! WARNING: Run this script in a clean Git checkout at the desired commit.
+#
+
+set -e
+
+ENV=$1
+
+if [[ $ENV != "staging" && $ENV != "prod" ]]; then
+  echo "First argument should be 'staging' or 'prod' "
+  exit
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT="$(dirname "$DIR")"
+
+WEBSITE_TAG=$(git rev-parse --short HEAD)
+
+cd $ROOT/mixer
+MIXER_TAG=$(git rev-parse --short HEAD)
+cd $DIR
+
+PROJECT_ID=$(yq read deploy/gke/$ENV.yaml project)
+# Only deploy to the primary region for now.
+# Once Bigtable replication is done, deploy for all regions
+REGION=$(yq read deploy/gke/$ENV.yaml region.primary)
+CLUSTER_NAME=website-$REGION
+
+cd $ROOT/deploy/overlays/$ENV
+
+# Deploy to GKE
+kustomize edit set image gcr.io/datcom-ci/datacommons-website=gcr.io/datcom-ci/datacommons-website:$WEBSITE_TAG
+kustomize edit set image gcr.io/datcom-ci/datacommons-mixer=gcr.io/datcom-ci/datacommons-mixer:$MIXER_TAG
+kustomize build > $ENV.yaml
+gcloud config set project $PROJECT_ID
+gcloud container clusters get-credentials $CLUSTER_NAME --region $REGION
+kubectl apply -f $ENV.yaml
+
+# Deploy Cloud Endpoints
+SERVICE_NAME="website-esp.endpoints.$PROJECT_ID.cloud.goog"
+API_TITLE=$SERVICE_NAME
+yq w --style=double $ROOT/gke/endpoints.yaml.tpl name $SERVICE_NAME > endpoints.yaml
+yq w -i endpoints.yaml title "$API_TITLE"
+
+# Deploy ESP configuration
+gsutil cp gs://artifacts.datcom-ci.appspot.com/mixer-grpc/mixer-grpc.$TAG.pb .
+gcloud endpoints services deploy mixer-grpc.$TAG.pb endpoints.yaml --project $PROJECT_ID

--- a/script/push_image.sh
+++ b/script/push_image.sh
@@ -13,16 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 # Build Docker image and push to Cloud Container Registry
 
-cd ../
-gcloud auth login
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT="$(dirname "$DIR")"
+
+IMAGE=gcr.io/datcom-ci/datacommons-website
+
 gcloud config set project datcom-ci
 export TAG="$(git rev-parse --short HEAD)"
-DOCKER_BUILDKIT=1 docker build --tag gcr.io/datcom-ci/website:$TAG .
-DOCKER_BUILDKIT=1 docker build --tag gcr.io/datcom-ci/website:latest .
-docker push gcr.io/datcom-ci/website:$TAG
-docker push gcr.io/datcom-ci/website:latest
-cd deployment
+DOCKER_BUILDKIT=1 docker build -f build/Dockerfile --tag $IMAGE:$TAG $ROOT
+DOCKER_BUILDKIT=1 docker build -f build/Dockerfile --tag $IMAGE:latest $ROOT
+docker push $IMAGE:$TAG
+docker push $IMAGE:latest

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -48,7 +48,7 @@ class MinikubeConfig(Config):
 
 
 class GKEConfig(Config):
-    SECRET_PROJECT = 'datcom-website-dev'
+    SECRET_PROJECT = 'datcom-website-staging'
     API_ROOT = 'http://127.0.0.1:8081'  # Port for Kubernetes ESP.
 
 

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -43,10 +43,12 @@ class DevelopmentConfig(Config):
 
 class MinikubeConfig(Config):
     DEVELOPMENT = True
+    SECRET_PROJECT = 'datcom-website-dev'
     API_ROOT = 'http://127.0.0.1:8081'  # Port for Kubernetes ESP.
 
 
 class GKEConfig(Config):
+    SECRET_PROJECT = 'datcom-website-dev'
     API_ROOT = 'http://127.0.0.1:8081'  # Port for Kubernetes ESP.
 
 

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -43,12 +43,10 @@ class DevelopmentConfig(Config):
 
 class MinikubeConfig(Config):
     DEVELOPMENT = True
-    SECRET_PROJECT = 'datcom-website-dev'
     API_ROOT = 'http://127.0.0.1:8081'  # Port for Kubernetes ESP.
 
 
 class GKEConfig(Config):
-    SECRET_PROJECT = 'datcom-website-staging'
     API_ROOT = 'http://127.0.0.1:8081'  # Port for Kubernetes ESP.
 
 

--- a/server/webdriver_tests/place_explorer_test.py
+++ b/server/webdriver_tests/place_explorer_test.py
@@ -134,7 +134,7 @@ class TestPlaceExplorer(WebdriverBaseTest):
         """
         Test the demographics link can work correctly.
         """
-        CHART_TITLE = "Gender distribution: states near California(2018)"
+        CHART_TITLE = "Gender distribution: states near California(2019)"
         # Load California page.
         self.driver.get(self.url_ + CA_URL)
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,53 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Skaffold (https://skaffold.dev/docs/quickstart/) configuration file that is
+# used to deploy website in a local Minikube cluster.
+# There are 3 steps involved here:
+#   build: builds website, mixer and api-compiler image.
+#   deploy: deploy website, mixer, esp, api-comipler to minikube.
+#   portFoward: expose the service in host port.
+
+apiVersion: skaffold/v2beta10
+kind: Config
+metadata:
+  name: website
+build:
+  local:
+    push: false
+  artifacts:
+    - image: datacommons/website
+      context: .
+      docker:
+        dockerfile: build/Dockerfile
+    - image: datacommons/mixer
+      context: mixer
+      docker:
+        dockerfile: build/Dockerfile
+        target: server
+    - image: datacommons/api-compiler
+      context: mixer
+      docker:
+        dockerfile: esp/Dockerfile
+deploy:
+  kubeContext: minikube
+  kustomize:
+    paths:
+      - deploy/overlays/dev
+portForward:
+  - resourceType: service
+    resourceName: website-service-dev
+    namespace: website
+    port: 8080
+    localPort: 8080


### PR DESCRIPTION
In this new flow, "Kustomize" is used to compose and patch k8s yaml files.
In local dev, Skaffold is used to manage building docker image, kustomize yaml files and deploy to Minikube cluster.

This PR adds the base, dev and staging yaml files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacommonsorg/website/757)
<!-- Reviewable:end -->
