### PR TITLE
Update dev instance rollout strategy

### DIFF
--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -43,4 +43,11 @@ patchesStrategicMerge:
     metadata:
       name: website-app
     spec:
-      replicas: 6
+      replicas: 4
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          # maximum number of Pods that can be created over the desired number of Pods
+          maxSurge: 2
+          # maximum number of Pods that can be unavailable during the update process
+          maxUnavailable: 75%


### PR DESCRIPTION
Right now it takes 5-10 mins for all the pods to be fully updated.

This is to make the dev instance update under 2 mins.