### PR TITLE
[i18n] fix embeds with unicode chars

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -113,7 +113,7 @@ function wrap(
     let lineNumber = 0;
     const lineHeight = 1.1; // ems
     const y = text.attr("y");
-    const dy = parseFloat(text.attr("dy"));
+    const dy = parseFloat(text.attr("dy") || "0");
     let tspan = text
       .text(null)
       .append("tspan")
@@ -1004,4 +1004,5 @@ export {
   drawLineChart,
   drawSingleBarChart,
   drawStackBarChart,
+  wrap,
 };

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -16,10 +16,9 @@
 
 import React from "react";
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from "reactstrap";
-import { randDomId, saveToFile } from "../shared/util";
+import { randDomId, saveToFile, urlToDomain } from "../shared/util";
 import * as d3 from "d3";
 import { intl } from "../i18n/i18n";
-import { urlToDomain } from "../shared/util";
 import { wrap } from "../chart/draw";
 
 // SVG adjustment related constants


### PR DESCRIPTION
Fix a few issues with chart embeds
- use XMLSerializer instead of outerHTML (which introduced non-xml compliant HTML entities like &nbsp;)
- use encodeURIComponent of the XML directly, rather than btoa which is not unicode compliant

Also handle wrapping with titles and sources which used to just overflow. Also converted each source to a domain.

![image](https://user-images.githubusercontent.com/6052978/108132324-7dd53800-7067-11eb-84cb-fa3af5377f98.png)


Some references:
https://css-tricks.com/probably-dont-base64-svg/
https://reference.codeproject.com/book/javascript/base64_encoding_and_decoding