### PR TITLE
[Graph Browser 2] Small fixes/changes

### DIFF
--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -60,7 +60,7 @@ td a {
 .card {
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
   padding: 7px 15px;
-  padding-right: 0px;
+  padding-right: 0;
   margin: 12px 0;
   position: relative;
   overflow: hidden;
@@ -96,6 +96,6 @@ td a {
 }
 
 .in-arc-table {
-  max-height: 20em;
+  max-height: 19em;
   overflow-y: scroll;
 }

--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -96,6 +96,6 @@ td a {
 }
 
 .in-arc-table {
-  max-height: 450px;
+  max-height: 20em;
   overflow-y: scroll;
 }

--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -60,6 +60,7 @@ td a {
 .card {
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
   padding: 7px 15px;
+  padding-right: 0px;
   margin: 12px 0;
   position: relative;
   overflow: hidden;
@@ -69,12 +70,17 @@ td a {
   margin-top: 15px;
 }
 
+.hide-dots .dot {
+  opacity: 0;
+}
+
 .dot {
   r: 2;
 }
 
 .dot:hover {
   r: 5;
+  opacity: 1;
 }
 
 #tooltip {
@@ -87,4 +93,9 @@ td a {
 
 .no-click circle {
   cursor: auto;
+}
+
+.in-arc-table {
+  max-height: 450px;
+  overflow-y: scroll;
 }

--- a/static/js/browser2/arc_table_row.tsx
+++ b/static/js/browser2/arc_table_row.tsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 
-const HREF_PREFIX = "/browser2/";
+const HREF_PREFIX = "/browser/";
 
 interface ArcTableRowProps {
   propertyLabel: string;

--- a/static/js/browser2/in_arc_subsection.tsx
+++ b/static/js/browser2/in_arc_subsection.tsx
@@ -58,26 +58,28 @@ export class InArcSubsection extends React.Component<InArcSubsectionPropType> {
             </span>
           </strong>
         </div>
-        <table className="node-table">
-          <tbody>
-            {arcValues.map((arcValue, index) => {
-              return (
-                <ArcTableRow
-                  key={this.props.property + index}
-                  propertyLabel={this.props.property}
-                  valueDcid={arcValue.dcid}
-                  valueText={arcValue.name ? arcValue.name : arcValue.dcid}
-                  provenanceId={arcValue.provenanceId}
-                  src={
-                    arcValue.provenanceId
-                      ? this.props.provDomain[arcValue.provenanceId]
-                      : null
-                  }
-                />
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="in-arc-table">
+          <table className="node-table">
+            <tbody>
+              {arcValues.map((arcValue, index) => {
+                return (
+                  <ArcTableRow
+                    key={this.props.property + index}
+                    propertyLabel={this.props.property}
+                    valueDcid={arcValue.dcid}
+                    valueText={arcValue.name ? arcValue.name : arcValue.dcid}
+                    provenanceId={arcValue.provenanceId}
+                    src={
+                      arcValue.provenanceId
+                        ? this.props.provDomain[arcValue.provenanceId]
+                        : null
+                    }
+                  />
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       </div>
     );
   }

--- a/static/js/browser2/observation_chart.tsx
+++ b/static/js/browser2/observation_chart.tsx
@@ -73,7 +73,9 @@ export class ObservationChart extends React.Component<
       });
     });
     if (data.length > MAX_DOTS) {
-      document.getElementById("svg-container" + this.props.idx).classList.add("hide-dots");
+      document
+        .getElementById("svg-container" + this.props.idx)
+        .classList.add("hide-dots");
     }
     const dataGroups = [new DataGroup("", data)];
     const svgContainerId: string = "svg-container" + this.props.idx;

--- a/static/js/browser2/observation_chart.tsx
+++ b/static/js/browser2/observation_chart.tsx
@@ -30,8 +30,9 @@ import { SourceSeries } from "./util";
 const WIDTH = 500;
 const HEIGHT = 250;
 
-const URI_PREFIX = "/browser2/";
+const URI_PREFIX = "/browser/";
 const TOOLTIP_ID = "tooltip";
+const MAX_DOTS = 100;
 
 interface ObservationChartPropType {
   sourceSeries: SourceSeries;
@@ -71,6 +72,9 @@ export class ObservationChart extends React.Component<
         value: Number(values[key]),
       });
     });
+    if (data.length > MAX_DOTS) {
+      document.getElementById("svg-container" + this.props.idx).classList.add("hide-dots");
+    }
     const dataGroups = [new DataGroup("", data)];
     const svgContainerId: string = "svg-container" + this.props.idx;
     drawLineChart(


### PR DESCRIPTION
Some small fixes/changes:
- limit height of in-arcs sections and allow scrolling
- only show dots on hover on the observation charts when there are too many dots
- update prefix of links to "/browser/" instead of "/browser2/" 

![screen-recording (4)](https://user-images.githubusercontent.com/69875368/111234621-2ebdec80-85ac-11eb-90d2-c663431f83a4.gif)
![screen-recording (5)](https://user-images.githubusercontent.com/69875368/111234644-3da49f00-85ac-11eb-933a-4c9f03a4ffc0.gif)

