### PR TITLE
Cloudbuild can only use https (not ssh) for git submodule update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mixer"]
 	path = mixer
-	url = git@github.com:datacommonsorg/mixer.git
+	url = https://github.com/datacommonsorg/mixer.git

--- a/build/ci/cloudbuild.deploy.yaml
+++ b/build/ci/cloudbuild.deploy.yaml
@@ -57,7 +57,6 @@ steps:
         # Update mixer
         git submodule update --init --recursive
         cd mixer
-        git remote set-url origin https://github.com/datacommonsorg/mixer.git
         git pull origin master
         git checkout master
 

--- a/build/ci/cloudbuild.deploy.yaml
+++ b/build/ci/cloudbuild.deploy.yaml
@@ -57,6 +57,7 @@ steps:
         # Update mixer
         git submodule update --init --recursive
         cd mixer
+        git remote set-url origin https://github.com/datacommonsorg/mixer.git
         git pull origin master
         git checkout master
 

--- a/build/ci/cloudbuild.deploy.yaml
+++ b/build/ci/cloudbuild.deploy.yaml
@@ -48,7 +48,7 @@ steps:
 
   # Deploy website with the latest mixer and base cache
   - id: autopush
-    name: "gcr.io/cloud-builders/git"
+    name: "gcr.io/datcom-ci/deploy-tool"
     entrypoint: /bin/bash
     args:
       - -c


### PR DESCRIPTION
Tested locally with cloud-build-local.