### PR TITLE
[Graph Browser 2] Stat Var Hierarchy Updates

### DIFF
--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -22,6 +22,7 @@ import lib.statvar_hierarchy_search as svh_search
 from services.datacommons import fetch_data
 from flask import Response
 from flask import request
+import routes.api.place as place_api
 
 bp = flask.Blueprint('api.browser', __name__, url_prefix='/api/browser')
 
@@ -237,3 +238,13 @@ def search_statvar_hierarchy():
     tokens = query.split()
     result = svh_search.get_search_result(tokens)
     return Response(json.dumps(list(result)), 200, mimetype='application/json')
+
+
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@bp.route('/num_stat_vars/<path:dcid>')
+def get_num_statvars(dcid):
+    """Returns number of stat vars for a dcid
+    """
+    statsvars = place_api.statsvars(dcid)
+    num_statvars = len(statsvars)
+    return Response(json.dumps(num_statvars), 200, mimetype='application/json')

--- a/static/js/browser2/arc_section.tsx
+++ b/static/js/browser2/arc_section.tsx
@@ -24,11 +24,13 @@ import _ from "lodash";
 
 import { InArcSection } from "./in_arc_section";
 import { OutArcSection } from "./out_arc_section";
+import { PageDisplayType } from "./util";
 
 interface ArcSectionPropType {
   dcid: string;
   nodeName: string;
   displayInArcs: boolean;
+  pageDisplayType: PageDisplayType;
 }
 
 interface ArcSectionStateType {
@@ -65,10 +67,14 @@ export class ArcSection extends React.Component<
     if (!this.state.isDataFetched) {
       return null;
     }
+    const propertiesHeader =
+      this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR
+        ? "Statistical Variable Properties"
+        : "Properties";
     return (
       <>
         <div className="browser-page-section">
-          <h3>Properties</h3>
+          <h3>{propertiesHeader}</h3>
           <OutArcSection
             dcid={this.props.dcid}
             labels={this.state.outLabels}

--- a/static/js/browser2/browser.ts
+++ b/static/js/browser2/browser.ts
@@ -34,11 +34,15 @@ window.onload = () => {
   if (!_.isEmpty(statVarId)) {
     document.title = `${statVarId} - ${document.title}`;
   }
-  axios
+  const typesPromise = axios
     .get(`/api/browser/propvals/typeOf/${dcid}`)
-    .then((resp) => {
-      const values = resp.data.values;
-      const types = values.out ? values.out : [];
+    .then((resp) => resp.data);
+  const statVarsPromise = axios
+    .get(`/api/place/statsvars/${dcid}`)
+    .then((resp) => resp.data);
+  Promise.all([typesPromise, statVarsPromise])
+    .then(([typesData, statVarsData]) => {
+      const types = typesData.values.out ? typesData.values.out : [];
       const listOfTypes = types.map((type) => type.dcid);
       const nodeType = getNodeType(dcid, listOfTypes, statVarId);
       const pageDisplayType = getPageDisplayType(listOfTypes, statVarId);
@@ -49,6 +53,8 @@ window.onload = () => {
           nodeType,
           pageDisplayType,
           statVarId,
+          shouldShowStatVarHierarchy:
+            !_.isEmpty(statVarsData) && _.isEmpty(statVarId),
         }),
         document.getElementById("node")
       );
@@ -61,6 +67,7 @@ window.onload = () => {
           nodeType: getNodeType(dcid, [], statVarId),
           pageDisplayType: PageDisplayType.GENERAL,
           statVarId,
+          shouldShowStatVarHierarchy: false,
         }),
         document.getElementById("node")
       );

--- a/static/js/browser2/browser.ts
+++ b/static/js/browser2/browser.ts
@@ -52,9 +52,9 @@ window.onload = () => {
           nodeName,
           nodeType,
           pageDisplayType,
-          statVarId,
           shouldShowStatVarHierarchy:
             !_.isEmpty(statVarsData) && _.isEmpty(statVarId),
+          statVarId,
         }),
         document.getElementById("node")
       );
@@ -66,8 +66,8 @@ window.onload = () => {
           nodeName,
           nodeType: getNodeType(dcid, [], statVarId),
           pageDisplayType: PageDisplayType.GENERAL,
-          statVarId,
           shouldShowStatVarHierarchy: false,
+          statVarId,
         }),
         document.getElementById("node")
       );

--- a/static/js/browser2/browser.ts
+++ b/static/js/browser2/browser.ts
@@ -42,7 +42,7 @@ window.onload = () => {
     .then((resp) => resp.data);
   Promise.all([typesPromise, numStatVarsPromise])
     .then(([typesData, numStatVars]) => {
-      const types = typesData.values.out ? typesData.values.out : [];
+      const types = typesData.values.out || [];
       const listOfTypes = types.map((type) => type.dcid);
       const nodeType = getNodeType(dcid, listOfTypes, statVarId);
       const pageDisplayType = getPageDisplayType(listOfTypes, statVarId);

--- a/static/js/browser2/browser.ts
+++ b/static/js/browser2/browser.ts
@@ -37,11 +37,11 @@ window.onload = () => {
   const typesPromise = axios
     .get(`/api/browser/propvals/typeOf/${dcid}`)
     .then((resp) => resp.data);
-  const statVarsPromise = axios
-    .get(`/api/place/statsvars/${dcid}`)
+  const numStatVarsPromise = axios
+    .get(`/api/browser/num_stat_vars/${dcid}`)
     .then((resp) => resp.data);
-  Promise.all([typesPromise, statVarsPromise])
-    .then(([typesData, statVarsData]) => {
+  Promise.all([typesPromise, numStatVarsPromise])
+    .then(([typesData, numStatVars]) => {
       const types = typesData.values.out ? typesData.values.out : [];
       const listOfTypes = types.map((type) => type.dcid);
       const nodeType = getNodeType(dcid, listOfTypes, statVarId);
@@ -52,8 +52,7 @@ window.onload = () => {
           nodeName,
           nodeType,
           pageDisplayType,
-          shouldShowStatVarHierarchy:
-            !_.isEmpty(statVarsData) && _.isEmpty(statVarId),
+          shouldShowStatVarHierarchy: numStatVars > 0 && _.isEmpty(statVarId),
           statVarId,
         }),
         document.getElementById("node")

--- a/static/js/browser2/browser.ts
+++ b/static/js/browser2/browser.ts
@@ -31,6 +31,9 @@ window.onload = () => {
   const nodeName = document.getElementById("node").dataset.nn;
   const urlParams = new URLSearchParams(window.location.search);
   const statVarId = urlParams.get("statVar") || "";
+  if (!_.isEmpty(statVarId)) {
+    document.title = `${statVarId} - ${document.title}`;
+  }
   axios
     .get(`/api/browser/propvals/typeOf/${dcid}`)
     .then((resp) => {

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -30,7 +30,8 @@ import { OutArcSection } from "./out_arc_section";
 import { InArcSection } from "./in_arc_section";
 
 const URL_PREFIX = "/browser/";
-
+const PLACE_STAT_VAR_PROPERTIES_HEADER = "Statistical Variable Properties";
+const GENERAL_PROPERTIES_HEADER = "Properties";
 interface BrowserPagePropType {
   dcid: string;
   nodeName: string;
@@ -74,8 +75,8 @@ export class BrowserPage extends React.Component<
       !_.isEmpty(this.state.inLabels);
     const outArcHeader =
       this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR
-        ? "Statistical Variable Properties"
-        : "Properties";
+        ? PLACE_STAT_VAR_PROPERTIES_HEADER
+        : GENERAL_PROPERTIES_HEADER;
     const arcDcid = this.getArcDcid();
     return (
       <>

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -78,10 +78,11 @@ export class BrowserPage extends React.Component<BrowserPagePropType> {
             displayInArcs={
               this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR
             }
+            pageDisplayType={this.props.pageDisplayType}
           />
           {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR && (
             <div className="browser-page-section">
-              <h3>Observations</h3>
+              <h3>{`Observations for ${this.props.nodeName}`}</h3>
               <ObservationChartSection
                 placeDcid={this.props.dcid}
                 statVarId={this.props.statVarId}

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -20,12 +20,14 @@
 
 import React from "react";
 import axios from "axios";
-import { ArcSection } from "./arc_section";
+import _ from "lodash";
 import { ImageSection } from "./image_section";
 import { ObservationChartSection } from "./observation_chart_section";
 import { StatVarHierarchy } from "./statvar_hierarchy";
 import { PageDisplayType } from "./types";
 import { WeatherChartSection } from "./weather_chart_section";
+import { OutArcSection } from "./out_arc_section";
+import { InArcSection } from "./in_arc_section";
 
 const URL_PREFIX = "/browser/";
 
@@ -35,11 +37,14 @@ interface BrowserPagePropType {
   pageDisplayType: PageDisplayType;
   statVarId: string;
   nodeType: string;
+  shouldShowStatVarHierarchy: boolean;
 }
 
 interface BrowserPageStateType {
   provDomain: { [key: string]: URL };
   dataFetched: boolean;
+  inLabels: string[];
+  outLabels: string[];
 }
 
 export class BrowserPage extends React.Component<
@@ -50,6 +55,8 @@ export class BrowserPage extends React.Component<
     super(props);
     this.state = {
       dataFetched: false,
+      inLabels: [],
+      outLabels: [],
       provDomain: {},
     };
   }
@@ -62,7 +69,13 @@ export class BrowserPage extends React.Component<
     if (!this.state.dataFetched) {
       return null;
     }
-
+    const showInArcSection =
+      this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR &&
+      !_.isEmpty(this.state.inLabels);
+    const outArcHeader =
+      this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR
+        ? "Statistical Variable Properties"
+        : "Properties";
     const arcDcid = this.getArcDcid();
     return (
       <>
@@ -91,15 +104,34 @@ export class BrowserPage extends React.Component<
           </>
         )}
         <div id="node-content">
-          <ArcSection
-            dcid={arcDcid}
-            nodeName={this.props.nodeName}
-            displayInArcs={
-              this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR
-            }
-            pageDisplayType={this.props.pageDisplayType}
-            provDomain={this.state.provDomain}
-          />
+          <div className="browser-page-section">
+            <h3>{outArcHeader}</h3>
+            <OutArcSection
+              dcid={arcDcid}
+              labels={this.state.outLabels}
+              provDomain={this.state.provDomain}
+            />
+          </div>
+          {this.props.shouldShowStatVarHierarchy && (
+            <div className="browser-page-section">
+              <h3>Statistical Variables</h3>
+              <StatVarHierarchy
+                dcid={this.props.dcid}
+                placeName={this.props.nodeName}
+              />
+            </div>
+          )}
+          {showInArcSection && (
+            <div className="browser-page-section">
+              <h3>In Arcs</h3>
+              <InArcSection
+                nodeName={this.props.nodeName}
+                dcid={this.props.dcid}
+                labels={this.state.inLabels}
+                provDomain={this.state.provDomain}
+              />
+            </div>
+          )}
           {this.props.pageDisplayType === PageDisplayType.PLACE_STAT_VAR && (
             <div className="browser-page-section">
               <h3>{`Observations for ${this.props.nodeName}`}</h3>
@@ -127,12 +159,6 @@ export class BrowserPage extends React.Component<
               <ImageSection dcid={this.props.dcid} />
             </div>
           )}
-          {this.props.pageDisplayType !== PageDisplayType.PLACE_STAT_VAR && (
-            <StatVarHierarchy
-              dcid={this.props.dcid}
-              placeName={this.props.nodeName}
-            />
-          )}
         </div>
       </>
     );
@@ -145,17 +171,24 @@ export class BrowserPage extends React.Component<
   }
 
   private fetchData(): void {
-    axios
+    const provenancePromise = axios
       .get("/api/browser/triples/Provenance")
-      .then((resp) => {
+      .then((resp) => resp.data);
+    const labelsPromise = axios
+      .get("/api/browser/proplabels/" + this.getArcDcid())
+      .then((resp) => resp.data);
+    Promise.all([labelsPromise, provenancePromise])
+      .then(([labelsData, ProvenanceData]) => {
         const provDomain = {};
-        for (const prov of resp.data) {
+        for (const prov of ProvenanceData) {
           if (prov["predicate"] === "typeOf" && !!prov["subjectName"]) {
             provDomain[prov["subjectId"]] = new URL(prov["subjectName"]).host;
           }
         }
         this.setState({
           dataFetched: true,
+          inLabels: labelsData["inLabels"],
+          outLabels: labelsData["outLabels"],
           provDomain,
         });
       })

--- a/static/js/browser2/statvar_group_node.tsx
+++ b/static/js/browser2/statvar_group_node.tsx
@@ -228,15 +228,15 @@ export class ChildStatVarGroupSection extends React.Component<
   render(): JSX.Element {
     const childStatVarGroups = this.props.data[this.props.statVarGroupId]
       .childStatVarGroups;
-    childStatVarGroups.sort((a, b) => {
-      if (a.id.startsWith(VARIABLES_STATVAR_GROUP_PREFIX)) {
-        return -1;
-      }
-      if (b.id.startsWith(VARIABLES_STATVAR_GROUP_PREFIX)) {
-        return 1;
-      }
-      return a > b ? 1 : -1;
-    });
+    const variableGroupItem = childStatVarGroups.find((svg) =>
+      svg.id.startsWith(VARIABLES_STATVAR_GROUP_PREFIX)
+    );
+    if (variableGroupItem) {
+      childStatVarGroups.filter((svg) =>
+        svg.id.startsWith(VARIABLES_STATVAR_GROUP_PREFIX)
+      );
+      childStatVarGroups.unshift(variableGroupItem);
+    }
     return (
       <div className="svg-node-child">
         {this.props.data[this.props.statVarGroupId].childStatVarGroups.map(

--- a/static/js/browser2/statvar_group_node.tsx
+++ b/static/js/browser2/statvar_group_node.tsx
@@ -32,7 +32,7 @@ const SCROLL_DELAY = 400;
 const BULLET_POINT_HTML = <span className="bullet">&#8226;</span>;
 const DOWN_ARROW_HTML = <i className="material-icons">remove</i>;
 const RIGHT_ARROW_HTML = <i className="material-icons">add</i>;
-
+const VARIABLES_STATVAR_GROUP_PREFIX = "dc/g/Variables_";
 interface StatVarGroupNodePropType {
   // the dcid of the node of the current browser page
   placeDcid: string;
@@ -226,6 +226,17 @@ export class ChildStatVarGroupSection extends React.Component<
   ChildStatVarGroupSectionPropType
 > {
   render(): JSX.Element {
+    const childStatVarGroups = this.props.data[this.props.statVarGroupId]
+      .childStatVarGroups;
+    childStatVarGroups.sort((a, b) => {
+      if (a.id.startsWith(VARIABLES_STATVAR_GROUP_PREFIX)) {
+        return -1;
+      }
+      if (b.id.startsWith(VARIABLES_STATVAR_GROUP_PREFIX)) {
+        return 1;
+      }
+      return a > b ? 1 : -1;
+    });
     return (
       <div className="svg-node-child">
         {this.props.data[this.props.statVarGroupId].childStatVarGroups.map(

--- a/static/js/browser2/statvar_hierarchy.tsx
+++ b/static/js/browser2/statvar_hierarchy.tsx
@@ -25,7 +25,9 @@ import _ from "lodash";
 import { StatVarHierarchySearch } from "./statvar_hierarchy_search";
 import { StatVarGroupNode } from "./statvar_group_node";
 import { StatVarGroupNodeType, StatVarNodeType } from "./types";
+import { loadSpinner, removeSpinner } from "./util";
 
+const LOADING_CONTAINER_ID = "stat-var-hierarchy-section";
 interface StatVarHierarchyPropType {
   dcid: string;
   placeName: string;
@@ -60,9 +62,6 @@ export class StatVarHierarchy extends React.Component<
   }
 
   render(): JSX.Element {
-    if (_.isEmpty(this.state.statVars) && _.isEmpty(this.state.errorMessage)) {
-      return null;
-    }
     const initialStatVarGroups = Object.keys(this.state.statVarGroups).filter(
       (svgId) => !("parent" in this.state.statVarGroups[svgId])
     );
@@ -82,8 +81,7 @@ export class StatVarHierarchy extends React.Component<
       return a > b ? 1 : -1;
     });
     return (
-      <div className="browser-page-section" id="stat-var-hierarchy-section">
-        <h3>Statistical Variables</h3>
+      <div id={LOADING_CONTAINER_ID} className="loading-spinner-container">
         {!_.isEmpty(this.state.errorMessage) && (
           <div className="error-message">{this.state.errorMessage}</div>
         )}
@@ -117,23 +115,29 @@ export class StatVarHierarchy extends React.Component<
             </div>
           </div>
         )}
+        <div id="browser-screen" className="screen">
+          <div id="spinner"></div>
+        </div>
       </div>
     );
   }
 
   private fetchData(): void {
+    loadSpinner(LOADING_CONTAINER_ID);
     axios
       .get(`/api/browser/statvar-hierarchy/${this.props.dcid}`)
       .then((resp) => {
         const data = resp.data;
         const statVarGroups = data["statVarGroups"];
         const statVars = data["statVars"];
+        removeSpinner(LOADING_CONTAINER_ID);
         this.setState({
           statVarGroups,
           statVars,
         });
       })
       .catch(() => {
+        removeSpinner(LOADING_CONTAINER_ID);
         this.setState({
           errorMessage: "Error retrieving stat var hierarchy.",
         });

--- a/static/js/browser2/util.test.ts
+++ b/static/js/browser2/util.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { getPageDisplayType, PageDisplayType } from "./types";
-import { removeLoadingMessage, getUnit } from "./util";
+import { getUnit } from "./util";
 
 test("getPageDisplayType", () => {
   // non empty stat var id
@@ -36,12 +36,6 @@ test("getPageDisplayType", () => {
   );
   // list of types doesn't contain anything special
   expect(getPageDisplayType(["country"], "")).toEqual(PageDisplayType.GENERAL);
-});
-
-test("removeLoadingMessage", () => {
-  document.body.innerHTML = '<div id="page-loading"></div>';
-  removeLoadingMessage();
-  expect(document.getElementById("page-loading").style.display).toBe("none");
 });
 
 test("getUnit", () => {

--- a/static/js/browser2/util.ts
+++ b/static/js/browser2/util.ts
@@ -22,17 +22,6 @@ import { SourceSeries } from "./types";
  */
 
 /**
- * Removes the loading message on the browser page if it is present.
- */
-export function removeLoadingMessage(): void {
-  // TODO (chejennifer): better way to handle loading
-  const loadingElem = document.getElementById("page-loading");
-  if (loadingElem) {
-    loadingElem.style.display = "none";
-  }
-}
-
-/**
  * Returns the unit for a sourceSeries if there is a unit.
  * @param sourceSeries
  */


### PR DESCRIPTION
- Before rendering browser page, find out if the page has stat var hierarchy by making call to get all stat vars for current dcid
- Move stat var hierarchy section after out arcs section & add loading spinner
- If a node has a "Variables" child stat var group, move that group to the top of the section

dev instance has been updated with these changes (eg. https://dev.datacommons.org/browser/geoId/12086)