### PR TITLE
Clean up ssl setup steps to be consistent with current deployment

### DIFF
--- a/gke/mci.yaml.tpl
+++ b/gke/mci.yaml.tpl
@@ -19,7 +19,7 @@ metadata:
   namespace: website
   annotations:
     # multi-domain is the certificate name, it is set in setup_ssl.sh
-    networking.gke.io/pre-shared-certs: multi-domain
+    networking.gke.io/pre-shared-certs: website-certificate
     networking.gke.io/static-ip: <IP>
 spec:
   template:

--- a/gke/setup_ssl.sh
+++ b/gke/setup_ssl.sh
@@ -19,4 +19,4 @@ DOMAIN=$(yq r config.yaml domain)
 echo $PROJECT_ID
 gcloud config set project $PROJECT_ID
 
-gcloud compute ssl-certificates create multi-domain --domains=$DOMAIN --global
+gcloud compute ssl-certificates create website-certificate --domains=$DOMAIN --global


### PR DESCRIPTION
This is update on one-time setup and does not have any effect on future deployment.

In current setup, "website-certificate" is Google managed cert and "multi-domain" is the self managed cert. This change is to align the script with actual deployment.