### PR TITLE
Fix loading hint invalidate error

### DIFF
--- a/static/js/browser/kg.js
+++ b/static/js/browser/kg.js
@@ -705,8 +705,8 @@ async function renderKGPage(
   // Add "More" to existing cards.
   util.appendMoreToAll();
 
-  const loadingElem = document.getElementById("page-loading");
   if (!hasPopObsError) {
+    const loadingElem = document.getElementById("page-loading");
     loadingElem.style.display = "none";
   }
 

--- a/static/js/browser/kg.js
+++ b/static/js/browser/kg.js
@@ -705,7 +705,14 @@ async function renderKGPage(
   // Add "More" to existing cards.
   util.appendMoreToAll();
 
-  if (NO_POP_TYPES.includes(type)) return;
+  const loadingElem = document.getElementById("page-loading");
+  if (!hasPopObsError) {
+    loadingElem.style.display = "none";
+  }
+
+  if (NO_POP_TYPES.includes(type)) {
+    return;
+  }
 
   const subPopHintElem = document.getElementById("subpop-hint");
   const populationElem = document.getElementById("population");
@@ -737,11 +744,6 @@ async function renderKGPage(
         }
       });
     }
-  }
-
-  const loadingElem = document.getElementById("page-loading");
-  if (!hasPopObsError) {
-    loadingElem.style.display = "none";
   }
 
   if (popobs) {


### PR DESCRIPTION
The render process terminates for Class node, hence the loading hint erasing should happen before that.

![image](https://user-images.githubusercontent.com/5951856/107700526-77f8e480-6c6c-11eb-81b5-3d988e1978f2.png)
