### PR TITLE
Use provenance url instead domain for sources

### DIFF
--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -199,7 +199,7 @@ def process_choropleth_data(all_sv_data):
                     most_recent_date = sorted_dates[-1]
                     result[geo][sv] = {
                         'data': source_values,
-                        'provenanceDomain': source.get('provenanceDomain', '')
+                        'provenanceUrl': source.get('provenanceUrl', '')
                     }
     return result
 

--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -134,7 +134,7 @@ def get_series(data, place, stat_vars):
             return {}, []
         series = data[place][sv]
         all_series.append(series['data'])
-        sources.add(series['provenanceDomain'])
+        sources.add(series['provenanceUrl'])
     # One series, no need to aggregate
     if num_sv == 1:
         return all_series[0], sources

--- a/server/tests/api_stats_test.py
+++ b/server/tests/api_stats_test.py
@@ -49,7 +49,6 @@ class TestApiGetStatsCollection(unittest.TestCase):
                     },
                     "measurementMethod": "CensusACS5yrSurvey",
                     "importName": "CensusACS5YearSurvey",
-                    "provenanceDomain": "census.gov",
                     "provenanceUrl": "https://www.census.gov/"
                 },
                 "Count_Person": {
@@ -62,8 +61,6 @@ class TestApiGetStatsCollection(unittest.TestCase):
                         "CensusPEPSurvey",
                     "importName":
                         "CensusPEP",
-                    "provenanceDomain":
-                        "census.gov",
                     "provenanceUrl":
                         "https://www.census.gov/programs-surveys/popest.html"
                 }

--- a/server/tests/chart_test.py
+++ b/server/tests/chart_test.py
@@ -258,13 +258,13 @@ class TestChoroplethDataHelpers(unittest.TestCase):
         source_series_1_source = 'provDomain1'
         source_series_1 = {
             'val': source_series_1_vals,
-            'provenanceDomain': source_series_1_source
+            'provenanceUrl': source_series_1_source
         }
         source_series_2_vals = {'2018': 1, '2013': 2}
         source_series_2_source = 'provDomain2'
         source_series_2 = {
             'val': source_series_2_vals,
-            'provenanceDomain': source_series_2_source
+            'provenanceUrl': source_series_2_source
         }
         test_data = {
             'dcid1': {
@@ -283,11 +283,11 @@ class TestChoroplethDataHelpers(unittest.TestCase):
             'dcid1': {
                 'SV1': {
                     'data': source_series_1_vals,
-                    'provenanceDomain': source_series_1_source
+                    'provenanceUrl': source_series_1_source
                 },
                 'SV3': {
                     'data': source_series_2_vals,
-                    'provenanceDomain': source_series_2_source
+                    'provenanceUrl': source_series_2_source
                 }
             }
         }

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -15,6 +15,7 @@
  */
 
 import * as d3 from "d3";
+import { urlToDomain } from "../shared/util";
 
 import {
   DataGroup,
@@ -760,7 +761,7 @@ function computeRanges(dataGroupsDict: { [geoId: string]: DataGroup[] }) {
  * @param statsVarsTitle: object from stats var dcid to display title.
  * @param dataGroupsDict: data groups for plotting.
  * @param plotParams: contains all plot params for chart.
- * @param source: an array of source domain.
+ * @param sources: an array of source domain.
  * @param unit the unit of the measurement.
  */
 function drawGroupLineChart(
@@ -771,7 +772,7 @@ function drawGroupLineChart(
   dataGroupsDict: { [place: string]: DataGroup[] },
   plotParams: PlotParams,
   ylabel?: string,
-  source?: string[],
+  sources?: string[],
   unit?: string
 ): void {
   // Get a non-empty array as dataGroups
@@ -867,8 +868,11 @@ function drawGroupLineChart(
     }
   }
   // add source info to the chart
-  if (source) {
-    const sourceText = "Data source: " + source.filter(Boolean).join(", ");
+  if (sources) {
+    const domains = new Set(
+      sources.map((source) => urlToDomain(source)).filter(Boolean)
+    );
+    const sourceText = "Data source: " + Array.from(domains).join(", ");
     svg
       .append("text")
       .attr("class", "label")

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -174,17 +174,15 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       return null;
     }
     const sourcesJsx = sources.map((source, index) => {
-      // TDOO(shifucun): Use provenance name and url from cache data
-      // https://github.com/datacommonsorg/website/issues/429
-      let sourceUrl = source;
-      if (source === "worldbank.org") {
-        sourceUrl = "www.worldbank.org";
-      } else if (source === "europa.eu") {
-        sourceUrl = "ec.europa.eu/eurostat";
-      }
+      const domain = source
+        .replace("http://", "")
+        .replace("https://", "")
+        .replace("www.", "")
+        .split(/[/?#]/)[0];
+
       return (
         <span key={source}>
-          <a href={"https://" + sourceUrl}>{source}</a>
+          <a href={source}>{domain}</a>
           {index < sources.length - 1 ? ", " : ""}
         </span>
       );

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -37,6 +37,7 @@ import _ from "lodash";
 import { FormattedMessage } from "react-intl";
 import { getStatsVarLabel } from "../shared/stats_var_labels";
 import { LocalizedLink, intl, localizeSearchParams } from "../i18n/i18n";
+import { urlToDomain } from "../shared/util";
 
 const CHART_HEIGHT = 194;
 const MIN_CHOROPLETH_DATAPOINTS = 9;
@@ -174,12 +175,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       return null;
     }
     const sourcesJsx = sources.map((source, index) => {
-      const domain = source
-        .replace("http://", "")
-        .replace("https://", "")
-        .replace("www.", "")
-        .split(/[/?#]/)[0];
-
+      const domain = urlToDomain(source);
       return (
         <span key={source}>
           <a href={source}>{domain}</a>

--- a/static/js/shared/data_fetcher.test.ts
+++ b/static/js/shared/data_fetcher.test.ts
@@ -41,7 +41,7 @@ test("fetch stats data", () => {
               "2012": 22000,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
@@ -49,7 +49,7 @@ test("fetch stats data", () => {
               "2012": 32000,
             },
             placeName: "California",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       });
@@ -64,7 +64,7 @@ test("fetch stats data", () => {
               "2012": 13000,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
@@ -72,7 +72,7 @@ test("fetch stats data", () => {
               "2012": 16000,
             },
             placeName: "California",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       });
@@ -99,7 +99,7 @@ test("fetch stats data", () => {
               "2012": 13000,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
@@ -107,7 +107,7 @@ test("fetch stats data", () => {
               "2012": 16000,
             },
             placeName: "California",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
         Count_Person: {
@@ -117,7 +117,7 @@ test("fetch stats data", () => {
               "2012": 22000,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
@@ -125,7 +125,7 @@ test("fetch stats data", () => {
               "2012": 32000,
             },
             placeName: "California",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       },
@@ -187,7 +187,7 @@ test("fetch stats data with state code", () => {
               "2012": 22000,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06085": {
             data: {
@@ -195,7 +195,7 @@ test("fetch stats data with state code", () => {
               "2012": 32000,
             },
             placeName: "Santa Clara",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       });
@@ -222,7 +222,7 @@ test("fetch stats data with state code", () => {
                 "2012": 22000,
               },
               placeName: "Arkansas",
-              provenanceDomain: "source1",
+              provenanceUrl: "source1",
             },
             "geoId/06085": {
               data: {
@@ -230,7 +230,7 @@ test("fetch stats data with state code", () => {
                 "2012": 32000,
               },
               placeName: "Santa Clara, CA",
-              provenanceDomain: "source2",
+              provenanceUrl: "source2",
             },
           },
         },
@@ -261,7 +261,7 @@ test("fetch stats data where latest date with data for all stat vars is not the 
         "2012": 22000,
       },
       placeName: "Arkansas",
-      provenanceDomain: "source1",
+      provenanceUrl: "source1",
     },
     "geoId/06": {
       data: {
@@ -269,7 +269,7 @@ test("fetch stats data where latest date with data for all stat vars is not the 
         "2013": 32000,
       },
       placeName: "California",
-      provenanceDomain: "source2",
+      provenanceUrl: "source2",
     },
   };
   mockedAxios.get.mockImplementation((url: string) => {
@@ -340,7 +340,7 @@ test("fetch stats data where there is no date with data for all stat vars", () =
         "2013": 22000,
       },
       placeName: "Arkansas",
-      provenanceDomain: "source1",
+      provenanceUrl: "source1",
     },
     "geoId/06": {
       data: {
@@ -348,7 +348,7 @@ test("fetch stats data where there is no date with data for all stat vars", () =
         "2012": 32000,
       },
       placeName: "California",
-      provenanceDomain: "source2",
+      provenanceUrl: "source2",
     },
   };
   mockedAxios.get.mockImplementation((url: string) => {
@@ -426,7 +426,7 @@ test("fetch stats data from cache where latest date with data for all stat vars 
             "2011": 1300,
             "2012": 2100,
           },
-          provenanceDomain: "source1",
+          provenanceUrl: "source1",
         },
       },
       "geoId/06": {
@@ -435,7 +435,7 @@ test("fetch stats data from cache where latest date with data for all stat vars 
             "2011": 200,
             "2013": 300,
           },
-          provenanceDomain: "source2",
+          provenanceUrl: "source2",
         },
       },
     }
@@ -448,14 +448,14 @@ test("fetch stats data from cache where latest date with data for all stat vars 
               "2011": 1300,
               "2012": 2100,
             },
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
               "2011": 200,
               "2013": 300,
             },
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       },
@@ -482,7 +482,7 @@ test("fetch stats data from cache where there is no date with data for all stat 
             "2010": 1300,
             "2012": 2100,
           },
-          provenanceDomain: "source1",
+          provenanceUrl: "source1",
         },
       },
       "geoId/06": {
@@ -491,7 +491,7 @@ test("fetch stats data from cache where there is no date with data for all stat 
             "2011": 200,
             "2013": 300,
           },
-          provenanceDomain: "source2",
+          provenanceUrl: "source2",
         },
       },
     }
@@ -504,14 +504,14 @@ test("fetch stats data from cache where there is no date with data for all stat 
               "2010": 1300,
               "2012": 2100,
             },
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
               "2011": 200,
               "2013": 300,
             },
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       },
@@ -535,7 +535,7 @@ test("fetch stats data with per capita with population size 0", () => {
               "2012": 0,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
         },
       });
@@ -548,7 +548,7 @@ test("fetch stats data with per capita with population size 0", () => {
               "2012": 13000,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
         },
       });
@@ -572,7 +572,7 @@ test("fetch stats data with per capita with population size 0", () => {
                 "2012": 0,
               },
               placeName: "Arkansas",
-              provenanceDomain: "source1",
+              provenanceUrl: "source1",
             },
           },
         },
@@ -598,7 +598,7 @@ test("StatsData test", () => {
         "geoId/02": {
           placeDcid: "geoId/02",
           placeName: "Place2",
-          provenanceDomain: "test.domain",
+          provenanceUrl: "test.domain",
           data: { "1990": 10, "1992": 20 },
         },
       },
@@ -619,7 +619,7 @@ test("Per capita with specified denominators test", () => {
               "2012": 22000,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
@@ -627,7 +627,7 @@ test("Per capita with specified denominators test", () => {
               "2012": 32000,
             },
             placeName: "California",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       });
@@ -642,7 +642,7 @@ test("Per capita with specified denominators test", () => {
               "2012": 13000,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
@@ -650,7 +650,7 @@ test("Per capita with specified denominators test", () => {
               "2012": 16000,
             },
             placeName: "California",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       });
@@ -680,7 +680,7 @@ test("Per capita with specified denominators test", () => {
               "2012": 1,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
@@ -688,7 +688,7 @@ test("Per capita with specified denominators test", () => {
               "2012": 1,
             },
             placeName: "California",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
         Count_Person_Female: {
@@ -698,7 +698,7 @@ test("Per capita with specified denominators test", () => {
               "2012": 1,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
@@ -706,7 +706,7 @@ test("Per capita with specified denominators test", () => {
               "2012": 1,
             },
             placeName: "California",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       },
@@ -771,14 +771,14 @@ test("Per capita with specified denominators test from cache", () => {
             "2011": 1300,
             "2012": 2100,
           },
-          provenanceDomain: "source1",
+          provenanceUrl: "source1",
         },
         Count_Person_Female: {
           data: {
             "2011": 500,
             "2012": 300,
           },
-          provenanceDomain: "source1",
+          provenanceUrl: "source1",
         },
       },
       "geoId/06": {
@@ -787,14 +787,14 @@ test("Per capita with specified denominators test from cache", () => {
             "2011": 200,
             "2012": 300,
           },
-          provenanceDomain: "source2",
+          provenanceUrl: "source2",
         },
         Count_Person_Female: {
           data: {
             "2011": 1000,
             "2012": 3000,
           },
-          provenanceDomain: "source2",
+          provenanceUrl: "source2",
         },
       },
     }
@@ -807,14 +807,14 @@ test("Per capita with specified denominators test from cache", () => {
               "2011": 1,
               "2012": 1,
             },
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
               "2011": 1,
               "2012": 1,
             },
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
         Count_Person_Female: {
@@ -823,14 +823,14 @@ test("Per capita with specified denominators test from cache", () => {
               "2011": 1,
               "2012": 1,
             },
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
           "geoId/06": {
             data: {
               "2011": 1,
               "2012": 1,
             },
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
         },
       },
@@ -858,7 +858,7 @@ test("Per capita with specified denominators test - missing place data", () => {
               "2012": 22000,
             },
             placeName: "USA",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
         },
       });
@@ -874,7 +874,7 @@ test("Per capita with specified denominators test - missing place data", () => {
               "2012": 2,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
           "country/USA": null,
         },
@@ -908,7 +908,7 @@ test("Per capita with specified denominators test - missing place data", () => {
               "2012": 22000,
             },
             placeName: "USA",
-            provenanceDomain: "source1",
+            provenanceUrl: "source1",
           },
         },
         UnemploymentRate_Person_Female: {
@@ -918,7 +918,7 @@ test("Per capita with specified denominators test - missing place data", () => {
               "2012": 2,
             },
             placeName: "Arkansas",
-            provenanceDomain: "source2",
+            provenanceUrl: "source2",
           },
           "country/USA": null,
         },
@@ -969,7 +969,7 @@ test("getTimeGroupWithStatsVar with missing data", () => {
             "2013": 0,
           },
           placeName: "Arkansas",
-          provenanceDomain: "source1",
+          provenanceUrl: "source1",
         },
       },
       Count_Person_Male: {
@@ -979,7 +979,7 @@ test("getTimeGroupWithStatsVar with missing data", () => {
             "2012": 13000,
           },
           placeName: "Arkansas",
-          provenanceDomain: "source1",
+          provenanceUrl: "source1",
         },
       },
     },

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -28,7 +28,7 @@ interface TimeSeries {
   };
   placeName?: string;
   placeDcid?: string;
-  provenanceDomain: string;
+  provenanceUrl: string;
 }
 
 interface StatApiResponse {
@@ -303,7 +303,7 @@ function getStatsDataFromCachedData(
         numStatVarsPerPlace[place] = 0;
       }
       const timeSeries = result.data[sv][place];
-      result.sources.add(timeSeries.provenanceDomain);
+      result.sources.add(timeSeries.provenanceUrl);
       if (Object.keys(timeSeries.data).length > 0) {
         numStatVarsPerPlace[place] = numStatVarsPerPlace[place] + 1;
       }
@@ -486,7 +486,7 @@ function fetchStatsData(
         if (Object.keys(timeSeries.data).length > 0) {
           numStatVarsPerPlace[place] = numStatVarsPerPlace[place] + 1;
         }
-        result.sources.add(timeSeries.provenanceDomain);
+        result.sources.add(timeSeries.provenanceUrl);
         for (const date in timeSeries.data) {
           if (date in numOccurencesPerDate) {
             numOccurencesPerDate[date] = numOccurencesPerDate[date] + 1;

--- a/static/js/shared/util.js
+++ b/static/js/shared/util.js
@@ -415,6 +415,18 @@ function saveToFile(filename, contents) {
   link.remove();
 }
 
+/**
+ * Get the domain from a url.
+ * @param {string} url
+ */
+function urlToDomain(url) {
+  return url
+    .replace("http://", "")
+    .replace("https://", "")
+    .replace("www.", "")
+    .split(/[/?#]/)[0];
+}
+
 export {
   STATS,
   OBS_KEYS,
@@ -441,4 +453,5 @@ export {
   saveToFile,
   setElementShown,
   unzip,
+  urlToDomain,
 };

--- a/static/js/tools/mock_functions.tsx
+++ b/static/js/tools/mock_functions.tsx
@@ -81,7 +81,7 @@ export function axios_mock(): void {
         "geoId/05": {
           placeDcid: "geoId/05",
           placeName: "Arkansas",
-          provenanceDomain: "census.gov",
+          provenanceUrl: "census.gov",
           data: { "2011": 37.3, "2012": 37.4, "2013": 37.5, "2014": 37.6 },
         },
       },
@@ -95,7 +95,7 @@ export function axios_mock(): void {
         "geoId/05": {
           placeDcid: "geoId/05",
           placeName: "Arkansas",
-          provenanceDomain: "census.gov",
+          provenanceUrl: "census.gov",
           data: { "1999": 37.3, "2010": 37.4, "2020": 37.5 },
         },
       },
@@ -108,7 +108,7 @@ export function axios_mock(): void {
         "geoId/05": {
           placeDcid: "geoId/05",
           placeName: "Arkansas",
-          provenanceDomain: "census.gov",
+          provenanceUrl: "census.gov",
           data: { "1999": 37.3, "2010": 37.4, "2020": 37.5 },
         },
       },

--- a/static/js/tools/scatter2/app.test.tsx
+++ b/static/js/tools/scatter2/app.test.tsx
@@ -208,8 +208,8 @@ test("all functionalities", async (done) => {
       8359.667,
       108149.894,
       6753.678,
-      "bls.gov",
-      "census.gov",
+      "https://www.bls.gov/",
+      "https://www.census.gov/",
       app
     );
     // Points
@@ -226,8 +226,8 @@ test("all functionalities", async (done) => {
     152696,
     6753.678,
     108149.894,
-    "census.gov",
-    "bls.gov",
+    "https://www.census.gov/",
+    "https://www.bls.gov/",
     app
   );
   expectCircles(3, app);
@@ -242,7 +242,15 @@ test("all functionalities", async (done) => {
     .at(0)
     .simulate("change", { target: { checked: true } });
   expectTitle("Employed Per Capita vs Number Of Establishments Per Capita");
-  expectInfo(0.024, 0.456, 0.005, 0.036, "census.gov", "bls.gov", app);
+  expectInfo(
+    0.024,
+    0.456,
+    0.005,
+    0.036,
+    "https://www.census.gov/",
+    "https://www.bls.gov/",
+    app
+  );
   expectCircles(3, app);
 
   // Log
@@ -277,7 +285,15 @@ test("all functionalities", async (done) => {
     expect(app.text()).toContain(
       "Housing Units Per Capita vs Employed Per Capita"
     );
-    expectInfo(0.456, 0.456, 0.036, 0.107, "bls.gov", "census.gov", app);
+    expectInfo(
+      0.456,
+      0.456,
+      0.036,
+      0.107,
+      "https://www.bls.gov/",
+      "https://www.census.gov/",
+      app
+    );
     expectCircles(3, app);
   });
 

--- a/static/js/tools/scatter2/app.test.tsx
+++ b/static/js/tools/scatter2/app.test.tsx
@@ -65,7 +65,6 @@ function mockAxios(): () => void {
       },
       measurementMethod: "CensusPEPSurvey",
       importName: "CensusPEP",
-      provenanceDomain: "census.gov",
       provenanceUrl: "https://www.census.gov/programs-surveys/popest.html",
     },
     Count_Person_Employed: {
@@ -77,14 +76,12 @@ function mockAxios(): () => void {
       measurementMethod: "BLSSeasonallyUnadjusted",
       observationPeriod: "P1Y",
       importName: "BLS_LAUS",
-      provenanceDomain: "bls.gov",
       provenanceUrl: "https://www.bls.gov/lau/",
     },
     Count_Establishment: {
       val: { "geoId/10001": 3422, "geoId/10003": 16056, "geoId/10005": 5601 },
       measurementMethod: "CensusCBPSurvey",
       importName: "CensusCountyBusinessPatterns",
-      provenanceDomain: "census.gov",
       provenanceUrl: "https://www.census.gov/",
     },
     Count_HousingUnit: {
@@ -95,7 +92,6 @@ function mockAxios(): () => void {
       },
       measurementMethod: "CensusACS5yrSurvey",
       importName: "CensusACS5YearSurvey",
-      provenanceDomain: "census.gov",
       provenanceUrl: "https://www.census.gov/",
     },
   };

--- a/static/js/tools/scatter2/chart_loader.tsx
+++ b/static/js/tools/scatter2/chart_loader.tsx
@@ -182,7 +182,7 @@ async function loadData(
  */
 function getProvenance(cache: Cache, statVar: string) {
   if (statVar in cache) {
-    return cache[statVar].provenanceDomain;
+    return cache[statVar].provenanceUrl;
   }
   return "";
 }

--- a/static/js/tools/scatter2/util.ts
+++ b/static/js/tools/scatter2/util.ts
@@ -36,7 +36,6 @@ interface SourceSeries {
   val: Record<string, number>;
   measurementMethod: string;
   importName: string;
-  provenanceDomain: string;
   provenanceUrl: string;
   observationPeriod: string;
   unit: string;


### PR DESCRIPTION
Still shows domain in both place page and timeline page.
This bundles the mixer change that removes provenance domain as well. So client and api changes are within one commit.

![image](https://user-images.githubusercontent.com/5951856/107683003-eaaa9580-6c55-11eb-9920-28cebbb4412b.png)
![image](https://user-images.githubusercontent.com/5951856/107709642-64ed1100-6c7a-11eb-966f-e29bfeb2ac2b.png)

