### PR TITLE
[i18n] Update chart coloring functions to handle i18n strings

### DIFF
--- a/static/js/chart/base.ts
+++ b/static/js/chart/base.ts
@@ -88,8 +88,8 @@ function getColorFn(labels: string[]): d3.ScaleOrdinal<string, string> {
     // TODO(beets): This relies on the fact that we will always have
     // stats_var_labels.json for the locale loaded. Ideally, we would look for
     // the gender in the stat var itself.
-    labels.length == 2 &&
-    labels[0] == translateVariableString("Count_Person_Female")
+    labels.length === 2 &&
+    labels[0] === translateVariableString("Count_Person_Female")
   ) {
     range = ["#a60000", "#3288bd"];
   } else {

--- a/static/js/chart/base.ts
+++ b/static/js/chart/base.ts
@@ -15,6 +15,7 @@
  */
 
 import * as d3 from "d3";
+import { translateVariableString } from "../i18n/i18n";
 
 const DEFAULT_COLOR = "#000";
 
@@ -83,14 +84,24 @@ function getDashes(n: number): string[] {
 function getColorFn(labels: string[]): d3.ScaleOrdinal<string, string> {
   let domain = labels;
   let range;
-  if (labels.length == 2 && labels[0] == "Female") {
+  if (
+    // TODO(beets): This relies on the fact that we will always have
+    // stats_var_labels.json for the locale loaded. Ideally, we would look for
+    // the gender in the stat var itself.
+    labels.length == 2 &&
+    labels[0] == translateVariableString("Count_Person_Female")
+  ) {
     range = ["#a60000", "#3288bd"];
   } else {
     if (labels.length == 1) {
       // Get varied but stable color scheme for single stat var charts.
+      const label = labels[0];
+      let charCodeSum = 0;
+      for (let i = 0; i < label.length; i++) {
+        charCodeSum += label.charCodeAt(i);
+      }
       domain = Array.from("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
-      domain = domain.concat(labels);
-      domain.sort();
+      domain[charCodeSum % domain.length] = label;
     }
     range = d3.quantize(
       d3.interpolateRgbBasis([

--- a/static/js/chart/base.ts
+++ b/static/js/chart/base.ts
@@ -95,7 +95,7 @@ function getColorFn(labels: string[]): d3.ScaleOrdinal<string, string> {
   } else {
     if (labels.length == 1) {
       // Get varied but stable color scheme for single stat var charts.
-      const label = labels[0];
+      const label = labels[0] || "";
       let charCodeSum = 0;
       for (let i = 0; i < label.length; i++) {
         charCodeSum += label.charCodeAt(i);


### PR DESCRIPTION
The former method leaves many charts in a deep purple, since most of the other languages have characters that are above the Latin-1 range. This brings the label into stable position between a-z so pages should look more colorful again (esp in ru, hi, ja, ko).

Note that this will change the colors for the en charts as well.

before:
![image](https://user-images.githubusercontent.com/6052978/108290741-e09d0100-7145-11eb-8ffe-46e80b2516a3.png)

new:
![image](https://user-images.githubusercontent.com/6052978/108290717-d549d580-7145-11eb-8932-d6223507de7e.png)
