### PR TITLE
[map] get basic map explorer view working

### DIFF
--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -17,17 +17,19 @@ import statistics
 import json
 import services.datacommons as dc
 import routes.api.place as place
+from flask import Response, request, g
+from flask import request
 
 # Map from a geographic level to its closest fine-grained level.
 LEVEL_MAP = {
-    "Country": "AdministrativeArea1",
-    "AdministrativeArea1": "AdministrativeArea2",
+    "Country": "State",
+    "State": "County",
 }
 
 # GeoJSON property to use, keyed by display level.
 GEOJSON_PROPERTY_MAP = {
-    "AdministrativeArea1": "geoJsonCoordinatesDP3",
-    "AdministrativeArea2": "geoJsonCoordinatesDP1",
+    "State": "geoJsonCoordinatesDP3",
+    "County": "geoJsonCoordinatesDP1",
 }
 
 # All choropleth endpoints are defined with the choropleth/ prefix.
@@ -267,14 +269,6 @@ def coerce_geojson_to_righthand_rule(geoJsonCords, obj_type):
         assert False, f"Type {obj_type} unknown!"
 
 
-# Defines the map from higher geos to their respective subgeos.
-SUB_GEO_LEVEL_MAP = {
-    "Country": "AdministrativeArea1",
-    "AdministrativeArea1": "AdministrativeArea2",
-    "AdministrativeArea2": "City"
-}
-
-
 @bp.route('child/statvars')
 def child_statvars():
     """
@@ -318,3 +312,84 @@ def child_statvars():
         stat_vars_for_subgeo = stat_vars_for_subgeo.union(
             place.statsvars(geoId))
     return json.dumps(list(stat_vars_for_subgeo))
+
+
+@bp.route('/geo2')
+def choropleth_geo2():
+    """Returns data for geographic subregions for a certain statistical
+            variable.
+
+    API Params:
+        geoDcid: The currently viewed geography to render, as a string.
+        level: The subgeographic level to pull and display information for,
+                as a string. Choices: State, County, City.
+
+    API Returns:
+        geoJson: geoJson format that includes statistical variables info,
+            geoDcid, and name for all subregions.
+    """
+    # Get required request parameters.
+    place_dcid = request.args.get("placeDcid")
+    if not place_dcid:
+        return Response(json.dumps("error: must provide a placeDcid field"),
+                        400,
+                        mimetype='application/json')
+    place_type = request.args.get("placeType")
+    if not place_type:
+        return Response(json.dumps("error: must provide a placeType field."),
+                        400,
+                        mimetype='application/json')
+    geo_json_prop = GEOJSON_PROPERTY_MAP.get(place_type, None)
+    if not geo_json_prop:
+        return Response(json.dumps("error: geojson data not available for the" +
+                                   f"placeType needed for {place_dcid}"),
+                        400,
+                        mimetype='application/json')
+    # Get list of all contained places.
+    geos_contained_in_place = dc.get_places_in([place_dcid],
+                                               place_type).get(place_dcid, [])
+    # Download statistical variable, names, and geojson for subgeos.
+    # Also, handle the case where only a fraction of values are returned.
+    names_by_geo = place.get_display_name(
+        '^'.join(geos_contained_in_place + [place_dcid]), g.locale)
+    geojson_by_geo = dc.get_property_values(geos_contained_in_place,
+                                            geo_json_prop)
+    # Process into a combined json object.
+    features = []
+    for geo_id, json_text in geojson_by_geo.items():
+        # Valid response needs at least geometry and a name.
+        if json_text and geo_id in names_by_geo:
+            geo_feature = {
+                "type": "Feature",
+                "geometry": {
+                    "type": "MultiPolygon",
+                },
+                "id": geo_id,
+                "properties": {
+                    # Choose the first name when multiple are present.
+                    "name": names_by_geo.get(geo_id, "Unnamed Area"),
+                    "hasSublevel": (place_type in LEVEL_MAP),
+                    "geoDcid": geo_id,
+                }
+            }
+            # Load, simplify, and add geoJSON coordinates.
+            # Exclude geo if no or multiple renderings are present.
+            if len(json_text) != 1:
+                continue
+
+            geojson = json.loads(json_text[0])
+            geo_feature['geometry']['coordinates'] = (
+                coerce_geojson_to_righthand_rule(geojson['coordinates'],
+                                                 geojson['type']))
+            features.append(geo_feature)
+
+    # Return as json payload.
+    return Response(json.dumps({
+        "type": "FeatureCollection",
+        "features": features,
+        "properties": {
+            "current_geo": names_by_geo.get(place_dcid, ["Unnamed Area"])[0]
+        }
+    }),
+                    200,
+                    mimetype='application/json')

--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -18,7 +18,6 @@ import json
 import services.datacommons as dc
 import routes.api.place as place
 from flask import Response, request, g
-from flask import request
 
 # Map from a geographic level to its closest fine-grained level.
 LEVEL_MAP = {

--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -315,6 +315,7 @@ def child_statvars():
 
 @bp.route('/geo2')
 def choropleth_geo2():
+    # TODO(chejennifer): delete /geo once new choropleth tool is ready
     """Returns data for geographic subregions for a certain statistical
             variable.
 

--- a/server/routes/tools.py
+++ b/server/routes/tools.py
@@ -33,7 +33,7 @@ def timeline_bulk_download():
 
 
 @bp.route('/map')
-def map():
+def map_explorer():
     # TODO(iancostello): Permit production use after development finishes.
     if os.environ.get('FLASK_ENV') == 'production':
         flask.abort(404)

--- a/server/routes/tools.py
+++ b/server/routes/tools.py
@@ -32,12 +32,13 @@ def timeline_bulk_download():
     return flask.render_template('tools/timeline_bulk_download.html')
 
 
-@bp.route('/choropleth')
-def choropleth():
+@bp.route('/map')
+def map():
     # TODO(iancostello): Permit production use after development finishes.
     if os.environ.get('FLASK_ENV') == 'production':
         flask.abort(404)
-    return flask.render_template('tools/choropleth.html')
+    return flask.render_template(
+        'tools/map.html', maps_api_key=current_app.config['MAPS_API_KEY'])
 
 
 @bp.route('/scatter')

--- a/server/templates/tools/map.html
+++ b/server/templates/tools/map.html
@@ -17,11 +17,13 @@
 {% extends 'base.html' %}
 
 {% set is_hide_full_footer = true %}
-{% set subpage_title = "Choropleth [Alpha]" %}
-{% set title = "Choropleth tool" %}
+{% set subpage_title = "Map Explorer" %}
+{% set title = "Map Explorer" %}
+{% set hide_search = True %}
 
 {% block head %}
-  <link rel="stylesheet" href={{url_for('static', filename='css/choropleth.min.css')}} >
+  <link rel="stylesheet" href={{url_for('static', filename='css/map.min.css')}} >
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 {% endblock %}
 
 {% block content %}
@@ -29,5 +31,6 @@
 {% endblock %}
 
 {% block footer %}
-  <script src={{url_for('static', filename='choropleth.js', t=config['VERSION'])}}></script>
+  <script src={{url_for('static', filename='map.js', t=config['VERSION'])}}></script>
+  <script src="https://maps.googleapis.com/maps/api/js?key={{maps_api_key}}&libraries=places" async defer></script>
 {% endblock %}

--- a/server/tests/tools_test.py
+++ b/server/tests/tools_test.py
@@ -29,6 +29,6 @@ class TestStaticPage(unittest.TestCase):
         assert response.status_code == 200
         assert b"Scatter Plot Explorer - Data Commons" in response.data
 
-    def test_choropleth(self):
-        response = app.test_client().get('/tools/choropleth')
+    def test_map(self):
+        response = app.test_client().get('/tools/map')
         assert response.status_code == 200

--- a/static/css/tools/map.scss
+++ b/static/css/tools/map.scss
@@ -71,6 +71,7 @@
   background: none;
 }
 
+// TODO(chejennifer): factor out some common styling
 .card {
   flex-grow: 1;
   flex-shrink: 1;

--- a/static/css/tools/map.scss
+++ b/static/css/tools/map.scss
@@ -37,7 +37,6 @@
 
 @include map-search;
 
-
 .place-options {
   display: flex;
   flex-wrap: wrap;
@@ -76,7 +75,7 @@
   flex-grow: 1;
   flex-shrink: 1;
   margin-bottom: 15px;
-  border: 1px solid rgba(0,0,0,.2);
+  border: 1px solid rgba(0, 0, 0, .2);
   padding: 15px;
 }
 

--- a/static/css/tools/map.scss
+++ b/static/css/tools/map.scss
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use "../search_place";
+@import 'base_tools';
+@import 'statvar_menu';
+@import '../draw';
+@import '../draw_choropleth';
+
+@mixin map-search {
+  @include search_place.search-place;
+
+  #search {
+    margin-bottom: 0;
+    box-shadow: none;
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    flex-grow: 1;
+  }
+
+  #search #location-field {
+    flex-wrap: nowrap;
+  }
+}
+
+@include map-search;
+
+
+.place-options {
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+}
+
+.place-options-section {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.5rem;
+  overflow: hidden;
+}
+
+#place-search-section {
+  flex-grow: 1;
+}
+
+.place-options-label {
+  padding-right: 1rem;
+}
+
+.place-options-card {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.search-icon {
+  padding: 0.5rem;
+}
+
+#location-field #ac {
+  background: none;
+}
+
+.card {
+  flex-grow: 1;
+  flex-shrink: 1;
+  margin-bottom: 15px;
+  border: 1px solid rgba(0,0,0,.2);
+  padding: 15px;
+}
+
+#main-pane #plot-container {
+  background: #f8f8f8;
+  direction: initial;
+  padding: 2rem;
+  overflow-y: scroll;
+}
+
+.chart-region {
+  flex-grow: 1;
+}
+
+.chart-section {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem 0;
+}
+
+.map-footer {
+  display: flex;
+  justify-content: space-between;
+  padding-top: 0.5rem;
+}
+
+.map-title {
+  text-align: center;
+}
+
+.sources {
+  font-size: 0.8rem;
+}
+
+.explore-timeline-link {
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  display: flex;
+}

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -40,7 +40,6 @@ const LEGEND_MARGIN_BOTTOM = TICK_SIZE;
 const LEGEND_MARGIN_RIGHT = 5;
 const LEGEND_IMG_WIDTH = 10;
 const NUM_TICKS = 5;
-const REDIRECT_BASE_URL = `/place/`;
 const HIGHLIGHTED_CLASS_NAME = "highlighted";
 
 /**
@@ -204,9 +203,10 @@ const onMouseMove = (
 
 const onMapClick = (
   domContainerId: string,
-  getBaseRedirectLink: (properties: GeoJsonFeatureProperties) => string
+  getRedirectLink: (properties: GeoJsonFeatureProperties) => string
 ) => (geo: GeoJsonFeature, index) => {
-  window.open(getBaseRedirectLink(geo.properties), "_blank");
+  const redirectLink = getRedirectLink(geo.properties);
+  window.open(redirectLink, "_blank");
   mouseOutAction(domContainerId, index);
 };
 

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -20,7 +20,7 @@
 
 import * as d3 from "d3";
 import * as geo from "geo-albers-usa-territories";
-import { GeoJsonData, GeoJsonFeature } from "./types";
+import { GeoJsonData, GeoJsonFeature, GeoJsonFeatureProperties } from "./types";
 import { getColorFn } from "./base";
 import { getStatsVarLabel } from "../shared/stats_var_labels";
 import { formatNumber } from "../i18n/i18n";
@@ -73,7 +73,8 @@ function drawChoropleth(
   },
   unit: string,
   statVar: string,
-  urlSuffix: string
+  canClick: boolean,
+  getRedirectLink: (geoDcid: GeoJsonFeatureProperties) => string
 ): void {
   const label = getStatsVarLabel(statVar);
   const maxColor = d3.color(getColorFn([label])(label));
@@ -115,7 +116,7 @@ function drawChoropleth(
   fitSize(chartWidth - legendWidth, chartHeight, geoJson, projection, geomap);
 
   // Build map objects.
-  mapContent
+  const mapObjects = mapContent
     .enter()
     .append("path")
     .attr("d", geomap)
@@ -141,10 +142,12 @@ function drawChoropleth(
     })
     .attr("stroke-width", STROKE_WIDTH)
     .attr("stroke", GEO_STROKE_COLOR)
-    .on("mouseover", onMouseOver(domContainerId))
+    .on("mouseover", onMouseOver(domContainerId, canClick))
     .on("mouseout", onMouseOut(domContainerId))
-    .on("mousemove", onMouseMove(domContainerId, dataValues, unit))
-    .on("click", onMapClick(domContainerId, urlSuffix));
+    .on("mousemove", onMouseMove(domContainerId, dataValues, unit));
+  if (canClick) {
+    mapObjects.on("click", onMapClick(domContainerId, getRedirectLink));
+  }
 
   // style highlighted region and bring to the front
   d3.select(domContainerId)
@@ -155,10 +158,15 @@ function drawChoropleth(
   addTooltip(domContainerId);
 }
 
-const onMouseOver = (domContainerId: string) => (_, index): void => {
+const onMouseOver = (domContainerId: string, canClick: boolean) => (
+  _,
+  index
+): void => {
   const container = d3.select(domContainerId);
   // show highlighted border and show cursor as a pointer
-  container.select("#geoPath" + index).classed("region-highlighted", true);
+  if (canClick) {
+    container.select("#geoPath" + index).classed("region-highlighted", true);
+  }
   // show tooltip
   container.select(`#${TOOLTIP_ID}`).style("display", "block");
 };
@@ -194,14 +202,11 @@ const onMouseMove = (
     .style("top", d3.event.offsetY + topOffset + "px");
 };
 
-const onMapClick = (domContainerId: string, urlSuffix: string) => (
-  geo: GeoJsonFeature,
-  index
-) => {
-  window.open(
-    `${REDIRECT_BASE_URL}${geo.properties.geoDcid}${urlSuffix}`,
-    "_blank"
-  );
+const onMapClick = (
+  domContainerId: string,
+  getBaseRedirectLink: (properties: GeoJsonFeatureProperties) => string
+) => (geo: GeoJsonFeature, index) => {
+  window.open(getBaseRedirectLink(geo.properties), "_blank");
   mouseOutAction(domContainerId, index);
 };
 

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -28,6 +28,7 @@ import {
   ChoroplethDataGroup,
   CachedChoroplethData,
   GeoJsonData,
+  GeoJsonFeatureProperties,
 } from "../chart/types";
 import { updatePageLayoutState } from "./place";
 import { ChartEmbed } from "./chart_embed";
@@ -40,6 +41,7 @@ import { urlToDomain } from "../shared/util";
 
 const CHART_HEIGHT = 194;
 const MIN_CHOROPLETH_DATAPOINTS = 9;
+const CHOROPLETH_REDIRECT_BASE_URL = `/place/`;
 
 interface ChartPropType {
   /**
@@ -366,6 +368,9 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       chartType === chartTypeEnum.CHOROPLETH &&
       this.state.choroplethDataGroup
     ) {
+      const getRedirectLink = (geoProperty: GeoJsonFeatureProperties) => {
+        return `${CHOROPLETH_REDIRECT_BASE_URL}${geoProperty.geoDcid}${this.placeLinkSearch}`;
+      };
       drawChoropleth(
         this.props.id,
         this.state.geoJson,
@@ -374,7 +379,8 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         this.state.choroplethDataGroup.data,
         this.props.unit,
         this.props.statsVars[0],
-        this.placeLinkSearch
+        true,
+        getRedirectLink
       );
     }
   }

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -41,7 +41,7 @@ import { urlToDomain } from "../shared/util";
 
 const CHART_HEIGHT = 194;
 const MIN_CHOROPLETH_DATAPOINTS = 9;
-const CHOROPLETH_REDIRECT_BASE_URL = `/place/`;
+const CHOROPLETH_REDIRECT_BASE_URL = "/place/";
 
 interface ChartPropType {
   /**

--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -40,7 +40,7 @@ function App(): JSX.Element {
   const showLoadingSpinner =
     isLoading.value.isDataLoading || isLoading.value.isPlaceInfoLoading;
   return (
-    <div>
+    <>
       <div id="plot-container">
         <Container>
           {!showChart && (
@@ -64,11 +64,11 @@ function App(): JSX.Element {
           </div>
         </Container>
       </div>
-    </div>
+    </>
   );
 }
 
-function AppWithContext(): JSX.Element {
+export function AppWithContext(): JSX.Element {
   const params = new URLSearchParams(
     decodeURIComponent(location.hash).replace("#", "?")
   );
@@ -99,5 +99,3 @@ function updateHash(context: ContextType): void {
     history.pushState({}, "", `/tools/map#${encodeURIComponent(hash)}`);
   }
 }
-
-export { AppWithContext };

--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Main app component for map explorer.
+ */
+
+import React, { useContext, useEffect } from "react";
+import { Context, ContextType, getInitialContext } from "./context";
+import { Container, Row } from "reactstrap";
+import _ from "lodash";
+import { PlaceOptions } from "./place_options";
+import {
+  applyHashPlaceInfo,
+  applyHashStatVarInfo,
+  updateHashPlaceInfo,
+  updateHashStatVarInfo,
+} from "./util";
+import { ChartLoader } from "./chart_loader";
+
+function App(): JSX.Element {
+  const { statVarInfo, placeInfo, isLoading } = useContext(Context);
+  const showChart =
+    !_.isEmpty(statVarInfo.value.statVar) &&
+    !_.isEmpty(placeInfo.value.enclosingPlace.dcid) &&
+    !_.isEmpty(placeInfo.value.enclosedPlaceType);
+  const showLoadingSpinner =
+    isLoading.value.isDataLoading || isLoading.value.isPlaceInfoLoading;
+  return (
+    <div>
+      <div id="plot-container">
+        <Container>
+          {!showChart && (
+            <Row>
+              <h1 className="mb-4">Map Explorer</h1>
+            </Row>
+          )}
+          <Row>
+            <PlaceOptions />
+          </Row>
+          {showChart && (
+            <Row id="chart-row">
+              <ChartLoader />
+            </Row>
+          )}
+          <div
+            id="screen"
+            style={{ display: showLoadingSpinner ? "block" : "none" }}
+          >
+            <div id="spinner"></div>
+          </div>
+        </Container>
+      </div>
+    </div>
+  );
+}
+
+function AppWithContext(): JSX.Element {
+  const params = new URLSearchParams(
+    decodeURIComponent(location.hash).replace("#", "?")
+  );
+  const store = getInitialContext(params);
+
+  useEffect(() => updateHash(store), [store]);
+  window.onhashchange = () => applyHash(store);
+
+  return (
+    <Context.Provider value={store}>
+      <App />
+    </Context.Provider>
+  );
+}
+
+function applyHash(context: ContextType): void {
+  const params = new URLSearchParams(
+    decodeURIComponent(location.hash).replace("#", "?")
+  );
+  context.placeInfo.set(applyHashPlaceInfo(params));
+  context.statVarInfo.set(applyHashStatVarInfo(params));
+}
+
+function updateHash(context: ContextType): void {
+  let hash = updateHashStatVarInfo("", context.statVarInfo.value);
+  hash = updateHashPlaceInfo(hash, context.placeInfo.value);
+  if (hash) {
+    history.pushState({}, "", `/tools/map#${encodeURIComponent(hash)}`);
+  }
+}
+
+export { AppWithContext };

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -55,7 +55,7 @@ export function Chart(props: ChartProps): JSX.Element {
   const placeDcid = props.placeInfo.enclosingPlace.dcid;
   const statVarDcid = _.findKey(props.statVarInfo.statVar);
   return (
-    <div>
+    <>
       <Container>
         <div className="chart-section">
           <div className="map-title">
@@ -74,7 +74,7 @@ export function Chart(props: ChartProps): JSX.Element {
           </div>
         </div>
       </Container>
-    </div>
+    </>
   );
 }
 

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -129,8 +129,7 @@ function getSourcesJsx(sources: Set<string>): JSX.Element[] {
 }
 
 function exploreTimelineOnClick(placeDcid: string, statVarDcid: string): void {
-  const uri = `/tools/timeline#place=${placeDcid}&statsVar=${statVarDcid}`;
-  window.open(uri);
+  window.open(`/tools/timeline#place=${placeDcid}&statsVar=${statVarDcid}`);
 }
 
 const getMapRedirectLink = (statVarInfo: StatVarInfo, placeInfo: PlaceInfo) => (
@@ -138,15 +137,15 @@ const getMapRedirectLink = (statVarInfo: StatVarInfo, placeInfo: PlaceInfo) => (
 ) => {
   let hash = updateHashStatVarInfo("", statVarInfo);
   const enclosingPlace = {
-    name: geoProperties.name,
     dcid: geoProperties.geoDcid,
+    name: geoProperties.name,
   };
   const enclosedPlaceType =
     USA_CHILD_PLACE_TYPES[placeInfo.enclosedPlaceType][0];
   hash = updateHashPlaceInfo(hash, {
-    enclosingPlace,
-    enclosedPlaceType,
     enclosedPlaces: [],
+    enclosedPlaceType,
+    enclosingPlace,
   });
   return `${MAP_REDIRECT_PREFIX}#${encodeURIComponent(hash)}`;
 };

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chart component for drawing a choropleth.
+ */
+
+import React, { useEffect } from "react";
+import { GeoJsonData, GeoJsonFeatureProperties } from "../../chart/types";
+import { PlaceInfo, StatVarInfo } from "./context";
+import { Container } from "reactstrap";
+import _ from "lodash";
+import { drawChoropleth } from "../../chart/draw_choropleth";
+import {
+  updateHashPlaceInfo,
+  updateHashStatVarInfo,
+  USA_CHILD_PLACE_TYPES,
+} from "./util";
+import { urlToDomain } from "../../shared/util";
+
+interface ChartProps {
+  geoJsonData: GeoJsonData;
+  dataValues: { [dcid: string]: number };
+  placeInfo: PlaceInfo;
+  statVarInfo: StatVarInfo;
+  statVarDates: { [dcid: string]: string };
+  sources: Set<string>;
+}
+
+const SVG_CONTAINER_ID = "choropleth_map";
+const MAP_REDIRECT_PREFIX = "/tools/map";
+
+export function Chart(props: ChartProps): JSX.Element {
+  useEffect(() => {
+    draw(props);
+  }, [props]);
+  const title = getTitle(
+    Object.values(props.statVarDates),
+    props.statVarInfo.name
+  );
+  const sourcesJsx = getSourcesJsx(props.sources);
+  const placeDcid = props.placeInfo.enclosingPlace.dcid;
+  const statVarDcid = _.findKey(props.statVarInfo.statVar);
+  return (
+    <div>
+      <Container>
+        <div className="chart-section">
+          <div className="map-title">
+            <h3>{title}</h3>
+          </div>
+          <div id={SVG_CONTAINER_ID}></div>
+          <div className="map-footer">
+            <div className="sources">Data from {sourcesJsx}</div>
+            <div
+              className="explore-timeline-link"
+              onClick={() => exploreTimelineOnClick(placeDcid, statVarDcid)}
+            >
+              <span className="explore-timeline-text">Explore timeline</span>
+              <i className="material-icons">keyboard_arrow_right</i>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </div>
+  );
+}
+
+function draw(props: ChartProps): void {
+  document.getElementById(SVG_CONTAINER_ID).innerHTML = "";
+  const width = document.getElementById(SVG_CONTAINER_ID).offsetWidth;
+  const height = (width * 2) / 5;
+  const getRedirectLink = getMapRedirectLink(
+    props.statVarInfo,
+    props.placeInfo
+  );
+  if (!_.isEmpty(props.geoJsonData) && !_.isEmpty(props.dataValues)) {
+    drawChoropleth(
+      SVG_CONTAINER_ID,
+      props.geoJsonData,
+      height,
+      width,
+      props.dataValues,
+      "",
+      props.statVarInfo.name,
+      props.placeInfo.enclosedPlaceType in USA_CHILD_PLACE_TYPES,
+      getRedirectLink
+    );
+  }
+}
+
+function getTitle(statVarDates: string[], statVarName: string): string {
+  const minDate = _.min(statVarDates);
+  const maxDate = _.max(statVarDates);
+  const dateRange =
+    minDate === maxDate ? `(${minDate})` : `(${minDate} - ${maxDate})`;
+  return `${statVarName} ${dateRange}`;
+}
+
+function getSourcesJsx(sources: Set<string>): JSX.Element[] {
+  const sourceList: string[] = Array.from(sources);
+  const seenSourceDomains = new Set();
+  const sourcesJsx = sourceList.map((source, index) => {
+    const domain = urlToDomain(source);
+    if (seenSourceDomains.has(domain)) {
+      return null;
+    }
+    seenSourceDomains.add(domain);
+    return (
+      <span key={source}>
+        {index > 0 ? ", " : ""}
+        <a href={source}>{domain}</a>
+      </span>
+    );
+  });
+  return sourcesJsx;
+}
+
+function exploreTimelineOnClick(placeDcid: string, statVarDcid: string): void {
+  const uri = `/tools/timeline#place=${placeDcid}&statsVar=${statVarDcid}`;
+  window.open(uri);
+}
+
+const getMapRedirectLink = (statVarInfo: StatVarInfo, placeInfo: PlaceInfo) => (
+  geoProperties: GeoJsonFeatureProperties
+) => {
+  let hash = updateHashStatVarInfo("", statVarInfo);
+  const enclosingPlace = {
+    name: geoProperties.name,
+    dcid: geoProperties.geoDcid,
+  };
+  const enclosedPlaceType =
+    USA_CHILD_PLACE_TYPES[placeInfo.enclosedPlaceType][0];
+  hash = updateHashPlaceInfo(hash, {
+    enclosingPlace,
+    enclosedPlaceType,
+    enclosedPlaces: [],
+  });
+  return `${MAP_REDIRECT_PREFIX}#${encodeURIComponent(hash)}`;
+};

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -139,7 +139,7 @@ function loadChartData(
   populationData: { [dcid: string]: SourceSeries },
   isPerCapita: boolean,
   geoJsonData: GeoJsonData,
-  setChartData: (data: any) => void
+  setChartData: (data: ChartData) => void
 ): void {
   const dataValues = {};
   const sources: Set<string> = new Set();

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Component for retrieving and transforming data into a form ready for drawing
+ * and passing the data to a `Chart` component that draws the choropleth.
+ */
+
+import React, { useContext, useEffect, useState } from "react";
+import _ from "lodash";
+import { GeoJsonData } from "../../chart/types";
+import {
+  getPopulationDate,
+  PlacePointStat,
+  SourceSeries,
+} from "../shared_util";
+import { Context, IsLoadingWrapper, PlaceInfo, StatVarInfo } from "./context";
+import { Chart } from "./chart";
+import axios from "axios";
+
+interface MapRawData {
+  geoJsonData: GeoJsonData;
+  statVarData: PlacePointStat;
+  populationData: { [dcid: string]: SourceSeries };
+}
+
+interface ChartData {
+  dataValues: { [dcid: string]: number };
+  sources: Set<string>;
+  statVarDates: { [dcid: string]: string };
+  geoJsonData: GeoJsonData;
+}
+
+export function ChartLoader(): JSX.Element {
+  const { placeInfo, statVarInfo, isLoading } = useContext(Context);
+  const [data, setData] = useState<MapRawData | undefined>(undefined);
+  const [chartData, setChartData] = useState<ChartData | undefined>(undefined);
+  useEffect(() => {
+    const placesLoaded =
+      !_.isEmpty(placeInfo.value.enclosingPlace.dcid) &&
+      !_.isEmpty(placeInfo.value.enclosedPlaces);
+    if (placesLoaded && !_.isEmpty(statVarInfo.value.statVar)) {
+      loadData(placeInfo.value, statVarInfo.value, isLoading, setData);
+    } else {
+      setData(undefined);
+    }
+  }, [placeInfo.value, statVarInfo.value.statVar]);
+  useEffect(() => {
+    if (!_.isEmpty(data)) {
+      loadChartData(
+        data.statVarData[_.findKey(statVarInfo.value.statVar)],
+        data.populationData,
+        statVarInfo.value.perCapita,
+        data.geoJsonData,
+        setChartData
+      );
+    }
+  }, [data, statVarInfo.value.perCapita]);
+  if (
+    _.isEmpty(chartData) ||
+    _.isEmpty(chartData.dataValues) ||
+    _.isEmpty(chartData.geoJsonData)
+  ) {
+    return null;
+  }
+  return (
+    <div className="chart-region">
+      <Chart
+        geoJsonData={chartData.geoJsonData}
+        dataValues={chartData.dataValues}
+        placeInfo={placeInfo.value}
+        statVarInfo={statVarInfo.value}
+        statVarDates={chartData.statVarDates}
+        sources={chartData.sources}
+      />
+    </div>
+  );
+}
+
+function loadData(
+  placeInfo: PlaceInfo,
+  statVarInfo: StatVarInfo,
+  isLoading: IsLoadingWrapper,
+  setData: (data: MapRawData) => void
+): void {
+  isLoading.setIsDataLoading(true);
+  const statVarDcid = _.findKey(statVarInfo.statVar);
+  const denomStatVars = Object.values(statVarInfo.statVar)[0].denominators;
+  const populationStatVar = _.isEmpty(denomStatVars)
+    ? "Count_Person"
+    : denomStatVars[0];
+  const enclosingPlaceDcid = placeInfo.enclosingPlace.dcid;
+  const enclosedPlaceType = placeInfo.enclosedPlaceType;
+  const statVarDataPromise = axios
+    .get(
+      `/api/stats/within-place?parent_place=${enclosingPlaceDcid}&child_type=${enclosedPlaceType}&stat_vars=${statVarDcid}`
+    )
+    .then((resp) => resp.data);
+  const populationPromise = axios
+    .post(`/api/stats/${populationStatVar}`, {
+      dcid: placeInfo.enclosedPlaces,
+    })
+    .then((resp) => resp.data);
+  const geoJsonPromise = axios
+    .get(
+      `/api/choropleth/geo2?placeDcid=${enclosingPlaceDcid}&placeType=${enclosedPlaceType}`
+    )
+    .then((resp) => resp.data);
+  Promise.all([statVarDataPromise, populationPromise, geoJsonPromise])
+    .then(([statVarData, populationData, geoJsonData]) => {
+      isLoading.setIsDataLoading(false);
+      setData({
+        geoJsonData,
+        populationData,
+        statVarData,
+      });
+    })
+    .catch(() => {
+      alert("Error fetching data.");
+      isLoading.setIsDataLoading(false);
+    });
+}
+
+function loadChartData(
+  statVarData: PlacePointStat,
+  populationData: { [dcid: string]: SourceSeries },
+  isPerCapita: boolean,
+  geoJsonData: GeoJsonData,
+  setChartData: (data: any) => void
+): void {
+  const dataValues = {};
+  const sources: Set<string> = new Set();
+  const statVarDates = {};
+  for (const dcid in statVarData.stat) {
+    if (_.isEmpty(statVarData.stat[dcid])) {
+      continue;
+    }
+    const statVarValue = statVarData.stat[dcid].value;
+    const importName = statVarData.stat[dcid].metadata.importName;
+    sources.add(statVarData.metadata[importName].provenanceUrl);
+    statVarDates[dcid] = statVarData.stat[dcid].date;
+    if (isPerCapita && dcid in populationData) {
+      const popDate = getPopulationDate(
+        populationData[dcid],
+        statVarData.stat[dcid]
+      );
+      dataValues[dcid] = statVarValue / populationData[dcid].data[popDate];
+      sources.add(populationData[dcid].provenanceUrl);
+    } else if (!isPerCapita) {
+      dataValues[dcid] = statVarValue;
+    }
+  }
+  setChartData({ dataValues, sources, statVarDates, geoJsonData });
+}

--- a/static/js/tools/map/context.ts
+++ b/static/js/tools/map/context.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useState } from "react";
+import { NamedPlace } from "../../shared/types";
+import { StatsVarNode } from "../statvar_menu/util";
+import { applyHashStatVarInfo, applyHashPlaceInfo } from "./util";
+
+/**
+ * Global app context for map explorer tool.
+ */
+
+interface Setter<T> {
+  (value: T): void;
+}
+
+interface StatVarInfo {
+  statVar: StatsVarNode;
+  name: string;
+  perCapita: boolean;
+}
+
+interface StatVarInfoWrapper {
+  value: StatVarInfo;
+
+  set: Setter<StatVarInfo>;
+  setStatVar: Setter<StatsVarNode>;
+  setStatVarName: Setter<string>;
+  setPerCapita: Setter<boolean>;
+}
+
+interface PlaceInfo {
+  enclosingPlace: NamedPlace;
+  enclosedPlaceType: string;
+  enclosedPlaces: Array<string>;
+}
+
+interface PlaceInfoWrapper {
+  value: PlaceInfo;
+
+  set: Setter<PlaceInfo>;
+  setEnclosingPlace: Setter<NamedPlace>;
+  setEnclosedPlaceType: Setter<string>;
+  setEnclosedPlaces: Setter<Array<string>>;
+}
+
+interface IsLoading {
+  isDataLoading: boolean;
+  isPlaceInfoLoading: boolean;
+}
+
+interface IsLoadingWrapper {
+  value: IsLoading;
+
+  set: Setter<IsLoading>;
+  setIsDataLoading: Setter<boolean>;
+  setIsPlaceInfoLoading: Setter<boolean>;
+}
+
+interface ContextType {
+  statVarInfo: StatVarInfoWrapper;
+  placeInfo: PlaceInfoWrapper;
+  isLoading: IsLoadingWrapper;
+}
+
+const Context = createContext({} as ContextType);
+
+function getInitialContext(params: URLSearchParams): ContextType {
+  const [statVarInfo, setStatVarInfo] = useState(applyHashStatVarInfo(params));
+  const [placeInfo, setPlaceInfo] = useState(applyHashPlaceInfo(params));
+  const [isLoading, setIsLoading] = useState({
+    isDataLoading: false,
+    isPlaceInfoLoading: false,
+  });
+  return {
+    statVarInfo: {
+      value: statVarInfo,
+      set: (statVarInfo) => setStatVarInfo(statVarInfo),
+      setStatVar: (statVar) => setStatVarInfo({ ...statVarInfo, statVar }),
+      setStatVarName: (name) => setStatVarInfo({ ...statVarInfo, name }),
+      setPerCapita: (perCapita) =>
+        setStatVarInfo({ ...statVarInfo, perCapita }),
+    },
+    placeInfo: {
+      value: placeInfo,
+      set: (placeInfo) => setPlaceInfo(placeInfo),
+      setEnclosingPlace: (enclosingPlace) =>
+        setPlaceInfo({
+          ...placeInfo,
+          enclosingPlace,
+          enclosedPlaceType: "",
+          enclosedPlaces: [],
+        }),
+      setEnclosedPlaceType: (enclosedPlaceType) =>
+        setPlaceInfo({ ...placeInfo, enclosedPlaceType, enclosedPlaces: [] }),
+      setEnclosedPlaces: (enclosedPlaces) =>
+        setPlaceInfo({ ...placeInfo, enclosedPlaces }),
+    },
+    isLoading: {
+      value: isLoading,
+      set: (isLoading) => setIsLoading(isLoading),
+      setIsDataLoading: (isDataLoading) =>
+        setIsLoading({ ...isLoading, isDataLoading }),
+      setIsPlaceInfoLoading: (isPlaceInfoLoading) =>
+        setIsLoading({ ...isLoading, isPlaceInfoLoading }),
+    },
+  };
+}
+
+export {
+  Context,
+  getInitialContext,
+  ContextType,
+  StatVarInfo,
+  StatVarInfoWrapper,
+  PlaceInfo,
+  PlaceInfoWrapper,
+  IsLoading,
+  IsLoadingWrapper,
+};

--- a/static/js/tools/map/context.ts
+++ b/static/js/tools/map/context.ts
@@ -86,13 +86,13 @@ function getInitialContext(params: URLSearchParams): ContextType {
     isPlaceInfoLoading: false,
   });
   return {
-    statVarInfo: {
-      value: statVarInfo,
-      set: (statVarInfo) => setStatVarInfo(statVarInfo),
-      setStatVar: (statVar) => setStatVarInfo({ ...statVarInfo, statVar }),
-      setStatVarName: (name) => setStatVarInfo({ ...statVarInfo, name }),
-      setPerCapita: (perCapita) =>
-        setStatVarInfo({ ...statVarInfo, perCapita }),
+    isLoading: {
+      value: isLoading,
+      set: (isLoading) => setIsLoading(isLoading),
+      setIsDataLoading: (isDataLoading) =>
+        setIsLoading({ ...isLoading, isDataLoading }),
+      setIsPlaceInfoLoading: (isPlaceInfoLoading) =>
+        setIsLoading({ ...isLoading, isPlaceInfoLoading }),
     },
     placeInfo: {
       value: placeInfo,
@@ -101,21 +101,21 @@ function getInitialContext(params: URLSearchParams): ContextType {
         setPlaceInfo({
           ...placeInfo,
           enclosingPlace,
-          enclosedPlaceType: "",
           enclosedPlaces: [],
+          enclosedPlaceType: "",
         }),
       setEnclosedPlaceType: (enclosedPlaceType) =>
-        setPlaceInfo({ ...placeInfo, enclosedPlaceType, enclosedPlaces: [] }),
+        setPlaceInfo({ ...placeInfo, enclosedPlaces: [], enclosedPlaceType }),
       setEnclosedPlaces: (enclosedPlaces) =>
         setPlaceInfo({ ...placeInfo, enclosedPlaces }),
     },
-    isLoading: {
-      value: isLoading,
-      set: (isLoading) => setIsLoading(isLoading),
-      setIsDataLoading: (isDataLoading) =>
-        setIsLoading({ ...isLoading, isDataLoading }),
-      setIsPlaceInfoLoading: (isPlaceInfoLoading) =>
-        setIsLoading({ ...isLoading, isPlaceInfoLoading }),
+    statVarInfo: {
+      value: statVarInfo,
+      set: (statVarInfo) => setStatVarInfo(statVarInfo),
+      setStatVar: (statVar) => setStatVarInfo({ ...statVarInfo, statVar }),
+      setStatVarName: (name) => setStatVarInfo({ ...statVarInfo, name }),
+      setPerCapita: (perCapita) =>
+        setStatVarInfo({ ...statVarInfo, perCapita }),
     },
   };
 }

--- a/static/js/tools/map/context.ts
+++ b/static/js/tools/map/context.ts
@@ -23,17 +23,23 @@ import { applyHashStatVarInfo, applyHashPlaceInfo } from "./util";
  * Global app context for map explorer tool.
  */
 
+// used to set fields in context
 interface Setter<T> {
   (value: T): void;
 }
 
-interface StatVarInfo {
+// Information relating to the stat var to plot
+export interface StatVarInfo {
+  // The stat var to plot
   statVar: StatsVarNode;
+  // Human readable name of the stat var
   name: string;
+  // Whether to plot per capita values
   perCapita: boolean;
 }
 
-interface StatVarInfoWrapper {
+// Wraps StatVarInfo with its setters
+export interface StatVarInfoWrapper {
   value: StatVarInfo;
 
   set: Setter<StatVarInfo>;
@@ -42,13 +48,18 @@ interface StatVarInfoWrapper {
   setPerCapita: Setter<boolean>;
 }
 
-interface PlaceInfo {
+// Information relating to the places to plot
+export interface PlaceInfo {
+  // Place that encloses the places to plot
   enclosingPlace: NamedPlace;
+  // The type of place to plot
   enclosedPlaceType: string;
+  // The places to plot
   enclosedPlaces: Array<string>;
 }
 
-interface PlaceInfoWrapper {
+// Wraps PlaceInfo with its setters
+export interface PlaceInfoWrapper {
   value: PlaceInfo;
 
   set: Setter<PlaceInfo>;
@@ -57,12 +68,16 @@ interface PlaceInfoWrapper {
   setEnclosedPlaces: Setter<Array<string>>;
 }
 
-interface IsLoading {
+// Information relating to things loading
+export interface IsLoading {
+  // Whether geojson and stat var data are being retrieved for plotting
   isDataLoading: boolean;
+  // Whether child places are being retrieved
   isPlaceInfoLoading: boolean;
 }
 
-interface IsLoadingWrapper {
+// Wraps IsLoading with its setters
+export interface IsLoadingWrapper {
   value: IsLoading;
 
   set: Setter<IsLoading>;
@@ -70,15 +85,15 @@ interface IsLoadingWrapper {
   setIsPlaceInfoLoading: Setter<boolean>;
 }
 
-interface ContextType {
+export interface ContextType {
   statVarInfo: StatVarInfoWrapper;
   placeInfo: PlaceInfoWrapper;
   isLoading: IsLoadingWrapper;
 }
 
-const Context = createContext({} as ContextType);
+export const Context = createContext({} as ContextType);
 
-function getInitialContext(params: URLSearchParams): ContextType {
+export function getInitialContext(params: URLSearchParams): ContextType {
   const [statVarInfo, setStatVarInfo] = useState(applyHashStatVarInfo(params));
   const [placeInfo, setPlaceInfo] = useState(applyHashPlaceInfo(params));
   const [isLoading, setIsLoading] = useState({
@@ -119,15 +134,3 @@ function getInitialContext(params: URLSearchParams): ContextType {
     },
   };
 }
-
-export {
-  Context,
-  getInitialContext,
-  ContextType,
-  StatVarInfo,
-  StatVarInfoWrapper,
-  PlaceInfo,
-  PlaceInfoWrapper,
-  IsLoading,
-  IsLoadingWrapper,
-};

--- a/static/js/tools/map/map.ts
+++ b/static/js/tools/map/map.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { AppWithContext } from "./app";
+
+window.onload = () => {
+  ReactDOM.render(
+    React.createElement(AppWithContext),
+    document.getElementById("main-pane")
+  );
+};

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -97,7 +97,7 @@ export function PlaceOptions(): JSX.Element {
 function selectEnclosedPlaceType(
   placeInfo: PlaceInfoWrapper,
   event: React.ChangeEvent<HTMLInputElement>
-) {
+): void {
   placeInfo.setEnclosedPlaceType(event.target.value);
 }
 
@@ -106,7 +106,7 @@ function selectEnclosedPlaceType(
  * @param place
  * @param dcid
  */
-function selectEnclosingPlace(place: PlaceInfoWrapper, dcid: string) {
+function selectEnclosingPlace(place: PlaceInfoWrapper, dcid: string): void {
   axios.get(`/api/place/name?dcid=${dcid}`).then((resp) => {
     place.setEnclosingPlace({ dcid: dcid, name: resp.data[dcid] });
   });
@@ -119,7 +119,7 @@ function selectEnclosingPlace(place: PlaceInfoWrapper, dcid: string) {
 function unselectEnclosingPlace(
   place: PlaceInfoWrapper,
   setEnclosedPlaceTypes: (placeTypes: string[]) => void
-) {
+): void {
   place.setEnclosingPlace({ dcid: "", name: "" });
   setEnclosedPlaceTypes([]);
 }
@@ -127,7 +127,7 @@ function unselectEnclosingPlace(
 function updateEnclosedPlaceTypes(
   dcid: string,
   setEnclosedPlaceTypes: (placeTypes: string[]) => void
-) {
+): void {
   const parentPlacePromise = axios
     .get(`/api/place/parent/${dcid}`)
     .then((resp) => resp.data);

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -107,9 +107,14 @@ function selectEnclosedPlaceType(
  * @param dcid
  */
 function selectEnclosingPlace(place: PlaceInfoWrapper, dcid: string): void {
-  axios.get(`/api/place/name?dcid=${dcid}`).then((resp) => {
-    place.setEnclosingPlace({ dcid: dcid, name: resp.data[dcid] });
-  });
+  axios
+    .get(`/api/place/name?dcid=${dcid}`)
+    .then((resp) => {
+      place.setEnclosingPlace({ dcid: dcid, name: resp.data[dcid] });
+    })
+    .catch(() => {
+      place.setEnclosingPlace({ dcid: dcid, name: dcid });
+    });
 }
 
 /**

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Place options for selecting the enclosing place and enclosed place type.
+ */
+
+import React, { useContext, useEffect, useState } from "react";
+import _ from "lodash";
+import axios from "axios";
+import { Card, Container, CustomInput } from "reactstrap";
+import { Context, IsLoadingWrapper, PlaceInfoWrapper } from "./context";
+import { SearchBar } from "../timeline/search";
+import { USA_CHILD_PLACE_TYPES } from "./util";
+
+export function PlaceOptions(): JSX.Element {
+  const { placeInfo, isLoading } = useContext(Context);
+  const [enclosedPlaceTypes, setEnclosedPlaceTypes] = useState([]);
+  if (placeInfo.value.enclosingPlace.dcid && _.isEmpty(enclosedPlaceTypes)) {
+    updateEnclosedPlaceTypes(
+      placeInfo.value.enclosingPlace.dcid,
+      setEnclosedPlaceTypes
+    );
+  }
+  useEffect(() => {
+    const placeInfoVal = placeInfo.value;
+    if (
+      placeInfoVal.enclosingPlace.dcid &&
+      placeInfoVal.enclosedPlaceType &&
+      _.isEmpty(placeInfoVal.enclosedPlaces)
+    ) {
+      loadEnclosedPlaces(placeInfo, isLoading);
+    }
+  }, [placeInfo.value]);
+  return (
+    <Card className="place-options-card">
+      <Container className="place-options">
+        <div className="place-options-section" id="place-search-section">
+          <div className="place-options-label">Plot places in</div>
+          <div id="search">
+            <SearchBar
+              places={
+                placeInfo.value.enclosingPlace.dcid
+                  ? {
+                      [placeInfo.value.enclosingPlace.dcid]:
+                        placeInfo.value.enclosingPlace.name,
+                    }
+                  : {}
+              }
+              addPlace={(e) => selectEnclosingPlace(placeInfo, e)}
+              removePlace={() =>
+                unselectEnclosingPlace(placeInfo, setEnclosedPlaceTypes)
+              }
+              numPlacesLimit={1}
+              countryRestrictions={["us"]}
+              customPlaceHolder={"Enter a country or state to get started"}
+            />
+          </div>
+        </div>
+        <div className="place-options-section">
+          <div className="place-options-label">of type</div>
+          <div>
+            <CustomInput
+              id="enclosed-place-type"
+              type="select"
+              value={placeInfo.value.enclosedPlaceType}
+              onChange={(e) => selectEnclosedPlaceType(placeInfo, e)}
+              className="pac-target-input"
+            >
+              <option value="">Select a place type</option>
+              {enclosedPlaceTypes.map((type) => (
+                <option value={type} key={type}>
+                  {type}
+                </option>
+              ))}
+            </CustomInput>
+          </div>
+        </div>
+      </Container>
+    </Card>
+  );
+}
+
+function selectEnclosedPlaceType(
+  placeInfo: PlaceInfoWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+) {
+  placeInfo.setEnclosedPlaceType(event.target.value);
+}
+
+/**
+ * Selects the enclosing place.
+ * @param place
+ * @param dcid
+ */
+function selectEnclosingPlace(place: PlaceInfoWrapper, dcid: string) {
+  axios.get(`/api/place/name?dcid=${dcid}`).then((resp) => {
+    place.setEnclosingPlace({ dcid: dcid, name: resp.data[dcid] });
+  });
+}
+
+/**
+ * Removes the enclosing place
+ * @param place
+ */
+function unselectEnclosingPlace(
+  place: PlaceInfoWrapper,
+  setEnclosedPlaceTypes: (placeTypes: string[]) => void
+) {
+  place.setEnclosingPlace({ dcid: "", name: "" });
+  setEnclosedPlaceTypes([]);
+}
+
+function updateEnclosedPlaceTypes(
+  dcid: string,
+  setEnclosedPlaceTypes: (placeTypes: string[]) => void
+) {
+  const parentPlacePromise = axios
+    .get(`/api/place/parent/${dcid}`)
+    .then((resp) => resp.data);
+  const placeTypePromise = axios
+    .get(`/api/place/type/${dcid}`)
+    .then((resp) => resp.data);
+  Promise.all([parentPlacePromise, placeTypePromise])
+    .then(([parents, placeType]) => {
+      const isUSPlace =
+        dcid === "country/USA" ||
+        parents.findIndex((parent) => parent.dcid === "country/USA") > -1;
+      if (isUSPlace) {
+        if (placeType in USA_CHILD_PLACE_TYPES) {
+          setEnclosedPlaceTypes(USA_CHILD_PLACE_TYPES[placeType]);
+        }
+      } else {
+        setEnclosedPlaceTypes([]);
+      }
+    })
+    .catch(() => {
+      setEnclosedPlaceTypes([]);
+    });
+}
+
+function loadEnclosedPlaces(
+  place: PlaceInfoWrapper,
+  isLoading: IsLoadingWrapper
+): void {
+  const placeDcid = place.value.enclosingPlace.dcid;
+  const enclosedPlaceType = place.value.enclosedPlaceType;
+  isLoading.setIsPlaceInfoLoading(true);
+  axios
+    .get(
+      `/api/place/places-in?dcid=${placeDcid}&placeType=${enclosedPlaceType}`
+    )
+    .then((resp) => {
+      const enclosedPlaces = resp.data[placeDcid];
+      isLoading.setIsPlaceInfoLoading(false);
+      if (!_.isEmpty(enclosedPlaces)) {
+        place.setEnclosedPlaces(enclosedPlaces);
+      } else {
+        alert(
+          `Sorry, ${place.value.enclosingPlace.name} does not contain places of type ` +
+            `${enclosedPlaceType}. Try picking another type or place.`
+        );
+      }
+    })
+    .catch(() => {
+      isLoading.setIsPlaceInfoLoading(false);
+      alert(
+        `Error fetching places of type ${enclosedPlaceType} for ${place.value.enclosingPlace.name}.`
+      );
+    });
+}

--- a/static/js/tools/map/util.test.ts
+++ b/static/js/tools/map/util.test.ts
@@ -23,35 +23,35 @@ import {
 } from "./util";
 
 const TestContext = ({
+  placeInfo: {
+    value: {
+      enclosingPlace: {
+        dcid: "geoId/10",
+        name: "Delaware",
+      },
+      enclosedPlaceType: "County",
+      enclosedPlaces: [
+        {
+          dcid: "geoId/10003",
+          name: "a county",
+        },
+        {
+          dcid: "geoId/10005",
+          name: "another county",
+        },
+      ],
+    },
+  },
   statVarInfo: {
     value: {
+      name: "People",
+      perCapita: false,
       statVar: {
         Count_Person: {
           denominators: [],
           paths: [],
         },
       },
-      name: "People",
-      perCapita: false,
-    },
-  },
-  placeInfo: {
-    value: {
-      enclosingPlace: {
-        name: "Delaware",
-        dcid: "geoId/10",
-      },
-      enclosedPlaceType: "County",
-      enclosedPlaces: [
-        {
-          name: "a county",
-          dcid: "geoId/10003",
-        },
-        {
-          name: "another county",
-          dcid: "geoId/10005",
-        },
-      ],
     },
   },
 } as unknown) as ContextType;

--- a/static/js/tools/map/util.test.ts
+++ b/static/js/tools/map/util.test.ts
@@ -66,7 +66,7 @@ test("updateHashPlaceInfo", () => {
 test("updateHashStatVarInfo", () => {
   history.pushState = jest.fn();
   const resultHash = updateHashStatVarInfo("", TestContext.statVarInfo.value);
-  const expectedHash = "&sv=Count_Person&svn=People&pc=0";
+  const expectedHash = "&sv=Count_Person&svp=&svd=&svn=People&pc=0";
   expect(resultHash).toEqual(expectedHash);
 });
 

--- a/static/js/tools/map/util.test.ts
+++ b/static/js/tools/map/util.test.ts
@@ -1,0 +1,98 @@
+import { ContextType } from "./context";
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  updateHashPlaceInfo,
+  updateHashStatVarInfo,
+  applyHashPlaceInfo,
+  applyHashStatVarInfo,
+} from "./util";
+
+const TestContext = ({
+  statVarInfo: {
+    value: {
+      statVar: {
+        Count_Person: {
+          denominators: [],
+          paths: [],
+        },
+      },
+      name: "People",
+      perCapita: false,
+    },
+  },
+  placeInfo: {
+    value: {
+      enclosingPlace: {
+        name: "Delaware",
+        dcid: "geoId/10",
+      },
+      enclosedPlaceType: "County",
+      enclosedPlaces: [
+        {
+          name: "a county",
+          dcid: "geoId/10003",
+        },
+        {
+          name: "another county",
+          dcid: "geoId/10005",
+        },
+      ],
+    },
+  },
+} as unknown) as ContextType;
+
+test("updateHashPlaceInfo", () => {
+  history.pushState = jest.fn();
+  const resultHash = updateHashPlaceInfo("", TestContext.placeInfo.value);
+  const expectedHash = "&pd=geoId/10&pn=Delaware&pt=County";
+  expect(resultHash).toEqual(expectedHash);
+});
+
+test("updateHashStatVarInfo", () => {
+  history.pushState = jest.fn();
+  const resultHash = updateHashStatVarInfo("", TestContext.statVarInfo.value);
+  const expectedHash = "&sv=Count_Person&svn=People&pc=0";
+  expect(resultHash).toEqual(expectedHash);
+});
+
+test("applyHashPlaceInfo", () => {
+  const context = { statVarInfo: {}, placeInfo: {} } as ContextType;
+  context.placeInfo.set = (value) => (context.placeInfo.value = value);
+  const urlParams = new URLSearchParams(
+    decodeURIComponent(
+      "#%26sv%3DCount_Person%26svn%3DPeople%26pc%3D0%26pd%3DgeoId%2F10%26pn%3DDelaware%26pt%3DCounty"
+    ).replace("#", "?")
+  );
+  const placeInfo = applyHashPlaceInfo(urlParams);
+  expect(placeInfo).toEqual({
+    ...TestContext.placeInfo.value,
+    enclosedPlaces: [],
+  });
+});
+
+test("applyHashPlaceInfo", () => {
+  const context = { statVarInfo: {}, placeInfo: {} } as ContextType;
+  context.statVarInfo.set = (value) => (context.statVarInfo.value = value);
+  const urlParams = new URLSearchParams(
+    decodeURIComponent(
+      "#%26sv%3DCount_Person%26svn%3DPeople%26pc%3D0%26pd%3DgeoId%2F10%26pn%3DDelaware%26pt%3DCounty"
+    ).replace("#", "?")
+  );
+  const statVarInfo = applyHashStatVarInfo(urlParams);
+  expect(statVarInfo).toEqual(TestContext.statVarInfo.value);
+});

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -25,43 +25,37 @@ import _ from "lodash";
 const USA_STATE_CHILD_TYPES = ["County"];
 const USA_COUNTRY_CHILD_TYPES = ["State", ...USA_STATE_CHILD_TYPES];
 
-const USA_CHILD_PLACE_TYPES = {
+export const USA_CHILD_PLACE_TYPES = {
   Country: USA_COUNTRY_CHILD_TYPES,
   State: USA_STATE_CHILD_TYPES,
 };
 
-const URLParamKeys = {
-  enclosedPlaceType: "pt",
-  enclosingPlaceDcid: "pd",
-  enclosingPlaceName: "pn",
-  perCapita: "pc",
-  statVarDcid: "sv",
-  statVarDenominator: "svd",
-  statVarName: "svn",
-  statVarPath: "svp",
+const URL_PARAM_KEYS = {
+  ENCLOSED_PLACE_TYPE: "pt",
+  ENCLOSING_PLACE_DCID: "pd",
+  ENLCOSING_PLACE_NAME: "pn",
+  PER_CAPITA: "pc",
+  STAT_VAR_DCID: "sv",
+  STAT_VAR_DENOM: "svd",
+  STAT_VAR_NAME: "svn",
+  STAT_VAR_PATH: "svp",
 };
 
-function applyHashStatVarInfo(params: URLSearchParams): StatVarInfo {
-  const dcid = params.get(URLParamKeys.statVarDcid);
+export function applyHashStatVarInfo(params: URLSearchParams): StatVarInfo {
+  const dcid = params.get(URL_PARAM_KEYS.STAT_VAR_DCID);
   if (!dcid) {
     return { name: "", perCapita: false, statVar: {} };
   }
+  const path = params.get(URL_PARAM_KEYS.STAT_VAR_PATH);
+  const denominator = params.get(URL_PARAM_KEYS.STAT_VAR_DENOM);
   const statVarNode: StatsVarNode = {
     [dcid]: {
-      denominators: [],
-      paths: [],
+      denominators: denominator ? [denominator] : [],
+      paths: path ? [path.split("-")] : [],
     },
   };
-  const path = params.get(URLParamKeys.statVarPath);
-  if (path) {
-    statVarNode[dcid].paths = [path.split("-")];
-  }
-  const denominator = params.get(URLParamKeys.statVarDenominator);
-  if (denominator) {
-    statVarNode[dcid].denominators = [denominator];
-  }
-  const statVarName = params.get(URLParamKeys.statVarName);
-  const perCapita = params.get(URLParamKeys.perCapita);
+  const statVarName = params.get(URL_PARAM_KEYS.STAT_VAR_NAME);
+  const perCapita = params.get(URL_PARAM_KEYS.PER_CAPITA);
   return {
     name: statVarName ? statVarName : dcid,
     perCapita: perCapita && perCapita === "1" ? true : false,
@@ -69,10 +63,10 @@ function applyHashStatVarInfo(params: URLSearchParams): StatVarInfo {
   };
 }
 
-function applyHashPlaceInfo(params: URLSearchParams): PlaceInfo {
-  const enclosingPlaceDcid = params.get(URLParamKeys.enclosingPlaceDcid);
-  const enclosingPlaceName = params.get(URLParamKeys.enclosingPlaceName);
-  const enclosedPlaceType = params.get(URLParamKeys.enclosedPlaceType);
+export function applyHashPlaceInfo(params: URLSearchParams): PlaceInfo {
+  const enclosingPlaceDcid = params.get(URL_PARAM_KEYS.ENCLOSING_PLACE_DCID);
+  const enclosingPlaceName = params.get(URL_PARAM_KEYS.ENLCOSING_PLACE_NAME);
+  const enclosedPlaceType = params.get(URL_PARAM_KEYS.ENCLOSED_PLACE_TYPE);
   return {
     enclosingPlace: {
       dcid: enclosingPlaceDcid ? enclosingPlaceDcid : "",
@@ -83,46 +77,46 @@ function applyHashPlaceInfo(params: URLSearchParams): PlaceInfo {
   };
 }
 
-function updateHashStatVarInfo(hash: string, statVarInfo: StatVarInfo): string {
+export function updateHashStatVarInfo(
+  hash: string,
+  statVarInfo: StatVarInfo
+): string {
   if (_.isEmpty(statVarInfo.statVar)) {
     return hash;
   }
   const statVarDcid = _.findKey(statVarInfo.statVar);
   if (statVarDcid) {
-    hash = `${hash}&${URLParamKeys.statVarDcid}=${statVarDcid}`;
     const node = statVarInfo.statVar[statVarDcid];
-    if (!_.isEmpty(node.paths)) {
-      hash = `${hash}&${URLParamKeys.statVarPath}=${node.paths[0].join("-")}`;
+    const paramMapping = {
+      [URL_PARAM_KEYS.STAT_VAR_DCID]: statVarDcid,
+      [URL_PARAM_KEYS.STAT_VAR_PATH]: !_.isEmpty(node.paths)
+        ? node.paths[0].join("-")
+        : "",
+      [URL_PARAM_KEYS.STAT_VAR_DENOM]: !_.isEmpty(node.denominators)
+        ? node.denominators[0]
+        : "",
+      [URL_PARAM_KEYS.STAT_VAR_NAME]: statVarInfo.name,
+      [URL_PARAM_KEYS.PER_CAPITA]: statVarInfo.perCapita ? "1" : "0",
+    };
+    let param = "";
+    for (const paramKey in paramMapping) {
+      param += `&${paramKey}=${paramMapping[paramKey]}`;
     }
-    if (!_.isEmpty(node.denominators)) {
-      hash = `${hash}&${URLParamKeys.statVarDenominator}=${node.denominators[0]}`;
-    }
-    if (!_.isEmpty(statVarInfo.name)) {
-      hash = `${hash}&${URLParamKeys.statVarName}=${statVarInfo.name}`;
-    }
-    hash = `${hash}&${URLParamKeys.perCapita}=${
-      statVarInfo.perCapita ? "1" : "0"
-    }`;
+    return hash + param;
   }
   return hash;
 }
 
-function updateHashPlaceInfo(hash: string, placeInfo: PlaceInfo): string {
+export function updateHashPlaceInfo(
+  hash: string,
+  placeInfo: PlaceInfo
+): string {
   if (_.isEmpty(placeInfo.enclosingPlace.dcid)) {
     return hash;
   }
-  hash = `${hash}&${URLParamKeys.enclosingPlaceDcid}=${placeInfo.enclosingPlace.dcid}`;
-  hash = `${hash}&${URLParamKeys.enclosingPlaceName}=${placeInfo.enclosingPlace.name}`;
+  let params = `&${URL_PARAM_KEYS.ENCLOSING_PLACE_DCID}=${placeInfo.enclosingPlace.dcid}&${URL_PARAM_KEYS.ENLCOSING_PLACE_NAME}=${placeInfo.enclosingPlace.name}`;
   if (!_.isEmpty(placeInfo.enclosedPlaceType)) {
-    hash = `${hash}&${URLParamKeys.enclosedPlaceType}=${placeInfo.enclosedPlaceType}`;
+    params = `${params}&${URL_PARAM_KEYS.ENCLOSED_PLACE_TYPE}=${placeInfo.enclosedPlaceType}`;
   }
-  return hash;
+  return hash + params;
 }
-
-export {
-  applyHashStatVarInfo,
-  applyHashPlaceInfo,
-  updateHashStatVarInfo,
-  updateHashPlaceInfo,
-  USA_CHILD_PLACE_TYPES,
-};

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility functions shared across different components of map explorer.
+ */
+
+import { StatVarInfo, PlaceInfo } from "./context";
+import { StatsVarNode } from "../statvar_menu/util";
+import _ from "lodash";
+
+const USA_STATE_CHILD_TYPES = ["County"];
+const USA_COUNTRY_CHILD_TYPES = ["State", ...USA_STATE_CHILD_TYPES];
+
+const USA_CHILD_PLACE_TYPES = {
+  Country: USA_COUNTRY_CHILD_TYPES,
+  State: USA_STATE_CHILD_TYPES,
+};
+
+const URLParamKeys = {
+  statVarDcid: "sv",
+  statVarPath: "svp",
+  statVarDenominator: "svd",
+  statVarName: "svn",
+  perCapita: "pc",
+  enclosingPlaceName: "pn",
+  enclosingPlaceDcid: "pd",
+  enclosedPlaceType: "pt",
+};
+
+function applyHashStatVarInfo(params: URLSearchParams): StatVarInfo {
+  const dcid = params.get(URLParamKeys.statVarDcid);
+  if (!dcid) {
+    return { statVar: {}, name: "", perCapita: false };
+  }
+  const statVarNode: StatsVarNode = {
+    [dcid]: {
+      paths: [],
+      denominators: [],
+    },
+  };
+  const path = params.get(URLParamKeys.statVarPath);
+  if (path) {
+    statVarNode[dcid].paths = [path.split("-")];
+  }
+  const denominator = params.get(URLParamKeys.statVarDenominator);
+  if (denominator) {
+    statVarNode[dcid].denominators = [denominator];
+  }
+  const statVarName = params.get(URLParamKeys.statVarName);
+  const perCapita = params.get(URLParamKeys.perCapita);
+  return {
+    statVar: statVarNode,
+    name: statVarName ? statVarName : dcid,
+    perCapita: perCapita && perCapita === "1" ? true : false,
+  };
+}
+
+function applyHashPlaceInfo(params: URLSearchParams): PlaceInfo {
+  const enclosingPlaceDcid = params.get(URLParamKeys.enclosingPlaceDcid);
+  const enclosingPlaceName = params.get(URLParamKeys.enclosingPlaceName);
+  const enclosedPlaceType = params.get(URLParamKeys.enclosedPlaceType);
+  return {
+    enclosingPlace: {
+      dcid: enclosingPlaceDcid ? enclosingPlaceDcid : "",
+      name: enclosingPlaceName ? enclosingPlaceName : "",
+    },
+    enclosedPlaceType: enclosedPlaceType ? enclosedPlaceType : "",
+    enclosedPlaces: [],
+  };
+}
+
+function updateHashStatVarInfo(hash: string, statVarInfo: StatVarInfo): string {
+  if (_.isEmpty(statVarInfo.statVar)) {
+    return hash;
+  }
+  const statVarDcid = _.findKey(statVarInfo.statVar);
+  if (statVarDcid) {
+    hash = `${hash}&${URLParamKeys.statVarDcid}=${statVarDcid}`;
+    const node = statVarInfo.statVar[statVarDcid];
+    if (!_.isEmpty(node.paths)) {
+      hash = `${hash}&${URLParamKeys.statVarPath}=${node.paths[0].join("-")}`;
+    }
+    if (!_.isEmpty(node.denominators)) {
+      hash = `${hash}&${URLParamKeys.statVarDenominator}=${node.denominators[0]}`;
+    }
+    if (!_.isEmpty(statVarInfo.name)) {
+      hash = `${hash}&${URLParamKeys.statVarName}=${statVarInfo.name}`;
+    }
+    hash = `${hash}&${URLParamKeys.perCapita}=${
+      statVarInfo.perCapita ? "1" : "0"
+    }`;
+  }
+  return hash;
+}
+
+function updateHashPlaceInfo(hash: string, placeInfo: PlaceInfo): string {
+  if (_.isEmpty(placeInfo.enclosingPlace.dcid)) {
+    return hash;
+  }
+  hash = `${hash}&${URLParamKeys.enclosingPlaceDcid}=${placeInfo.enclosingPlace.dcid}`;
+  hash = `${hash}&${URLParamKeys.enclosingPlaceName}=${placeInfo.enclosingPlace.name}`;
+  if (!_.isEmpty(placeInfo.enclosedPlaceType)) {
+    hash = `${hash}&${URLParamKeys.enclosedPlaceType}=${placeInfo.enclosedPlaceType}`;
+  }
+  return hash;
+}
+
+export {
+  applyHashStatVarInfo,
+  applyHashPlaceInfo,
+  updateHashStatVarInfo,
+  updateHashPlaceInfo,
+  USA_CHILD_PLACE_TYPES,
+};

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -31,25 +31,25 @@ const USA_CHILD_PLACE_TYPES = {
 };
 
 const URLParamKeys = {
+  enclosedPlaceType: "pt",
+  enclosingPlaceDcid: "pd",
+  enclosingPlaceName: "pn",
+  perCapita: "pc",
   statVarDcid: "sv",
-  statVarPath: "svp",
   statVarDenominator: "svd",
   statVarName: "svn",
-  perCapita: "pc",
-  enclosingPlaceName: "pn",
-  enclosingPlaceDcid: "pd",
-  enclosedPlaceType: "pt",
+  statVarPath: "svp",
 };
 
 function applyHashStatVarInfo(params: URLSearchParams): StatVarInfo {
   const dcid = params.get(URLParamKeys.statVarDcid);
   if (!dcid) {
-    return { statVar: {}, name: "", perCapita: false };
+    return { name: "", perCapita: false, statVar: {} };
   }
   const statVarNode: StatsVarNode = {
     [dcid]: {
-      paths: [],
       denominators: [],
+      paths: [],
     },
   };
   const path = params.get(URLParamKeys.statVarPath);
@@ -63,9 +63,9 @@ function applyHashStatVarInfo(params: URLSearchParams): StatVarInfo {
   const statVarName = params.get(URLParamKeys.statVarName);
   const perCapita = params.get(URLParamKeys.perCapita);
   return {
-    statVar: statVarNode,
     name: statVarName ? statVarName : dcid,
     perCapita: perCapita && perCapita === "1" ? true : false,
+    statVar: statVarNode,
   };
 }
 
@@ -78,8 +78,8 @@ function applyHashPlaceInfo(params: URLSearchParams): PlaceInfo {
       dcid: enclosingPlaceDcid ? enclosingPlaceDcid : "",
       name: enclosingPlaceName ? enclosingPlaceName : "",
     },
-    enclosedPlaceType: enclosedPlaceType ? enclosedPlaceType : "",
     enclosedPlaces: [],
+    enclosedPlaceType: enclosedPlaceType ? enclosedPlaceType : "",
   };
 }
 

--- a/static/js/tools/scatter/chart_loader.tsx
+++ b/static/js/tools/scatter/chart_loader.tsx
@@ -25,11 +25,10 @@ import axios from "axios";
 import { saveToFile } from "../../shared/util";
 import {
   getPopulationDate,
-  getStatsWithinPlace,
-  nodeGetStatVar,
   PlacePointStat,
   SourceSeries,
-} from "./util";
+} from "../shared_util";
+import { getStatsWithinPlace, nodeGetStatVar } from "./util";
 import { Chart } from "./chart";
 import {
   Context,

--- a/static/js/tools/scatter/util.test.ts
+++ b/static/js/tools/scatter/util.test.ts
@@ -15,7 +15,7 @@ import { ContextType } from "./context";
  * limitations under the License.
  */
 
-import { updateHash, applyHash, getPopulationDate } from "./util";
+import { updateHash, applyHash } from "./util";
 
 const TestContext = ({
   x: {
@@ -102,88 +102,4 @@ test("applyHash", () => {
     ...TestContext.place.value,
     enclosedPlaces: [],
   });
-});
-
-test("getPopulationDate", () => {
-  const basePopData = {
-    data: {
-      "2017": 1,
-      "2018": 2,
-      "2020": 3,
-    },
-    placeName: "geoId/06",
-    provenanceUrl: "provenance",
-  };
-  const baseStatData = {
-    date: "2018",
-    value: 10,
-    metadata: {
-      importName: "importName",
-    },
-  };
-  expect(getPopulationDate(basePopData, baseStatData)).toEqual("2018");
-
-  const statDataDateEarlierThanPopData = {
-    ...baseStatData,
-    date: "2016",
-  };
-  expect(
-    getPopulationDate(basePopData, statDataDateEarlierThanPopData)
-  ).toEqual("2017");
-
-  const statDataDateLaterThanPopData = {
-    ...baseStatData,
-    date: "2021",
-  };
-  expect(getPopulationDate(basePopData, statDataDateLaterThanPopData)).toEqual(
-    "2020"
-  );
-
-  const statDataNoMatchingDate = {
-    ...baseStatData,
-    date: "2019",
-  };
-  expect(getPopulationDate(basePopData, statDataNoMatchingDate)).toEqual(
-    "2018"
-  );
-
-  const statDataDateMoreSpecific = {
-    ...baseStatData,
-    date: "2018-07",
-  };
-  expect(getPopulationDate(basePopData, statDataDateMoreSpecific)).toEqual(
-    "2018"
-  );
-
-  const statDataDateMoreSpecificNoMatching = {
-    ...baseStatData,
-    date: "2019-07",
-  };
-  expect(
-    getPopulationDate(basePopData, statDataDateMoreSpecificNoMatching)
-  ).toEqual("2018");
-
-  const popDataDateMoreSpecific = {
-    ...basePopData,
-    data: {
-      "2018-02": 1,
-      "2018-03": 2,
-      "2018-04": 3,
-    },
-  };
-  expect(getPopulationDate(popDataDateMoreSpecific, baseStatData)).toEqual(
-    "2018-04"
-  );
-
-  const popDataDateMoreSpecificNoMatching = {
-    ...basePopData,
-    data: {
-      "2019-02": 1,
-      "2019-03": 2,
-      "2019-04": 3,
-    },
-  };
-  expect(
-    getPopulationDate(popDataDateMoreSpecificNoMatching, baseStatData)
-  ).toEqual("2019-02");
 });

--- a/static/js/tools/scatter/util.ts
+++ b/static/js/tools/scatter/util.ts
@@ -20,7 +20,6 @@
 
 import axios from "axios";
 import _ from "lodash";
-import * as d3 from "d3";
 import { StatsVarNode } from "../statvar_menu/util";
 import {
   ContextType,
@@ -30,28 +29,7 @@ import {
   EmptyPlace,
   FieldToAbbreviation,
 } from "./context";
-
-interface PlacePointStatMetadata {
-  provenanceUrl: string;
-  measurementMethod: string;
-  unit?: string;
-}
-
-interface PlacePointStatData {
-  date: string;
-  value: number;
-  metadata: { importName: string };
-}
-interface PlacePointStat {
-  metadata: { [importName: string]: PlacePointStatMetadata };
-  stat: { [dcid: string]: PlacePointStatData };
-}
-
-interface SourceSeries {
-  data: { [date: string]: number };
-  placeName: string;
-  provenanceUrl: string;
-}
+import { PlacePointStat } from "../shared_util";
 
 async function getPlacesInNames(
   dcid: string,
@@ -280,46 +258,10 @@ function updateHashPlace(hash: string, place: PlaceInfo): string {
   return hash;
 }
 
-/**
- * Helper function to choose the date to use for the population data.
- * @param popData
- * @param statData
- */
-function getPopulationDate(
-  popData: SourceSeries,
-  statData: PlacePointStatData
-): string {
-  const xPopDataDates = Object.keys(popData.data);
-  let popDate = xPopDataDates.find((date) => date === statData.date);
-  if (!popDate && !_.isEmpty(xPopDataDates)) {
-    // Filter for all population dates encompassed by the stat var date.
-    // ie. if stat var date is year, filter for all population dates with
-    // the same year
-    const encompassedPopDates = xPopDataDates.filter((date) => {
-      return date.includes(statData.date);
-    });
-    if (encompassedPopDates.length > 0) {
-      // when there are multiple population dates encompassed by the stat var
-      // date, choose the latest date
-      popDate = encompassedPopDates[encompassedPopDates.length - 1];
-    } else {
-      // From ordered list of population dates, choose the date immediately
-      // before the stat var date (if there is a date that encompasses the stat
-      // var date, this will get chosen). If none, return the first pop date.
-      const idx = d3.bisect(xPopDataDates, statData.date);
-      popDate = idx > 0 ? xPopDataDates[idx - 1] : xPopDataDates[0];
-    }
-  }
-  return popDate;
-}
-
 export {
   getPlacesInNames,
   getStatsWithinPlace,
   nodeGetStatVar,
   updateHash,
   applyHash,
-  getPopulationDate,
-  PlacePointStat,
-  SourceSeries,
 };

--- a/static/js/tools/shared_util.test.ts
+++ b/static/js/tools/shared_util.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getPopulationDate } from "./shared_util";
+
+test("getPopulationDate", () => {
+  const basePopData = {
+    data: {
+      "2017": 1,
+      "2018": 2,
+      "2020": 3,
+    },
+    placeName: "geoId/06",
+    provenanceUrl: "provenance",
+  };
+  const baseStatData = {
+    date: "2018",
+    value: 10,
+    metadata: {
+      importName: "importName",
+    },
+  };
+  expect(getPopulationDate(basePopData, baseStatData)).toEqual("2018");
+
+  const statDataDateEarlierThanPopData = {
+    ...baseStatData,
+    date: "2016",
+  };
+  expect(
+    getPopulationDate(basePopData, statDataDateEarlierThanPopData)
+  ).toEqual("2017");
+
+  const statDataDateLaterThanPopData = {
+    ...baseStatData,
+    date: "2021",
+  };
+  expect(getPopulationDate(basePopData, statDataDateLaterThanPopData)).toEqual(
+    "2020"
+  );
+
+  const statDataNoMatchingDate = {
+    ...baseStatData,
+    date: "2019",
+  };
+  expect(getPopulationDate(basePopData, statDataNoMatchingDate)).toEqual(
+    "2018"
+  );
+
+  const statDataDateMoreSpecific = {
+    ...baseStatData,
+    date: "2018-07",
+  };
+  expect(getPopulationDate(basePopData, statDataDateMoreSpecific)).toEqual(
+    "2018"
+  );
+
+  const statDataDateMoreSpecificNoMatching = {
+    ...baseStatData,
+    date: "2019-07",
+  };
+  expect(
+    getPopulationDate(basePopData, statDataDateMoreSpecificNoMatching)
+  ).toEqual("2018");
+
+  const popDataDateMoreSpecific = {
+    ...basePopData,
+    data: {
+      "2018-02": 1,
+      "2018-03": 2,
+      "2018-04": 3,
+    },
+  };
+  expect(getPopulationDate(popDataDateMoreSpecific, baseStatData)).toEqual(
+    "2018-04"
+  );
+
+  const popDataDateMoreSpecificNoMatching = {
+    ...basePopData,
+    data: {
+      "2019-02": 1,
+      "2019-03": 2,
+      "2019-04": 3,
+    },
+  };
+  expect(
+    getPopulationDate(popDataDateMoreSpecificNoMatching, baseStatData)
+  ).toEqual("2019-02");
+});

--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as d3 from "d3";
+import _ from "lodash";
+
+/**
+ * Functions and interfaces shared between tools components
+ */
+
+interface PlacePointStatMetadata {
+  provenanceUrl: string;
+  measurementMethod: string;
+  unit?: string;
+}
+
+interface PlacePointStatData {
+  date: string;
+  value: number;
+  metadata: { importName: string };
+}
+interface PlacePointStat {
+  metadata: { [importName: string]: PlacePointStatMetadata };
+  stat: { [dcid: string]: PlacePointStatData };
+}
+
+interface SourceSeries {
+  data: { [date: string]: number };
+  placeName: string;
+  provenanceUrl: string;
+}
+
+/**
+ * Helper function to choose the date to use for population data.
+ * @param popData
+ * @param statData
+ */
+function getPopulationDate(
+  popData: SourceSeries,
+  statData: PlacePointStatData
+): string {
+  const xPopDataDates = Object.keys(popData.data);
+  let popDate = xPopDataDates.find((date) => date === statData.date);
+  if (!popDate && !_.isEmpty(xPopDataDates)) {
+    // Filter for all population dates encompassed by the stat var date.
+    // ie. if stat var date is year, filter for all population dates with
+    // the same year
+    const encompassedPopDates = xPopDataDates.filter((date) => {
+      return date.includes(statData.date);
+    });
+    if (encompassedPopDates.length > 0) {
+      // when there are multiple population dates encompassed by the stat var
+      // date, choose the latest date
+      popDate = encompassedPopDates[encompassedPopDates.length - 1];
+    } else {
+      // From ordered list of population dates, choose the date immediately
+      // before the stat var date (if there is a date that encompasses the stat
+      // var date, this will get chosen). If none, return the first pop date.
+      const idx = d3.bisect(xPopDataDates, statData.date);
+      popDate = idx > 0 ? xPopDataDates[idx - 1] : xPopDataDates[0];
+    }
+  }
+  return popDate;
+}
+
+export { getPopulationDate, PlacePointStat, SourceSeries, PlacePointStatData };

--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -26,17 +26,17 @@ interface PlacePointStatMetadata {
   unit?: string;
 }
 
-interface PlacePointStatData {
+export interface PlacePointStatData {
   date: string;
   value: number;
   metadata: { importName: string };
 }
-interface PlacePointStat {
+export interface PlacePointStat {
   metadata: { [importName: string]: PlacePointStatMetadata };
   stat: { [dcid: string]: PlacePointStatData };
 }
 
-interface SourceSeries {
+export interface SourceSeries {
   data: { [date: string]: number };
   placeName: string;
   provenanceUrl: string;
@@ -47,7 +47,7 @@ interface SourceSeries {
  * @param popData
  * @param statData
  */
-function getPopulationDate(
+export function getPopulationDate(
   popData: SourceSeries,
   statData: PlacePointStatData
 ): string {
@@ -74,5 +74,3 @@ function getPopulationDate(
   }
   return popDate;
 }
-
-export { getPopulationDate, PlacePointStat, SourceSeries, PlacePointStatData };

--- a/static/js/tools/timeline/search.tsx
+++ b/static/js/tools/timeline/search.tsx
@@ -51,6 +51,8 @@ interface SearchBarPropType {
   addPlace: (place: string) => void;
   removePlace: (place: string) => void;
   numPlacesLimit?: number; // Maximum number of places allowed
+  countryRestrictions?: string[];
+  customPlaceHolder?: string;
 }
 
 class SearchBar extends Component<SearchBarPropType> {
@@ -101,6 +103,11 @@ class SearchBar extends Component<SearchBarPropType> {
       types: ["(regions)"],
       fields: ["place_id", "name", "types"],
     };
+    if (this.props.countryRestrictions) {
+      options["componentRestrictions"] = {
+        country: this.props.countryRestrictions,
+      };
+    }
     if (google.maps) {
       this.ac = new google.maps.places.Autocomplete(
         this.inputElem.current,
@@ -143,8 +150,9 @@ class SearchBar extends Component<SearchBarPropType> {
         this.inputElem.current.placeholder = "Add another place";
       }
     } else {
-      this.inputElem.current.placeholder =
-        "Enter a country, state, county, or city to get started";
+      this.inputElem.current.placeholder = this.props.customPlaceHolder
+        ? this.props.customPlaceHolder
+        : "Enter a country, state, county, or city to get started";
     }
   }
 }

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -8596,10 +8596,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.65.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -9068,12 +9065,6 @@
       "requires": {
         "postcss": "^7.0.14"
       }
-    },
-    "icu4c-data": {
-      "version": "0.65.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.65.2.tgz",
-      "integrity": "sha512-c5LRnVavxDKGyRXkFWjZFrT/OpuixepdvihKwgbWoktNJ0t5X7ORyTQdFmq47cCzsmxcZWtaWqTMJR6S6N/3CQ==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",

--- a/static/webpack.config.js
+++ b/static/webpack.config.js
@@ -25,9 +25,9 @@ const config = {
       __dirname + "/js/tools/scatter/scatter.ts",
       __dirname + "/css/tools/scatter.scss",
     ],
-    choropleth: [
-      __dirname + "/js/tools/choropleth/choropleth_template.tsx",
-      __dirname + "/css/tools/choropleth.scss",
+    map: [
+      __dirname + "/js/tools/map/map.ts",
+      __dirname + "/css/tools/map.scss",
     ],
     dev: [__dirname + "/js/dev.ts", __dirname + "/css/dev.scss"],
     timeline: [


### PR DESCRIPTION
- rename choropleth to map
- things added: 
    - main component for map explorer
    - context for map explorer
    - fetching chart data & drawing choropleth with that data
    - component for choosing the place and place type
- update to draw_choropleth function so that the link that onclick redirects to gets passed into the function

Left the stat var menu out for now, but we can get map to show up by updating the hash link.

dev is updated with these changes & you can go to http://dev.datacommons.org/tools/map#%26sv%3DCount_Person_Female%26svn%3DCount_Person_Female%26pc%3D0 and then select the place and place type to see the choropleth.