### PR TITLE
Disable flaky webdriver test

### DIFF
--- a/server/webdriver_tests/place_explorer_i18n_test.py
+++ b/server/webdriver_tests/place_explorer_i18n_test.py
@@ -35,26 +35,28 @@ class TestPlaceI18nExplorer(WebdriverBaseTest):
             (By.ID, 'place-type'), 'アジア 内の 国')
         WebDriverWait(self.driver, self.TIMEOUT_SEC).until(place_type_present)
 
-        # Test strings in GDP comparison chart
-        gdp_chart = self.driver.find_element_by_xpath(
-            '//*[@id="main-pane"]/section[1]/div/div[5]/div')
-        self.assertEqual(
-            gdp_chart.find_element_by_xpath('h4').text, '日本 の 1 人あたりの国内総生産')
+        # TODO(beets): Re-enable this test after fixing flakiness in finding
+        # the chart
+        # # Test strings in GDP comparison chart
+        # gdp_chart = self.driver.find_element_by_xpath(
+        #     '//*[@id="main-pane"]/section[1]/div/div[5]/div')
+        # self.assertEqual(
+        #     gdp_chart.find_element_by_xpath('h4').text, '日本 の 1 人あたりの国内総生産')
 
-        # Test that chart tick values are translated
-        y_text = gdp_chart.find_elements_by_class_name(
-            'y')[0].find_elements_by_tag_name('text')
-        self.assertEqual(y_text[0].text, 'USD 0')
-        self.assertEqual(y_text[1].text, 'USD 1万')
+        # # Test that chart tick values are translated
+        # y_text = gdp_chart.find_elements_by_class_name(
+        #     'y')[0].find_elements_by_tag_name('text')
+        # self.assertEqual(y_text[0].text, 'USD 0')
+        # self.assertEqual(y_text[1].text, 'USD 1万')
 
-        x_text = gdp_chart.find_elements_by_class_name(
-            'x')[0].find_elements_by_tag_name('text')
-        self.assertEqual(x_text[0].text, '1960')
+        # x_text = gdp_chart.find_elements_by_class_name(
+        #     'x')[0].find_elements_by_tag_name('text')
+        # self.assertEqual(x_text[0].text, '1960')
 
-        # Test that sv labels are translated
-        sv_legend = gdp_chart.find_elements_by_class_name('legend')[0]
-        sv_label = sv_legend.find_elements_by_tag_name('a')[0]
-        self.assertEqual(sv_label.text, '1 人あたりの GDP')
+        # # Test that sv labels are translated
+        # sv_legend = gdp_chart.find_elements_by_class_name('legend')[0]
+        # sv_label = sv_legend.find_elements_by_tag_name('a')[0]
+        # self.assertEqual(sv_label.text, '1 人あたりの GDP')
 
         # Test that topics are translated
         health_topic = self.driver.find_element_by_xpath(


### PR DESCRIPTION
The position of the GDP comparison chart in Japanese for country/JPN is flaky. Disable this part of the test for now to unblock others.