### PR TITLE
[i18n] Propagate hl parameters

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -26,6 +26,7 @@ from opencensus.ext.flask.flask_middleware import FlaskMiddleware
 from opencensus.ext.stackdriver.trace_exporter import StackdriverExporter
 from opencensus.trace.propagation import google_cloud_format
 from opencensus.trace.samplers import AlwaysOnSampler
+from functools import wraps
 
 propagator = google_cloud_format.GoogleCloudFormatPropagator()
 
@@ -142,5 +143,12 @@ def create_app():
     def get_locale():
         # TODO(beets): Also use request.accept_languages.best_match()
         return g.locale
+
+    # Propagate hl parameter to all links (if not 'en')
+    @app.url_defaults
+    def add_language_code(endpoint, values):
+        if 'hl' in values or g.locale == 'en':
+            return
+        values['hl'] = g.locale
 
     return app

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -941,6 +941,7 @@ function buildInChartLegend(
 }
 
 export {
+  appendLegendElem,
   drawGroupBarChart,
   drawGroupLineChart,
   drawHistogram,

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -941,7 +941,6 @@ function buildInChartLegend(
 }
 
 export {
-  appendLegendElem,
   drawGroupBarChart,
   drawGroupLineChart,
   drawHistogram,

--- a/static/js/i18n/i18n.tsx
+++ b/static/js/i18n/i18n.tsx
@@ -88,12 +88,10 @@ function LocalizedLink(props: LocalizedLinkProps): JSX.Element {
   if (intl.locale == "en") {
     href = props.href;
   } else {
-    let url = new URL(props.href, document.location.origin);
-    let urlParams = new URLSearchParams(url.searchParams);
+    const url = new URL(props.href, document.location.origin);
+    const urlParams = new URLSearchParams(url.searchParams);
     urlParams.set("hl", intl.locale);
     url.search = urlParams.toString();
-    console.log(urlParams.toString());
-    console.log(url.toString());
     href = url.toString();
   }
   return (

--- a/static/js/i18n/i18n.tsx
+++ b/static/js/i18n/i18n.tsx
@@ -18,6 +18,7 @@
  * Helpers for formatJS i18n library. More info at formatjs.io
  */
 
+import React from "react";
 import { createIntl, createIntlCache, IntlCache, IntlShape } from "react-intl";
 
 // A single cache instance can be shared for all locales.
@@ -76,4 +77,30 @@ function translateVariableString(id: string): string {
   });
 }
 
-export { loadLocaleData, intl, translateVariableString };
+interface LocalizedLinkProps {
+  className?: string;
+  href: string;
+  text: string;
+}
+
+function LocalizedLink(props: LocalizedLinkProps): JSX.Element {
+  let href;
+  if (intl.locale == "en") {
+    href = props.href;
+  } else {
+    let url = new URL(props.href, document.location.origin);
+    let urlParams = new URLSearchParams(url.searchParams);
+    urlParams.set("hl", intl.locale);
+    url.search = urlParams.toString();
+    console.log(urlParams.toString());
+    console.log(url.toString());
+    href = url.toString();
+  }
+  return (
+    <a href={href} className={props.className ? props.className : null}>
+      {props.text}
+    </a>
+  );
+}
+
+export { LocalizedLink, loadLocaleData, intl, translateVariableString };

--- a/static/js/i18n/i18n.tsx
+++ b/static/js/i18n/i18n.tsx
@@ -77,12 +77,22 @@ function translateVariableString(id: string): string {
   });
 }
 
+/**
+ * Properties for LocalizedLink. Property names are analogous to those for <a> tags.
+ */
 interface LocalizedLinkProps {
   className?: string;
   href: string;
   text: string;
 }
 
+/**
+ * Adds / updates the hl parameter for the link to maintain the current page's locale.
+ * TODO(beets): Add tests for this component.
+ *
+ * @param props: <a> tag properties to include
+ * @return An <a> tag JSX element.
+ */
 function LocalizedLink(props: LocalizedLinkProps): JSX.Element {
   let href;
   if (intl.locale == "en") {

--- a/static/js/i18n/i18n.tsx
+++ b/static/js/i18n/i18n.tsx
@@ -78,6 +78,37 @@ function translateVariableString(id: string): string {
 }
 
 /**
+ * Adds / updates the hl parameter for the searchParams to maintain the current
+ * page's locale.
+ * TODO(beets): Add tests for this function.
+ *
+ * @param searchParams: to update
+ * @return potentially updated searchParams
+ */
+function localizeSearchParams(searchParams: URLSearchParams): URLSearchParams {
+  if (intl.locale == "en") {
+    return searchParams;
+  }
+  searchParams.set("hl", intl.locale);
+  return searchParams;
+}
+
+/**
+ * Adds / updates the hl parameter for the link to maintain the current page's locale.
+ * TODO(beets): Add tests for this function.
+ *
+ * @param href: to update
+ * @return potentially updated href
+ */
+function localizeLink(href: string): string {
+  const url = new URL(href, document.location.origin);
+  url.search = localizeSearchParams(
+    new URLSearchParams(url.searchParams)
+  ).toString();
+  return url.toString();
+}
+
+/**
  * Properties for LocalizedLink. Property names are analogous to those for <a> tags.
  */
 interface LocalizedLinkProps {
@@ -94,16 +125,7 @@ interface LocalizedLinkProps {
  * @return An <a> tag JSX element.
  */
 function LocalizedLink(props: LocalizedLinkProps): JSX.Element {
-  let href;
-  if (intl.locale == "en") {
-    href = props.href;
-  } else {
-    const url = new URL(props.href, document.location.origin);
-    const urlParams = new URLSearchParams(url.searchParams);
-    urlParams.set("hl", intl.locale);
-    url.search = urlParams.toString();
-    href = url.toString();
-  }
+  const href = localizeLink(props.href);
   return (
     <a href={href} className={props.className ? props.className : null}>
       {props.text}
@@ -111,4 +133,10 @@ function LocalizedLink(props: LocalizedLinkProps): JSX.Element {
   );
 }
 
-export { LocalizedLink, loadLocaleData, intl, translateVariableString };
+export {
+  LocalizedLink,
+  localizeSearchParams,
+  loadLocaleData,
+  intl,
+  translateVariableString,
+};

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -36,6 +36,7 @@ import { drawChoropleth } from "../chart/draw_choropleth";
 import _ from "lodash";
 import { FormattedMessage } from "react-intl";
 import { getStatsVarLabel } from "../shared/stats_var_labels";
+import { LocalizedLink, intl } from "../i18n/i18n";
 
 const CHART_HEIGHT = 194;
 const MIN_CHOROPLETH_DATAPOINTS = 9;
@@ -217,23 +218,29 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
                   description="Hyperlink text to export the data shown in charts."
                 />
               </a>
-              <a className="explore-more" href={exploreUrl}>
-                <FormattedMessage
-                  id="chart_metadata-explore_more"
-                  defaultMessage="Explore More ›"
-                  description="Hyperlink text to explore the data in a different page. Please keep the '›' symbol."
-                />
-              </a>
+              <LocalizedLink
+                className="explore-more"
+                href={exploreUrl}
+                text={intl.formatMessage({
+                  id: "chart_metadata-explore_more",
+                  defaultMessage: "Explore More ›",
+                  description:
+                    "Hyperlink text to explore the data in a different page. Please keep the '›' symbol.",
+                })}
+              />
             </div>
           </footer>
         </div>
-        <a className="feedback" href="/feedback">
-          <FormattedMessage
-            id="chart_metadata-feedback"
-            defaultMessage="Feedback"
-            description="Text label for hyperlink to give Data Commons feedback on something on our website."
-          />
-        </a>
+        <LocalizedLink
+          className="feedback"
+          href="/feedback"
+          text={intl.formatMessage({
+            id: "chart_metadata-feedback",
+            defaultMessage: "Feedback",
+            description:
+              "Text label for hyperlink to give Data Commons feedback on something on our website.",
+          })}
+        />
         <ChartEmbed ref={this.embedModalElement} />
       </div>
     );

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -218,15 +218,15 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
                   description="Hyperlink text to export the data shown in charts."
                 />
               </a>
-              {intl.locale != 'en' ? null :
-                            <a className="explore-more" href={exploreUrl}>
-                            <FormattedMessage
-                              id="chart_metadata-explore_more"
-                              defaultMessage="Explore More ›"
-                              description="Hyperlink text to explore the data in a different page. Please keep the '›' symbol."
-                            />
-                          </a>
-  }
+              {intl.locale != "en" ? null : (
+                <a className="explore-more" href={exploreUrl}>
+                  <FormattedMessage
+                    id="chart_metadata-explore_more"
+                    defaultMessage="Explore More ›"
+                    description="Hyperlink text to explore the data in a different page. Please keep the '›' symbol."
+                  />
+                </a>
+              )}
             </div>
           </footer>
         </div>

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -218,16 +218,15 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
                   description="Hyperlink text to export the data shown in charts."
                 />
               </a>
-              <LocalizedLink
-                className="explore-more"
-                href={exploreUrl}
-                text={intl.formatMessage({
-                  id: "chart_metadata-explore_more",
-                  defaultMessage: "Explore More ›",
-                  description:
-                    "Hyperlink text to explore the data in a different page. Please keep the '›' symbol.",
-                })}
-              />
+              {intl.locale != 'en' ? null :
+                            <a className="explore-more" href={exploreUrl}>
+                            <FormattedMessage
+                              id="chart_metadata-explore_more"
+                              defaultMessage="Explore More ›"
+                              description="Hyperlink text to explore the data in a different page. Please keep the '›' symbol."
+                            />
+                          </a>
+  }
             </div>
           </footer>
         </div>

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -25,7 +25,7 @@ import { randDomId } from "../shared/util";
 import { Chart } from "./chart";
 import { displayNameForPlaceType } from "./util";
 import _ from "lodash";
-import { intl } from "../i18n/i18n";
+import { intl, localizeSearchParams } from "../i18n/i18n";
 import { defineMessages } from "react-intl";
 
 interface ChartBlockPropType {
@@ -158,11 +158,12 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
 
     if (!_.isEmpty(this.props.data.trend)) {
       const id = randDomId();
-      const rankingParam = new URLSearchParams(`h=${this.props.dcid}`);
+      let rankingParam = new URLSearchParams(`h=${this.props.dcid}`);
       this.props.data.denominator && rankingParam.set("pc", "1");
       this.props.data.scaling &&
         rankingParam.set("scaling", String(this.props.data.scaling));
       this.props.data.unit && rankingParam.set("unit", this.props.data.unit);
+      rankingParam = localizeSearchParams(rankingParam);
       chartElements.push(
         <Chart
           key={id}

--- a/static/js/place/main.tsx
+++ b/static/js/place/main.tsx
@@ -15,7 +15,7 @@
  */
 import React from "react";
 import { RawIntlProvider } from "react-intl";
-import { intl, translateVariableString } from "../i18n/i18n";
+import { intl, LocalizedLink, translateVariableString } from "../i18n/i18n";
 import { ChartBlock } from "./chart_block";
 import { Overview } from "./overview";
 import {
@@ -102,18 +102,24 @@ class MainPane extends React.Component<MainPanePropType> {
           if (isOverview && Object.keys(this.props.pageChart).length > 1) {
             subtopicHeader = (
               <h3 id={topic}>
-                <a href={`/place/${this.props.dcid}?topic=${topic}`}>
-                  {this.props.categoryStrings[topic]}
-                </a>
+                <LocalizedLink
+
+
+                                                    href={`/place/${this.props.dcid}?topic=${topic}`}
+                  text={this.props.categoryStrings[topic]}
+                />
                 <span className="more">
-                  <a href={`/place/${this.props.dcid}?topic=${topic}`}>
-                    {intl.formatMessage({
+                  <LocalizedLink
+                   
+                   
+                    href={`/place/${this.props.dcid}?topic=${topic}`}
+                    text={intl.formatMessage({
                       id: "more_charts",
                       defaultMessage: "More charts ›",
                       description:
                         "Link to explore more charts about a particular domain, such as Education or Health.",
                     })}
-                  </a>
+                  />
                 </span>
               </h3>
             );

--- a/static/js/place/main.tsx
+++ b/static/js/place/main.tsx
@@ -103,15 +103,11 @@ class MainPane extends React.Component<MainPanePropType> {
             subtopicHeader = (
               <h3 id={topic}>
                 <LocalizedLink
-
-
-                                                    href={`/place/${this.props.dcid}?topic=${topic}`}
+                  href={`/place/${this.props.dcid}?topic=${topic}`}
                   text={this.props.categoryStrings[topic]}
                 />
                 <span className="more">
                   <LocalizedLink
-                   
-                   
                     href={`/place/${this.props.dcid}?topic=${topic}`}
                     text={intl.formatMessage({
                       id: "more_charts",

--- a/static/js/place/page_subtitle.tsx
+++ b/static/js/place/page_subtitle.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from "react";
-import { intl } from "../i18n/i18n";
+import { intl, LocalizedLink } from "../i18n/i18n";
 
 interface PageSubtitlePropsType {
   category: string;
@@ -49,14 +49,15 @@ class PageSubtitle extends React.Component<PageSubtitlePropsType> {
         <h2 className="col-12 pt-2">
           {this.props.categoryDisplayStr}
           <span className="more">
-            <a href={"/place/" + dcid}>
-              {intl.formatMessage({
+            <LocalizedLink
+              href={"/place/" + dcid}
+              text={intl.formatMessage({
                 id: "link-return_to_overview",
                 defaultMessage: "Back to overview ›",
                 description:
                   "Text for the link present in subtopic place pages directing the user back to the Overview page. Please keep the '›' symbol.",
               })}
-            </a>
+            />
           </span>
         </h2>
       );

--- a/static/js/place/parent_breadcrumbs.tsx
+++ b/static/js/place/parent_breadcrumbs.tsx
@@ -16,7 +16,7 @@
 
 import React from "react";
 import { displayNameForPlaceType } from "./util";
-import { intl } from "../i18n/i18n";
+import { intl, LocalizedLink } from "../i18n/i18n";
 import { RawIntlProvider, FormattedMessage } from "react-intl";
 
 interface ParentPlacePropsType {
@@ -39,13 +39,11 @@ class ParentPlace extends React.Component<ParentPlacePropsType> {
       }
       return (
         <React.Fragment key={dcid}>
-          <a
+          <LocalizedLink
             className="place-links"
-            href="#"
-            onClick={this._handleClick.bind(this, dcid)}
-          >
-            {name}
-          </a>
+            href={`/place/${dcid}`}
+            text={name}
+          />
           {index < num - 1 && <span>, </span>}
         </React.Fragment>
       );
@@ -66,14 +64,6 @@ class ParentPlace extends React.Component<ParentPlacePropsType> {
         />
       </RawIntlProvider>
     );
-  }
-
-  _handleClick(dcid: string, e: Event): void {
-    e.preventDefault();
-    const queryString = window.location.search;
-    const urlParams = new URLSearchParams(queryString);
-    urlParams.set("dcid", dcid);
-    window.location.search = urlParams.toString();
   }
 }
 

--- a/static/js/place/ranking.tsx
+++ b/static/js/place/ranking.tsx
@@ -17,7 +17,7 @@
 import React from "react";
 import axios from "axios";
 import { FormattedMessage } from "react-intl";
-import { intl, translateVariableString } from "../i18n/i18n";
+import { intl, LocalizedLink, translateVariableString } from "../i18n/i18n";
 
 interface RankingPropsType {
   dcid: string;
@@ -96,7 +96,10 @@ class Ranking extends React.Component<RankingPropsType, RankingStateType> {
                         }
                         return (
                           <td key={text + index}>
-                            <a href={rankingInfo.rankingUrl}>{text}</a>
+                            <LocalizedLink
+                              href={rankingInfo.rankingUrl}
+                              text={text}
+                            />
                           </td>
                         );
                       })}

--- a/static/js/place/topic_menu.tsx
+++ b/static/js/place/topic_menu.tsx
@@ -16,7 +16,7 @@
 
 import React from "react";
 import { PageChart } from "../chart/types";
-import { intl } from "../i18n/i18n";
+import { intl, LocalizedLink } from "../i18n/i18n";
 
 interface MenuCategoryPropsType {
   dcid: string;
@@ -39,12 +39,11 @@ class MenuCategory extends React.Component<MenuCategoryPropsType> {
 
     return (
       <li className="nav-item">
-        <a
+        <LocalizedLink
           href={hrefString}
           className={`nav-link ${selectCategory === category ? "active" : ""}`}
-        >
-          {this.props.categoryDisplayStr}
-        </a>
+          text={this.props.categoryDisplayStr}
+        />
         <ul
           className={
             "nav flex-column " + (category !== selectCategory ? "collapse" : "")
@@ -55,9 +54,11 @@ class MenuCategory extends React.Component<MenuCategoryPropsType> {
             {topics.map((topic: string) => {
               return (
                 <li className="nav-item" key={topic}>
-                  <a href={`${hrefString}#${topic}`} className="nav-link">
-                    {topic}
-                  </a>
+                  <LocalizedLink
+                    href={`${hrefString}#${topic}`}
+                    className="nav-link"
+                    text={topic}
+                  />
                 </li>
               );
             })}

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -20,7 +20,7 @@ import { LocationRankData } from "./ranking_types";
 import { RankingHistogram } from "./ranking_histogram";
 import { RankingTable } from "./ranking_table";
 import { displayNameForPlaceType } from "../place/util";
-import { intl, translateVariableString } from "../i18n/i18n";
+import { intl, LocalizedLink, translateVariableString } from "../i18n/i18n";
 import { defineMessages } from "react-intl";
 import { getStatsVarTitle } from "../shared/stats_var_titles";
 
@@ -119,8 +119,9 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
       const search = params.toString();
       const href = window.location.pathname + (search ? "?" + search : "");
       return (
-        <a href={href}>
-          {intl.formatMessage(
+        <LocalizedLink
+          href={href}
+          text={intl.formatMessage(
             {
               id: "ranking-sort_top",
               defaultMessage: "Show Highest {rankSize}",
@@ -131,7 +132,7 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
               rankSize: RANK_SIZE,
             }
           )}
-        </a>
+        />
       );
     }
     // show link to bottom 100
@@ -141,8 +142,9 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
       (search == "" ? "?" : search + "&") +
       GET_BOTTOM_PARAM;
     return (
-      <a href={href}>
-        {intl.formatMessage(
+      <LocalizedLink
+        href={href}
+        text={intl.formatMessage(
           {
             id: "ranking-sort_bottom",
             defaultMessage: "Show Lowest {rankSize}",
@@ -151,7 +153,7 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
           },
           { rankSize: RANK_SIZE }
         )}
-      </a>
+      />
     );
   }
 

--- a/static/js/ranking/ranking_table.tsx
+++ b/static/js/ranking/ranking_table.tsx
@@ -16,7 +16,7 @@
 
 import React from "react";
 import { Ranking, RankInfo } from "./ranking_types";
-import { intl } from "../i18n/i18n";
+import { intl, LocalizedLink } from "../i18n/i18n";
 import { displayNameForPlaceType } from "../place/util";
 
 interface RankingTablePropType {
@@ -65,9 +65,10 @@ class RankingTable extends React.Component<RankingTablePropType> {
       <tr key={rankInfo.rank} data-dcid={rankInfo.placeDcid}>
         <td>{rankInfo.rank ? rankInfo.rank : 0}</td>
         <td>
-          <a href={`/place/${rankInfo.placeDcid}`}>
-            {rankInfo.placeName || rankInfo.placeDcid}
-          </a>
+          <LocalizedLink
+            href={`/place/${rankInfo.placeDcid}`}
+            text={rankInfo.placeName || rankInfo.placeDcid}
+          />
         </td>
         <td className="text-center">
           <span className="num-value">


### PR DESCRIPTION
- append hl parameter to all flask links that use url_for 
- append hl parameter to relevant js links (added a new react functional component for this)

in both cases, only propagates hl parameter if it's not 'en'.

- also disables 'explore more' link for non-en languages, since it won't be translated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacommonsorg/website/781)
<!-- Reviewable:end -->
