### PR TITLE
[Graph Browser 2] Fix bug with the stat var hierarchy search

### DIFF
--- a/server/lib/statvar_hierarchy_search.py
+++ b/server/lib/statvar_hierarchy_search.py
@@ -147,9 +147,9 @@ def get_search_result(tokens: List[str]) -> List[str]:
     search_index: Dict[str, Dict[
         str, RankingInformation]] = current_app.config['STAT_VAR_SEARCH_INDEX']
     token_result_ids: Set[str] = {}
-    token_result_nodes: Dict[str, RankingInformation] = {}
+    token_result_nodes: Dict[str, RankingInformation] = dict()
     if len(tokens) > 0:
-        token_result_nodes = search_index.get(tokens[0], {})
+        token_result_nodes.update(search_index.get(tokens[0], {}))
         token_result_ids = set(token_result_nodes.keys())
     for token in tokens[1:]:
         curr_token_result: Dict[str, RankingInformation] = search_index.get(

--- a/server/tests/statvar_hierarchy_search_test.py
+++ b/server/tests/statvar_hierarchy_search_test.py
@@ -178,3 +178,52 @@ class TestGetSearchResult(unittest.TestCase):
                 ["token3", "token4", "token2"])
             expected_result = ['sv_1_2']
             assert result == expected_result
+
+    def test_search_statvar_hierarchy_multiple_queries(self):
+        search_index = {
+            'token5': {
+                'group_3': {
+                    'approxNumPv': 2,
+                    'rankingName': 'token2 token4, token6'
+                },
+                'sv_1_2': {
+                    'approxNumPv': 3,
+                    'rankingName': 'token2 token3, token4'
+                }
+            },
+            'token6': {
+                'sv_1_2': {
+                    'approxNumPv': 3,
+                    'rankingName': 'token2 token3, token4'
+                },
+                'sv_1_1': {
+                    'approxNumPv': 3,
+                    'rankingName': 'token2 token3'
+                }
+            },
+            'token7': {
+                'group_3': {
+                    'approxNumPv': 2,
+                    'rankingName': 'token2 token4, token6'
+                },
+                'sv3': {
+                    'approxNumPv': 20,
+                    'rankingName': 'token4'
+                },
+                'sv_1_2': {
+                    'approxNumPv': 3,
+                    'rankingName': 'token2 token3, token4'
+                }
+            }
+        }
+
+        with app.app_context():
+            app.config['STAT_VAR_SEARCH_INDEX'] = search_index
+            result1 = svh_search.get_search_result(["token6", "token7"])
+            expected_result1 = ['sv_1_2']
+            assert result1 == expected_result1
+
+            result2 = svh_search.get_search_result(
+                ["token6", "token7", "token5"])
+            expected_result2 = ['sv_1_2']
+            assert result2 == expected_result2


### PR DESCRIPTION
There was a bug with the stat var hierarchy search where the results returned was an intersection between the results of each of the tokens except for the first token. This happened because the variable used to save all the results for the tokens was set to be the object in the search index for the first token instead of a new object that read in the object in the search index for the first token. Fixed and added a test.