### PR TITLE
stat var hierarchy bugs

### DIFF
--- a/static/js/browser2/statvar_group_node.tsx
+++ b/static/js/browser2/statvar_group_node.tsx
@@ -57,7 +57,7 @@ interface StatVarGroupNodePropType {
 }
 
 interface StatVarGroupNodeStateType {
-  isRendered: boolean;
+  toggledOpen: boolean;
 }
 
 export class StatVarGroupNode extends React.Component<
@@ -69,7 +69,7 @@ export class StatVarGroupNode extends React.Component<
   constructor(props: StatVarGroupNodePropType) {
     super(props);
     this.state = {
-      isRendered: this.props.open,
+      toggledOpen: false,
     };
     this.highlightedStatVar = React.createRef();
     this.scrollToHighlighted = this.scrollToHighlighted.bind(this);
@@ -92,19 +92,26 @@ export class StatVarGroupNode extends React.Component<
         title: triggerTitle,
       });
     };
+    console.log(
+      this.props.statVarGroupId,
+      this.props.open,
+      this.state.toggledOpen
+    );
     return (
       <Collapsible
         trigger={getTrigger(false)}
         triggerWhenOpen={getTrigger(true)}
-        open={this.props.open}
-        onOpening={() => this.setState({ isRendered: true })}
+        open={this.props.open || this.state.toggledOpen}
+        handleTriggerClick={() =>
+          this.setState({ toggledOpen: !this.state.toggledOpen })
+        }
         transitionTime={200}
         onOpen={this.scrollToHighlighted}
         containerElementProps={
           this.props.isSelected ? { class: "highlighted-stat-var-group" } : {}
         }
       >
-        {this.state.isRendered && (
+        {(this.props.open || this.state.toggledOpen) && (
           <>
             {this.props.pathToSelection.length < 2 &&
               this.props.data[this.props.statVarGroupId].childStatVars && (

--- a/static/js/browser2/statvar_group_node.tsx
+++ b/static/js/browser2/statvar_group_node.tsx
@@ -49,10 +49,13 @@ interface StatVarGroupNodePropType {
   // whether the current component has been selected and should be highlighted
   isSelected: boolean;
   // whether the current component should be opened when rendered
-  open: boolean;
+  startsOpened: boolean;
 }
 
 interface StatVarGroupNodeStateType {
+  // whether user has manually expanded this node. If this node has been toggled
+  // open, we want to render an expanded collapsible by passing in true for the
+  // open prop.
   toggledOpen: boolean;
 }
 
@@ -105,7 +108,7 @@ export class StatVarGroupNode extends React.Component<
       <Collapsible
         trigger={getTrigger(false)}
         triggerWhenOpen={getTrigger(true)}
-        open={this.props.open || this.state.toggledOpen}
+        open={this.props.startsOpened || this.state.toggledOpen}
         handleTriggerClick={() =>
           this.setState({ toggledOpen: !this.state.toggledOpen })
         }
@@ -117,7 +120,7 @@ export class StatVarGroupNode extends React.Component<
             : {}
         }
       >
-        {(this.props.open || this.state.toggledOpen) && (
+        {(this.props.startsOpened || this.state.toggledOpen) && (
           <>
             {this.props.pathToSelection.length < 2 &&
               this.props.data[this.props.statVarGroupId].childStatVars && (

--- a/static/js/browser2/statvar_group_section.tsx
+++ b/static/js/browser2/statvar_group_section.tsx
@@ -75,7 +75,9 @@ export class StatVarGroupSection extends React.Component<
                   data={this.props.data}
                   pathToSelection={this.props.pathToSelection.slice(1)}
                   specializedEntity={childStatVarGroup.specializedEntity}
-                  open={this.props.pathToSelection[0] === childStatVarGroup.id}
+                  startsOpened={
+                    this.props.pathToSelection[0] === childStatVarGroup.id
+                  }
                   isSelected={this.props.pathToSelection.length === 1}
                 />
               </div>

--- a/static/js/browser2/statvar_hierarchy.tsx
+++ b/static/js/browser2/statvar_hierarchy.tsx
@@ -97,6 +97,9 @@ export class StatVarHierarchy extends React.Component<
 
   render(): JSX.Element {
     if (this.state.searchSelectionCleared) {
+      // return null when selected search result gets cleared so the stat var
+      // hierarchy sections can be reset by removing all the sections and then
+      // rendering them again after the componentDidUpdate hook.
       return null;
     }
     // TODO(shifucun): this should be obtained from the root of root.

--- a/static/js/browser2/statvar_hierarchy.tsx
+++ b/static/js/browser2/statvar_hierarchy.tsx
@@ -155,7 +155,7 @@ export class StatVarHierarchy extends React.Component<
                         data={this.svgInfo}
                         pathToSelection={this.state.focusPath.slice(1)}
                         isSelected={this.state.focusPath.length === 1}
-                        open={this.state.focusPath[0] === svgId}
+                        startsOpened={this.state.focusPath[0] === svgId}
                       />
                     </Context.Provider>
                   );

--- a/static/js/browser2/statvar_hierarchy.tsx
+++ b/static/js/browser2/statvar_hierarchy.tsx
@@ -52,6 +52,7 @@ interface StatVarHierarchyStateType {
   svPath: Record<string, string[]>;
   // Error message.
   errorMessage: string;
+  // Indicates when search input was cleared after a result was selected.
   searchSelectionCleared: boolean;
   // Select or de-select a stat var with its path.
   togglePath: (sv: string, path?: string[]) => void;
@@ -72,9 +73,9 @@ export class StatVarHierarchy extends React.Component<
     super(props);
     this.state = {
       errorMessage: "",
-      searchSelectionCleared: false,
       focus: "",
       focusPath: [],
+      searchSelectionCleared: false,
       svPath: null,
       togglePath: this.togglePath,
     };
@@ -208,7 +209,7 @@ export class StatVarHierarchy extends React.Component<
     this.setState({
       focus: selection,
       focusPath: path,
-      searchSelectionCleared
+      searchSelectionCleared,
     });
     // If selection is stat var, added it to svPath.
     if (selection != "" && !selection.startsWith("dc/g")) {

--- a/static/js/browser2/statvar_hierarchy.tsx
+++ b/static/js/browser2/statvar_hierarchy.tsx
@@ -41,6 +41,7 @@ interface StatVarHierarchyStateType {
   statVars: { [statVarId: string]: StatVarNodeType };
   pathToSelection: string[];
   errorMessage: string;
+  searchSelectionCleared: boolean;
 }
 
 export class StatVarHierarchy extends React.Component<
@@ -54,6 +55,7 @@ export class StatVarHierarchy extends React.Component<
       pathToSelection: [],
       statVarGroups: {},
       statVars: {},
+      searchSelectionCleared: false,
     };
     this.onSearchSelectionChange = this.onSearchSelectionChange.bind(this);
   }
@@ -62,7 +64,16 @@ export class StatVarHierarchy extends React.Component<
     this.fetchData();
   }
 
+  componentDidUpdate(): void {
+    if (this.state.searchSelectionCleared) {
+      this.setState({ searchSelectionCleared: false });
+    }
+  }
+
   render(): JSX.Element {
+    if (this.state.searchSelectionCleared) {
+      return null;
+    }
     const rootStatVarGroups = Object.keys(this.state.statVarGroups).filter(
       (svgId) => !("parent" in this.state.statVarGroups[svgId])
     );
@@ -161,8 +172,11 @@ export class StatVarHierarchy extends React.Component<
         parent = this.state.statVarGroups[parent].parent;
       }
     }
+    const searchSelectionCleared =
+      !_.isEmpty(this.state.pathToSelection) && _.isEmpty(pathToSelection);
     this.setState({
       pathToSelection,
+      searchSelectionCleared,
     });
   }
 }


### PR DESCRIPTION
fixed bugs:
- when section is expanded and user selects a search result within that section, result won't show up.
- when user clears search result, the expanded section (from the selected search result) is rendered and then closed

![screen-recording (16)](https://user-images.githubusercontent.com/69875368/119183062-6de34080-ba28-11eb-8f49-e5e04bde624d.gif)
