### PR TITLE
[Graph Browser 2] Make rows in arc table expandable

### DIFF
--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -51,6 +51,7 @@
 
 .property-column {
   word-wrap: break-word;
+  vertical-align: top;
 }
 
 td a {
@@ -98,10 +99,6 @@ td a {
 .in-arc-table {
   max-height: 19em;
   overflow-y: scroll;
-}
-
-.property-column {
-  vertical-align: top;
 }
 
 .provenance-column {

--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -109,7 +109,7 @@ td a {
 }
 
 .clickable-text {
-  color: #660000;
+  color: var(--link-color);
   cursor: pointer;
 }
 

--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -99,3 +99,20 @@ td a {
   max-height: 19em;
   overflow-y: scroll;
 }
+
+.property-column {
+  vertical-align: top;
+}
+
+.provenance-column {
+  vertical-align: top;
+}
+
+.clickable-text {
+  color: #660000;
+  cursor: pointer;
+}
+
+.clickable-text:hover {
+  text-decoration: underline;
+}

--- a/static/js/browser2/arc_section.tsx
+++ b/static/js/browser2/arc_section.tsx
@@ -24,7 +24,6 @@ import _ from "lodash";
 
 import { InArcSection } from "./in_arc_section";
 import { OutArcSection } from "./out_arc_section";
-import { PageDisplayType } from "./util";
 
 interface ArcSectionPropType {
   dcid: string;

--- a/static/js/browser2/arc_table_row.tsx
+++ b/static/js/browser2/arc_table_row.tsx
@@ -20,18 +20,39 @@
  */
 
 import React from "react";
+import _ from "lodash";
+import { ArcValue } from "./util";
 
 const HREF_PREFIX = "/browser/";
+const NUM_VALUES_UNEXPANDED = 10;
 
-interface ArcTableRowProps {
+interface ArcTableRowPropType {
   propertyLabel: string;
-  valueDcid?: string;
-  valueText: string;
-  provenanceId?: string;
+  values: Array<ArcValue>;
+  provenanceId: string;
   src: URL;
 }
-export class ArcTableRow extends React.Component<ArcTableRowProps> {
+
+interface ArcTableRowStateType {
+  expanded: boolean;
+}
+
+export class ArcTableRow extends React.Component<
+  ArcTableRowPropType,
+  ArcTableRowStateType
+> {
+  constructor(props: ArcTableRowPropType) {
+    super(props);
+    this.state = {
+      expanded: false,
+    };
+  }
+
   render(): JSX.Element {
+    const values = this.state.expanded
+      ? this.props.values
+      : _.slice(this.props.values, 0, NUM_VALUES_UNEXPANDED);
+    const hasMoreValues = this.props.values.length > NUM_VALUES_UNEXPANDED;
     return (
       <tr>
         <td className="property-column" width="25%">
@@ -40,20 +61,48 @@ export class ArcTableRow extends React.Component<ArcTableRowProps> {
           </a>
         </td>
         <td width="50%">
-          {this.props.valueDcid ? (
-            <a href={HREF_PREFIX + this.props.valueDcid}>
-              {this.props.valueText}
-            </a>
-          ) : (
-            <span className="out-arc-text">{this.props.valueText}</span>
-          )}
+          <div className="values-row">
+            {values.map((value) => {
+              return (
+                <div className="arc-text" key={value.text}>
+                  {value.dcid ? (
+                    <a href={HREF_PREFIX + value.dcid}>{value.text}</a>
+                  ) : (
+                    <span>{value.text}</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          {this.state.expanded ? (
+            <div className="clickable-text" onClick={this.showLess.bind(this)}>
+              Show less
+            </div>
+          ) : null}
+          {hasMoreValues && !this.state.expanded ? (
+            <div className="clickable-text" onClick={this.showMore.bind(this)}>
+              Show more
+            </div>
+          ) : null}
         </td>
-        <td width="25%">
+        <td width="25%" className="provenance-column">
           {this.props.provenanceId && (
             <a href={HREF_PREFIX + this.props.provenanceId}>{this.props.src}</a>
           )}
         </td>
       </tr>
     );
+  }
+
+  private showMore(): void {
+    this.setState({
+      expanded: true,
+    });
+  }
+
+  private showLess(): void {
+    this.setState({
+      expanded: false,
+    });
   }
 }

--- a/static/js/browser2/in_arc_section.tsx
+++ b/static/js/browser2/in_arc_section.tsx
@@ -21,7 +21,7 @@
 import React from "react";
 import axios from "axios";
 import { InArcSubsection } from "./in_arc_subsection";
-import { removeLoadingMessage } from "./util";
+import { InArcValue, removeLoadingMessage } from "./util";
 
 const IGNORED_PARENT_TYPES = new Set(["StatisticalPopulation"]);
 
@@ -32,7 +32,7 @@ interface InArcSectionsPropType {
   provDomain: { [key: string]: URL };
 }
 interface InArcSectionStateType {
-  data: { [parentType: string]: { [property: string]: Array<any> } };
+  data: { [parentType: string]: { [property: string]: Array<InArcValue> } };
   parentTypes: string[];
 }
 

--- a/static/js/browser2/in_arc_subsection.tsx
+++ b/static/js/browser2/in_arc_subsection.tsx
@@ -20,12 +20,13 @@
 
 import React from "react";
 import { ArcTableRow } from "./arc_table_row";
+import { InArcValue } from "./util";
 
 interface InArcSubsectionPropType {
   nodeName: string;
   parentType: string;
   property: string;
-  arcValues: Array<any>;
+  arcValues: Array<InArcValue>;
   provDomain: { [key: string]: URL };
 }
 
@@ -62,15 +63,15 @@ export class InArcSubsection extends React.Component<InArcSubsectionPropType> {
           <table className="node-table">
             <tbody>
               {arcValues.map((arcValue, index) => {
+                const valueText = arcValue.name ? arcValue.name : arcValue.dcid;
                 return (
                   <ArcTableRow
                     key={this.props.property + index}
                     propertyLabel={this.props.property}
-                    valueDcid={arcValue.dcid}
-                    valueText={arcValue.name ? arcValue.name : arcValue.dcid}
+                    values={[{ dcid: arcValue.dcid, text: valueText }]}
                     provenanceId={arcValue.provenanceId}
                     src={
-                      arcValue.provenanceId
+                      this.props.provDomain[arcValue.provenanceId]
                         ? this.props.provDomain[arcValue.provenanceId]
                         : null
                     }

--- a/static/js/browser2/util.ts
+++ b/static/js/browser2/util.ts
@@ -20,6 +20,16 @@
 
 import _ from "lodash";
 
+export interface ArcValue {
+  text: string;
+  dcid?: string;
+}
+
+export interface InArcValue {
+  provenanceId: string;
+  dcid: string;
+  name?: string;
+}
 export interface SourceSeries {
   provenanceDomain: string;
   val: { [key: string]: string };


### PR DESCRIPTION
- Update the ArcTableRows component to take in an array of values. The arc table row will show up to 10 values and be able to expand and collapse. 
- Update OutArcsSection component to group values by predicate and provenance Id & pass a list of values for each combination of predicate and provenance id to the ArcTableRows component
- Also removed the any types

![screen-recording (6)](https://user-images.githubusercontent.com/69875368/111551061-99059700-873c-11eb-8a34-abd7ad3b6189.gif)


I had also experimented with other ways to separate the list of values in each row:
- vertically aligned dot was confusing, especially when values had dashes: https://screenshot.googleplex.com/33MDP7y6QAGocwP
- comma could be confusing as to whether we are looking at a single value or multiple values: https://screenshot.googleplex.com/NYP2tjv26mPakuX