### PR TITLE
[Graph Browser 2] Show image for biological specimen pages

### DIFF
--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -20,6 +20,7 @@
 
 import React from "react";
 import { ArcSection } from "./arc_section";
+import { ImageSection } from "./image_section";
 import { ObservationChartSection } from "./observation_chart_section";
 import { PageDisplayType } from "./util";
 import { WeatherChartSection } from "./weather_chart_section";
@@ -56,6 +57,10 @@ export class BrowserPage extends React.Component<BrowserPagePropType> {
           {this.props.pageDisplayType ===
           PageDisplayType.PLACE_WITH_WEATHER_INFO ? (
             <WeatherChartSection dcid={this.props.dcid} />
+          ) : null}
+          {this.props.pageDisplayType ===
+          PageDisplayType.BIOLOGICAL_SPECIMEN ? (
+            <ImageSection dcid={this.props.dcid} />
           ) : null}
         </div>
       </>

--- a/static/js/browser2/image_section.tsx
+++ b/static/js/browser2/image_section.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Component for rendering the image for the imageUrl property value.
+ */
+
+import React from "react";
+import axios from "axios";
+import _ from "lodash";
+
+const PROPERTY_LABEL = "imageUrl";
+
+interface ImageSectionPropType {
+  dcid: string;
+}
+
+interface ImageSectionStateType {
+  imageUrls: string[];
+}
+
+export class ImageSection extends React.Component<
+  ImageSectionPropType,
+  ImageSectionStateType
+> {
+  constructor(props: ImageSectionPropType) {
+    super(props);
+    this.state = {
+      imageUrls: [],
+    };
+  }
+
+  componentDidMount(): void {
+    this.fetchData();
+  }
+
+  render(): JSX.Element {
+    if (_.isEmpty(this.state.imageUrls)) {
+      return null;
+    }
+    return (
+      <>
+        {this.state.imageUrls.map((url, idx) => {
+          return (
+            <div key={"image" + idx} className="card">
+              <img src={url} />
+            </div>
+          );
+        })}
+      </>
+    );
+  }
+
+  private fetchData(): void {
+    axios
+      .get(`/api/browser/propvals/${PROPERTY_LABEL}/${this.props.dcid}`)
+      .then((resp) => {
+        const data = resp.data;
+        if (!data || _.isEmpty(data.values)) {
+          return;
+        }
+        this.setState({
+          imageUrls: data.values.out,
+        });
+      });
+  }
+}

--- a/static/js/browser2/image_section.tsx
+++ b/static/js/browser2/image_section.tsx
@@ -22,7 +22,7 @@ import React from "react";
 import axios from "axios";
 import _ from "lodash";
 
-const PROPERTY_LABEL = "imageUrl";
+const IMAGE_URL_PROPERTY_LABEL = "imageUrl";
 
 interface ImageSectionPropType {
   dcid: string;
@@ -66,14 +66,17 @@ export class ImageSection extends React.Component<
 
   private fetchData(): void {
     axios
-      .get(`/api/browser/propvals/${PROPERTY_LABEL}/${this.props.dcid}`)
+      .get(
+        `/api/browser/propvals/${IMAGE_URL_PROPERTY_LABEL}/${this.props.dcid}`
+      )
       .then((resp) => {
         const data = resp.data;
         if (!data || _.isEmpty(data.values)) {
           return;
         }
+        const imgUrls = data.values.out.map((imgUrlValue) => imgUrlValue.value);
         this.setState({
-          imageUrls: data.values.out,
+          imageUrls: imgUrls,
         });
       });
   }

--- a/static/js/browser2/util.ts
+++ b/static/js/browser2/util.ts
@@ -34,7 +34,7 @@ export enum PageDisplayType {
   PLACE_STAT_VAR,
   PLACE_WITH_WEATHER_INFO,
   GENERAL,
-  PAGE_WITH_IMAGE,
+  BIOLOGICAL_SPECIMEN,
 }
 
 /**
@@ -44,7 +44,7 @@ export enum PageDisplayType {
 export const nodeTypeToPageDisplayTypeMapping = {
   CensusZipCodeTabulationArea: PageDisplayType.PLACE_WITH_WEATHER_INFO,
   City: PageDisplayType.PLACE_WITH_WEATHER_INFO,
-  BiologicalSpecimen: PageDisplayType.PAGE_WITH_IMAGE,
+  BiologicalSpecimen: PageDisplayType.BIOLOGICAL_SPECIMEN,
 };
 
 /**

--- a/static/js/browser2/util.ts
+++ b/static/js/browser2/util.ts
@@ -34,6 +34,7 @@ export enum PageDisplayType {
   PLACE_STAT_VAR,
   PLACE_WITH_WEATHER_INFO,
   GENERAL,
+  PAGE_WITH_IMAGE,
 }
 
 /**
@@ -43,6 +44,7 @@ export enum PageDisplayType {
 export const nodeTypeToPageDisplayTypeMapping = {
   CensusZipCodeTabulationArea: PageDisplayType.PLACE_WITH_WEATHER_INFO,
   City: PageDisplayType.PLACE_WITH_WEATHER_INFO,
+  BiologicalSpecimen: PageDisplayType.PAGE_WITH_IMAGE,
 };
 
 /**


### PR DESCRIPTION
- Add new ImageSection component that displays images from the imageUrl property of a node
- Render ImageSection component when the PageDisplayType is BiologicalSpecimen
![screen-recording (7)](https://user-images.githubusercontent.com/69875368/111701897-b861fa00-87f8-11eb-9213-237d38f202fa.gif)
