### PR TITLE
Increase Flask worker and GKE load balancer timeout to 60s

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -36,4 +36,4 @@ COPY server/. /workspace/server/
 
 # Run server
 WORKDIR /workspace/server
-CMD if [ "$ENV" = "local" ] ; then python3.7 main.py ; else exec gunicorn --bind :8080 main:app ; fi
+CMD if [ "$ENV" = "local" ] ; then python3.7 main.py ; else exec gunicorn --timeout 60 --bind :8080 main:app ; fi

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -43,7 +43,7 @@ patchesStrategicMerge:
     metadata:
       name: website-app
     spec:
-      replicas: 4
+      replicas: 6
       strategy:
         type: RollingUpdate
         rollingUpdate:

--- a/gke/backendconfig.yaml
+++ b/gke/backendconfig.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.gke.io/v1
-kind: MultiClusterService
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
 metadata:
-  name: website-mcs
+  name: backendconfig
   namespace: website
-  annotations:
-    cloud.google.com/backend-config: '{"ports": {"8080":"backendconfig"}}'
 spec:
-  template:
-    spec:
-      selector:
-        app: website-app
-      ports:
-        - name: web
-          protocol: TCP
-          port: 8080
-          targetPort: 8080
+  timeoutSec: 60
+  connectionDraining:
+    drainingTimeoutSec: 60

--- a/gke/mcs.yaml
+++ b/gke/mcs.yaml
@@ -18,6 +18,8 @@ metadata:
   name: website-mcs
   namespace: website
   annotations:
+    # Refers to the backend config from backendconfig.yaml.
+    # This is to get 60s timeout for the Cloud Load Balancer.
     cloud.google.com/backend-config: '{"ports": {"8080":"backendconfig"}}'
 spec:
   template:

--- a/gke/setup_config_cluster.sh
+++ b/gke/setup_config_cluster.sh
@@ -31,6 +31,7 @@ yq w mci.yaml.tpl \
   $(yq r config.yaml ip) \
   > mci.yaml
 
+kubectl apply -f backendconfig.yaml
 kubectl apply -f mci.yaml
 kubectl apply -f mcs.yaml
 


### PR DESCRIPTION
The default timeout is 30s, which prevents a large stat-var-hierarchy cache to serve.