### PR TITLE
[i18n] Use same locale for Maps API

### DIFF
--- a/server/routes/place.py
+++ b/server/routes/place.py
@@ -36,6 +36,7 @@ def place(place_dcid=None):
     if not place_dcid:
         return flask.render_template(
             'place_landing.html',
+            locale=g.locale,
             maps_api_key=current_app.config['MAPS_API_KEY'])
 
     place_type = place_api.get_place_type(place_dcid)

--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -79,6 +79,6 @@
 
 {% block footer %}
 <script src={{url_for('static', filename='place.js', t=config['GAE_VERSION'])}}></script>
-<script src="https://maps.googleapis.com/maps/api/js?key={{maps_api_key}}&libraries=places" async
+<script src="https://maps.googleapis.com/maps/api/js?key={{maps_api_key}}&libraries=places&language={{locale}}" async
   defer></script>
 {% endblock %}

--- a/server/templates/place_landing.html
+++ b/server/templates/place_landing.html
@@ -36,6 +36,7 @@
 {% block content %}
 <div id="body" class="container">
   <h1 class="mb-4">{% trans %}Place Explorer{% endtrans %}</h1>
+  <h3 id="locale" data-lc="{{ locale }}"></h3>
 
   <div class="search border mb-4">
     <div id="location-field">
@@ -168,6 +169,6 @@
 <script
   src={{url_for('static', filename='place_landing.js', t=config['GAE_VERSION'])}}></script>
 <script
-  src="https://maps.googleapis.com/maps/api/js?key={{maps_api_key}}&libraries=places"
+  src="https://maps.googleapis.com/maps/api/js?key={{maps_api_key}}&libraries=places&language={{locale}}"
   async defer></script>
 {% endblock %}

--- a/static/js/i18n/i18n.tsx
+++ b/static/js/i18n/i18n.tsx
@@ -140,6 +140,7 @@ function LocalizedLink(props: LocalizedLinkProps): JSX.Element {
 
 export {
   LocalizedLink,
+  localizeLink,
   localizeSearchParams,
   loadLocaleData,
   intl,

--- a/static/js/place/place_landing.ts
+++ b/static/js/place/place_landing.ts
@@ -15,7 +15,13 @@
  */
 
 import { initSearchAutocomplete } from "./search";
+import { loadLocaleData } from "../i18n/i18n";
 
 window.onload = () => {
-  initSearchAutocomplete();
+  const locale = document.getElementById("locale").dataset.lc;
+  loadLocaleData(locale, [
+    import(`../i18n/compiled-lang/${locale}/place.json`),
+  ]).then(() => {
+    initSearchAutocomplete();
+  });
 };

--- a/static/js/place/search.ts
+++ b/static/js/place/search.ts
@@ -15,12 +15,14 @@
  */
 
 import axios from "axios";
-import { intl } from "../i18n/i18n";
+import { intl, localizeLink } from "../i18n/i18n";
 let ac: google.maps.places.Autocomplete;
 let acs: google.maps.places.AutocompleteService;
 
 /**
  * Setup search input autocomplete
+ *
+ * Note: i18n.loadLocaleData must be called before this.
  */
 function initSearchAutocomplete(): void {
   // Create the autocomplete object, restricting the search predictions to
@@ -75,7 +77,7 @@ function getPlaceAndRender(place_id, place_name): void {
   axios
     .get(`/api/placeid2dcid/${place_id}`)
     .then((resp) => {
-      window.location.href = `/place/${resp.data}`;
+      window.location.href = localizeLink(`/place/${resp.data}`);
     })
     .catch(() => {
       placeNotFoundAlert(place_name);


### PR DESCRIPTION
Use the page's locale for the Maps API. This localizes the overview map, and the autocomplete search box (both english and the selected locale show up). The hl param is propagated on selections as well.

![image](https://user-images.githubusercontent.com/6052978/106663830-1b554580-6559-11eb-8c94-744902bb3438.png)

![image](https://user-images.githubusercontent.com/6052978/106663874-2dcf7f00-6559-11eb-8b4d-e44c3b0bb8d9.png)
