### PR TITLE
[Graph Browser 2] More observation chart updates/fixes

### DIFF
--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -28,6 +28,7 @@ bp = flask.Blueprint('api.browser', __name__, url_prefix='/api/browser')
 NO_MMETHOD_KEY = 'no_mmethod'
 NO_OBSPERIOD_KEY = 'no_obsPeriod'
 
+
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
 @bp.route('/triples/<path:dcid>')
 def triple_api(dcid):

--- a/static/js/browser2/statvar_node.tsx
+++ b/static/js/browser2/statvar_node.tsx
@@ -87,6 +87,7 @@ export class StatVarNode extends React.Component<
               placeDcid={this.props.placeDcid}
               statVarId={this.props.statVar.id}
               placeName={this.props.nodeName}
+              statVarName={this.props.statVar.displayName}
             />
           </div>
         )}

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -175,7 +175,7 @@ function getTooltipContent(
       const dataPoint = dataGroup.value.find(
         (val) => val.time === highlightedTime
       );
-      if (dataPoint && dataPoint.value !== null) {
+      if (dataPoint) {
         tooltipDate = dataPoint.label;
         let rowLabel =
           dataGroups.length === 1 && places.length === 1 ? dataPoint.label : "";
@@ -185,10 +185,10 @@ function getTooltipContent(
         if (places.length > 1) {
           rowLabel += ` ${place}`;
         }
-        tooltipContent += `${rowLabel}: ${formatNumber(
-          dataPoint.value,
-          unit
-        )}<br/>`;
+        const value = dataPoint.value
+          ? formatNumber(dataPoint.value, unit)
+          : "N/A";
+        tooltipContent += `${rowLabel}: ${value}<br/>`;
       }
     }
   }


### PR DESCRIPTION
- Fix bug where if an observation chart has no measurement method or observation period, clicking on a point on the chart may redirect to the wrong observation node. 
    - Fixed by updating the sparql query to return more fields and then filtering on those fields
- Update the table view column name to be the stat var display name instead of the stat var id because the stat var id may be a non human curated string
- Update tooltip to show "N/A" for null values (used to just not show the value)