### PR TITLE
Various updates for scatter2

### DIFF
--- a/static/css/tools/scatter2.scss
+++ b/static/css/tools/scatter2.scss
@@ -93,6 +93,7 @@
   padding: 10px;
   border-radius: 8px;
   opacity: 0.9;
+  z-index: 2;
 }
 
 #statvar-modal .row {
@@ -134,4 +135,25 @@
 
 .plot-options-input {
   width: 15rem;
+}
+
+.info-message {
+  padding: 1.2rem 0rem;
+}
+
+body {
+  font-size: 0.9rem;
+}
+
+.plot-options-label {
+  min-width: 8rem;
+}
+
+.input-area-hidden #place-list {
+  flex-grow: 1;
+}
+
+.input-area-hidden #ac {
+  visibility: hidden;
+  width: 0px;
 }

--- a/static/js/tools/scatter2/app.tsx
+++ b/static/js/tools/scatter2/app.tsx
@@ -37,13 +37,19 @@ import { updateHash, applyHash } from "./util";
 
 function App(): JSX.Element {
   const { x, y, place, isLoading } = useContext(Context);
-  const hideInfo = shouldHideInfo(x.value, y.value, place.value);
+  const showChart = shouldShowChart(x.value, y.value, place.value);
+  const showChooseStatVarMessage = shouldShowChooseStatVarMessage(
+    x.value,
+    y.value,
+    place.value
+  );
+  const showInfo = !showChart && !showChooseStatVarMessage;
   return (
     <div>
       <StatVarChooser />
       <div id="plot-container">
         <Container>
-          {!hideInfo && (
+          {!showChart && (
             <Row>
               <h1 className="mb-4">Scatter Plot Tool</h1>
             </Row>
@@ -51,13 +57,19 @@ function App(): JSX.Element {
           <Row>
             <PlaceOptions />
           </Row>
-          {hideInfo ? (
-            <Row id="chart-row">
-              <ChartLoader />
+          {showChooseStatVarMessage && (
+            <Row className="info-message">
+              Choose 2 statistical variables from the left pane.
             </Row>
-          ) : (
+          )}
+          {showInfo && (
             <Row>
               <Info />
+            </Row>
+          )}
+          {showChart && (
+            <Row id="chart-row">
+              <ChartLoader />
             </Row>
           )}
         </Container>
@@ -101,12 +113,24 @@ function shouldDisplaySpinner(isLoading: IsLoadingWrapper): boolean {
  * @param y
  * @param place
  */
-function shouldHideInfo(x: Axis, y: Axis, place: PlaceInfo): boolean {
+function shouldShowChart(x: Axis, y: Axis, place: PlaceInfo): boolean {
   return (
     !_.isEmpty(place.enclosedPlaceType) &&
     !_.isEmpty(place.enclosingPlace.dcid) &&
     !_.isEmpty(x.statVar) &&
     !_.isEmpty(y.statVar)
+  );
+}
+
+function shouldShowChooseStatVarMessage(
+  x: Axis,
+  y: Axis,
+  place: PlaceInfo
+): boolean {
+  return (
+    !_.isEmpty(place.enclosedPlaceType) &&
+    !_.isEmpty(place.enclosingPlace.dcid) &&
+    (_.isEmpty(x.statVar) || _.isEmpty(y.statVar))
   );
 }
 

--- a/static/js/tools/scatter2/chart.tsx
+++ b/static/js/tools/scatter2/chart.tsx
@@ -50,12 +50,17 @@ function Chart(props: ChartPropsType): JSX.Element {
     }
   });
   const sourceList: string[] = Array.from(sources);
+  const seenSourceDomains = new Set();
   const sourcesJsx = sourceList.map((source, index) => {
     const domain = urlToDomain(source);
+    if (seenSourceDomains.has(domain)) {
+      return null;
+    }
+    seenSourceDomains.add(domain);
     return (
       <span key={source}>
+        {index > 0 ? ", " : ""}
         <a href={source}>{domain}</a>
-        {index < sourceList.length - 1 ? ", " : ""}
       </span>
     );
   });
@@ -318,11 +323,17 @@ function addTooltip(
   const onTooltipMouseover = (point: Point) => {
     let xSource = urlToDomain(point.xSource);
     if (xPerCapita && point.xPopSource) {
-      xSource += `, ${urlToDomain(point.xPopSource)}`;
+      const xPopDomain = urlToDomain(point.xPopSource);
+      if (xPopDomain !== xSource) {
+        xSource += `, ${xPopDomain}`;
+      }
     }
     let ySource = urlToDomain(point.ySource);
     if (yPerCapita && point.yPopSource) {
-      ySource += `, ${urlToDomain(point.yPopSource)}`;
+      const yPopDomain = urlToDomain(point.yPopSource);
+      if (yPopDomain !== ySource) {
+        ySource += `, ${yPopDomain}`;
+      }
     }
     const html =
       `${point.place.name || point.place.dcid}<br/>` +

--- a/static/js/tools/scatter2/chart_loader.tsx
+++ b/static/js/tools/scatter2/chart_loader.tsx
@@ -62,6 +62,7 @@ type Cache = {
   // key here is stat var.
   statsVarData: Record<string, PlacePointStat>;
   populationData: { [statVar: string]: { [dcid: string]: SourceSeries } };
+  noDataError: boolean;
 };
 
 function ChartLoader(): JSX.Element {
@@ -79,7 +80,7 @@ function ChartLoader(): JSX.Element {
     <div>
       {shouldRenderChart && (
         <>
-          {_.isEmpty(points) ? (
+          {cache.noDataError ? (
             <div className="error-message">
               Sorry, no data available. Try different stat vars or place
               options.
@@ -123,7 +124,7 @@ function useCache(): Cache {
    */
   useEffect(() => {
     if (!arePlacesLoaded(placeVal) || !areStatVarNamesLoaded(xVal, yVal)) {
-      setCache({ statsVarData: {}, populationData: {} });
+      setCache({ statsVarData: {}, populationData: {}, noDataError: false });
       return;
     }
     if (!areDataLoaded(cache, xVal, yVal)) {
@@ -184,6 +185,7 @@ async function loadData(
       const cache = {
         populationData,
         statsVarData,
+        noDataError: _.isEmpty(statsVarData),
       };
       isLoading.setAreDataLoading(false);
       setCache(cache);

--- a/static/js/tools/scatter2/info.tsx
+++ b/static/js/tools/scatter2/info.tsx
@@ -37,9 +37,96 @@ function Info(): JSX.Element {
           to choose from, arranged in a topical hierarchy.
         </li>
       </ol>
-
-      {/* TODO(intrepiditee): Add descriptions examples */}
-
+      <p>Or you can start your exploration from these interesting points ...</p>
+      <ul>
+        <li>
+          <b>Asians Per Capita vs Median Income</b> for counties in
+          <a
+            href={
+              "#%26svx%3DMedian_Income_Person%26svpx%3D0-3%26svnx%3DMedian%20income%26svy%3DCount_Person_AsianAlone%26svpy%3D0-14-1%26svdy%3DCount_Person%26svny%3DAsian%20Alone%26pcy%3D1%26epd%3DgeoId%2F06%26epn%3DCalifornia%26ept%3DCounty"
+            }
+          >
+            {" "}
+            California
+          </a>
+          ,
+          <a
+            href={
+              "#%26svx%3DMedian_Income_Person%26svpx%3D0-3%26svnx%3DMedian%20income%26svy%3DCount_Person_AsianAlone%26svpy%3D0-14-1%26svdy%3DCount_Person%26svny%3DAsian%20Alone%26pcy%3D1%26epd%3DgeoId%2F48%26epn%3DTexas%26ept%3DCounty"
+            }
+          >
+            {" "}
+            Texas
+          </a>
+          ,
+          <a
+            href={
+              "#%26svx%3DMedian_Income_Person%26svpx%3D0-3%26svnx%3DMedian%20income%26svy%3DCount_Person_AsianAlone%26svpy%3D0-14-1%26svdy%3DCount_Person%26svny%3DAsian%20Alone%26pcy%3D1%26epd%3DgeoId%2F17%26epn%3DIllinois%26ept%3DCounty"
+            }
+          >
+            {" "}
+            Illinois
+          </a>
+          ,
+          <a
+            href={
+              "#%26svx%3DMedian_Income_Person%26svpx%3D0-3%26svnx%3DMedian%20income%26svy%3DCount_Person_AsianAlone%26svpy%3D0-14-1%26svdy%3DCount_Person%26svny%3DAsian%20Alone%26pcy%3D1%26epd%3Dcountry%2FUSA%26epn%3DUnited%20States%20of%20America%26ept%3DCounty"
+            }
+          >
+            {" "}
+            USA
+          </a>
+        </li>
+        <li>
+          <b>Bachelor Degree Attained vs Females Per Capita</b> for counties in
+          <a
+            href={
+              "#%26svx%3DCount_Person_Female%26svpx%3D0-8-0%26svdx%3DCount_Person%26svnx%3DFemale%26pcx%3D1%26svy%3DCount_Person_EducationalAttainmentBachelorsDegree%26svpy%3D2-0-6%26svdy%3DCount_Person_25OrMoreYears%26svny%3DBachelors%20Degree%26pcy%3D1%26epd%3DgeoId%2F06%26epn%3DCalifornia%26ept%3DCounty"
+            }
+          >
+            {" "}
+            California
+          </a>
+          ,
+          <a
+            href={
+              "#%26svx%3DCount_Person_Female%26svpx%3D0-8-0%26svdx%3DCount_Person%26svnx%3DFemale%26pcx%3D1%26svy%3DCount_Person_EducationalAttainmentBachelorsDegree%26svpy%3D2-0-6%26svdy%3DCount_Person_25OrMoreYears%26svny%3DBachelors%20Degree%26pcy%3D1%26epd%3DgeoId%2F36%26epn%3DNew%20York%26ept%3DCounty"
+            }
+          >
+            {" "}
+            New York
+          </a>
+          ,
+          <a
+            href={
+              "#%26svx%3DCount_Person_Female%26svpx%3D0-8-0%26svdx%3DCount_Person%26svnx%3DFemale%26pcx%3D1%26svy%3DCount_Person_EducationalAttainmentBachelorsDegree%26svpy%3D2-0-6%26svdy%3DCount_Person_25OrMoreYears%26svny%3DBachelors%20Degree%26pcy%3D1%26epd%3DgeoId%2F56%26epn%3DWyoming%26ept%3DCounty"
+            }
+          >
+            {" "}
+            Wyoming
+          </a>
+        </li>
+        <li>
+          <b>Foreign Born vs Unemployment Rate</b> for
+          <a
+            href={
+              "#%26svx%3DUnemploymentRate_Person%26svpx%3D3-3%26svnx%3DUnemployment%20Rate%26svy%3DCount_Person_ForeignBorn%26svpy%3D0-12-2%26svdy%3DCount_Person%26svny%3DForeign%20Born%26pcy%3D1%26epd%3Dcountry%2FUSA%26epn%3DUnited%20States%20of%20America%26ept%3DState"
+            }
+          >
+            {" "}
+            US states
+          </a>
+          ,
+          <a
+            href={
+              "#%26svx%3DUnemploymentRate_Person%26svpx%3D3-3%26svnx%3DUnemployment%20Rate%26svy%3DCount_Person_ForeignBorn%26svpy%3D0-12-2%26svdy%3DCount_Person%26svny%3DForeign%20Born%26pcy%3D1%26epd%3Dcountry%2FUSA%26epn%3DUnited%20States%20of%20America%26ept%3DCounty"
+            }
+          >
+            {" "}
+            US counties
+          </a>
+        </li>
+      </ul>
       <p>Take the data and use it on your site!</p>
       <p>
         <a href="mailto:collaborations@datacommons.org">Send</a> us your

--- a/static/js/tools/scatter2/place_options.tsx
+++ b/static/js/tools/scatter2/place_options.tsx
@@ -92,7 +92,7 @@ function PlaceOptions(): JSX.Element {
       <Container>
         <Row className="centered-items-row">
           <Col xs="auto">Plot places in</Col>
-          <Col>
+          <Col xs="7">
             <div id="search">
               <SearchBar
                 places={

--- a/static/js/tools/scatter2/plot_options.tsx
+++ b/static/js/tools/scatter2/plot_options.tsx
@@ -19,7 +19,7 @@
  * lower and upper bounds for populations.
  */
 
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { FormGroup, Label, Input, Card, Button } from "reactstrap";
 import { AxisWrapper, Context, PlaceInfoWrapper } from "./context";
 
@@ -30,11 +30,19 @@ import { Container, Row, Col } from "reactstrap";
 // the dates.
 function PlotOptions(): JSX.Element {
   const { place, x, y } = useContext(Context);
+  const [lowerBound, setLowerBound] = useState(
+    place.value.lowerBound.toString()
+  );
+  const [upperBound, setUpperBound] = useState(
+    place.value.upperBound.toString()
+  );
   return (
     <Card id="plot-options">
       <Container>
         <Row className="plot-options-row">
-          <Col sm={1}>Per capita:</Col>
+          <Col sm={1} className="plot-options-label">
+            Per capita:
+          </Col>
           <Col sm="auto">
             <FormGroup check>
               <Label check>
@@ -44,7 +52,7 @@ function PlotOptions(): JSX.Element {
                   checked={x.value.perCapita}
                   onChange={(e) => checkPerCapita(x, e)}
                 />
-                x-axis
+                X-axis
               </Label>
             </FormGroup>
           </Col>
@@ -57,13 +65,15 @@ function PlotOptions(): JSX.Element {
                   checked={y.value.perCapita}
                   onChange={(e) => checkPerCapita(y, e)}
                 />
-                y-axis
+                Y-axis
               </Label>
             </FormGroup>
           </Col>
         </Row>
         <Row className="plot-options-row">
-          <Col sm={1}>Log scale:</Col>
+          <Col sm={1} className="plot-options-label">
+            Log scale:
+          </Col>
           <Col sm="auto">
             <FormGroup check>
               <Label check>
@@ -73,7 +83,7 @@ function PlotOptions(): JSX.Element {
                   checked={x.value.log}
                   onChange={(e) => checkLog(x, e)}
                 />
-                x-axis
+                X-axis
               </Label>
             </FormGroup>
           </Col>
@@ -86,13 +96,15 @@ function PlotOptions(): JSX.Element {
                   checked={y.value.log}
                   onChange={(e) => checkLog(y, e)}
                 />
-                y-axis
+                Y-axis
               </Label>
             </FormGroup>
           </Col>
         </Row>
         <Row className="plot-options-row centered-items-row">
-          <Col sm={1}>Swap:</Col>
+          <Col sm={1} className="plot-options-label">
+            Swap:
+          </Col>
           <Col sm="auto">
             <Button
               id="swap-axes"
@@ -106,13 +118,16 @@ function PlotOptions(): JSX.Element {
           </Col>
         </Row>
         <Row className="plot-options-row centered-items-row">
-          <Col sm={2}>Filter by population:</Col>
+          <Col sm={2} className="plot-options-label">
+            Filter by population:
+          </Col>
           <Col sm="auto">
             <FormGroup check>
               <Input
                 type="number"
-                onChange={(e) => selectLowerBound(place, e)}
-                value={place.value.lowerBound}
+                onChange={(e) => selectLowerBound(place, e, setLowerBound)}
+                value={lowerBound}
+                onBlur={() => setLowerBound(place.value.lowerBound.toString())}
               />
             </FormGroup>
           </Col>
@@ -121,12 +136,9 @@ function PlotOptions(): JSX.Element {
             <FormGroup check>
               <Input
                 type="number"
-                onChange={(e) => selectUpperBound(place, e)}
-                value={
-                  place.value.upperBound === Number.POSITIVE_INFINITY
-                    ? 1e10
-                    : place.value.upperBound
-                }
+                onChange={(e) => selectUpperBound(place, e, setUpperBound)}
+                value={upperBound}
+                onBlur={() => setUpperBound(place.value.upperBound.toString())}
               />
             </FormGroup>
           </Col>
@@ -178,9 +190,13 @@ function checkLog(
  */
 function selectLowerBound(
   place: PlaceInfoWrapper,
-  event: React.ChangeEvent<HTMLInputElement>
+  event: React.ChangeEvent<HTMLInputElement>,
+  setLowerBound: (lowerBound: string) => void
 ): void {
-  place.setLowerBound(parseInt(event.target.value) || 0);
+  if (event.target.value) {
+    place.setLowerBound(parseInt(event.target.value));
+  }
+  setLowerBound(event.target.value);
 }
 
 /**
@@ -190,9 +206,13 @@ function selectLowerBound(
  */
 function selectUpperBound(
   place: PlaceInfoWrapper,
-  event: React.ChangeEvent<HTMLInputElement>
+  event: React.ChangeEvent<HTMLInputElement>,
+  setUpperBound: (upperBound: string) => void
 ): void {
-  place.setUpperBound(parseInt(event.target.value) || 1e10);
+  if (event.target.value) {
+    place.setUpperBound(parseInt(event.target.value));
+  }
+  setUpperBound(event.target.value);
 }
 
 export { PlotOptions };

--- a/static/js/tools/timeline/search.tsx
+++ b/static/js/tools/timeline/search.tsx
@@ -65,12 +65,16 @@ class SearchBar extends Component<SearchBarPropType> {
   }
 
   render(): JSX.Element {
+    const placeIds = Object.keys(this.props.places);
+    const hideInput = this.props.numPlacesLimit
+      ? placeIds.length >= this.props.numPlacesLimit
+      : false;
     return (
-      <div id="location-field">
+      <div id="location-field" className={hideInput ? "input-area-hidden" : ""}>
         <div id="search-icon"></div>
         <span id="prompt">Find : </span>
         <span id="place-list">
-          {Object.keys(this.props.places).map((placeId) => (
+          {placeIds.map((placeId) => (
             <Chip
               placeId={placeId}
               placeName={


### PR DESCRIPTION
- add examples to info page
- show directions to pick stat vars after user has picked place and place type
- fix the error message that flashes right before chart loads
- fix a bug where if per capita is chosen but the data is unavailable, options section and chart section both disappears so user can't change their selected options
- fix the filter by population input boxes where it wouldn't let user clear the input
- update place search input so that it doesn't mislead users into thinking they can search for additional places once they've chosen a place

updated dev instance