### PR TITLE
Move popobs cache unzip from server to client

### DIFF
--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -33,4 +33,4 @@ def triple_api(dcid):
 @bp.route('/popobs/<path:dcid>')
 def popobs_api(dcid):
     """Returns all the triples given a node dcid."""
-    return json.dumps(dc.get_pop_obs(dcid))
+    return dc.get_pop_obs(dcid)

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -340,8 +340,9 @@ def get_observations(dcids,
 
 def get_pop_obs(dcid):
     url = API_ROOT + API_ENDPOINTS['get_pop_obs'] + '?dcid={}'.format(dcid)
-    params = {'dcid': dcid}
-    return send_request(url, req_json=params, compress=True, post=False)
+    return requests.get(url, headers={
+        'Content-Type': 'application/json'
+    }).json()['payload']
 
 
 def get_place_obs(place_type,

--- a/static/js/browser/kg.js
+++ b/static/js/browser/kg.js
@@ -477,15 +477,16 @@ function trimArcsForPredicate(dcid, predicate, maxValues, outArcs) {
   // Trim values past count.
   var numSeen = 0;
   outArcs = outArcs.filter(
-      (p) => !(p["predicate"] == predicate && ++numSeen > maxValues));
+    (p) => !(p["predicate"] == predicate && ++numSeen > maxValues)
+  );
 
   // If trimmed, add an indicator.
   if (nArcs > maxValues) {
     const extra = (nArcs - maxValues).toString();
     outArcs.push({
-      "subjectId": dcid,
-      "predicate": predicate,
-      "objectValue": "(... " + extra + " more ...)",
+      subjectId: dcid,
+      predicate: predicate,
+      objectValue: "(... " + extra + " more ...)",
     });
   }
   return outArcs;
@@ -551,7 +552,9 @@ async function renderKGPage(
   // Get popobs
   const popobs = await axios
     .get(`/api/browser/popobs/${locId}`)
-    .then((resp) => resp.data);
+    .then((resp) => {
+      return JSON.parse(util.unzip(resp.data));
+    });
 
   // Get out arcs of population from popobs information.
   if (util.isPopulation(type)) {


### PR DESCRIPTION
The raw popobs cache for geoId/06 is 9.7Mb, which is not bad. Unzip it on flask server is very slow and leads to timeout. 

This way reduces the memcache object size, also user can leverage the browser cache which also use a smaller object.

Tested this on local instance, California page loads in about 15s, compared with timeout after 40s.