### PR TITLE
[Graph Browser 2] UI updates

### DIFF
--- a/server/templates/browser/node.html
+++ b/server/templates/browser/node.html
@@ -17,7 +17,7 @@
    {% extends 'base.html' %}
 
    {% set main_id = 'dc-browser2' %}
-   {% set title = node_name + '- Graph Browser' %}
+   {% set title = node_name + ' - Graph Browser' %}
    {% set subpage_title = 'Graph Browser' %}
    {% set subpage_url = url_for('browser.browser_main') %}
 

--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -21,14 +21,14 @@
   margin: 20px 0;
 }
 
-.node-about {
+.browser-header-title {
   color: #666;
-  font-size: 1.7rem;
+  font-size: 1.5rem;
 }
 
-.node-type {
+.browser-header-subtitle {
   color: #666;
-  font-size: 1.2rem;
+  font-size: 1rem;
 }
 
 .node-table {
@@ -161,6 +161,13 @@ td a {
 .statvar-search-input {
   width: 100%;
   border-radius: 6px;
+}
+
+.clear-search {
+  position: absolute;
+  right: 0.3rem;
+  top: 0.1rem;
+  cursor: pointer;
 }
 
 .search-result-value {

--- a/static/js/browser2/arc_table_row.tsx
+++ b/static/js/browser2/arc_table_row.tsx
@@ -24,7 +24,7 @@ import _ from "lodash";
 import { ArcValue } from "./util";
 
 const HREF_PREFIX = "/browser/";
-const NUM_VALUES_UNEXPANDED = 10;
+const NUM_VALUES_UNEXPANDED = 5;
 
 interface ArcTableRowPropType {
   propertyLabel: string;

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -44,18 +44,20 @@ export class BrowserPage extends React.Component<BrowserPagePropType> {
         <div className="browser-page-header">
           {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR && (
             <div className="browser-header-title">
-              <span>Statistical Variable: </span>
+              Statistical Variable:
               <a href={URL_PREFIX + this.props.statVarId}>
-                {this.props.statVarId}
+                {" " + this.props.statVarId}
               </a>
             </div>
           )}
           <div className="browser-header-title">
-            <span>About: </span>
+            About:
             {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR ? (
-              <a href={URL_PREFIX + this.props.dcid}>{this.props.nodeName}</a>
+              <a href={URL_PREFIX + this.props.dcid}>
+                {" " + this.props.nodeName}
+              </a>
             ) : (
-              <span>{this.props.nodeName}</span>
+              <span>{" " + this.props.nodeName}</span>
             )}
           </div>
           {this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR && (

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -26,6 +26,8 @@ import { StatVarHierarchy } from "./statvar_hierarchy";
 import { PageDisplayType } from "./util";
 import { WeatherChartSection } from "./weather_chart_section";
 
+const URL_PREFIX = "/browser/";
+
 interface BrowserPagePropType {
   dcid: string;
   nodeName: string;
@@ -36,12 +38,37 @@ interface BrowserPagePropType {
 
 export class BrowserPage extends React.Component<BrowserPagePropType> {
   render(): JSX.Element {
-    const pageTitle = this.getPageTitle();
     const arcDcid = this.getArcDcid();
     return (
       <>
-        <div className="node-about">{"About: " + pageTitle}</div>
-        <div className="node-type">{"type: " + this.props.nodeType}</div>
+        <div className="browser-page-header">
+          {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR && (
+            <div className="browser-header-title">
+              <span>Statistical Variable: </span>
+              <a href={URL_PREFIX + this.props.statVarId}>
+                {this.props.statVarId}
+              </a>
+            </div>
+          )}
+          <div className="browser-header-title">
+            <span>About: </span>
+            {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR ? (
+              <a href={URL_PREFIX + this.props.dcid}>{this.props.nodeName}</a>
+            ) : (
+              <span>{this.props.nodeName}</span>
+            )}
+          </div>
+          {this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR && (
+            <>
+              <div className="browser-header-subtitle">
+                {"dcid: " + this.props.dcid}
+              </div>
+              <div className="browser-header-subtitle">
+                {"typeOf: " + this.props.nodeType}
+              </div>
+            </>
+          )}
+        </div>
         <div id="node-content">
           <ArcSection
             dcid={arcDcid}
@@ -52,7 +79,7 @@ export class BrowserPage extends React.Component<BrowserPagePropType> {
           />
           {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR && (
             <div className="browser-page-section">
-              <h3>Observation Charts</h3>
+              <h3>Observations</h3>
               <ObservationChartSection
                 placeDcid={this.props.dcid}
                 statVarId={this.props.statVarId}
@@ -63,7 +90,7 @@ export class BrowserPage extends React.Component<BrowserPagePropType> {
           {this.props.pageDisplayType ===
             PageDisplayType.PLACE_WITH_WEATHER_INFO && (
             <div className="browser-page-section">
-              <h3>Weather Charts</h3>
+              <h3>Weather Observations</h3>
               <WeatherChartSection dcid={this.props.dcid} />
             </div>
           )}
@@ -83,12 +110,6 @@ export class BrowserPage extends React.Component<BrowserPagePropType> {
         </div>
       </>
     );
-  }
-
-  private getPageTitle(): string {
-    return this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR
-      ? `${this.props.statVarId} in ${this.props.nodeName}`
-      : this.props.nodeName;
   }
 
   private getArcDcid(): string {

--- a/static/js/browser2/image_section.tsx
+++ b/static/js/browser2/image_section.tsx
@@ -63,6 +63,9 @@ export class ImageSection extends React.Component<
             </div>
           );
         })}
+        <div id="browser-screen" className="screen">
+          <div id="spinner"></div>
+        </div>
       </div>
     );
   }

--- a/static/js/browser2/observation_chart.tsx
+++ b/static/js/browser2/observation_chart.tsx
@@ -23,6 +23,7 @@ import axios from "axios";
 import { DataGroup, DataPoint } from "../chart/base";
 import { drawLineChart } from "../chart/draw";
 import { getUnit, SourceSeries } from "./util";
+import { randDomId } from "../shared/util";
 
 // Chart size
 const WIDTH = 500;
@@ -53,6 +54,7 @@ export class ObservationChart extends React.Component<
   ObservationChartPropType,
   ObservationChartStateType
 > {
+  private containerId: string;
   private sortedDates: string[] = Object.keys(
     this.props.sourceSeries.val
   ).sort();
@@ -63,6 +65,7 @@ export class ObservationChart extends React.Component<
       errorMessage: "",
       showTableView: false,
     };
+    this.containerId = randDomId();
   }
 
   componentDidMount(): void {
@@ -96,7 +99,7 @@ export class ObservationChart extends React.Component<
           </span>
         </div>
         <div
-          id={this.svgContainerId() + "-content-area"}
+          id={this.containerId + "-content-area"}
           style={{ position: "relative" }}
         >
           <div style={{ display: tableVisibility }}>
@@ -125,7 +128,9 @@ export class ObservationChart extends React.Component<
                         >
                           <td width="50%">{date}</td>
                           <td width="50%">
-                            {this.props.sourceSeries.val[date] + unit}
+                            <div className="clickable-text">
+                              {this.props.sourceSeries.val[date] + unit}
+                            </div>
                           </td>
                         </tr>
                       );
@@ -136,7 +141,7 @@ export class ObservationChart extends React.Component<
             </div>
           </div>
           <div
-            id={this.svgContainerId()}
+            id={this.containerId}
             className={svgContainerClass}
             style={{ display: chartVisibility }}
           />
@@ -151,11 +156,6 @@ export class ObservationChart extends React.Component<
     );
   }
 
-  private svgContainerId(): string {
-    const statVarId = this.props.statVarId.replace("/", "");
-    return statVarId + this.props.idx;
-  }
-
   private plot(): void {
     const values = this.props.sourceSeries.val;
     const data = [];
@@ -168,7 +168,7 @@ export class ObservationChart extends React.Component<
     });
     const dataGroups = [new DataGroup("", data)];
     drawLineChart(
-      this.svgContainerId(),
+      this.containerId,
       WIDTH,
       HEIGHT,
       dataGroups,
@@ -180,13 +180,14 @@ export class ObservationChart extends React.Component<
   }
 
   private handleDotClick = (dotData: DataPoint): void => {
-    if (this.props.canClickObs) {
-      const date = dotData.label;
-      this.redirectToObsPage(date);
-    }
+    const date = dotData.label;
+    this.redirectToObsPage(date);
   };
 
   private redirectToObsPage(date: string): void {
+    if (!this.props.canClickObs) {
+      return;
+    }
     if (date in this.props.dateToDcid) {
       const obsDcid = this.props.dateToDcid[date];
       const uri = URI_PREFIX + obsDcid;
@@ -229,14 +230,14 @@ export class ObservationChart extends React.Component<
 
   private loadSpinner(): void {
     document
-      .getElementById(this.svgContainerId() + "-content-area")
+      .getElementById(this.containerId + "-content-area")
       .getElementsByClassName("screen")[0]
       .classList.add("d-block");
   }
 
   private removeSpinner(): void {
     document
-      .getElementById(this.svgContainerId() + "-content-area")
+      .getElementById(this.containerId + "-content-area")
       .getElementsByClassName("screen")[0]
       .classList.remove("d-block");
   }

--- a/static/js/browser2/observation_chart.tsx
+++ b/static/js/browser2/observation_chart.tsx
@@ -54,7 +54,8 @@ export class ObservationChart extends React.Component<
   ObservationChartPropType,
   ObservationChartStateType
 > {
-  private containerId: string;
+  private chartId: string;
+  private chartContainerId: string;
   private sortedDates: string[] = Object.keys(
     this.props.sourceSeries.val
   ).sort();
@@ -65,7 +66,8 @@ export class ObservationChart extends React.Component<
       errorMessage: "",
       showTableView: false,
     };
-    this.containerId = randDomId();
+    this.chartId = randDomId();
+    this.chartContainerId = this.chartId + "container";
   }
 
   componentDidMount(): void {
@@ -98,10 +100,7 @@ export class ObservationChart extends React.Component<
             {this.state.showTableView ? "show chart" : "show table"}
           </span>
         </div>
-        <div
-          id={this.containerId + "-content-area"}
-          style={{ position: "relative" }}
-        >
+        <div id={this.chartContainerId} style={{ position: "relative" }}>
           <div style={{ display: tableVisibility }}>
             <div className="observations-table">
               <table className="node-table">
@@ -141,7 +140,7 @@ export class ObservationChart extends React.Component<
             </div>
           </div>
           <div
-            id={this.containerId}
+            id={this.chartId}
             className={svgContainerClass}
             style={{ display: chartVisibility }}
           />
@@ -168,7 +167,7 @@ export class ObservationChart extends React.Component<
     });
     const dataGroups = [new DataGroup("", data)];
     drawLineChart(
-      this.containerId,
+      this.chartId,
       WIDTH,
       HEIGHT,
       dataGroups,
@@ -230,14 +229,14 @@ export class ObservationChart extends React.Component<
 
   private loadSpinner(): void {
     document
-      .getElementById(this.containerId + "-content-area")
+      .getElementById(this.chartContainerId)
       .getElementsByClassName("screen")[0]
       .classList.add("d-block");
   }
 
   private removeSpinner(): void {
     document
-      .getElementById(this.containerId + "-content-area")
+      .getElementById(this.chartContainerId)
       .getElementsByClassName("screen")[0]
       .classList.remove("d-block");
   }

--- a/static/js/browser2/out_arc_section.tsx
+++ b/static/js/browser2/out_arc_section.tsx
@@ -104,6 +104,13 @@ export class OutArcSection extends React.Component<
                 <strong>Provenance</strong>
               </td>
             </tr>
+            <ArcTableRow
+              key={DCID_PREDICATE}
+              propertyLabel={DCID_PREDICATE}
+              values={[{ text: this.props.dcid }]}
+              provenanceId={""}
+              src={null}
+            />
             {predicates.map((predicate) => {
               const valuesByProvenance = this.state.data[predicate];
               return Object.keys(valuesByProvenance).map(
@@ -124,13 +131,6 @@ export class OutArcSection extends React.Component<
                 }
               );
             })}
-            <ArcTableRow
-              key={DCID_PREDICATE}
-              propertyLabel={DCID_PREDICATE}
-              values={[{ text: this.props.dcid }]}
-              provenanceId={""}
-              src={null}
-            />
           </tbody>
         </table>
       </div>

--- a/static/js/browser2/statvar_hierarchy_search.tsx
+++ b/static/js/browser2/statvar_hierarchy_search.tsx
@@ -54,6 +54,7 @@ export class StatVarHierarchySearch extends React.Component<
     this.onInputChanged = this.onInputChanged.bind(this);
     this.search = this.search.bind(this);
     this.onResultSelected = this.onResultSelected.bind(this);
+    this.onInputClear = this.onInputClear.bind(this);
   }
 
   render(): JSX.Element {
@@ -63,14 +64,21 @@ export class StatVarHierarchySearch extends React.Component<
       this.state.showNoResultsMessage;
     return (
       <div className="statvar-hierarchy-search-section">
+        <div className="search-input-container"></div>
         <input
           className="statvar-search-input"
           type="text"
           value={this.state.query}
           onChange={this.onInputChanged}
-          placeholder="Search"
+          placeholder="Filter"
           onBlur={() => this.setState({ showNoResultsMessage: false })}
         />
+        <span
+          className="material-icons clear-search"
+          onClick={this.onInputClear}
+        >
+          clear
+        </span>
         {renderResults && (
           <div className="statvar-hierarchy-search-results">
             {!_.isEmpty(this.state.svgResults) && (
@@ -154,6 +162,16 @@ export class StatVarHierarchySearch extends React.Component<
           showNoResultsMessage: true,
         });
       });
+  };
+
+  private onInputClear = () => {
+    this.props.onSelectionChange("");
+    this.setState({
+      query: "",
+      svResults: [],
+      svgResults: [],
+      showNoResultsMessage: false,
+    });
   };
 
   private processSearchResults(

--- a/static/js/browser2/statvar_hierarchy_search.tsx
+++ b/static/js/browser2/statvar_hierarchy_search.tsx
@@ -168,9 +168,9 @@ export class StatVarHierarchySearch extends React.Component<
     this.props.onSelectionChange("");
     this.setState({
       query: "",
+      showNoResultsMessage: false,
       svResults: [],
       svgResults: [],
-      showNoResultsMessage: false,
     });
   };
 


### PR DESCRIPTION
- update page headers
- update each row to show 5 items (instead of 10) when collapsed
- fix weather observations table showing error when clicking on a row (rows for weather observations tables should not be clickable)
- make observation table values look clickable (not just on hover)
- update stat var hierarchy search input box placeholder to be "filter" instead of "search" & add ability to clear input
- filter out observations with measurement method of GoogleKGHumanCurated or HumanCuratedStats
- fix observation charts spinner problem where if we have 2 of the same stat vars expanded in the stat var hierarchy, when expanding the second one, the spinner will appear on the chart that is already expanded 
    - fixed this by giving each observation chart section a randomId

the dev instance has been updated with these changes (eg. https://dev.datacommons.org/browser/geoId/12086)