### PR TITLE
[scatter] revert log axis and update landing page examples

### DIFF
--- a/static/js/tools/scatter2/chart.tsx
+++ b/static/js/tools/scatter2/chart.tsx
@@ -274,24 +274,25 @@ function addXAxis(
   max: number,
   unit?: string
 ): d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number> {
-  const xScale = d3.scaleLinear().domain([min, max]).range([0, width]).nice();
-  g.append("g")
-    .attr("transform", `translate(0,${height})`)
-    .call(
-      d3
-        .axisBottom(xScale)
-        .ticks(10, d3.format(perCapita ? ".3f" : "d"))
-        .tickFormat((d) => {
-          return formatNumber(d.valueOf(), unit);
-        })
-    );
+  const xScale = (log ? d3.scaleLog() : d3.scaleLinear())
+    .domain([min, max])
+    .range([0, width])
+    .nice();
+  const xAxis = d3.axisBottom(xScale).ticks(10);
+  if (!log) {
+    xAxis.tickFormat((d) => {
+      return formatNumber(d.valueOf());
+    });
+  }
+  g.append("g").attr("transform", `translate(0,${height})`).call(xAxis);
+  const unitLabelString = unit ? ` (${unit})` : "";
   g.append("text")
     .attr("text-anchor", "middle")
     .attr(
       "transform",
       `translate(${width / 2},${height + marginBottom / 2 + 10})`
     )
-    .text(xLabel);
+    .text(xLabel + unitLabelString);
   return xScale;
 }
 
@@ -317,22 +318,25 @@ function addYAxis(
   max: number,
   unit?: string
 ): d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number> {
-  const yScale = d3.scaleLinear().domain([min, max]).range([height, 0]).nice();
-  g.append("g").call(
-    d3
-      .axisLeft(yScale)
-      .ticks(10, d3.format(perCapita ? ".3f" : "d"))
-      .tickFormat((d) => {
-        return formatNumber(d.valueOf(), unit);
-      })
-  );
+  const yScale = (log ? d3.scaleLog() : d3.scaleLinear())
+    .domain([min, max])
+    .range([height, 0])
+    .nice();
+  const yAxis = d3.axisLeft(yScale).ticks(10);
+  if (!log) {
+    yAxis.tickFormat((d) => {
+      return formatNumber(d.valueOf());
+    });
+  }
+  g.append("g").call(yAxis);
+  const unitLabelString = unit ? ` (${unit})` : "";
   g.append("text")
     .attr("text-anchor", "middle")
     .attr(
       "transform",
       `rotate(-90) translate(${-height / 2},${-(marginLeft / 2 + 5)})`
     )
-    .text(yLabel);
+    .text(yLabel + unitLabelString);
   return yScale;
 }
 

--- a/static/js/tools/scatter2/chart_loader.tsx
+++ b/static/js/tools/scatter2/chart_loader.tsx
@@ -234,8 +234,7 @@ function usePoints(cache: Cache): Array<Point> {
       return;
     }
     const points = getPoints(xVal, yVal, placeVal, cache);
-    const pointsCapita = computeCapita(points, xVal.perCapita, yVal.perCapita);
-    setPoints(computeLog(pointsCapita, xVal.log, yVal.log));
+    setPoints(computeCapita(points, xVal.perCapita, yVal.perCapita));
 
     const downloadButton = document.getElementById("download-link");
     if (downloadButton) {
@@ -271,20 +270,6 @@ function computeCapita(
     ...point,
     xVal: xPerCapita ? point.xVal / point.xPop : point.xVal,
     yVal: yPerCapita ? point.yVal / point.yPop : point.yVal,
-  }));
-}
-/**
- * computes the log for each `xVal` and `yVal` if per capita is
- * selected for that axis.
- * @param points
- * @param xPerCapita
- * @param yPerCapita
- */
-function computeLog(points: Array<Point>, xLog: boolean, yLog: boolean) {
-  return points.map((point) => ({
-    ...point,
-    xVal: xLog ? Math.log(point.xVal) : point.xVal,
-    yVal: yLog ? Math.log(point.yVal) : point.yVal,
   }));
 }
 

--- a/static/js/tools/scatter2/info.tsx
+++ b/static/js/tools/scatter2/info.tsx
@@ -100,10 +100,10 @@ function Info(): JSX.Element {
           </a>
         </li>
         <li>
-          <b>Foreign Born vs Unemployment Rate</b> for{" "}
+          <b>Covid-19 Cases vs African American Per Capita</b> for{" "}
           <a
             href={
-              "#&svx=UnemploymentRate_Person&svpx=3-3&svnx=Unemployment_Rate&svy=Count_Person_ForeignBorn&svpy=0-12-2&svdy=Count_Person&svny=Foreign_Born&pcy=1&epd=country%2FUSA&epn=United%20States%20of%20America&ept=State"
+              "#&svx=Count_Person_BlackOrAfricanAmericanAlone&svpx=0-14-2&svdx=Count_Person&svnx=Black_Or_African_American_Alone&pcx=1&svy=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive&svpy=5-2-0-1&svdy=Count_Person&svny=Positive&pcy=1&epd=country/USA&epn=United%20States%20of%20America&ept=State"
             }
           >
             US states
@@ -111,7 +111,7 @@ function Info(): JSX.Element {
           ,{" "}
           <a
             href={
-              "#&svx=UnemploymentRate_Person&svpx=3-3&svnx=Unemployment_Rate&svy=Count_Person_ForeignBorn&svpy=0-12-2&svdy=Count_Person&svny=Foreign_Born&pcy=1&epd=country%2FUSA&epn=United%20States%20of%20America&ept=County"
+              "#&svx=Count_Person_BlackOrAfricanAmericanAlone&svpx=0-14-2&svdx=Count_Person&svnx=Black_Or_African_American_Alone&pcx=1&svy=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive&svpy=5-2-0-1&svdy=Count_Person&svny=Positive&pcy=1&epd=country/USA&epn=United%20States%20of%20America&ept=County"
             }
           >
             US counties


### PR DESCRIPTION
- revert the change where I updated the axes to not change when switching to logscale
- for landing page examples, replace "foreign born vs unemployment rate" with "covid cases vs african american per capita" 