### PR TITLE
Place Page Choropleth Fixes

### DIFF
--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -262,7 +262,7 @@ def get_date_range(dates):
     sorted_dates_list = sorted(list(dates))
     date_range = sorted_dates_list[0]
     if len(sorted_dates_list) > 1:
-        date_range = f'{sorted_dates_list[0]} - {sorted_dates_list[-1]}'
+        date_range = f'{sorted_dates_list[0]} to {sorted_dates_list[-1]}'
     return date_range
 
 

--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -262,7 +262,7 @@ def get_date_range(dates):
     sorted_dates_list = sorted(list(dates))
     date_range = sorted_dates_list[0]
     if len(sorted_dates_list) > 1:
-        date_range = f'{sorted_dates_list[0]} to {sorted_dates_list[-1]}'
+        date_range = f'{sorted_dates_list[0]} – {sorted_dates_list[-1]}'
     return date_range
 
 

--- a/server/tests/chart_test.py
+++ b/server/tests/chart_test.py
@@ -433,7 +433,7 @@ class TestChoroplethData(unittest.TestCase):
         assert set(response_data_sv2_sources) == set([source1, source3])
         expected_data = {
             sv1: {
-                'date': f'{sv1_date1} to {sv1_date2}',
+                'date': f'{sv1_date1} – {sv1_date2}',
                 'data': {
                     geo1: sv1_val,
                     geo2: sv1_val

--- a/server/tests/chart_test.py
+++ b/server/tests/chart_test.py
@@ -433,7 +433,7 @@ class TestChoroplethData(unittest.TestCase):
         assert set(response_data_sv2_sources) == set([source1, source3])
         expected_data = {
             sv1: {
-                'date': f'{sv1_date1} - {sv1_date2}',
+                'date': f'{sv1_date1} to {sv1_date2}',
                 'data': {
                     geo1: sv1_val,
                     geo2: sv1_val

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -379,10 +379,11 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       };
       const getTooltipHtml = (place: NamedPlace) => {
         let value = "Data Missing";
-        if (this.state.choroplethDataGroup[place.dcid]) {
+        if (this.state.choroplethDataGroup.data[place.dcid]) {
           value = formatNumber(
             Math.round(
-              (this.state.choroplethDataGroup[place.dcid] + Number.EPSILON) *
+              (this.state.choroplethDataGroup.data[place.dcid] +
+                Number.EPSILON) *
                 100
             ) / 100,
             this.props.unit


### PR DESCRIPTION
- for date range in title, use "[start date] to [end date]" instead of "[start date] - [end date]" (eg. "2020-03 to 2020-04" vs "2020-03-2020-04")
- the function for getting tooltip html for place pages had a bug causing it to always show "data missing"