### PR TITLE
[Graph Browser 2] Show arcs for place stat var pages

### DIFF
--- a/static/js/browser2/arc_section.tsx
+++ b/static/js/browser2/arc_section.tsx
@@ -24,10 +24,12 @@ import _ from "lodash";
 
 import { InArcSection } from "./in_arc_section";
 import { OutArcSection } from "./out_arc_section";
+import { PageDisplayType } from "./util";
 
 interface ArcSectionPropType {
   dcid: string;
   nodeName: string;
+  pageDisplayType: PageDisplayType;
 }
 
 interface ArcSectionStateType {
@@ -64,12 +66,14 @@ export class ArcSection extends React.Component<
           labels={this.state.outLabels}
           provDomain={this.state.provDomain}
         />
-        <InArcSection
-          nodeName={this.props.nodeName}
-          dcid={this.props.dcid}
-          labels={this.state.inLabels}
-          provDomain={this.state.provDomain}
-        />
+        {this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR ? (
+          <InArcSection
+            nodeName={this.props.nodeName}
+            dcid={this.props.dcid}
+            labels={this.state.inLabels}
+            provDomain={this.state.provDomain}
+          />
+        ) : null}
       </>
     );
   }

--- a/static/js/browser2/arc_section.tsx
+++ b/static/js/browser2/arc_section.tsx
@@ -29,7 +29,7 @@ import { PageDisplayType } from "./util";
 interface ArcSectionPropType {
   dcid: string;
   nodeName: string;
-  pageDisplayType: PageDisplayType;
+  displayInArcs: boolean;
 }
 
 interface ArcSectionStateType {
@@ -66,7 +66,7 @@ export class ArcSection extends React.Component<
           labels={this.state.outLabels}
           provDomain={this.state.provDomain}
         />
-        {this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR ? (
+        {this.props.displayInArcs ? (
           <InArcSection
             nodeName={this.props.nodeName}
             dcid={this.props.dcid}

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -42,7 +42,9 @@ export class BrowserPage extends React.Component<BrowserPagePropType> {
           <ArcSection
             dcid={arcDcid}
             nodeName={this.props.nodeName}
-            displayInArcs={this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR}
+            displayInArcs={
+              this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR
+            }
           />
           {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR ? (
             <ObservationChartSection

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -42,7 +42,7 @@ export class BrowserPage extends React.Component<BrowserPagePropType> {
           <ArcSection
             dcid={arcDcid}
             nodeName={this.props.nodeName}
-            pageDisplayType={this.props.pageDisplayType}
+            displayInArcs={this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR}
           />
           {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR ? (
             <ObservationChartSection

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -33,23 +33,24 @@ interface BrowserPagePropType {
 
 export class BrowserPage extends React.Component<BrowserPagePropType> {
   render(): JSX.Element {
-    const pageName =
-      this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR
-        ? `${this.props.statVarId} in ${this.props.nodeName}`
-        : this.props.nodeName;
+    const pageTitle = this.getPageTitle();
+    const arcDcid = this.getArcDcid();
     return (
       <>
-        <div className="node-about">{"About: " + pageName}</div>
+        <div className="node-about">{"About: " + pageTitle}</div>
         <div id="node-content">
+          <ArcSection
+            dcid={arcDcid}
+            nodeName={this.props.nodeName}
+            pageDisplayType={this.props.pageDisplayType}
+          />
           {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR ? (
             <ObservationChartSection
               placeDcid={this.props.dcid}
               statVarId={this.props.statVarId}
               placeName={this.props.nodeName}
             />
-          ) : (
-            <ArcSection dcid={this.props.dcid} nodeName={this.props.nodeName} />
-          )}
+          ) : null}
           {this.props.pageDisplayType ===
           PageDisplayType.PLACE_WITH_WEATHER_INFO ? (
             <WeatherChartSection dcid={this.props.dcid} />
@@ -57,5 +58,17 @@ export class BrowserPage extends React.Component<BrowserPagePropType> {
         </div>
       </>
     );
+  }
+
+  private getPageTitle(): string {
+    return this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR
+      ? `${this.props.statVarId} in ${this.props.nodeName}`
+      : this.props.nodeName;
+  }
+
+  private getArcDcid(): string {
+    return this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR
+      ? this.props.statVarId
+      : this.props.dcid;
   }
 }

--- a/static/js/browser2/out_arc_section.tsx
+++ b/static/js/browser2/out_arc_section.tsx
@@ -31,6 +31,8 @@ const IGNORED_OUT_ARC_PROPERTIES = new Set([
   "geoJsonCoordinatesDP1",
   "geoJsonCoordinatesDP2",
   "geoJsonCoordinatesDP3",
+  "censusACSTableId",
+  "populationType",
 ]);
 const PROPERTIES_TO_TRIM = new Set(["nameWithLanguage"]);
 const NUM_VALUES_TRIMMED = 10;


### PR DESCRIPTION
For place stat var pages, show the arcs for the stat var by updating BrowserPage to also render the ArcSection for the PLACE_STAT_VAR pageDisplayType. 
![Screen Shot 2021-03-15 at 8 14 33 PM](https://user-images.githubusercontent.com/69875368/111250743-11e4e180-85cb-11eb-8a88-c3a71e33c5f4.png)
