### PR TITLE
[map] make legend shorter

### DIFF
--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -262,6 +262,8 @@ function addTooltip(domContainerId: string) {
  * Draw a color scale legend.
  * @param color The d3 linearScale that encodes the color gradient to be
  *        plotted.
+ * @param margins Optional object that holds the margin top and margin bottom
+ *        of the legend to be plotted
  *
  * @return the width of the legend
  */

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -81,7 +81,8 @@ function drawChoropleth(
   canClick: boolean,
   getRedirectLink: (geoDcid: GeoJsonFeatureProperties) => string,
   getTooltipHtml: (place: NamedPlace) => string,
-  zoomDcid?: string
+  zoomDcid?: string,
+  legendMargins?: { top: number; bottom: number }
 ): void {
   const label = getStatsVarLabel(statVar);
   const maxColor = d3.color(getColorFn([label])(label));
@@ -116,7 +117,8 @@ function drawChoropleth(
     chartWidth,
     chartHeight,
     colorScale,
-    unit
+    unit,
+    legendMargins
   );
 
   // Scale and center the map
@@ -268,9 +270,12 @@ function generateLegend(
   chartWidth: number,
   chartHeight: number,
   color: d3.ScaleLinear<number, number>,
-  unit: string
+  unit: string,
+  margins?: { top: number; bottom: number }
 ) {
-  const height = chartHeight - LEGEND_MARGIN_TOP - LEGEND_MARGIN_BOTTOM;
+  const marginTop = margins ? margins.top : LEGEND_MARGIN_TOP;
+  const marginBottom = margins ? margins.bottom : LEGEND_MARGIN_BOTTOM;
+  const height = chartHeight - marginTop - marginBottom;
   const n = Math.min(color.domain().length, color.range().length);
 
   const legend = svg.append("g").attr("class", "legend");
@@ -279,7 +284,7 @@ function generateLegend(
     .append("image")
     .attr("id", "legend-img")
     .attr("x", 0)
-    .attr("y", LEGEND_MARGIN_TOP)
+    .attr("y", marginTop)
     .attr("width", LEGEND_IMG_WIDTH)
     .attr("height", height)
     .attr("preserveAspectRatio", "none")
@@ -293,7 +298,7 @@ function generateLegend(
   const yScale = d3.scaleLinear().domain(color.domain()).range([0, height]);
   legend
     .append("g")
-    .attr("transform", `translate(0, ${LEGEND_MARGIN_TOP})`)
+    .attr("transform", `translate(0, ${marginTop})`)
     .call(
       d3
         .axisRight(yScale)

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -100,6 +100,7 @@ function draw(
   document.getElementById(SVG_CONTAINER_ID).innerHTML = "";
   const width = document.getElementById(SVG_CONTAINER_ID).offsetWidth;
   const height = (width * 2) / 5;
+  const legendMargins = height * 0.2;
   const getRedirectLink = getMapRedirectLink(
     props.statVarInfo,
     props.placeInfo
@@ -134,7 +135,8 @@ function draw(
         props.mapDataValues,
         props.unit
       ),
-      zoomDcid
+      zoomDcid,
+      { top: legendMargins, bottom: legendMargins }
     );
   }
 }


### PR DESCRIPTION
Make the legend shorter in map explorer by allowing customization of legend height when using the draw_choropleth funciton.

<img width="1464" alt="Screen Shot 2021-06-21 at 9 48 29 AM" src="https://user-images.githubusercontent.com/69875368/122798793-d7e44500-d275-11eb-8b31-5e742c35cc59.png">
