### PR TITLE
Extract cached_name to a shared library

### DIFF
--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -22,6 +22,7 @@ from flask_babel import gettext
 from cache import cache
 import services.datacommons as dc
 from services.datacommons import fetch_data
+from routes.api.shared import cached_name
 import routes.api.stats as stats_api
 import lib.i18n as i18n
 
@@ -76,33 +77,6 @@ def get_place_type(place_dcid):
             or chosen_type == 'Place':
             chosen_type = place_type
     return chosen_type
-
-
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def cached_name(dcids):
-    """Returns display names for set of dcids.
-
-    Args:
-        dcids: ^ separated string of dcids. It must be a single string for the cache.
-
-    Returns:
-        A dictionary of display place names, keyed by dcid.
-    """
-    dcids = dcids.split('^')
-    response = fetch_data('/node/property-values', {
-        'dcids': dcids,
-        'property': 'name',
-        'direction': 'out'
-    },
-                          compress=False,
-                          post=True)
-    result = {}
-    for dcid in dcids:
-        if not dcid:
-            continue
-        values = response[dcid].get('out')
-        result[dcid] = values[0]['value'] if values else ''
-    return result
 
 
 def get_name(dcids):

--- a/server/routes/api/shared.py
+++ b/server/routes/api/shared.py
@@ -14,8 +14,7 @@
 
 from services.datacommons import fetch_data
 from cache import cache
-"""Common library for functions used by multiple tools
-"""
+"""Common library for functions used by multiple tools"""
 
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.

--- a/server/routes/api/shared.py
+++ b/server/routes/api/shared.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from services.datacommons import fetch_data
+from cache import cache
+"""Common library for functions used by multiple tools
+"""
+
+
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+def cached_name(dcids):
+    """Returns display names for set of dcids.
+
+    Args:
+        dcids: ^ separated string of dcids. It must be a single string for the cache.
+
+    Returns:
+        A dictionary of display place names, keyed by dcid.
+    """
+    dcids = dcids.split('^')
+    response = fetch_data('/node/property-values', {
+        'dcids': dcids,
+        'property': 'name',
+        'direction': 'out'
+    },
+                          compress=False,
+                          post=True)
+    result = {}
+    for dcid in dcids:
+        if not dcid:
+            continue
+        values = response[dcid].get('out')
+        result[dcid] = values[0]['value'] if values else ''
+    return result

--- a/server/tests/api_place_test.py
+++ b/server/tests/api_place_test.py
@@ -127,27 +127,13 @@ class TestApiParentPlaces(unittest.TestCase):
 
 class TestApiPlaceName(unittest.TestCase):
 
-    @patch('routes.api.place.fetch_data')
-    def test_parent_places(self, mock_fetch_data):
-        mock_response = {
-            'geoId/06': {
-                'out': [{
-                    'value': 'California',
-                    'provenance': 'prov1'
-                }]
-            },
-            'geoId/07': {
-                'out': []
-            },
-            'geoId/08': {
-                'out': [{
-                    'value': 'Colorado',
-                    'provenance': 'prov2'
-                }]
-            }
+    @patch('routes.api.place.cached_name')
+    def test_parent_places(self, mock_cached_name):
+        mock_cached_name.return_value = {
+            'geoId/06': 'California',
+            'geoId/07': '',
+            'geoId/08': 'Colorado'
         }
-        mock_fetch_data.side_effect = (
-            lambda url, req, compress, post: mock_response)
 
         response = app.test_client().get(
             '/api/place/name?dcid=geoId/06&dcid=geoId/07&dcid=geoId/08')
@@ -163,8 +149,10 @@ class TestApiPlaceI18nName(unittest.TestCase):
 
     @patch('lib.i18n.AVAILABLE_LANGUAGES',
            ['en', 'io', 'la', 'la-ru', 'it', 'ru'])
+    @patch('routes.api.place.cached_name')
     @patch('routes.api.place.fetch_data')
-    def test_parent_places(self, mock_fetch_data):
+    def test_parent_places(self, mock_fetch_data, mock_cached_name):
+        mock_cached_name.return_value = {'geoId/08': 'Colorado'}
         mock_response = {
             'geoId/05': {
                 'out': [{

--- a/server/tests/api_shared_test.py
+++ b/server/tests/api_shared_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import unittest
 import routes.api.shared as shared_api
 

--- a/server/tests/api_shared_test.py
+++ b/server/tests/api_shared_test.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+import routes.api.shared as shared_api
+
+from unittest.mock import patch
+
+
+class TestCachedName(unittest.TestCase):
+
+    @patch('routes.api.shared.fetch_data')
+    def test_cached_name(self, mock_data_fetcher):
+        dcid1 = 'geoId/06'
+        dcid2 = 'geoId/07'
+        dcid3 = 'geoId/08'
+        mock_response = {
+            dcid1: {
+                'out': [{
+                    'value': 'California',
+                    'provenance': 'prov1'
+                }]
+            },
+            dcid2: {
+                'out': []
+            },
+            dcid3: {
+                'out': [{
+                    'value': 'Colorado',
+                    'provenance': 'prov2'
+                }]
+            }
+        }
+        mock_data_fetcher.side_effect = (
+            lambda url, req, compress, post: mock_response)
+
+        result = shared_api.cached_name('^'.join([dcid1, dcid2, dcid3]))
+        assert result == {dcid1: 'California', dcid2: '', dcid3: 'Colorado'}


### PR DESCRIPTION
- Create a new file for shared flask APIs and functions
- Extract the cached_name function from place api into the new shared file