### PR TITLE
[Graph Browser 2] Use triples to get out arcs for observation nodes

### DIFF
--- a/static/js/browser2/arc_section.tsx
+++ b/static/js/browser2/arc_section.tsx
@@ -20,7 +20,6 @@
 
 import React from "react";
 import axios from "axios";
-import _ from "lodash";
 
 import { InArcSection } from "./in_arc_section";
 import { OutArcSection } from "./out_arc_section";

--- a/static/js/browser2/arc_section.tsx
+++ b/static/js/browser2/arc_section.tsx
@@ -35,7 +35,8 @@ interface ArcSectionStateType {
   inLabels: string[];
   outLabels: string[];
   provDomain: { [key: string]: URL };
-  dataFetched: boolean;
+  isDataFetched: boolean;
+  errorMessage: string;
 }
 
 export class ArcSection extends React.Component<
@@ -45,10 +46,11 @@ export class ArcSection extends React.Component<
   constructor(props: ArcSectionPropType) {
     super(props);
     this.state = {
+      errorMessage: "",
       inLabels: [],
+      isDataFetched: false,
       outLabels: [],
       provDomain: {},
-      dataFetched: false,
     };
   }
 
@@ -57,7 +59,7 @@ export class ArcSection extends React.Component<
   }
 
   render(): JSX.Element {
-    if (!this.state.dataFetched) {
+    if (!this.state.isDataFetched) {
       return null;
     }
     return (
@@ -74,6 +76,9 @@ export class ArcSection extends React.Component<
             labels={this.state.inLabels}
             provDomain={this.state.provDomain}
           />
+        ) : null}
+        {this.state.errorMessage ? (
+          <div className="error-message">{this.state.errorMessage}</div>
         ) : null}
       </>
     );
@@ -98,12 +103,12 @@ export class ArcSection extends React.Component<
           inLabels: labelsData["inLabels"],
           outLabels: labelsData["outLabels"],
           provDomain,
-          dataFetched: true,
+          isDataFetched: true,
         });
       })
       .catch(() => {
         this.setState({
-          dataFetched: true,
+          errorMessage: `Error retrieving property labels for ${this.props.dcid}`,
         });
       });
   }

--- a/static/js/browser2/in_arc_section.tsx
+++ b/static/js/browser2/in_arc_section.tsx
@@ -20,6 +20,7 @@
 
 import React from "react";
 import axios from "axios";
+import _ from "lodash";
 import { InArcSubsection } from "./in_arc_subsection";
 import { InArcValue, removeLoadingMessage } from "./util";
 
@@ -75,6 +76,9 @@ export class InArcSection extends React.Component<
   }
 
   private fetchData(): void {
+    if (_.isEmpty(this.props.labels)) {
+      return;
+    }
     const propValuesPromises = this.props.labels.map((label) => {
       return axios
         .get(`/api/browser/propvals/${label}/${this.props.dcid}`)

--- a/static/js/browser2/out_arc_section.tsx
+++ b/static/js/browser2/out_arc_section.tsx
@@ -147,7 +147,8 @@ export class OutArcSection extends React.Component<
             if (!(predicate in outArcsByPredicateAndProvenance)) {
               outArcsByPredicateAndProvenance[predicate] = {};
             }
-            const outArcsOfPredicate = outArcsByPredicateAndProvenance[predicate];
+            const outArcsOfPredicate =
+              outArcsByPredicateAndProvenance[predicate];
             const provId = value.provenanceId;
             if (!(provId in outArcsOfPredicate)) {
               outArcsOfPredicate[provId] = [];

--- a/static/js/browser2/out_arc_section.tsx
+++ b/static/js/browser2/out_arc_section.tsx
@@ -121,7 +121,8 @@ export class OutArcSection extends React.Component<
   }
 
   private fetchData(): void {
-    // If a node doesn't have out arc property labels (ie. Observation Nodes), try getting the out arcs from triples data.
+    // If a node doesn't have out arc property labels (ie. Observation Nodes),
+    // try getting the out arcs from triples data.
     if (_.isEmpty(this.props.labels)) {
       this.fetchDataFromTriples();
       return;
@@ -146,9 +147,10 @@ export class OutArcSection extends React.Component<
             if (!(predicate in outArcsByPredicateAndProvenance)) {
               outArcsByPredicateAndProvenance[predicate] = {};
             }
+            const outArcsOfPredicate = outArcsByPredicateAndProvenance[predicate];
             const provId = value.provenanceId;
-            if (!(provId in outArcsByPredicateAndProvenance[predicate])) {
-              outArcsByPredicateAndProvenance[predicate][provId] = [];
+            if (!(provId in outArcsOfPredicate)) {
+              outArcsOfPredicate[provId] = [];
             }
             let valueText = "";
             if (value.dcid) {
@@ -156,7 +158,7 @@ export class OutArcSection extends React.Component<
             } else {
               valueText = value.value;
             }
-            outArcsByPredicateAndProvenance[predicate][provId].push({
+            outArcsOfPredicate[provId].push({
               dcid: value.dcid,
               text: valueText,
             });
@@ -184,10 +186,10 @@ export class OutArcSection extends React.Component<
     axios.get("/api/browser/triples/" + this.props.dcid).then((resp) => {
       const triplesData = resp.data;
       const outArcs = triplesData.filter(
-        (t) => t["subjectId"] == this.props.dcid
+        (t) => t.subjectId === this.props.dcid
       );
       const outArcsByPredicateAndProvenance: OutArcData = {};
-      outArcs.forEach((outArc) => {
+      for (const outArc of outArcs) {
         const predicate = outArc.predicate;
         if (IGNORED_OUT_ARC_PROPERTIES.has(predicate)) {
           return;
@@ -195,9 +197,10 @@ export class OutArcSection extends React.Component<
         if (!outArcsByPredicateAndProvenance[predicate]) {
           outArcsByPredicateAndProvenance[predicate] = {};
         }
+        const outArcsOfPredicate = outArcsByPredicateAndProvenance[predicate];
         const provId = outArc.provenanceId;
-        if (!(provId in outArcsByPredicateAndProvenance[predicate])) {
-          outArcsByPredicateAndProvenance[predicate][provId] = [];
+        if (!(provId in outArcsOfPredicate)) {
+          outArcsOfPredicate[provId] = [];
         }
         let valueText = "";
         let valueDcid: string;
@@ -207,11 +210,11 @@ export class OutArcSection extends React.Component<
         } else {
           valueText = outArc.objectValue;
         }
-        outArcsByPredicateAndProvenance[predicate][provId].push({
+        outArcsOfPredicate[provId].push({
           dcid: valueDcid,
           text: valueText,
         });
-      });
+      }
       removeLoadingMessage();
       this.setState({
         data: outArcsByPredicateAndProvenance,

--- a/static/js/browser2/out_arc_section.tsx
+++ b/static/js/browser2/out_arc_section.tsx
@@ -136,7 +136,7 @@ export class OutArcSection extends React.Component<
     });
     Promise.all(propValuesPromises)
       .then((propValuesData) => {
-        const outArcsByPredicateAndProvenance: OutArcData = {};
+        const outArcsByPredProv: OutArcData = {};
         propValuesData.forEach((valuesData) => {
           if (!valuesData || _.isEmpty(valuesData.values)) {
             return;
@@ -144,11 +144,10 @@ export class OutArcSection extends React.Component<
           const predicate = valuesData.property;
           const values = valuesData.values.out;
           for (const value of values) {
-            if (!(predicate in outArcsByPredicateAndProvenance)) {
-              outArcsByPredicateAndProvenance[predicate] = {};
+            if (!(predicate in outArcsByPredProv)) {
+              outArcsByPredProv[predicate] = {};
             }
-            const outArcsOfPredicate =
-              outArcsByPredicateAndProvenance[predicate];
+            const outArcsOfPredicate = outArcsByPredProv[predicate];
             const provId = value.provenanceId;
             if (!(provId in outArcsOfPredicate)) {
               outArcsOfPredicate[provId] = [];
@@ -167,7 +166,7 @@ export class OutArcSection extends React.Component<
         });
         removeLoadingMessage();
         this.setState({
-          data: outArcsByPredicateAndProvenance,
+          data: outArcsByPredProv,
         });
       })
       .catch(() => removeLoadingMessage());
@@ -189,16 +188,16 @@ export class OutArcSection extends React.Component<
       const outArcs = triplesData.filter(
         (t) => t.subjectId === this.props.dcid
       );
-      const outArcsByPredicateAndProvenance: OutArcData = {};
+      const outArcsByPredProv: OutArcData = {};
       for (const outArc of outArcs) {
         const predicate = outArc.predicate;
         if (IGNORED_OUT_ARC_PROPERTIES.has(predicate)) {
           return;
         }
-        if (!outArcsByPredicateAndProvenance[predicate]) {
-          outArcsByPredicateAndProvenance[predicate] = {};
+        if (!outArcsByPredProv[predicate]) {
+          outArcsByPredProv[predicate] = {};
         }
-        const outArcsOfPredicate = outArcsByPredicateAndProvenance[predicate];
+        const outArcsOfPredicate = outArcsByPredProv[predicate];
         const provId = outArc.provenanceId;
         if (!(provId in outArcsOfPredicate)) {
           outArcsOfPredicate[provId] = [];
@@ -218,7 +217,7 @@ export class OutArcSection extends React.Component<
       }
       removeLoadingMessage();
       this.setState({
-        data: outArcsByPredicateAndProvenance,
+        data: outArcsByPredProv,
       });
     });
   }


### PR DESCRIPTION
Observation nodes have no property labels or property values, so in order to get out arcs, fetch data from api/browser/triples