### PR TITLE
Fix broken links to the tutorials page

### DIFF
--- a/go/template/base.gohtml
+++ b/go/template/base.gohtml
@@ -80,7 +80,7 @@
                 <div class="dropdown-menu" aria-labelledby="nav-doc-dropdown">
                   <a class="dropdown-item" href="http://docs.datacommons.org">Documentation</a>
                   <a class="dropdown-item" href="http://docs.datacommons.org/api">API's</a>
-                  <a class="dropdown-item" href="http://docs.datacommons.org/tutorials.html">Tutorials</a>
+                  <a class="dropdown-item" href="http://docs.datacommons.org/tutorials">Tutorials</a>
                   <a class="dropdown-item" href="https://docs.datacommons.org/contributing/">Contribute</a>
                 </div>
               </li>
@@ -125,7 +125,7 @@
             <h6>Documentation</h6>
             <a href="http://docs.datacommons.org">Documentation</a>
             <a href="http://docs.datacommons.org/api">API's</a>
-            <a href="http://docs.datacommons.org/tutorials.html">Tutorials</a>
+            <a href="http://docs.datacommons.org/tutorials">Tutorials</a>
             <a href="https://docs.datacommons.org/contributing/">Contribute</a>
           </section>
           <section class="col-12 col-sm-6 col-md-4">

--- a/server/routes/redirects.py
+++ b/server/routes/redirects.py
@@ -52,7 +52,7 @@ def documentation():
 
 @bp.route('/colab')
 def colab():
-    return redirect('https://docs.datacommons.org/tutorials.html', code=302)
+    return redirect('https://docs.datacommons.org/tutorials', code=302)
 
 
 @bp.route('/getinvolved')

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -80,7 +80,7 @@
                 <div class="dropdown-menu" aria-labelledby="nav-doc-dropdown">
                   <a class="dropdown-item" href="http://docs.datacommons.org">{% trans %}Documentation{% endtrans %}</a>
                   <a class="dropdown-item" href="http://docs.datacommons.org/api">{% trans %}API's{% endtrans %}</a>
-                  <a class="dropdown-item" href="http://docs.datacommons.org/tutorials.html">{% trans %}Tutorials{% endtrans %}</a>
+                  <a class="dropdown-item" href="http://docs.datacommons.org/tutorials">{% trans %}Tutorials{% endtrans %}</a>
                   <a class="dropdown-item" href="https://docs.datacommons.org/contributing/">{% trans %}Contribute{% endtrans %}</a>
                 </div>
               </li>
@@ -133,7 +133,7 @@
             {# TRANSLATORS: The label for a link to our API documentation. #}
             <a href="http://docs.datacommons.org/api">{% trans %}API's{% endtrans %}</a>
             {# TRANSLATORS: The label for a link to our API tutorials. #}
-            <a href="http://docs.datacommons.org/tutorials.html">{% trans %}Tutorials{% endtrans %}</a>
+            <a href="http://docs.datacommons.org/tutorials">{% trans %}Tutorials{% endtrans %}</a>
             {# TRANSLATORS: The label for a link to instructions about contributing to the project. #}
             <a href="https://docs.datacommons.org/contributing/">{% trans %}Contribute{% endtrans %}</a>
             {# TRANSLATORS: The label for a link to the project's github repository (for open sourced code). #}

--- a/server/templates/static/homepage.html
+++ b/server/templates/static/homepage.html
@@ -150,7 +150,7 @@
     {# TRANSLATORS: The label for a link to our API documentation. See this string at https://datacommons.org #}
     <li><a href="http://docs.datacommons.org/api/">{% trans %}See API documentation.{% endtrans %}</a></li>
     {# TRANSLATORS: Blog post entry. Please take care to maintain valid <a> tags in translation. See this string in action at https://datacommons.org #}
-      <li><a href="http://docs.datacommons.org/tutorials.html">{% trans %}See some sample Python notebooks.{% endtrans %}</a></li>
+      <li><a href="http://docs.datacommons.org/tutorials">{% trans %}See some sample Python notebooks.{% endtrans %}</a></li>
   </ul>
 </section>
 


### PR DESCRIPTION
Testing: brought up a local server and navigated to "Tutorials" under "Documentation". Also, checked http://localhost:8080/colab.