### PR TITLE
[Graph Browser 2] Fix/Improve opening observation node page from observation chart

### DIFF
--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -64,10 +64,10 @@ def get_property_labels(dcid):
 
 
 @cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
-@bp.route('/observation-id')
-def get_observation_id():
-    """Returns the dcid of the observation node for a combination of predicates: observedNodeLocation,
-    statisticalVariable, observationDate, measurementMethod (optional), observationPeriod (optional)"""
+@bp.route('/observation-ids')
+def get_observation_ids():
+    """Returns a mapping of date to observation node dcid for a combination of predicates: 
+    observedNodeLocation, statisticalVariable, measurementMethod (optional), observationPeriod (optional)"""
     place_id = request.args.get("place")
     if not place_id:
         return Response(json.dumps("error: must provide a place field"),
@@ -78,36 +78,35 @@ def get_observation_id():
         return Response(json.dumps("error: must provide a statVar field"),
                         400,
                         mimetype='application/json')
-    date = request.args.get("date")
-    if not date:
-        return Response(json.dumps("error: must provide a date field"),
-                        400,
-                        mimetype='application/json')
     measurement_method = request.args.get("measurementMethod", "")
     observation_period = request.args.get("obsPeriod", "")
     measurement_method_line = ""
     if measurement_method:
-        measurement_method_line = f"""?observation measurementMethod {measurement_method} ."""
+        measurement_method_line = f"""?svObservation measurementMethod {measurement_method} ."""
     observation_period_line = ""
     if observation_period:
-        observation_period_line = f"""?observation observationPeriod {observation_period} ."""
+        observation_period_line = f"""?svObservation observationPeriod {observation_period} ."""
     sparql_query = '''
-        SELECT ?dcid
+        SELECT ?dcid ?obsDate
         WHERE {{ 
-            ?observation typeOf Observation .
-            ?observation statisticalVariable {} . 
-            ?observation observedNodeLocation {} .
-            ?observation dcid ?dcid .
-            ?observation observationDate "{}" .
+            ?svObservation typeOf StatVarObservation .
+            ?svObservation variableMeasured {} . 
+            ?svObservation observationAbout {} .
+            ?svObservation dcid ?dcid .
+            ?svObservation observationDate ?obsDate .
             {}
             {}
         }}
-    '''.format(stat_var_id, place_id, date, measurement_method_line,
+    '''.format(stat_var_id, place_id, measurement_method_line,
                observation_period_line)
     result = ""
     (_, rows) = dc.query(sparql_query)
-    if len(rows) > 0:
-        cells = rows[0].get("cells", [])
-        if len(cells) > 0:
-            result = cells[0].get('value', '')
+    result = {}
+    for row in rows:
+        cells = row.get('cells', [])
+        if not len(cells) == 2:
+            continue
+        obsDate = cells[1].get('value', '')
+        dcid = cells[0].get('value', '')
+        result[obsDate] = dcid
     return Response(json.dumps(result), 200, mimetype='application/json')

--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -80,12 +80,12 @@ def get_observation_ids():
                         mimetype='application/json')
     measurement_method = request.args.get("measurementMethod", "")
     observation_period = request.args.get("obsPeriod", "")
-    measurement_method_line = ""
+    measurement_method_triple = ""
     if measurement_method:
-        measurement_method_line = f"""?svObservation measurementMethod {measurement_method} ."""
-    observation_period_line = ""
+        measurement_method_triple = f"""?svObservation measurementMethod {measurement_method} ."""
+    observation_period_triple = ""
     if observation_period:
-        observation_period_line = f"""?svObservation observationPeriod {observation_period} ."""
+        observation_period_triple = f"""?svObservation observationPeriod {observation_period} ."""
     sparql_query = '''
         SELECT ?dcid ?obsDate
         WHERE {{ 
@@ -97,14 +97,14 @@ def get_observation_ids():
             {}
             {}
         }}
-    '''.format(stat_var_id, place_id, measurement_method_line,
-               observation_period_line)
+    '''.format(stat_var_id, place_id, measurement_method_triple,
+               observation_period_triple)
     result = ""
     (_, rows) = dc.query(sparql_query)
     result = {}
     for row in rows:
         cells = row.get('cells', [])
-        if not len(cells) == 2:
+        if len(cells) != 2:
             continue
         obsDate = cells[1].get('value', '')
         dcid = cells[0].get('value', '')

--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -66,7 +66,7 @@ def get_property_labels(dcid):
 @cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
 @bp.route('/observation-ids')
 def get_observation_ids():
-    """Returns a mapping of date to observation node dcid for a combination of predicates: 
+    """Returns a mapping of date to observation node dcid for a combination of predicates:
     observedNodeLocation, statisticalVariable, measurementMethod (optional), observationPeriod (optional)"""
     place_id = request.args.get("place")
     if not place_id:

--- a/server/routes/browser.py
+++ b/server/routes/browser.py
@@ -30,8 +30,6 @@ def browser_main():
 def browser_node(dcid):
     if os.environ.get('FLASK_ENV') == 'svobs' or os.environ.get(
             'FLASK_ENV') == 'development-svobs':
-        print('HEREE')
-        print(dcid)
         node_name = shared_api.cached_name(dcid).get(dcid)
         if not node_name:
             node_name = dcid

--- a/server/tests/api_browser_test.py
+++ b/server/tests/api_browser_test.py
@@ -49,7 +49,6 @@ class TestObservationId(unittest.TestCase):
         expected_obs_id = "test_obs_id"
 
         def side_effect(query):
-            print(query)
             if query == expected_query:
                 return (['?dcid', '?obsDate'], [{
                     'cells': [{
@@ -86,7 +85,6 @@ class TestObservationId(unittest.TestCase):
         expected_obs_id = "test_obs_id"
 
         def side_effect(query):
-            print(query)
             if query == expected_query:
                 return (['?dcid', '?obsDate'], [{
                     'cells': [{

--- a/server/tests/api_browser_test.py
+++ b/server/tests/api_browser_test.py
@@ -24,71 +24,84 @@ class TestObservationId(unittest.TestCase):
     def test_required_predicates(self):
         """Failure if required fields are not present."""
         no_stat_var = app.test_client().get(
-            '/api/browser/observation-id?place=country/USA&date=2008')
+            '/api/browser/observation-ids?place=country/USA')
         assert no_stat_var.status_code == 400
 
         no_place = app.test_client().get(
-            '/api/browser/observation-id?statVar=testStatVar&date=2008')
+            '/api/browser/observation-ids?statVar=testStatVar')
         assert no_place.status_code == 400
-
-        no_date = app.test_client().get(
-            '/api/browser/observation-id?statVar=testStatVar&place=geoId/06')
-        assert no_date.status_code == 400
 
     @patch('routes.api.browser.dc.query')
     def test_observation_node_dcid_returned(self, mock_query):
         expected_query = '''
-        SELECT ?dcid
+        SELECT ?dcid ?obsDate
         WHERE { 
-            ?observation typeOf Observation .
-            ?observation statisticalVariable test_stat_var . 
-            ?observation observedNodeLocation geoId/06 .
-            ?observation dcid ?dcid .
-            ?observation observationDate "2006" .
+            ?svObservation typeOf StatVarObservation .
+            ?svObservation variableMeasured test_stat_var . 
+            ?svObservation observationAbout geoId/06 .
+            ?svObservation dcid ?dcid .
+            ?svObservation observationDate ?obsDate .
             
             
         }
     '''
+        obs_date = "2001"
         expected_obs_id = "test_obs_id"
 
         def side_effect(query):
+            print(query)
             if query == expected_query:
-                return (['?dcid'], [{'cells': [{'value': expected_obs_id}]}])
+                return (['?dcid', '?obsDate'], [{
+                    'cells': [{
+                        'value': expected_obs_id
+                    }, {
+                        'value': obs_date
+                    }]
+                }])
             else:
                 return ([], [])
 
         mock_query.side_effect = side_effect
         response = app.test_client().get(
-            'api/browser/observation-id?statVar=test_stat_var&place=geoId/06&date=2006'
-        )
+            'api/browser/observation-ids?statVar=test_stat_var&place=geoId/06')
         assert response.status_code == 200
-        assert json.loads(response.data) == expected_obs_id
+        result = json.loads(response.data)
+        assert result[obs_date] == expected_obs_id
 
     @patch('routes.api.browser.dc.query')
     def test_with_optional_predicates(self, mock_query):
         expected_query = '''
-        SELECT ?dcid
+        SELECT ?dcid ?obsDate
         WHERE { 
-            ?observation typeOf Observation .
-            ?observation statisticalVariable test_stat_var . 
-            ?observation observedNodeLocation geoId/06 .
-            ?observation dcid ?dcid .
-            ?observation observationDate "2006" .
-            ?observation measurementMethod testMethod .
-            ?observation observationPeriod testObsPeriod .
+            ?svObservation typeOf StatVarObservation .
+            ?svObservation variableMeasured test_stat_var . 
+            ?svObservation observationAbout geoId/06 .
+            ?svObservation dcid ?dcid .
+            ?svObservation observationDate ?obsDate .
+            ?svObservation measurementMethod testMethod .
+            ?svObservation observationPeriod testObsPeriod .
         }
     '''
+        obs_date = "2001"
         expected_obs_id = "test_obs_id"
 
         def side_effect(query):
+            print(query)
             if query == expected_query:
-                return (['?dcid'], [{'cells': [{'value': expected_obs_id}]}])
+                return (['?dcid', '?obsDate'], [{
+                    'cells': [{
+                        'value': expected_obs_id
+                    }, {
+                        'value': obs_date
+                    }]
+                }])
             else:
                 return ([], [])
 
         mock_query.side_effect = side_effect
         response = app.test_client().get(
-            'api/browser/observation-id?statVar=test_stat_var&place=geoId/06&date=2006&measurementMethod=testMethod&obsPeriod=testObsPeriod'
+            'api/browser/observation-ids?statVar=test_stat_var&place=geoId/06&measurementMethod=testMethod&obsPeriod=testObsPeriod'
         )
         assert response.status_code == 200
-        assert json.loads(response.data) == expected_obs_id
+        result = json.loads(response.data)
+        assert result[obs_date] == expected_obs_id

--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -99,3 +99,8 @@ td a {
   max-height: 19em;
   overflow-y: scroll;
 }
+
+.error-message {
+  font: 14px;
+  color: var(--dc-red-lite);
+}

--- a/static/js/browser2/observation_chart.tsx
+++ b/static/js/browser2/observation_chart.tsx
@@ -129,8 +129,8 @@ export class ObservationChart extends React.Component<
     axios.get(request).then((resp) => {
       const data = resp.data;
       this.setState({
-        dateToDcid: data,
         canClickDots: true,
+        dateToDcid: data,
       });
     });
   }

--- a/static/js/browser2/observation_chart.tsx
+++ b/static/js/browser2/observation_chart.tsx
@@ -46,7 +46,7 @@ interface ObservationChartPropType {
 
 interface ObservationChartStateType {
   canClickDots: boolean;
-  obsDcidMapping: { [date: string]: string };
+  dateToDcid: { [date: string]: string };
   errorMessage: string;
 }
 
@@ -58,7 +58,7 @@ export class ObservationChart extends React.Component<
     super(props);
     this.state = {
       canClickDots: false,
-      obsDcidMapping: {},
+      dateToDcid: {},
       errorMessage: "",
     };
   }
@@ -129,7 +129,7 @@ export class ObservationChart extends React.Component<
     axios.get(request).then((resp) => {
       const data = resp.data;
       this.setState({
-        obsDcidMapping: data,
+        dateToDcid: data,
         canClickDots: true,
       });
     });
@@ -184,12 +184,12 @@ export class ObservationChart extends React.Component<
 
   private handleDotClick = (dotData: DotDataPoint): void => {
     const date = dotData.label;
-    const obsDcid = this.state.obsDcidMapping[date];
+    const obsDcid = this.state.dateToDcid[date];
     if (obsDcid) {
       const uri = URI_PREFIX + obsDcid;
       window.open(uri);
     } else if (this.state.canClickDots) {
-      this.updateErrorMessage(NO_OBSDCID_ERROR_MESSAGE)
+      this.updateErrorMessage(NO_OBSDCID_ERROR_MESSAGE);
     }
   };
 

--- a/static/js/browser2/observation_chart_section.tsx
+++ b/static/js/browser2/observation_chart_section.tsx
@@ -78,7 +78,7 @@ export class ObservationChartSection extends React.Component<
                 idx={index}
                 statVarId={this.props.statVarId}
                 placeDcid={this.props.placeDcid}
-                canClickDots={true}
+                hasClickableDots={true}
               />
             </div>
           );
@@ -101,9 +101,7 @@ export class ObservationChartSection extends React.Component<
         this.setState({
           data: sourceSeries,
           infoMessage: _.isEmpty(sourceSeries)
-            ? this.props.statVarId +
-              " is not a statistical variable for " +
-              this.props.placeName
+            ? `No data for ${this.props.statVarId} in ${this.props.placeName}`
             : "",
         });
       })

--- a/static/js/browser2/weather_chart_section.tsx
+++ b/static/js/browser2/weather_chart_section.tsx
@@ -70,7 +70,7 @@ export class WeatherChartSection extends React.Component<
                 idx={index}
                 statVarId={measuredProperty}
                 placeDcid={this.props.dcid}
-                canClickDots={false}
+                hasClickableDots={false}
               />
             </div>
           );


### PR DESCRIPTION
- update the flask server endpoint to use new statVarObservation table & return a mapping of date to dcids
- update observationChart component to retrieve observation dcids for all the data points on the chart & have it in the state so onClick will open the observation node page right away 