### PR TITLE
[map] add per capita and breadcrumbs

### DIFF
--- a/static/css/tools/map.scss
+++ b/static/css/tools/map.scss
@@ -101,7 +101,7 @@
 .map-footer {
   display: flex;
   justify-content: space-between;
-  padding-top: 0.5rem;
+  padding-top: 1.5rem;
 }
 
 .map-title {
@@ -114,7 +114,15 @@
 
 .explore-timeline-link {
   cursor: pointer;
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-weight: $headings-font-weight;
   display: flex;
+}
+
+.chart-options, .explore-timeline-link  {
+  font-size: 0.9rem;
+}
+
+.breadcrumbs-title {
+  font-weight: $headings-font-weight;
+  padding-top: 0.3rem;
 }

--- a/static/css/tools/map.scss
+++ b/static/css/tools/map.scss
@@ -118,7 +118,8 @@
   display: flex;
 }
 
-.chart-options, .explore-timeline-link  {
+.chart-options,
+.explore-timeline-link {
   font-size: 0.9rem;
 }
 

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -25,23 +25,26 @@ import { Container } from "reactstrap";
 import _ from "lodash";
 import { drawChoropleth } from "../../chart/draw_choropleth";
 import {
+  MAP_REDIRECT_PREFIX,
   updateHashPlaceInfo,
   updateHashStatVarInfo,
   USA_CHILD_PLACE_TYPES,
 } from "./util";
 import { urlToDomain } from "../../shared/util";
+import { ChartOptions } from "./chart_options";
 
 interface ChartProps {
   geoJsonData: GeoJsonData;
-  dataValues: { [dcid: string]: number };
+  mapDataValues: { [dcid: string]: number };
+  breadcrumbDataValues: { [dcid: string]: number };
   placeInfo: PlaceInfo;
   statVarInfo: StatVarInfo;
   statVarDates: { [dcid: string]: string };
   sources: Set<string>;
+  unit: string;
 }
 
 const SVG_CONTAINER_ID = "choropleth_map";
-const MAP_REDIRECT_PREFIX = "/tools/map";
 
 export function Chart(props: ChartProps): JSX.Element {
   useEffect(() => {
@@ -62,6 +65,12 @@ export function Chart(props: ChartProps): JSX.Element {
             <h3>{title}</h3>
           </div>
           <div id={SVG_CONTAINER_ID}></div>
+          <ChartOptions
+            dataValues={props.breadcrumbDataValues}
+            placeInfo={props.placeInfo}
+            statVarDates={props.statVarDates}
+            unit={props.unit}
+          />
           <div className="map-footer">
             <div className="sources">Data from {sourcesJsx}</div>
             <div
@@ -86,13 +95,13 @@ function draw(props: ChartProps): void {
     props.statVarInfo,
     props.placeInfo
   );
-  if (!_.isEmpty(props.geoJsonData) && !_.isEmpty(props.dataValues)) {
+  if (!_.isEmpty(props.geoJsonData) && !_.isEmpty(props.mapDataValues)) {
     drawChoropleth(
       SVG_CONTAINER_ID,
       props.geoJsonData,
       height,
       width,
-      props.dataValues,
+      props.mapDataValues,
       "",
       props.statVarInfo.name,
       props.placeInfo.enclosedPlaceType in USA_CHILD_PLACE_TYPES,
@@ -146,6 +155,7 @@ const getMapRedirectLink = (statVarInfo: StatVarInfo, placeInfo: PlaceInfo) => (
     enclosedPlaces: [],
     enclosedPlaceType,
     enclosingPlace,
+    parentPlaces: [],
   });
   return `${MAP_REDIRECT_PREFIX}#${encodeURIComponent(hash)}`;
 };

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -169,15 +169,21 @@ function loadChartData(
       continue;
     }
     let statVarValue = statVarData.stat[dcid].value;
-    if (isPerCapita && dcid in populationData) {
-      const popDate = getPopulationDate(
-        populationData[dcid],
-        statVarData.stat[dcid]
-      );
-      statVarValue = statVarValue / populationData[dcid].data[popDate];
-      sources.add(populationData[dcid].provenanceUrl);
-    } else if (isPerCapita && !(dcid in populationData)) {
-      continue;
+    if (isPerCapita) {
+      if (dcid in populationData) {
+        const popDate = getPopulationDate(
+          populationData[dcid],
+          statVarData.stat[dcid]
+        );
+        const popValue = populationData[dcid].data[popDate];
+        statVarValue =
+          popValue === 0
+            ? statVarValue
+            : statVarValue / populationData[dcid].data[popDate];
+        sources.add(populationData[dcid].provenanceUrl);
+      } else {
+        continue;
+      }
     }
     if (
       placeInfo.parentPlaces.find((place) => place.dcid === dcid) ||

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -176,10 +176,13 @@ function loadChartData(
           statVarData.stat[dcid]
         );
         const popValue = populationData[dcid].data[popDate];
-        statVarValue =
-          popValue === 0
-            ? statVarValue
-            : statVarValue / populationData[dcid].data[popDate];
+        if (popValue === 0) {
+          // TODO (chejennifer): invalid cases like this one and the one where
+          // there's no population data for dcid when isPerCapita is true,
+          // tooltip should show as data invalid instead of data missing.
+          continue;
+        }
+        statVarValue = statVarValue / popValue;
         sources.add(populationData[dcid].provenanceUrl);
       } else {
         continue;

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -130,7 +130,7 @@ function fetchData(
     )
     .then((resp) => resp.data);
   const statVarDataPromise = axios
-    .post(`/api/stats/set`, {
+    .post("/api/stats/set", {
       places: placeInfo.enclosedPlaces.concat(breadcrumbPlaceDcids),
       stat_vars: statVarDcid,
     })
@@ -193,11 +193,11 @@ function loadChartData(
   }
   const unit = getUnit(statVarData);
   setChartData({
+    breadcrumbDataValues,
+    geoJsonData,
     mapDataValues,
     sources,
     statVarDates,
-    geoJsonData,
     unit,
-    breadcrumbDataValues,
   });
 }

--- a/static/js/tools/map/chart_options.tsx
+++ b/static/js/tools/map/chart_options.tsx
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+/**
+ * Component to allow per capita toggling and navigating to a parent place map.
+ */
+
 import React, { useContext } from "react";
 import { Context, ParentPlace, PlaceInfo, StatVarInfo } from "./context";
 import { FormGroup, Label, Input } from "reactstrap";

--- a/static/js/tools/map/chart_options.tsx
+++ b/static/js/tools/map/chart_options.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useContext } from "react";
+import { Context, ParentPlace, PlaceInfo, StatVarInfo } from "./context";
+import { FormGroup, Label, Input } from "reactstrap";
+import _ from "lodash";
+import { formatNumber } from "../../i18n/i18n";
+import {
+  updateHashPlaceInfo,
+  updateHashStatVarInfo,
+  USA_CHILD_PLACE_TYPES,
+  MAP_REDIRECT_PREFIX,
+} from "./util";
+
+interface ChartOptionsPropType {
+  dataValues: { [dcid: string]: number };
+  placeInfo: PlaceInfo;
+  statVarDates: { [dcid: string]: string };
+  unit: string;
+}
+export function ChartOptions(props: ChartOptionsPropType): JSX.Element {
+  const { statVarInfo } = useContext(Context);
+  const enclosingPlace = props.placeInfo.enclosingPlace;
+  const enclosingPlaceValue =
+    enclosingPlace.dcid in props.dataValues
+      ? formatNumber(props.dataValues[enclosingPlace.dcid], props.unit)
+      : "N/A";
+  const enclosingPlaceDate =
+    enclosingPlace.dcid in props.statVarDates
+      ? ` (${props.statVarDates[enclosingPlace.dcid]})`
+      : "";
+  const parentPlaces = !_.isEmpty(props.placeInfo.parentPlaces)
+    ? props.placeInfo.parentPlaces.reverse()
+    : [];
+  return (
+    <div className="chart-options">
+      <div>
+        <FormGroup check>
+          <Label check>
+            <Input
+              id="per-capita"
+              type="checkbox"
+              checked={statVarInfo.value.perCapita}
+              onChange={(e) => statVarInfo.setPerCapita(e.target.checked)}
+            />
+            Per capita
+          </Label>
+        </FormGroup>
+      </div>
+      <div className="breadcrumbs-title">{statVarInfo.value.name}</div>
+      <div>
+        {enclosingPlace.name}
+        {enclosingPlaceDate}: {enclosingPlaceValue}
+      </div>
+      {parentPlaces.map((place) => {
+        const value =
+          place.dcid in props.dataValues
+            ? formatNumber(props.dataValues[place.dcid], props.unit)
+            : "N/A";
+        const date =
+          place.dcid in props.statVarDates
+            ? ` (${props.statVarDates[place.dcid]})`
+            : "";
+        const redirectLink = getRedirectLink(statVarInfo.value, place);
+        return (
+          <div key={place.dcid}>
+            <a href={redirectLink}>{place.name}</a>
+            {date}: {value}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function getRedirectLink(
+  statVarInfo: StatVarInfo,
+  place: ParentPlace
+): string {
+  let hash = updateHashStatVarInfo("", statVarInfo);
+  const enclosingPlace = {
+    dcid: place.dcid,
+    name: place.name,
+  };
+  let enclosedPlaceType = "";
+  for (const type of place.types) {
+    if (type in USA_CHILD_PLACE_TYPES) {
+      enclosedPlaceType = USA_CHILD_PLACE_TYPES[type][0];
+      break;
+    }
+  }
+  hash = updateHashPlaceInfo(hash, {
+    enclosedPlaces: [],
+    enclosedPlaceType,
+    enclosingPlace,
+    parentPlaces: [],
+  });
+  return `${MAP_REDIRECT_PREFIX}#${encodeURIComponent(hash)}`;
+}

--- a/static/js/tools/map/chart_options.tsx
+++ b/static/js/tools/map/chart_options.tsx
@@ -104,9 +104,9 @@ export function getRedirectLink(
     }
   }
   hash = updateHashPlaceInfo(hash, {
+    enclosingPlace,
     enclosedPlaces: [],
     enclosedPlaceType,
-    enclosingPlace,
     parentPlaces: [],
   });
   return `${MAP_REDIRECT_PREFIX}#${encodeURIComponent(hash)}`;

--- a/static/js/tools/map/context.ts
+++ b/static/js/tools/map/context.ts
@@ -28,6 +28,12 @@ interface Setter<T> {
   (value: T): void;
 }
 
+export interface ParentPlace {
+  dcid: string;
+  name: string;
+  types: Array<string>;
+}
+
 // Information relating to the stat var to plot
 export interface StatVarInfo {
   // The stat var to plot
@@ -56,6 +62,8 @@ export interface PlaceInfo {
   enclosedPlaceType: string;
   // The places to plot
   enclosedPlaces: Array<string>;
+  // The parent places of the enclosing place
+  parentPlaces: Array<ParentPlace>;
 }
 
 // Wraps PlaceInfo with its setters
@@ -66,6 +74,7 @@ export interface PlaceInfoWrapper {
   setEnclosingPlace: Setter<NamedPlace>;
   setEnclosedPlaceType: Setter<string>;
   setEnclosedPlaces: Setter<Array<string>>;
+  setParentPlaces: Setter<Array<ParentPlace>>;
 }
 
 // Information relating to things loading
@@ -118,11 +127,19 @@ export function getInitialContext(params: URLSearchParams): ContextType {
           enclosingPlace,
           enclosedPlaces: [],
           enclosedPlaceType: "",
+          parentPlaces: null,
         }),
       setEnclosedPlaceType: (enclosedPlaceType) =>
-        setPlaceInfo({ ...placeInfo, enclosedPlaces: [], enclosedPlaceType }),
+        setPlaceInfo({
+          ...placeInfo,
+          enclosedPlaces: [],
+          enclosedPlaceType,
+          parentPlaces: null,
+        }),
       setEnclosedPlaces: (enclosedPlaces) =>
         setPlaceInfo({ ...placeInfo, enclosedPlaces }),
+      setParentPlaces: (parentPlaces) =>
+        setPlaceInfo({ ...placeInfo, parentPlaces }),
     },
     statVarInfo: {
       value: statVarInfo,

--- a/static/js/tools/map/context.ts
+++ b/static/js/tools/map/context.ts
@@ -28,6 +28,7 @@ interface Setter<T> {
   (value: T): void;
 }
 
+// Information regarding a parent place.
 export interface ParentPlace {
   dcid: string;
   name: string;

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -170,7 +170,7 @@ function loadParentPlaces(place: PlaceInfoWrapper): void {
     .then((resp) => {
       const parentsData = resp.data;
       const filteredParentsData = parentsData.filter(
-        (parent) => parent.types.indexOf("Continent") == -1
+        (parent) => parent.types.indexOf("Continent") === -1
       );
       const parentNamedPlaces = filteredParentsData.map((parent) => {
         return { dcid: parent.dcid, name: parent.name, types: parent.types };

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -29,20 +29,26 @@ import { USA_CHILD_PLACE_TYPES } from "./util";
 export function PlaceOptions(): JSX.Element {
   const { placeInfo, isLoading } = useContext(Context);
   const [enclosedPlaceTypes, setEnclosedPlaceTypes] = useState([]);
-  if (placeInfo.value.enclosingPlace.dcid && _.isEmpty(enclosedPlaceTypes)) {
-    updateEnclosedPlaceTypes(
-      placeInfo.value.enclosingPlace.dcid,
-      setEnclosedPlaceTypes
-    );
-  }
+  useEffect(() => {
+    if (placeInfo.value.enclosingPlace.dcid) {
+      updateEnclosedPlaceTypes(
+        placeInfo.value.enclosingPlace.dcid,
+        setEnclosedPlaceTypes
+      );
+    }
+  }, [placeInfo.value.enclosingPlace]);
   useEffect(() => {
     const placeInfoVal = placeInfo.value;
-    if (
-      placeInfoVal.enclosingPlace.dcid &&
-      placeInfoVal.enclosedPlaceType &&
-      _.isEmpty(placeInfoVal.enclosedPlaces)
-    ) {
-      loadEnclosedPlaces(placeInfo, isLoading);
+    if (placeInfoVal.enclosingPlace.dcid) {
+      if (_.isNull(placeInfoVal.parentPlaces)) {
+        loadParentPlaces(placeInfo);
+      }
+      if (
+        placeInfoVal.enclosedPlaceType &&
+        _.isEmpty(placeInfoVal.enclosedPlaces)
+      ) {
+        loadEnclosedPlaces(placeInfo, isLoading);
+      }
     }
   }, [placeInfo.value]);
   return (
@@ -155,6 +161,23 @@ function updateEnclosedPlaceTypes(
     .catch(() => {
       setEnclosedPlaceTypes([]);
     });
+}
+
+function loadParentPlaces(place: PlaceInfoWrapper): void {
+  const placeDcid = place.value.enclosingPlace.dcid;
+  axios
+    .get(`/api/place/parent/${placeDcid}`)
+    .then((resp) => {
+      const parentsData = resp.data;
+      const filteredParentsData = parentsData.filter(
+        (parent) => parent.types.indexOf("Continent") == -1
+      );
+      const parentNamedPlaces = filteredParentsData.map((parent) => {
+        return { dcid: parent.dcid, name: parent.name, types: parent.types };
+      });
+      place.setParentPlaces(parentNamedPlaces);
+    })
+    .catch(() => place.setParentPlaces([]));
 }
 
 function loadEnclosedPlaces(

--- a/static/js/tools/map/util.test.ts
+++ b/static/js/tools/map/util.test.ts
@@ -82,10 +82,11 @@ test("applyHashPlaceInfo", () => {
   expect(placeInfo).toEqual({
     ...TestContext.placeInfo.value,
     enclosedPlaces: [],
+    parentPlaces: null,
   });
 });
 
-test("applyHashPlaceInfo", () => {
+test("applyHashStatVarInfo", () => {
   const context = { statVarInfo: {}, placeInfo: {} } as ContextType;
   context.statVarInfo.set = (value) => (context.statVarInfo.value = value);
   const urlParams = new URLSearchParams(

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -41,6 +41,8 @@ const URL_PARAM_KEYS = {
   STAT_VAR_PATH: "svp",
 };
 
+export const MAP_REDIRECT_PREFIX = "/tools/map";
+
 export function applyHashStatVarInfo(params: URLSearchParams): StatVarInfo {
   const dcid = params.get(URL_PARAM_KEYS.STAT_VAR_DCID);
   if (!dcid) {
@@ -74,6 +76,7 @@ export function applyHashPlaceInfo(params: URLSearchParams): PlaceInfo {
     },
     enclosedPlaces: [],
     enclosedPlaceType: enclosedPlaceType ? enclosedPlaceType : "",
+    parentPlaces: null,
   };
 }
 

--- a/static/js/tools/scatter/chart_loader.tsx
+++ b/static/js/tools/scatter/chart_loader.tsx
@@ -25,6 +25,7 @@ import axios from "axios";
 import { saveToFile } from "../../shared/util";
 import {
   getPopulationDate,
+  getUnit,
   PlacePointStat,
   SourceSeries,
 } from "../shared_util";
@@ -85,8 +86,8 @@ function ChartLoader(): JSX.Element {
   if (cache.statsVarData) {
     const xStatData = cache.statsVarData[xStatVar];
     const yStatData = cache.statsVarData[yStatVar];
-    xUnits = xStatData ? getUnits(xStatData) : null;
-    yUnits = yStatData ? getUnits(yStatData) : null;
+    xUnits = xStatData ? getUnit(xStatData) : null;
+    yUnits = yStatData ? getUnit(yStatData) : null;
   }
   return (
     <div>
@@ -468,14 +469,6 @@ function getLabel(name: string, perCapita: boolean): string {
     name = _.startCase(name);
   }
   return `${name}${perCapita ? " Per Capita" : ""}`;
-}
-
-function getUnits(placePointStat: PlacePointStat): string {
-  const metadata = placePointStat.metadata;
-  const metadataKeys = Object.keys(metadata);
-  if (metadataKeys.length > 0) {
-    return metadata[metadataKeys[0]].unit;
-  }
 }
 
 export { ChartLoader, Point };

--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -74,3 +74,20 @@ export function getPopulationDate(
   }
   return popDate;
 }
+
+/**
+ * Helper function to get units given a PlacePointStat
+ * @param placePointStat
+ */
+export function getUnit(placePointStat: PlacePointStat): string {
+  const metadata = placePointStat.metadata;
+  if (_.isEmpty(metadata)) {
+    return "";
+  }
+  const metadataKeys = Object.keys(metadata);
+  if (metadataKeys.length > 0) {
+    return metadata[metadataKeys[0]].unit;
+  } else {
+    return "";
+  }
+}


### PR DESCRIPTION
added new ChartOptions component that contains the per capita toggle and breadcrumbs

dev is updated with these changes (eg. http://dev.datacommons.org/tools/map#%26sv%3DCount_Person_EducationalAttainmentBachelorsDegree%26pc%3D1)