### PR TITLE
Increase wait time for mixer start up

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -121,7 +121,7 @@ def create_app():
     app.config['BABEL_TRANSLATION_DIRECTORIES'] = 'i18n'
 
     if not cfg.TEST:
-        timeout = 30  # seconds
+        timeout = 120  # seconds
         counter = 0
         isOpen = False
         while not isOpen:


### PR DESCRIPTION
Mixer now takes longer time to start due to the increased size of stat var group cache