### PR TITLE
fix highlight facts

### DIFF
--- a/static/js/place/place_highlight.tsx
+++ b/static/js/place/place_highlight.tsx
@@ -47,21 +47,21 @@ class PlaceHighlight extends React.Component<PlaceHighlightPropsType> {
       }
       const factStatVar = Object.keys(factData)[0];
       const factValue = factData[factStatVar];
-    const sourcesJsx = factSnapshot.sources.map((source, index) => {
-      const domain = urlToDomain(source);
+      const sourcesJsx = factSnapshot.sources.map((source, index) => {
+        const domain = urlToDomain(source);
+        return (
+          <span key={source}>
+            <a href={source}>{domain}</a>
+            {index < factSnapshot.sources.length - 1 ? ", " : ""}
+          </span>
+        );
+      });
       return (
-        <span key={source}>
-          <a href={source}>{domain}</a>
-          {index < factSnapshot.sources.length - 1 ? ", " : ""}
-        </span>
+        <h4 key={factStatVar}>
+          {factTitle}: {factValue.toLocaleString(intl.locale)} (
+          {factSnapshot.date.toLocaleString()}) {sourcesJsx}
+        </h4>
       );
-    });
-    return (
-      <h4 key={factStatVar}>
-        {factTitle}: {factValue.toLocaleString(intl.locale)} (
-        {factSnapshot.date.toLocaleString()}) {sourcesJsx}
-      </h4>
-    );
     });
 
     return <>{facts}</>;

--- a/static/js/place/place_highlight.tsx
+++ b/static/js/place/place_highlight.tsx
@@ -16,6 +16,8 @@
 
 import React from "react";
 import { PageHighlight } from "../chart/types";
+import { urlToDomain } from "../shared/util";
+import { intl } from "../i18n/i18n";
 import _ from "lodash";
 
 interface PlaceHighlightPropsType {
@@ -45,13 +47,21 @@ class PlaceHighlight extends React.Component<PlaceHighlightPropsType> {
       }
       const factStatVar = Object.keys(factData)[0];
       const factValue = factData[factStatVar];
+    const sourcesJsx = factSnapshot.sources.map((source, index) => {
+      const domain = urlToDomain(source);
       return (
-        <h4 key={factStatVar}>
-          {factTitle}: {factValue.toLocaleString()} (
-          {factSnapshot.date.toLocaleString()}){" "}
-          <span>{factSnapshot.sources.join(", ")}</span>
-        </h4>
+        <span key={source}>
+          <a href={source}>{domain}</a>
+          {index < factSnapshot.sources.length - 1 ? ", " : ""}
+        </span>
       );
+    });
+    return (
+      <h4 key={factStatVar}>
+        {factTitle}: {factValue.toLocaleString(intl.locale)} (
+        {factSnapshot.date.toLocaleString()}) {sourcesJsx}
+      </h4>
+    );
     });
 
     return <>{facts}</>;


### PR DESCRIPTION
- Linkify provenance links
- Display only the domain

was:
![image](https://user-images.githubusercontent.com/6052978/108248863-369f8380-7109-11eb-82cd-83bf5a2fd479.png)

now:
![image](https://user-images.githubusercontent.com/6052978/108248920-46b76300-7109-11eb-8275-f006229b4525.png)
