### PR TITLE
Add check when getting date range for choropleth charts

### DIFF
--- a/server/routes/api/chart.py
+++ b/server/routes/api/chart.py
@@ -260,6 +260,8 @@ def get_date_range(dates):
     """
     dates = filter(lambda x: x != "", dates)
     sorted_dates_list = sorted(list(dates))
+    if not sorted_dates_list:
+        return ""
     date_range = sorted_dates_list[0]
     if len(sorted_dates_list) > 1:
         date_range = f'{sorted_dates_list[0]} – {sorted_dates_list[-1]}'

--- a/server/tests/chart_test.py
+++ b/server/tests/chart_test.py
@@ -241,6 +241,21 @@ class TestChoroplethDataHelpers(unittest.TestCase):
             "2019", test_denom_data)
         assert result_denom_date_less_specific_no_match == 2
 
+    def test_get_date_range(self):
+        test_single_date = {"2019"}
+        single_date_result = chart_api.get_date_range(test_single_date)
+        assert single_date_result == "2019"
+        test_multiple_dates = {"2019", "2018", "2017"}
+        multiple_date_result = chart_api.get_date_range(test_multiple_dates)
+        assert multiple_date_result == "2017 – 2019"
+        test_empty_dates = {}
+        empty_date_result = chart_api.get_date_range(test_empty_dates)
+        assert empty_date_result == ""
+        test_empty_valid_dates = {""}
+        empty_valid_date_result = chart_api.get_date_range(
+            test_empty_valid_dates)
+        assert empty_valid_date_result == ""
+
 
 class TestChoroplethData(unittest.TestCase):
 


### PR DESCRIPTION
There was a case where the list of dates was empty which caused a list index out of range error. This check will prevent future errors like this when getting date range.