### PR TITLE
scatter2 various client side updates

### DIFF
--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -66,6 +66,7 @@ def get_property_value(dcid, prop, out=True):
     return dc.get_property_values([dcid], prop, out)[dcid]
 
 
+@bp.route('/type/<path:place_dcid>')
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def get_place_type(place_dcid):
     place_types = get_property_value(place_dcid, 'typeOf')

--- a/static/css/tools/scatter2.scss
+++ b/static/css/tools/scatter2.scss
@@ -123,3 +123,15 @@
 .plot-options-swap-button {
   margin-left: -1.6rem;
 }
+
+.centered-items-row {
+  align-items: center;
+}
+
+.place-options-label {
+  font-size: 1.1rem;
+}
+
+.plot-options-input {
+  width: 15rem;
+}

--- a/static/css/tools/scatter2.scss
+++ b/static/css/tools/scatter2.scss
@@ -110,3 +110,16 @@
   border-radius: 3px;
   background: #f8d7da;
 }
+
+#enclosed-place-type {
+  height: 100%;
+  font-size: 1rem;
+}
+
+.plot-options-row {
+  padding: 0.5rem 0rem;
+}
+
+.plot-options-swap-button {
+  margin-left: -1.6rem;
+}

--- a/static/js/tools/scatter2/app.test.tsx
+++ b/static/js/tools/scatter2/app.test.tsx
@@ -221,6 +221,24 @@ function mockAxios(): () => void {
     .calledWith("../../data/hierarchy_statsvar.json")
     .mockResolvedValue({ data: hierarchy });
 
+  when(axios.get)
+    .calledWith("/api/place/parent/geoId/10")
+    .mockResolvedValue({
+      data: ["country/USA"],
+    });
+
+  when(axios.get).calledWith("/api/place/type/geoId/10").mockResolvedValue({
+    data: "State",
+  });
+
+  when(axios.get)
+    .calledWith("/api/place/places-in?dcid=geoId/10&placeType=County")
+    .mockResolvedValue({
+      data: {
+        "geoId/10": ["geoId/10001", "geoId/10003", "geoId/10005"],
+      },
+    });
+
   return () => {
     axios.get = get;
     axios.post = post;
@@ -230,20 +248,6 @@ function mockAxios(): () => void {
 function expectCircles(n: number, app: Enzyme.ReactWrapper): void {
   const $ = Cheerio.load(app.html());
   expect($("circle").length).toEqual(n);
-}
-
-function expectInfo(
-  xMean: number,
-  yMean: number,
-  xStd: number,
-  yStd: number,
-  app: Enzyme.ReactWrapper
-): void {
-  const text = app.text();
-  expect(text).toContain(`X Mean: ${xMean}`);
-  expect(text).toContain(`Y Mean: ${yMean}`);
-  expect(text).toContain(`X Standard Deviation: ${xStd}`);
-  expect(text).toContain(`Y Standard Deviation: ${yStd}`);
 }
 
 test("all functionalities", async (done) => {
@@ -272,18 +276,16 @@ test("all functionalities", async (done) => {
   await waitFor(() => {
     // Title
     expect(app.text()).toContain("Number Of Establishments vs Employed");
-    // Stats
-    expectInfo(152696, 8359.667, 108149.894, 6753.678, app);
     // Points
     expectCircles(3, app);
+    //expect(app.find("#plot-options")).toHaveLength(1);
   });
-
+  app.update();
   // Swap axes
   app.find("#swap-axes").at(0).simulate("click");
   const expectTitle = (title: string) => expect(app.text()).toContain(title);
 
   expectTitle("Employed vs Number Of Establishments");
-  expectInfo(8359.667, 152696, 6753.678, 108149.894, app);
   expectCircles(3, app);
 
   // Per capita
@@ -296,7 +298,6 @@ test("all functionalities", async (done) => {
     .at(0)
     .simulate("change", { target: { checked: true } });
   expectTitle("Employed Per Capita vs Number Of Establishments Per Capita");
-  expectInfo(0.024, 0.456, 0.005, 0.036, app);
   expectCircles(3, app);
 
   // Log
@@ -331,7 +332,6 @@ test("all functionalities", async (done) => {
     expect(app.text()).toContain(
       "Housing Units Per Capita vs Employed Per Capita"
     );
-    expectInfo(0.456, 0.456, 0.036, 0.107, app);
     expectCircles(3, app);
   });
 

--- a/static/js/tools/scatter2/app.tsx
+++ b/static/js/tools/scatter2/app.tsx
@@ -23,7 +23,6 @@ import _ from "lodash";
 import { Container, Row } from "reactstrap";
 import { StatVarChooser } from "./statvar";
 import { PlaceOptions } from "./place_options";
-import { PlotOptions } from "./plot_options";
 import { ChartLoader } from "./chart_loader";
 import { Info } from "./info";
 import { Spinner } from "./spinner";
@@ -51,9 +50,6 @@ function App(): JSX.Element {
           )}
           <Row>
             <PlaceOptions />
-          </Row>
-          <Row>
-            <PlotOptions />
           </Row>
           {hideInfo ? (
             <Row id="chart-row">

--- a/static/js/tools/scatter2/chart_loader.tsx
+++ b/static/js/tools/scatter2/chart_loader.tsx
@@ -39,6 +39,7 @@ import {
   IsLoadingWrapper,
 } from "./context";
 import { StatsVarNode } from "../statvar_menu/util";
+import { PlotOptions } from "./plot_options";
 
 /**
  * Represents a point in the scatter plot.
@@ -53,6 +54,8 @@ interface Point {
   ySource: string;
   xPop?: number;
   yPop?: number;
+  xPopSource?: string;
+  yPopSource?: string;
 }
 
 type Cache = {
@@ -82,15 +85,18 @@ function ChartLoader(): JSX.Element {
               options.
             </div>
           ) : (
-            <Chart
-              points={points}
-              xLabel={getLabel(xVal.name, xVal.perCapita)}
-              yLabel={getLabel(yVal.name, yVal.perCapita)}
-              xLog={xVal.log}
-              yLog={yVal.log}
-              xPerCapita={xVal.perCapita}
-              yPerCapita={yVal.perCapita}
-            />
+            <>
+              <Chart
+                points={points}
+                xLabel={getLabel(xVal.name, xVal.perCapita)}
+                yLabel={getLabel(yVal.name, yVal.perCapita)}
+                xLog={xVal.log}
+                yLog={yVal.log}
+                xPerCapita={xVal.perCapita}
+                yPerCapita={yVal.perCapita}
+              />
+              <PlotOptions />
+            </>
           )}
         </>
       )}
@@ -274,6 +280,7 @@ function getPoints(
           return null;
         }
         let xPop = null;
+        let xPopSource = null;
         const placeXPopData = xPopData[place.dcid];
         if (placeXPopData) {
           const matchingDate = Object.keys(placeXPopData.data).find((date) => {
@@ -281,8 +288,10 @@ function getPoints(
             return placeXStatData.date.includes(popYear);
           });
           xPop = placeXPopData.data[matchingDate];
+          xPopSource = placeXPopData.provenanceUrl;
         }
         let yPop = null;
+        let yPopSource = null;
         const placeYPopData = yPopData[place.dcid];
         if (placeYPopData) {
           const matchingDate = Object.keys(placeYPopData.data).find((date) => {
@@ -290,17 +299,20 @@ function getPoints(
             return placeYStatData.date.includes(popYear);
           });
           yPop = placeYPopData.data[matchingDate];
+          yPopSource = placeYPopData.provenanceUrl;
         }
         return {
           place,
           xDate: placeXStatData.date,
           xPop,
+          xPopSource,
           xSource:
             xStatData.metadata[placeXStatData.metadata.importName]
               .provenanceUrl,
           xVal: placeXStatData.value,
           yDate: placeYStatData.date,
           yPop,
+          yPopSource,
           ySource:
             yStatData.metadata[placeYStatData.metadata.importName]
               .provenanceUrl,

--- a/static/js/tools/scatter2/info.tsx
+++ b/static/js/tools/scatter2/info.tsx
@@ -29,8 +29,8 @@ function Info(): JSX.Element {
       </p>
       <ol>
         <li>
-          Select the type of places you want to plot in the dropdown menu and
-          enter the containing place in the search box above.
+          Enter the containing place in the search box and then select the type
+          of places you want to plot in the dropdown menu above.
         </li>
         <li>
           Pick two variables in the left pane. There are thousands of variables

--- a/static/js/tools/scatter2/info.tsx
+++ b/static/js/tools/scatter2/info.tsx
@@ -29,8 +29,8 @@ function Info(): JSX.Element {
       </p>
       <ol>
         <li>
-          Enter a place in the search box and then select the type
-          of places you want to plot in the dropdown menu above.
+          Enter a place in the search box and then select the type of places you
+          want to plot in the dropdown menu above.
         </li>
         <li>
           Pick two variables in the left pane. There are thousands of variables

--- a/static/js/tools/scatter2/info.tsx
+++ b/static/js/tools/scatter2/info.tsx
@@ -29,7 +29,7 @@ function Info(): JSX.Element {
       </p>
       <ol>
         <li>
-          Enter the containing place in the search box and then select the type
+          Enter a place in the search box and then select the type
           of places you want to plot in the dropdown menu above.
         </li>
         <li>

--- a/static/js/tools/scatter2/place_options.tsx
+++ b/static/js/tools/scatter2/place_options.tsx
@@ -90,7 +90,7 @@ function PlaceOptions(): JSX.Element {
   return (
     <Card>
       <Container>
-        <Row>
+        <Row className="centered-items-row">
           <Col xs="auto">Plot places in</Col>
           <Col>
             <div id="search">

--- a/static/js/tools/scatter2/plot_options.tsx
+++ b/static/js/tools/scatter2/plot_options.tsx
@@ -19,8 +19,8 @@
  * lower and upper bounds for populations.
  */
 
-import React, { useContext, useState } from "react";
-import { FormGroup, Label, Input, Card, Button, Collapse } from "reactstrap";
+import React, { useContext } from "react";
+import { FormGroup, Label, Input, Card, Button } from "reactstrap";
 import { AxisWrapper, Context, PlaceInfoWrapper } from "./context";
 
 import { Container, Row, Col } from "reactstrap";
@@ -30,119 +30,106 @@ import { Container, Row, Col } from "reactstrap";
 // the dates.
 function PlotOptions(): JSX.Element {
   const { place, x, y } = useContext(Context);
-
-  const [open, setOpen] = useState(false);
-
   return (
-    <Card>
-      <Container id="plot-options">
-        <Row>
-          <Col xs="auto">
+    <Card id="plot-options">
+      <Container>
+        <Row className="plot-options-row">
+          <Col sm={1}>Per capita:</Col>
+          <Col sm="auto">
+            <FormGroup check>
+              <Label check>
+                <Input
+                  id="per-capita-x"
+                  type="checkbox"
+                  checked={x.value.perCapita}
+                  onChange={(e) => checkPerCapita(x, e)}
+                />
+                x-axis
+              </Label>
+            </FormGroup>
+          </Col>
+          <Col sm="auto">
+            <FormGroup check>
+              <Label check>
+                <Input
+                  id="per-capita-y"
+                  type="checkbox"
+                  checked={y.value.perCapita}
+                  onChange={(e) => checkPerCapita(y, e)}
+                />
+                y-axis
+              </Label>
+            </FormGroup>
+          </Col>
+        </Row>
+        <Row className="plot-options-row">
+          <Col sm={1}>Log scale:</Col>
+          <Col sm="auto">
+            <FormGroup check>
+              <Label check>
+                <Input
+                  id="log-x"
+                  type="checkbox"
+                  checked={x.value.log}
+                  onChange={(e) => checkLog(x, e)}
+                />
+                x-axis
+              </Label>
+            </FormGroup>
+          </Col>
+          <Col sm="auto">
+            <FormGroup check>
+              <Label check>
+                <Input
+                  id="log-y"
+                  type="checkbox"
+                  checked={y.value.log}
+                  onChange={(e) => checkLog(y, e)}
+                />
+                y-axis
+              </Label>
+            </FormGroup>
+          </Col>
+        </Row>
+        <Row className="plot-options-row">
+          <Col sm={1}>Swap:</Col>
+          <Col sm="auto">
             <Button
-              className="flex-container"
-              color="light"
+              id="swap-axes"
               size="sm"
-              onClick={() => setOpen(!open)}
+              color="light"
+              onClick={() => swapAxes(x, y)}
+              className="plot-options-swap-button"
             >
-              <i className="material-icons">
-                {open ? "expand_less" : "expand_more"}
-              </i>
-              Options
+              Swap X and Y axes
             </Button>
           </Col>
         </Row>
-        <Row>
-          <Collapse isOpen={open} className="flex-container">
-            <Container>
-              <Row>
-                <Col xs="3">Only plot places of this size</Col>
-                <Col>
-                  <FormGroup check>
-                    <Input
-                      type="number"
-                      onChange={(e) => selectLowerBound(place, e)}
-                      value={place.value.lowerBound}
-                    />
-                  </FormGroup>
-                </Col>
-                <Col xs="auto">to</Col>
-                <Col>
-                  <FormGroup check>
-                    <Input
-                      type="number"
-                      onChange={(e) => selectUpperBound(place, e)}
-                      value={
-                        place.value.upperBound === Number.POSITIVE_INFINITY
-                          ? 1e10
-                          : place.value.upperBound
-                      }
-                    />
-                  </FormGroup>
-                </Col>
-              </Row>
-              <Row>
-                <Col xs="3">Plot Options</Col>
-                <Col>
-                  <Button
-                    id="swap-axes"
-                    size="sm"
-                    color="light"
-                    onClick={() => swapAxes(x, y)}
-                  >
-                    Swap X and Y axes
-                  </Button>
-                </Col>
-                <Col>
-                  <FormGroup check>
-                    <Label check>
-                      <Input
-                        id="per-capita-x"
-                        type="checkbox"
-                        checked={x.value.perCapita}
-                        onChange={(e) => checkPerCapita(x, e)}
-                      />
-                      Plot X-axis per capita
-                    </Label>
-                  </FormGroup>
-                  <FormGroup check>
-                    <Label check>
-                      <Input
-                        id="per-capita-y"
-                        type="checkbox"
-                        checked={y.value.perCapita}
-                        onChange={(e) => checkPerCapita(y, e)}
-                      />
-                      Plot Y-axis per capita
-                    </Label>
-                  </FormGroup>
-                </Col>
-                <Col>
-                  <FormGroup check>
-                    <Label check>
-                      <Input
-                        id="log-x"
-                        type="checkbox"
-                        checked={x.value.log}
-                        onChange={(e) => checkLog(x, e)}
-                      />
-                      Plot X-axis on log scale
-                    </Label>
-                  </FormGroup>
-                  <FormGroup check>
-                    <Label check>
-                      <Input
-                        id="log-y"
-                        type="checkbox"
-                        checked={y.value.log}
-                        onChange={(e) => checkLog(y, e)}
-                      />
-                      Plot Y-axis on log scale
-                    </Label>
-                  </FormGroup>
-                </Col>
-              </Row>
-            </Container>
-          </Collapse>
+        <Row className="plot-options-row">
+          <Col sm={2}>Filter by population:</Col>
+          <Col>
+            <FormGroup check>
+              <Input
+                type="number"
+                onChange={(e) => selectLowerBound(place, e)}
+                value={place.value.lowerBound}
+              />
+            </FormGroup>
+          </Col>
+          <Col sm="auto">to</Col>
+          <Col>
+            <FormGroup check>
+              <Input
+                type="number"
+                onChange={(e) => selectUpperBound(place, e)}
+                value={
+                  place.value.upperBound === Number.POSITIVE_INFINITY
+                    ? 1e10
+                    : place.value.upperBound
+                }
+              />
+            </FormGroup>
+          </Col>
         </Row>
       </Container>
     </Card>

--- a/static/js/tools/scatter2/plot_options.tsx
+++ b/static/js/tools/scatter2/plot_options.tsx
@@ -91,7 +91,7 @@ function PlotOptions(): JSX.Element {
             </FormGroup>
           </Col>
         </Row>
-        <Row className="plot-options-row">
+        <Row className="plot-options-row centered-items-row">
           <Col sm={1}>Swap:</Col>
           <Col sm="auto">
             <Button
@@ -105,9 +105,9 @@ function PlotOptions(): JSX.Element {
             </Button>
           </Col>
         </Row>
-        <Row className="plot-options-row">
+        <Row className="plot-options-row centered-items-row">
           <Col sm={2}>Filter by population:</Col>
-          <Col>
+          <Col sm="auto">
             <FormGroup check>
               <Input
                 type="number"
@@ -117,7 +117,7 @@ function PlotOptions(): JSX.Element {
             </FormGroup>
           </Col>
           <Col sm="auto">to</Col>
-          <Col>
+          <Col sm="auto">
             <FormGroup check>
               <Input
                 type="number"

--- a/static/js/tools/statvar_menu/util.tsx
+++ b/static/js/tools/statvar_menu/util.tsx
@@ -43,7 +43,7 @@ function getStatsVarInfo(
  * @param dcids
  * @param sample Whether to sample `sampleSize` places from the given places, and only
  * get the statvars for them.
- * @param sampleSize
+ * @param sampleSize Since the stat vars for places of the same type are relatively uniform, default sample size can be small to speed up this function.
  */
 async function getStatsVar(
   dcids: string[],

--- a/static/js/tools/statvar_menu/util.tsx
+++ b/static/js/tools/statvar_menu/util.tsx
@@ -48,7 +48,7 @@ function getStatsVarInfo(
 async function getStatsVar(
   dcids: string[],
   sample = false,
-  sampleSize = 50
+  sampleSize = 5
 ): Promise<Set<string>> {
   if (dcids.length === 0) {
     return Promise.resolve(new Set<string>());


### PR DESCRIPTION
- swap the order of the place options selection, and populate place types selection depending on the selected place
- move the plot options to below the chart and remove the stats from under the chart
- add source attribution
- get child place names in background to decrease loading time after selecting place and child place type

![screen-recording (15)](https://user-images.githubusercontent.com/69875368/117361492-f382c000-ae6e-11eb-9e69-141971927a26.gif)
