### PR TITLE
Update webiste config based on mixer autopush/staging deployment

### DIFF
--- a/build/ci/cloudbuild.deploy.yaml
+++ b/build/ci/cloudbuild.deploy.yaml
@@ -46,14 +46,4 @@ steps:
         git commit -m "Deployed website to autopush at commit https://github.com/datacommonsorg/website/commit/$SHORT_SHA"
         git push origin master
 
-  # Deploy website with the latest mixer and base cache
-  - id: autopush
-    name: "gcr.io/datcom-ci/deploy-tool"
-    entrypoint: /bin/bash
-    args:
-      - -c
-      - |
-        set -e
-        ./scripts/autopush.sh
-
 timeout: 3600s

--- a/build/ci/cloudbuild.deploy.yaml
+++ b/build/ci/cloudbuild.deploy.yaml
@@ -41,9 +41,9 @@ steps:
         # Configure Git to create commits with Cloud Build's service account
         git config user.email $(gcloud auth list --filter=status:ACTIVE --format='value(account)')
         git checkout master
-        echo $SHORT_SHA > website/staging/commit_hash.txt
-        git add website/staging/commit_hash.txt
-        git commit -m "Deployed website to staging at commit https://github.com/datacommonsorg/website/commit/$SHORT_SHA"
+        echo $SHORT_SHA > website/autopush/commit_hash.txt
+        git add website/autopush/commit_hash.txt
+        git commit -m "Deployed website to autopush at commit https://github.com/datacommonsorg/website/commit/$SHORT_SHA"
         git push origin master
 
   # Deploy website with the latest mixer and base cache

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Website App Kubernetes Deployment config. (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
-# This is to be extended by the dev/staging/prod overlay.
+# This is to be extended by the dev/autopush/staging/prod overlay.
 # The deployment contains Flask web server container , gRPC mixer container and ESP container that transcodes grpc to JSON.
 
 apiVersion: apps/v1

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Kustomization for staging website running on GCP `datcom-website-staging` project.
-# - Adds "staging" suffix to all the resources.
+# Kustomization for autopush website running on GCP `datcom-website-autopush` project.
+# - Adds "autopush" suffix to all the resources.
 # - Set environmnet variables.
 # - Update replicas.
 
@@ -30,7 +30,7 @@ configMapGenerator:
   - name: website-configmap
     behavior: create
     literals:
-      - flaskEnv=staging
+      - flaskEnv=autopush
       - gcsBucket=datcom-website-autopush-resources
       - secretProject=datcom-website-autopush
   - name: mixer-configmap

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -37,7 +37,7 @@ configMapGenerator:
     behavior: create
     literals:
       - flaskEnv=minikube
-      - gcsBucket=datcom-website-staging-resources
+      - gcsBucket=datcom-website-autopush-resources
       - secretProject=datcom-website-dev
   - name: mixer-configmap
     behavior: create

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -118,8 +118,8 @@ on Minikube, hance disabled.
 
 ## Develop with Flask (Not Recommended)
 
-This way the website talks to the staging Mixer which might not be the same version
-as the submodule and may have API compatibility issue.
+This way the website talks to the [autopush Mixer](autopush.api.datacommons.org)
+which might not be the same version as the submodule and may have API compatibility issue.
 
 ### Package javascript and static assets
 
@@ -146,7 +146,8 @@ The GKE configuration is stored [here](deploy/gke/prod.yaml).
 ### placeid2dcid.json
 
 This file is stored in GCS bucket. The bucket is set in the config files
-[staging](deploy/gke/staging.yaml) and [prod](deploy/gke/prod.yaml).
+[autopush](deploy/gke/autopush.yaml), [staging](deploy/gke/staging.yaml) and
+[prod](deploy/gke/prod.yaml).
 
 ### Redis memcache
 

--- a/run_server.sh
+++ b/run_server.sh
@@ -17,7 +17,7 @@ set -e
 python3 -m venv .env
 source .env/bin/activate
 
-export GOOGLE_CLOUD_PROJECT=datcom-website-staging
+export GOOGLE_CLOUD_PROJECT=datcom-website-autopush
 export FLASK_ENV=development
 
 pip3 install -r server/requirements.txt -q

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -31,7 +31,7 @@ ENV=$1
 REGION=$2
 
 if [[ $ENV != "staging" && $ENV != "prod" && $ENV != "autopush" ]]; then
-  echo "First argument should be 'staging' or 'prod' "
+  echo "First argument should be 'staging' or 'prod' or 'autopush'"
   exit
 fi
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -45,7 +45,7 @@ def createMiddleWare(app, exporter):
 def create_app():
     app = Flask(__name__, static_folder="dist", static_url_path="")
 
-    if os.environ.get('FLASK_ENV') in ['production', 'staging']:
+    if os.environ.get('FLASK_ENV') in ['production', 'staging', 'autopush']:
         createMiddleWare(app, StackdriverExporter())
         import googlecloudprofiler
         # Profiler initialization. It starts a daemon thread which continuously
@@ -66,6 +66,8 @@ def create_app():
         cfg = import_string('configmodule.WebdriverConfig')()
     elif os.environ.get('FLASK_ENV') == 'staging':
         cfg = import_string('configmodule.StagingConfig')()
+    elif os.environ.get('FLASK_ENV') == 'autopush':
+        cfg = import_string('configmodule.AutopushConfig')()
     elif os.environ.get('FLASK_ENV') == 'development':
         cfg = import_string('configmodule.DevelopmentConfig')()
     elif os.environ.get('FLASK_ENV') == 'minikube':

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -25,7 +25,11 @@ class ProductionConfig(Config):
 
 
 class StagingConfig(Config):
-    GA_ACCOUNT = 'UA-117119267-2'
+    pass
+
+
+class AutopushConfig(Config):
+    pass
 
 
 class MinikubeConfig(Config):
@@ -35,16 +39,16 @@ class MinikubeConfig(Config):
 class DevelopmentConfig(Config):
     DEVELOPMENT = True
     SECRET_PROJECT = 'datcom-website-dev'
-    API_PROJECT = 'datcom-mixer-staging'
-    API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
-    GCS_BUCKET = 'datcom-website-staging-resources'
+    API_PROJECT = 'datcom-mixer-autopush'
+    API_ROOT = 'https://autopush.api.datacommons.org'
+    GCS_BUCKET = 'datcom-website-autopush-resources'
 
 
 class WebdriverConfig(Config):
     WEBDRIVER = True
     SECRET_PROJECT = 'datcom-website-dev'
     API_PROJECT = 'datcom-mixer-staging'
-    API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
+    API_ROOT = 'https://staging.api.datacommons.org'
     GCS_BUCKET = ''
 
 

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -32,6 +32,8 @@ elif os.environ.get('FLASK_ENV') == 'production':
     cfg = import_string('configmodule.ProductionConfig')()
 elif os.environ.get('FLASK_ENV') == 'staging':
     cfg = import_string('configmodule.StagingConfig')()
+elif os.environ.get('FLASK_ENV') == 'autopush':
+    cfg = import_string('configmodule.AutopushConfig')()
 elif os.environ.get('FLASK_ENV') == 'minikube':
     cfg = import_string('configmodule.MinikubeConfig')()
 elif os.environ.get('FLASK_ENV') == 'gke':

--- a/static/js/shared/util.js
+++ b/static/js/shared/util.js
@@ -63,7 +63,7 @@ const API_DATA = {
     key: "AIzaSyCJXDc2HxXL3u76PqQfYXuT1oGB-f4uC1I",
   },
   staging: {
-    root: "https://mixer.endpoints.datcom-mixer-staging.cloud.goog",
+    root: "https://staging.api.datacommons.org",
     key: "AIzaSyDffCx9SDfXDJ-lZdsCsYO4296UOH25oz8",
   },
 };

--- a/tools/pv_tree_generator/dc_request.py
+++ b/tools/pv_tree_generator/dc_request.py
@@ -16,9 +16,8 @@
 import requests
 import json
 import collections
-from google.cloud import secretmanager
 
-API_ROOT = 'https://mixer.endpoints.datcom-mixer-staging.cloud.goog'
+API_ROOT = 'https://staging.api.datacommons.org'
 
 
 def get_sv_dcids():


### PR DESCRIPTION
- Fix some config issues for autopush deploy
- Let local development talking to autopush instance
- Webdriver test still talking to staging. Long term, the webdriver should be a k8s test that uses current code, instead of talking to other services
- Remove autopush from the push step. Now all the autopush is triggered from "deployment" repo "autopush" version update