### PR TITLE
More fix for production deployment

### DIFF
--- a/gke/create_cluster.sh
+++ b/gke/create_cluster.sh
@@ -30,7 +30,8 @@ gcloud container clusters create $CLUSTER_NAME \
   --region=$REGION \
   --machine-type=e2-highmem-4 \
   --enable-ip-alias \
-  --workload-pool=$PROJECT_ID.svc.id.goog
+  --workload-pool=$PROJECT_ID.svc.id.goog \
+  --scopes=https://www.googleapis.com/auth/trace.append
 
 # Register cluster using Workload Identity ([Documentation](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster#register_cluster))
 gcloud beta container hub memberships register $CLUSTER_NAME \

--- a/gke/setup_robot_account.sh
+++ b/gke/setup_robot_account.sh
@@ -48,6 +48,7 @@ declare -a roles=(
     "roles/monitoring.metricWriter"
     "roles/stackdriver.resourceMetadata.writer"
     "roles/compute.networkViewer"
+    "roles/cloudtrace.agent"
 )
 for role in "${roles[@]}"
 do

--- a/server/cache.py
+++ b/server/cache.py
@@ -22,15 +22,7 @@ from flask_caching import Cache
 REDIS_CONFIG = '/datacommons/redis/redis.json'
 
 # TODO(boxu): delete this after migrating to gke
-if os.environ.get('FLASK_ENV') == 'production':
-    cache = Cache(
-        config={
-            'CACHE_TYPE': 'redis',
-            'CACHE_REDIS_HOST': '10.58.224.3',
-            'CACHE_REDIS_PORT': '6379',
-            'CACHE_REDIS_URL': 'redis://10.58.224.3:6379'
-        })
-elif os.path.isfile(REDIS_CONFIG):
+if os.path.isfile(REDIS_CONFIG):
     with open(REDIS_CONFIG) as f:
         redis = json.load(f)
         metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/zone"
@@ -50,6 +42,5 @@ elif os.path.isfile(REDIS_CONFIG):
                 })
         else:
             cache = Cache(config={'CACHE_TYPE': 'simple'})
-
 else:
     cache = Cache(config={'CACHE_TYPE': 'simple'})


### PR DESCRIPTION
- Use --scopes=https://www.googleapis.com/auth/trace.append, so cloud tracing can work in GKE
- Update redis cache environment