### PR TITLE
Allow stat var hierarchy to display checkbox instead of stat line charts

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -35,6 +35,7 @@ if [[ ! $SELENIUM_SERVER ]]
 function setup_python {
   python3 -m venv .env
   source .env/bin/activate
+  pip install --upgrade pip
   pip3 install -r server/requirements.txt -q
 }
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,7 +5,7 @@ attrs==19.3.0
 google-cloud-profiler
 google-cloud-storage
 google-cloud-secret-manager==1.0.0
-jinja2
+jinja2==2.11.3
 parameterized
 pytest-parallel
 requests
@@ -20,3 +20,4 @@ opencensus
 opencensus-ext-stackdriver
 opencensus-ext-flask
 typing_extensions
+Werkzeug==1.0.1

--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -152,8 +152,8 @@ def statvar_hierarchy_helper(svg_id, svg_map, processed_svg_map, processed_sv,
 
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
-@bp.route('/statvar-hierarchy/<path:dcid>')
-def get_statvar_hierarchy(dcid):
+@bp.route('/statvar-hierarchy', methods=['POST'])
+def get_statvar_hierarchy():
     """Returns the stat var groups objects and stat vars objects relevant to a
     specific dcid.
 
@@ -164,7 +164,8 @@ def get_statvar_hierarchy(dcid):
     Each stat var object (keyed by its stat var id) will have its parent stat
     var group id.
     """
-    svg_map = dc.get_statvar_groups([dcid])
+    dcids = request.json.get('dcids', [])
+    svg_map = dc.get_statvar_groups(dcids)
     processed_svg_map = {}
     processed_sv = {}
     seen_sv = set()

--- a/server/templates/browser/node.html
+++ b/server/templates/browser/node.html
@@ -22,8 +22,8 @@
    {% set subpage_url = url_for('browser.browser_main') %}
 
    {% block head %}
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href={{url_for('static', filename='css/browser.min.css', t=config['VERSION'])}} >
+   <link rel="stylesheet" href={{url_for('static', filename='css/browser.min.css', t=config['VERSION'])}} >
+   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
    {% endblock %}
 
    {% block content %}

--- a/server/templates/dev/dev.html
+++ b/server/templates/dev/dev.html
@@ -19,7 +19,8 @@
 {% set title = 'Dev page' %}
 
 {% block head %}
-  <link rel="stylesheet" href={{url_for('static', filename='css/dev.min.css')}}>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href={{url_for('static', filename='css/dev.min.css')}}>
   <style>
     .chart {
       margin: 20px;

--- a/server/templates/dev/dev.html
+++ b/server/templates/dev/dev.html
@@ -19,8 +19,8 @@
 {% set title = 'Dev page' %}
 
 {% block head %}
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href={{url_for('static', filename='css/dev.min.css')}}>
+  <link rel="stylesheet" href={{url_for('static', filename='css/dev.min.css')}}>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <style>
     .chart {
       margin: 20px;

--- a/server/templates/tools/timeline.html
+++ b/server/templates/tools/timeline.html
@@ -22,8 +22,8 @@
 {% set hide_search = True %}
 
 {% block head %}
-<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 <link rel="stylesheet" href={{url_for('static', filename='css/timeline.min.css', t=config['VERSION'])}}>
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 {% endblock %}
 
 {% block content %}

--- a/server/templates/tools/timeline_bulk_download.html
+++ b/server/templates/tools/timeline_bulk_download.html
@@ -22,8 +22,8 @@ limitations under the License.
 {% set hide_search = True %}
 
 {% block head %}
-<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 <link rel="stylesheet" href={{url_for('static', filename='css/timeline.min.css' , t=config['VERSION'])}}>
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 {% endblock %}
 
 {% block content %}

--- a/server/tests/api_browser_test.py
+++ b/server/tests/api_browser_test.py
@@ -192,7 +192,8 @@ class TestStatVarHierarchy(unittest.TestCase):
                 }],
             }
         }
-        response = app.test_client().post('api/browser/statvar-hierarchy')
+        response = app.test_client().post('api/browser/statvar-hierarchy',
+                                          json={})
         assert response.status_code == 200
         result = json.loads(response.data)
         expected_result = {

--- a/server/tests/api_browser_test.py
+++ b/server/tests/api_browser_test.py
@@ -192,8 +192,7 @@ class TestStatVarHierarchy(unittest.TestCase):
                 }],
             }
         }
-        response = app.test_client().get(
-            'api/browser/statvar-hierarchy/geoId/06')
+        response = app.test_client().post('api/browser/statvar-hierarchy')
         assert response.status_code == 200
         result = json.loads(response.data)
         expected_result = {

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -29,7 +29,8 @@ import { PageDisplayType } from "./types";
 import { WeatherChartSection } from "./weather_chart_section";
 import { OutArcSection } from "./out_arc_section";
 import { InArcSection } from "./in_arc_section";
-import { StatVarHierarchyType, Context } from "../shared/context";
+import { Context } from "../shared/context";
+import { StatVarHierarchyType } from "../shared/types";
 
 const URL_PREFIX = "/browser/";
 const PLACE_STAT_VAR_PROPERTIES_HEADER = "Statistical Variable Properties";
@@ -129,7 +130,7 @@ export class BrowserPage extends React.Component<
             <div className="browser-page-section">
               <h3>Statistical Variables</h3>
               <Context.Provider
-                value={{ StatVarHierarchyType: StatVarHierarchyType.GRAPH }}
+                value={{ StatVarHierarchyType: StatVarHierarchyType.BROWSER }}
               >
                 <StatVarHierarchy
                   places={[

--- a/static/js/browser2/browser_page.tsx
+++ b/static/js/browser2/browser_page.tsx
@@ -29,10 +29,12 @@ import { PageDisplayType } from "./types";
 import { WeatherChartSection } from "./weather_chart_section";
 import { OutArcSection } from "./out_arc_section";
 import { InArcSection } from "./in_arc_section";
+import { StatVarHierarchyType, Context } from "../shared/context";
 
 const URL_PREFIX = "/browser/";
 const PLACE_STAT_VAR_PROPERTIES_HEADER = "Statistical Variable Properties";
 const GENERAL_PROPERTIES_HEADER = "Properties";
+
 interface BrowserPagePropType {
   dcid: string;
   nodeName: string;
@@ -126,10 +128,15 @@ export class BrowserPage extends React.Component<
           {this.props.shouldShowStatVarHierarchy && (
             <div className="browser-page-section">
               <h3>Statistical Variables</h3>
-              <StatVarHierarchy
-                dcid={this.props.dcid}
-                placeName={this.props.nodeName}
-              />
+              <Context.Provider
+                value={{ StatVarHierarchyType: StatVarHierarchyType.GRAPH }}
+              >
+                <StatVarHierarchy
+                  places={[
+                    { dcid: this.props.dcid, name: this.props.nodeName },
+                  ]}
+                />
+              </Context.Provider>
             </div>
           )}
           {showInArcSection && (

--- a/static/js/browser2/statvar_checkbox.tsx
+++ b/static/js/browser2/statvar_checkbox.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Component for rendering a stat var node in the stat var hierarchy.
+ */
+
+import React from "react";
+
+interface StatVarCheckboxPropType {
+  statVar: string;
+}
+
+interface StatVarCheckboxStateType {
+  checked: boolean;
+}
+
+export class StatVarCheckbox extends React.Component<
+  StatVarCheckboxPropType,
+  StatVarCheckboxStateType
+> {
+  constructor(props: StatVarCheckboxPropType) {
+    super(props);
+    this.state = {
+      checked: false,
+    };
+
+    this.handleInputChange = this.handleInputChange.bind(this);
+  }
+
+  private handleInputChange(): void {
+    console.log(this.props.statVar);
+    this.setState({
+      checked: !this.state.checked,
+    });
+  }
+
+  render(): JSX.Element {
+    return (
+      <form>
+        <label>
+          {this.props.statVar}
+          <input
+            type="checkbox"
+            checked={this.state.checked}
+            onChange={this.handleInputChange}
+          />
+        </label>
+      </form>
+    );
+  }
+}

--- a/static/js/browser2/statvar_checkbox.tsx
+++ b/static/js/browser2/statvar_checkbox.tsx
@@ -15,7 +15,7 @@
  */
 
 /**
- * Component for rendering a stat var node in the stat var hierarchy.
+ * Component for rendering a stat var checkbox in the stat var hierarchy.
  */
 
 import React from "react";

--- a/static/js/browser2/statvar_checkbox.tsx
+++ b/static/js/browser2/statvar_checkbox.tsx
@@ -42,7 +42,6 @@ export class StatVarCheckbox extends React.Component<
   }
 
   private handleInputChange(): void {
-    console.log(this.props.statVar);
     this.setState({
       checked: !this.state.checked,
     });

--- a/static/js/browser2/statvar_group_node.tsx
+++ b/static/js/browser2/statvar_group_node.tsx
@@ -29,7 +29,8 @@ import {
 import { StatVarNode } from "./statvar_node";
 import { StatVarCheckbox } from "./statvar_checkbox";
 import { NamedPlace } from "../shared/types";
-import { Context, StatVarHierarchyType } from "../shared/context";
+import { Context } from "../shared/context";
+import { StatVarHierarchyType } from "../shared/types";
 
 const SCROLL_DELAY = 400;
 const BULLET_POINT_HTML = <span className="bullet">&#8226;</span>;
@@ -205,7 +206,8 @@ export function ChildStatVarSection(
               StatVarHierarchyType.TIMELINE && (
               <StatVarCheckbox statVar={statVar.id} />
             )}
-            {appContext.StatVarHierarchyType == StatVarHierarchyType.GRAPH && (
+            {appContext.StatVarHierarchyType ==
+              StatVarHierarchyType.BROWSER && (
               <StatVarNode
                 place={props.places[0]}
                 selected={isSelected}

--- a/static/js/browser2/statvar_group_node.tsx
+++ b/static/js/browser2/statvar_group_node.tsx
@@ -18,7 +18,7 @@
  * Component for rendering a stat var group node in the stat var hierarchy
  */
 
-import React from "react";
+import React, { useContext } from "react";
 import _ from "lodash";
 import Collapsible from "react-collapsible";
 import {
@@ -27,6 +27,9 @@ import {
   StatVarHierarchyNodeType,
 } from "./types";
 import { StatVarNode } from "./statvar_node";
+import { StatVarCheckbox } from "./statvar_checkbox";
+import { NamedPlace } from "../shared/types";
+import { Context, StatVarHierarchyType } from "../shared/context";
 
 const SCROLL_DELAY = 400;
 const BULLET_POINT_HTML = <span className="bullet">&#8226;</span>;
@@ -35,10 +38,8 @@ const RIGHT_ARROW_HTML = <i className="material-icons">add</i>;
 const VARIABLES_STATVAR_GROUP_PREFIX = "dc/g/Variables_";
 
 interface StatVarGroupNodePropType {
-  // the dcid of the node of the current browser page
-  placeDcid: string;
-  // the name of the node of the current browser page
-  placeName: string;
+  // A list of named places object.
+  places: NamedPlace[];
   // the dcid of the current stat var group
   statVarGroupId: string;
   // the mapping of all stat var groups to their corresponding information
@@ -111,8 +112,7 @@ export class StatVarGroupNode extends React.Component<
                     this.props.data[this.props.statVarGroupId].childStatVars
                   }
                   pathToSelection={this.props.pathToSelection}
-                  placeDcid={this.props.placeDcid}
-                  placeName={this.props.placeName}
+                  places={this.props.places}
                   highlightedStatVar={this.highlightedStatVar}
                 />
               )}
@@ -122,8 +122,7 @@ export class StatVarGroupNode extends React.Component<
                 statVarGroupId={this.props.statVarGroupId}
                 pathToSelection={this.props.pathToSelection}
                 highlightedStatVar={this.highlightedStatVar}
-                placeDcid={this.props.placeDcid}
-                placeName={this.props.placeName}
+                places={this.props.places}
               />
             )}
           </>
@@ -183,38 +182,42 @@ export class StatVarHierarchyNodeHeader extends React.Component<
 interface ChildStatVarSectionPropType {
   data: StatVarNodeType[];
   pathToSelection: string[];
-  placeDcid: string;
-  placeName: string;
+  places: NamedPlace[];
   highlightedStatVar: React.RefObject<HTMLDivElement>;
 }
 
-export class ChildStatVarSection extends React.Component<
-  ChildStatVarSectionPropType
-> {
-  render(): JSX.Element {
-    return (
-      <div className="svg-node-child">
-        {this.props.data.map((statVar) => {
-          const isSelected =
-            this.props.pathToSelection.length === 1 &&
-            this.props.pathToSelection[0] === statVar.id;
-          return (
-            <div
-              key={statVar.id}
-              ref={isSelected ? this.props.highlightedStatVar : null}
-            >
+export function ChildStatVarSection(
+  props: ChildStatVarSectionPropType
+): JSX.Element {
+  const appContext = useContext(Context);
+  console.log(appContext);
+  return (
+    <div className="svg-node-child">
+      {props.data.map((statVar) => {
+        const isSelected =
+          props.pathToSelection.length === 1 &&
+          props.pathToSelection[0] === statVar.id;
+        return (
+          <div
+            key={statVar.id}
+            ref={isSelected ? props.highlightedStatVar : null}
+          >
+            {appContext.StatVarHierarchyType ==
+              StatVarHierarchyType.TIMELINE && (
+              <StatVarCheckbox statVar={statVar.id} />
+            )}
+            {appContext.StatVarHierarchyType == StatVarHierarchyType.GRAPH && (
               <StatVarNode
-                nodeName={this.props.placeName}
-                placeDcid={this.props.placeDcid}
+                place={props.places[0]}
                 selected={isSelected}
                 statVar={statVar}
               />
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 interface ChildStatVarGroupSectionPropType {
@@ -222,8 +225,7 @@ interface ChildStatVarGroupSectionPropType {
   statVarGroupId: string;
   pathToSelection: string[];
   highlightedStatVar: React.RefObject<HTMLDivElement>;
-  placeDcid: string;
-  placeName: string;
+  places: NamedPlace[];
 }
 
 export class ChildStatVarGroupSection extends React.Component<
@@ -258,8 +260,7 @@ export class ChildStatVarGroupSection extends React.Component<
                 }
               >
                 <StatVarGroupNode
-                  placeDcid={this.props.placeDcid}
-                  placeName={this.props.placeName}
+                  places={this.props.places}
                   statVarGroupId={childStatVarGroup.id}
                   data={this.props.data}
                   pathToSelection={this.props.pathToSelection.slice(1)}

--- a/static/js/browser2/statvar_group_node.tsx
+++ b/static/js/browser2/statvar_group_node.tsx
@@ -190,7 +190,6 @@ export function ChildStatVarSection(
   props: ChildStatVarSectionPropType
 ): JSX.Element {
   const appContext = useContext(Context);
-  console.log(appContext);
   return (
     <div className="svg-node-child">
       {props.data.map((statVar) => {

--- a/static/js/browser2/statvar_hierarchy.tsx
+++ b/static/js/browser2/statvar_hierarchy.tsx
@@ -26,14 +26,14 @@ import { StatVarHierarchySearch } from "./statvar_hierarchy_search";
 import { StatVarGroupNode } from "./statvar_group_node";
 import { StatVarGroupNodeType, StatVarNodeType } from "./types";
 import { loadSpinner, removeSpinner } from "./util";
+import { NamedPlace } from "../shared/types";
 
 const LOADING_CONTAINER_ID = "stat-var-hierarchy-section";
 const SORTED_FIRST_SVG_ID = "dc/g/Demographics";
 const SORTED_LAST_SVG_ID = "dc/g/Miscellaneous";
 
 interface StatVarHierarchyPropType {
-  dcid: string;
-  placeName: string;
+  places: NamedPlace[];
 }
 
 interface StatVarHierarchyStateType {
@@ -101,8 +101,7 @@ export class StatVarHierarchy extends React.Component<
                 ) {
                   return (
                     <StatVarGroupNode
-                      placeDcid={this.props.dcid}
-                      placeName={this.props.placeName}
+                      places={this.props.places}
                       statVarGroupId={svgId}
                       data={this.state.statVarGroups}
                       pathToSelection={this.state.pathToSelection.slice(1)}
@@ -126,7 +125,9 @@ export class StatVarHierarchy extends React.Component<
   private fetchData(): void {
     loadSpinner(LOADING_CONTAINER_ID);
     axios
-      .get(`/api/browser/statvar-hierarchy/${this.props.dcid}`)
+      .post("/api/browser/statvar-hierarchy", {
+        dcids: this.props.places.map((place) => place.dcid),
+      })
       .then((resp) => {
         const data = resp.data;
         const statVarGroups = data["statVarGroups"];

--- a/static/js/browser2/statvar_node.tsx
+++ b/static/js/browser2/statvar_node.tsx
@@ -24,11 +24,11 @@ import { StatVarHierarchyNodeHeader } from "./statvar_group_node";
 import Collapsible from "react-collapsible";
 import { ObservationChartSection } from "./observation_chart_section";
 import { URI_PREFIX } from "./constants";
+import { NamedPlace } from "../shared/types";
 
 interface StatVarNodePropType {
-  placeDcid: string;
+  place: NamedPlace;
   statVar: StatVarNodeType;
-  nodeName: string;
   selected: boolean;
 }
 
@@ -62,23 +62,23 @@ export class StatVarNode extends React.Component<
         open={this.props.selected}
         onOpening={() => this.setState({ renderContent: true })}
         containerElementProps={
-          this.props.selected ? { class: "highlighted-stat-var" } : {}
+          this.props.selected ? { className: "highlighted-stat-var" } : {}
         }
       >
         {this.state.renderContent && (
           <div className="statvars-charts-section">
             <h5 className="stat-var-link">
               <a
-                href={`${URI_PREFIX}${this.props.placeDcid}?statVar=${this.props.statVar.id}`}
+                href={`${URI_PREFIX}${this.props.place.dcid}?statVar=${this.props.statVar.id}`}
               >
-                {this.props.statVar.id} for {this.props.nodeName}
+                {this.props.statVar.id} for {this.props.place.name}
                 <span className="material-icons">open_in_new</span>
               </a>
             </h5>
             <ObservationChartSection
-              placeDcid={this.props.placeDcid}
+              placeDcid={this.props.place.dcid}
               statVarId={this.props.statVar.id}
-              placeName={this.props.nodeName}
+              placeName={this.props.place.name}
               statVarName={this.props.statVar.displayName}
             />
           </div>
@@ -93,7 +93,7 @@ export class StatVarNode extends React.Component<
   };
 
   private onClickPlaceStatVarLink = () => {
-    const uri = `${URI_PREFIX}${this.props.placeDcid}?statVar=${this.props.statVar.id}`;
+    const uri = `${URI_PREFIX}${this.props.place.dcid}?statVar=${this.props.statVar.id}`;
     window.open(uri);
   };
 }

--- a/static/js/dev_page.tsx
+++ b/static/js/dev_page.tsx
@@ -30,6 +30,8 @@ import {
   drawGroupLineChart,
 } from "./chart/draw";
 import { randDomId } from "./shared/util";
+import { StatVarHierarchyType, Context } from "./shared/context";
+import { StatVarHierarchy } from "./browser2/statvar_hierarchy";
 
 interface DevChartPropType {
   id: string;
@@ -843,7 +845,18 @@ class DevPage extends React.Component {
       ></DevChart>
     );
 
-    return <>{chartElements}</>;
+    return (
+      <div>
+        {chartElements}
+        <div style={{ width: "400px" }}>
+          <Context.Provider
+            value={{ StatVarHierarchyType: StatVarHierarchyType.TIMELINE }}
+          >
+            <StatVarHierarchy places={[]} />
+          </Context.Provider>
+        </div>
+      </div>
+    );
   }
 }
 

--- a/static/js/dev_page.tsx
+++ b/static/js/dev_page.tsx
@@ -30,7 +30,8 @@ import {
   drawGroupLineChart,
 } from "./chart/draw";
 import { randDomId } from "./shared/util";
-import { StatVarHierarchyType, Context } from "./shared/context";
+import { Context } from "./shared/context";
+import { StatVarHierarchyType } from "./shared/types";
 import { StatVarHierarchy } from "./browser2/statvar_hierarchy";
 
 interface DevChartPropType {

--- a/static/js/shared/context.ts
+++ b/static/js/shared/context.ts
@@ -15,15 +15,12 @@
  */
 
 /**
- * Global app context.
+ * This module holds the global context of the Website.
+ *
+ * The context is meant to be shared among all visulization tools.
  */
 
 import { createContext } from "react";
-
-export const StatVarHierarchyType = {
-  GRAPH: "GRAPH",
-  TIMELINE: "TIMELINE",
-};
 
 // Global app state
 interface ContextType {

--- a/static/js/shared/context.ts
+++ b/static/js/shared/context.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-@import "base";
-@import "tools/statvar_menu";
-@import "draw";
-@import "browser";
+/**
+ * Global app context.
+ */
 
-.card {
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
-  position: relative;
+import { createContext } from "react";
+
+export const StatVarHierarchyType = {
+  GRAPH: "GRAPH",
+  TIMELINE: "TIMELINE",
+};
+
+// Global app state
+interface ContextType {
+  StatVarHierarchyType: string;
 }
 
-.screenshot-image {
-  margin: 10px;
-}
+export const Context = createContext({} as ContextType);

--- a/static/js/shared/types.ts
+++ b/static/js/shared/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-@import "base";
-@import "tools/statvar_menu";
-@import "draw";
-@import "browser";
-
-.card {
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
-  position: relative;
-}
-
-.screenshot-image {
-  margin: 10px;
+export interface NamedPlace {
+  name: string;
+  dcid: string;
 }

--- a/static/js/shared/types.ts
+++ b/static/js/shared/types.ts
@@ -14,7 +14,21 @@
  * limitations under the License.
  */
 
+/**
+ * Struct to hold a place with dcid and display name. This is commonly used
+ * throught out the repo.
+ *
+ * TODO(shifucun): migrate existing code to use this struct whenever possible.
+ */
 export interface NamedPlace {
   name: string;
   dcid: string;
 }
+
+/**
+ * Enum type of the stat var hierarchy wizard.
+ */
+export const StatVarHierarchyType = {
+  BROWSER: "BROWSER",
+  TIMELINE: "TIMELINE",
+};

--- a/static/js/shared/types.ts
+++ b/static/js/shared/types.ts
@@ -16,7 +16,7 @@
 
 /**
  * Struct to hold a place with dcid and display name. This is commonly used
- * throught out the repo.
+ * throughout the repo.
  *
  * TODO(shifucun): migrate existing code to use this struct whenever possible.
  */

--- a/static/js/tools/scatter2/chart_loader.tsx
+++ b/static/js/tools/scatter2/chart_loader.tsx
@@ -33,12 +33,12 @@ import {
 import { Chart } from "./chart";
 import {
   Context,
-  NamedPlace,
   Axis,
   AxisWrapper,
   PlaceInfo,
   IsLoadingWrapper,
 } from "./context";
+import { NamedPlace } from "../../shared/types";
 import { StatsVarNode } from "../statvar_menu/util";
 import { PlotOptions } from "./plot_options";
 

--- a/static/js/tools/scatter2/context.ts
+++ b/static/js/tools/scatter2/context.ts
@@ -20,6 +20,7 @@
 
 import { createContext, useState } from "react";
 import { StatsVarNode } from "../statvar_menu/util";
+import { NamedPlace } from "../../shared/types";
 
 interface Axis {
   // StatVar to plot for this axis
@@ -53,11 +54,6 @@ interface AxisWrapper {
   setStatVarName: Setter<string>;
   setLog: Setter<boolean>;
   setPerCapita: Setter<boolean>;
-}
-
-interface NamedPlace {
-  name: string;
-  dcid: string;
 }
 
 interface PlaceInfo {
@@ -366,7 +362,6 @@ export {
   ContextType,
   Axis,
   AxisWrapper,
-  NamedPlace,
   PlaceInfo,
   PlaceInfoWrapper,
   DateInfo,

--- a/static/js/tools/scatter2/statvar.tsx
+++ b/static/js/tools/scatter2/statvar.tsx
@@ -41,9 +41,9 @@ import {
   EmptyAxis,
   Axis,
   AxisWrapper,
-  NamedPlace,
   IsLoadingWrapper,
 } from "./context";
+import { NamedPlace } from "../../shared/types";
 import { nodeGetStatVar } from "./util";
 
 interface NamedStatVar {

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -8583,7 +8583,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.65.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -9052,6 +9055,12 @@
       "requires": {
         "postcss": "^7.0.14"
       }
+    },
+    "icu4c-data": {
+      "version": "0.65.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.65.2.tgz",
+      "integrity": "sha512-c5LRnVavxDKGyRXkFWjZFrT/OpuixepdvihKwgbWoktNJ0t5X7ORyTQdFmq47cCzsmxcZWtaWqTMJR6S6N/3CQ==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",


### PR DESCRIPTION
* Stat var hierachy taking multiple places, which is the case for timeline, scatter plot.
* Store stat var hierarchy type in context.
* Check the stat var hierarchy type and render accordingly. 
![image](https://user-images.githubusercontent.com/5951856/117892323-645e1980-b26d-11eb-8fb9-91a4b613f34a.png)
