### PR TITLE
Forward other parameters from search explore more

### DIFF
--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -19,6 +19,7 @@ class Config:
     API_PROJECT = ''
     GA_ACCOUNT = ''
     MAPS_API_KEY = ''
+    SCHEME = 'https'
 
 
 class ProductionConfig(Config):
@@ -35,6 +36,7 @@ class AutopushConfig(Config):
 
 class MinikubeConfig(Config):
     DEVELOPMENT = True
+    SCHEME = 'http'
 
 
 class DevelopmentConfig(Config):
@@ -43,6 +45,7 @@ class DevelopmentConfig(Config):
     API_PROJECT = 'datcom-mixer-autopush'
     API_ROOT = 'https://autopush.api.datacommons.org'
     GCS_BUCKET = 'datcom-website-autopush-resources'
+    SCHEME = 'http'
 
 
 class DevelopmentLiteConfig(Config):
@@ -50,6 +53,7 @@ class DevelopmentLiteConfig(Config):
     LITE = True
     API_PROJECT = 'datcom-mixer-autopush'
     API_ROOT = 'https://autopush.api.datacommons.org'
+    SCHEME = 'http'
 
 
 class WebdriverConfig(Config):
@@ -58,6 +62,7 @@ class WebdriverConfig(Config):
     API_PROJECT = 'datcom-mixer-staging'
     API_ROOT = 'https://staging.api.datacommons.org'
     GCS_BUCKET = ''
+    SCHEME = 'http'
 
 
 class TestConfig(Config):
@@ -65,3 +70,4 @@ class TestConfig(Config):
     API_PROJECT = 'api-project'
     API_ROOT = 'api-root'
     GCS_BUCKET = 'gcs-bucket'
+    SCHEME = 'http'

--- a/server/routes/place.py
+++ b/server/routes/place.py
@@ -49,11 +49,16 @@ def place(place_dcid=None):
     dcid = flask.request.args.get('dcid', None)
     topic = flask.request.args.get('topic', None)
     if dcid:
+        # Traffic from "explore more" in Search. Forward along all parameters,
+        # except for dcid, to the new URL format.
+        redirect_args = dict(flask.request.args)
+        redirect_args['place_dcid'] = dcid
+        del redirect_args['dcid']
+        redirect_args['topic'] = topic
         url = flask.url_for('place.place',
-                            place_dcid=dcid,
-                            topic=topic,
+                            **redirect_args,
                             _external=True,
-                            _scheme="https")
+                            _scheme=current_app.config.get('SCHEME', 'https'))
         return flask.redirect(url)
 
     if not place_dcid:

--- a/server/routes/redirects.py
+++ b/server/routes/redirects.py
@@ -15,7 +15,7 @@
 browser.datacommons.org with datacommons.org
 """
 
-from flask import Blueprint, redirect, request, url_for
+from flask import Blueprint, current_app, redirect, request, url_for
 
 bp = Blueprint(
     "redirects",
@@ -35,14 +35,20 @@ def kg():
 
 @bp.route('/gni')
 def gni():
-    return redirect(url_for('tools.timeline', _external=True, _scheme="https"),
-                    code=302)
+    return redirect(
+        url_for('tools.timeline',
+                _external=True,
+                _scheme=current_app.config.get('SCHEME', 'https'),
+                code=302))
 
 
 @bp.route('/scatter')
 def scatter():
-    return redirect(url_for('tools.scatter', _external=True, _scheme="https"),
-                    code=302)
+    return redirect(
+        url_for('tools.scatter',
+                _external=True,
+                _scheme=current_app.config.get('SCHEME', 'https'),
+                code=302))
 
 
 @bp.route('/documentation')

--- a/server/tests/place_test.py
+++ b/server/tests/place_test.py
@@ -14,6 +14,7 @@
 
 import unittest
 from unittest.mock import patch
+from flask import request
 
 from main import app
 
@@ -104,3 +105,11 @@ class TestPlacePage(unittest.TestCase):
         response = app.test_client().get('/explore/place?dcid=geoId/06',
                                          follow_redirects=False)
         assert response.status_code == 302
+
+        test_client = app.test_client()
+        with test_client:
+            response = test_client.get(
+                '/place?dcid=geoId/06&utm_medium=explore&mprop=count&popt=Person&hl=fr',
+                follow_redirects=True)
+            assert '/place/geoId/06?utm_medium=explore&mprop=count&popt=Person&hl=fr' in request.url
+            assert response.status_code == 200

--- a/server/webdriver_tests/place_explorer_test.py
+++ b/server/webdriver_tests/place_explorer_test.py
@@ -163,36 +163,30 @@ class TestPlaceExplorer(WebdriverBaseTest):
         # Assert chart title is correct.
         self.assertEqual(CHART_TITLE, chart_title)
 
-    ## TODO(beets): Re-enable this test when feasible (without sacrificing potential ssl downgrade)
-    ## NOTE: Test case was re-designed but was not tested due to SSL issues. Possibly failing.
-    # def test_demographics_redirect_link(self):
-    #     """
-    #     Test a place page with demographics after a redirect.
-    #     """
-    #     # Load California's Demographics page.
-    #     self.driver.get(self.url_ + '/place?dcid=geoId/06&topic=Demographics')
+    def test_demographics_redirect_link(self):
+        """
+        Test a place page with demographics after a redirect.
+        """
+        # Load California's Demographics page.
+        start_url = self.url_ + '/place?dcid=geoId/06&topic=Demographics&utm_medium=um'
+        self.driver.get(start_url)
 
-    #     # Wait until the page has loaded.
-    #     element_present = EC.presence_of_element_located(
-    #         (By.CSS_SELECTOR, '.subtopic:nth-node(4)'))
-    #     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
+        # Wait for redirect.
+        WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
+            lambda driver: driver.current_url != start_url)
+        self.assertTrue("topic=Demographics" in self.driver.current_url)
+        self.assertTrue("utm_medium=um" in self.driver.current_url)
 
-    #     # Assert "Demographics" is part of the URL.
-    #     self.assertTrue("Demographics" in self.driver.current_url)
+        element_present = EC.presence_of_element_located(
+            (By.XPATH, '//*[@id="main-pane"]/section[4]/div/div[2]/div/h4'))
+        WebDriverWait(self.driver, self.TIMEOUT_SEC * 2).until(element_present)
 
-    #     # Get the Age topic from the list of topics.
-    #     age_topic = self.driver.find_element_by_css_selector(
-    #         ".subtopic:nth-child(4)")
-    #     age_across_places_chart = age_topic.find_element_by_css_selector(
-    #         ".col:nth-child(2)")
+        chart_title = self.driver.find_element_by_xpath(
+            '//*[@id="main-pane"]/section[4]/div/div[2]/div/h4').text
 
-    #     chart_title = age_across_places_chart.find_element_by_tag_name(
-    #         "h4").text
-
-    #     # Assert chart title is correct.
-    #     self.assertEqual(
-    #         "Population by Gender Per Capita: states near California(2018)",
-    #         chart_title, chart_title)
+        # Assert chart title is correct.
+        self.assertEqual("Gender distribution: states near California(2019)",
+                         chart_title)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The URL's from explore more use the dcid parameter, rather than path, e.g. https://datacommons.org/place?utm_medium=explore&dcid=geoId/1304000&mprop=count&popt=Person&hl=en

We were correcting that to /place/geoId/1304000 and only forwarding along the topic parameter. That's why the utm_medium wasn't picked up by GA.

This fixes things so all parameters are forwarded. If this works well from an analytics standpoint, I'll fix the URL's on search to avoid the redirect.
