### PR TITLE
[map] few updates

### DIFF
--- a/static/css/draw_choropleth.scss
+++ b/static/css/draw_choropleth.scss
@@ -26,6 +26,7 @@
   border-radius: 3px;
   border: 0.5px solid #dee2e6;
   padding: 0.3rem;
+  white-space: nowrap;
 }
 
 .choropleth-legend {

--- a/static/css/tools/map.scss
+++ b/static/css/tools/map.scss
@@ -123,6 +123,10 @@
   font-size: 0.9rem;
 }
 
+.chart-options {
+  padding-top: 1rem;
+}
+
 .breadcrumbs-title {
   font-weight: $headings-font-weight;
   padding-top: 0.3rem;
@@ -130,6 +134,11 @@
 
 #tooltip footer {
   margin-top: .5rem;
+}
+
+#choropleth-map {
+  overflow-x: hidden;
+  overflow-y: hidden;
 }
 
 .legend rect {
@@ -142,4 +151,31 @@
   padding: 15px;
   border-radius: 3px;
   background: #f8d7da;
+}
+
+.zoom-button {
+  cursor: pointer;
+  border: 1px solid rgba(0, 0, 0, 0.125);
+  padding: 0.1rem;
+  display: flex;
+  width: fit-content;
+}
+
+.zoom-button:hover {
+  background-color: var(--dc-gray-lite);
+}
+
+.map-section-container {
+  position: relative;
+}
+
+.zoom-button-section {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  background-color: #f8f8f8;
+}
+
+.zoom-button i {
+  font-size: 1.3rem;
 }

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -68,6 +68,24 @@ function fitSize(
   projection.scale(s).translate([translateX, translateY]);
 }
 
+/** Draws a choropleth chart
+ *
+ * @param containerId id of the div to draw the choropleth in
+ * @param geoJson the geojson data for drawing choropleth
+ * @param chartHeight height for the chart
+ * @param chartWidth width for the chart
+ * @param dataValues data values for plotting
+ * @param unit the unit of measurement
+ * @param statVar the stat var the choropleth is showing
+ * @param canClick whether the regions on the map should be clickable
+ * @param getRedirectLink function to get the link to redirect to when region on
+ *                        the map is clicked
+ * @param getTooltipHtml function to get the html content for the tooltip
+ * @param zoomDcid the dcid of the region to zoom in on when drawing the chart
+ * @param zoomInButtonId the id of the zoom in button
+ * @param zoomOutButtonId the id of the zoom out button
+ * @param legendMargins the top and bottom margins for the legend
+ */
 function drawChoropleth(
   containerId: string,
   geoJson: GeoJsonData,
@@ -82,6 +100,8 @@ function drawChoropleth(
   getRedirectLink: (geoDcid: GeoJsonFeatureProperties) => string,
   getTooltipHtml: (place: NamedPlace) => string,
   zoomDcid?: string,
+  zoomInButtonId?: string,
+  zoomOutButtonId?: string,
   legendMargins?: { top: number; bottom: number }
 ): void {
   const label = getStatsVarLabel(statVar);
@@ -194,6 +214,30 @@ function drawChoropleth(
     .attr("stroke-width", HIGHLIGHTED_STROKE_WIDTH)
     .attr("stroke", HIGHLIGHTED_STROKE_COLOR);
   addTooltip(domContainerId);
+
+  if (zoomInButtonId || zoomOutButtonId) {
+    const zoom = d3
+      .zoom()
+      .scaleExtent([1, Infinity])
+      .translateExtent([
+        [0, 0],
+        [chartWidth, chartHeight],
+      ])
+      .on("zoom", function () {
+        map.selectAll("path").attr("transform", d3.event.transform);
+      });
+    svg.call(zoom);
+    if (zoomInButtonId) {
+      d3.select(`#${zoomInButtonId}`).on("click", () => {
+        svg.call(zoom.scaleBy, 2);
+      });
+    }
+    if (zoomOutButtonId) {
+      d3.select(`#${zoomOutButtonId}`).on("click", () => {
+        svg.call(zoom.scaleBy, 0.5);
+      });
+    }
+  }
 }
 
 const onMouseOver = (domContainerId: string, canClick: boolean) => (

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -81,7 +81,8 @@ function drawChoropleth(
   canClick: boolean,
   getRedirectLink: (geoDcid: GeoJsonFeatureProperties) => string,
   getTooltipHtml: (place: NamedPlace) => string,
-  zoomDcid?: string
+  zoomDcid?: string,
+  legendMargins?: { top: number; bottom: number }
 ): void {
   const label = getStatsVarLabel(statVar);
   const maxColor = d3.color(getColorFn([label])(label));
@@ -116,7 +117,8 @@ function drawChoropleth(
     chartWidth,
     chartHeight,
     colorScale,
-    unit
+    unit,
+    legendMargins
   );
 
   // Scale and center the map
@@ -260,6 +262,8 @@ function addTooltip(domContainerId: string) {
  * Draw a color scale legend.
  * @param color The d3 linearScale that encodes the color gradient to be
  *        plotted.
+ * @param margins Optional object that holds the margin top and margin bottom
+ *        of the legend to be plotted
  *
  * @return the width of the legend
  */
@@ -268,9 +272,12 @@ function generateLegend(
   chartWidth: number,
   chartHeight: number,
   color: d3.ScaleLinear<number, number>,
-  unit: string
+  unit: string,
+  margins?: { top: number; bottom: number }
 ) {
-  const height = chartHeight - LEGEND_MARGIN_TOP - LEGEND_MARGIN_BOTTOM;
+  const marginTop = margins ? margins.top : LEGEND_MARGIN_TOP;
+  const marginBottom = margins ? margins.bottom : LEGEND_MARGIN_BOTTOM;
+  const height = chartHeight - marginTop - marginBottom;
   const n = Math.min(color.domain().length, color.range().length);
 
   const legend = svg.append("g").attr("class", "legend");
@@ -279,7 +286,7 @@ function generateLegend(
     .append("image")
     .attr("id", "legend-img")
     .attr("x", 0)
-    .attr("y", LEGEND_MARGIN_TOP)
+    .attr("y", marginTop)
     .attr("width", LEGEND_IMG_WIDTH)
     .attr("height", height)
     .attr("preserveAspectRatio", "none")
@@ -293,7 +300,7 @@ function generateLegend(
   const yScale = d3.scaleLinear().domain(color.domain()).range([0, height]);
   legend
     .append("g")
-    .attr("transform", `translate(0, ${LEGEND_MARGIN_TOP})`)
+    .attr("transform", `translate(0, ${marginTop})`)
     .call(
       d3
         .axisRight(yScale)

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -78,8 +78,7 @@ function fitSize(
  * @param unit the unit of measurement
  * @param statVar the stat var the choropleth is showing
  * @param canClick whether the regions on the map should be clickable
- * @param getRedirectLink function to get the link to redirect to when region on
- *                        the map is clicked
+ * @param redirectAction function that runs when region on map is clicked
  * @param getTooltipHtml function to get the html content for the tooltip
  * @param zoomDcid the dcid of the region to zoom in on when drawing the chart
  * @param zoomInButtonId the id of the zoom in button
@@ -223,7 +222,7 @@ function drawChoropleth(
         [0, 0],
         [chartWidth, chartHeight],
       ])
-      .on("zoom", function () {
+      .on("zoom", function (): void {
         mapObjects.on("mousemove", null).on("mouseover", null);
         d3.select(`#${TOOLTIP_ID}`).style("display", "none");
         map
@@ -231,7 +230,7 @@ function drawChoropleth(
           .classed("region-highlighted", false)
           .attr("transform", d3.event.transform);
       })
-      .on("end", function () {
+      .on("end", function (): void {
         mapObjects
           .on(
             "mousemove",
@@ -307,7 +306,7 @@ const onMapClick = (
   mouseOutAction(domContainerId, index);
 };
 
-function mouseOutAction(domContainerId: string, index: number) {
+function mouseOutAction(domContainerId: string, index: number): void {
   const container = d3.select(domContainerId);
   container.select("#geoPath" + index).classed("region-highlighted", false);
   container.select(`#${TOOLTIP_ID}`).style("display", "none");
@@ -317,7 +316,7 @@ function mouseHoverAction(
   domContainerId: string,
   index: number,
   canClick: boolean
-) {
+): void {
   const container = d3.select(domContainerId);
   // show highlighted border and show cursor as a pointer
   if (canClick) {
@@ -327,7 +326,7 @@ function mouseHoverAction(
   container.select(`#${TOOLTIP_ID}`).style("display", "block");
 }
 
-function addTooltip(domContainerId: string) {
+function addTooltip(domContainerId: string): void {
   d3.select(domContainerId)
     .attr("style", "position: relative")
     .append("div")

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -374,8 +374,9 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       chartType === chartTypeEnum.CHOROPLETH &&
       this.state.choroplethDataGroup
     ) {
-      const getRedirectLink = (geoProperty: GeoJsonFeatureProperties) => {
-        return `${CHOROPLETH_REDIRECT_BASE_URL}${geoProperty.geoDcid}${this.placeLinkSearch}`;
+      const redirectAction = (geoProperty: GeoJsonFeatureProperties) => {
+        const redirectLink = `${CHOROPLETH_REDIRECT_BASE_URL}${geoProperty.geoDcid}${this.placeLinkSearch}`;
+        window.open(redirectLink, "_blank");
       };
       const getTooltipHtml = (place: NamedPlace) => {
         let value = "Data Missing";
@@ -400,7 +401,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         this.props.unit,
         this.props.statsVars[0],
         true,
-        getRedirectLink,
+        redirectAction,
         getTooltipHtml
       );
     }

--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -100,7 +100,9 @@ function applyHash(context: ContextType): void {
 function updateHash(context: ContextType): void {
   let hash = updateHashStatVarInfo("", context.statVarInfo.value);
   hash = updateHashPlaceInfo(hash, context.placeInfo.value);
-  if (hash) {
-    history.pushState({}, "", `/tools/map#${encodeURIComponent(hash)}`);
+  const newHash = encodeURIComponent(hash);
+  const currentHash = location.hash.replace("#", "");
+  if (newHash && newHash !== currentHash) {
+    history.pushState({}, "", `/tools/map#${newHash}`);
   }
 }

--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -26,6 +26,7 @@ import { PlaceOptions } from "./place_options";
 import {
   applyHashPlaceInfo,
   applyHashStatVarInfo,
+  MAP_REDIRECT_PREFIX,
   updateHashPlaceInfo,
   updateHashStatVarInfo,
 } from "./util";
@@ -103,6 +104,6 @@ function updateHash(context: ContextType): void {
   const newHash = encodeURIComponent(hash);
   const currentHash = location.hash.replace("#", "");
   if (newHash && newHash !== currentHash) {
-    history.pushState({}, "", `/tools/map#${newHash}`);
+    history.pushState({}, "", `${MAP_REDIRECT_PREFIX}#${newHash}`);
   }
 }

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -48,7 +48,9 @@ interface ChartProps {
   unit: string;
 }
 
-const SVG_CONTAINER_ID = "choropleth_map";
+const SVG_CONTAINER_ID = "choropleth-map";
+const ZOOM_IN_BUTTON_ID = "zoom-in-button";
+const ZOOM_OUT_BUTTON_ID = "zoom-out-button";
 
 export function Chart(props: ChartProps): JSX.Element {
   const [errorMessage, setErrorMessage] = useState("");
@@ -71,6 +73,17 @@ export function Chart(props: ChartProps): JSX.Element {
           ) : (
             <div id={SVG_CONTAINER_ID}></div>
           )}
+          <div className="map-section-container">
+            <div id={SVG_CONTAINER_ID}></div>
+            <div className="zoom-button-section">
+              <div id={ZOOM_IN_BUTTON_ID} className="zoom-button">
+                <i className="material-icons">add</i>
+              </div>
+              <div id={ZOOM_OUT_BUTTON_ID} className="zoom-button">
+                <i className="material-icons">remove</i>
+              </div>
+            </div>
+          </div>
           <ChartOptions
             dataValues={props.breadcrumbDataValues}
             placeInfo={props.placeInfo}
@@ -136,6 +149,8 @@ function draw(
         props.unit
       ),
       zoomDcid,
+      ZOOM_IN_BUTTON_ID,
+      ZOOM_OUT_BUTTON_ID,
       { top: legendMargins, bottom: legendMargins }
     );
   }

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -100,6 +100,7 @@ function draw(
   document.getElementById(SVG_CONTAINER_ID).innerHTML = "";
   const width = document.getElementById(SVG_CONTAINER_ID).offsetWidth;
   const height = (width * 2) / 5;
+  const legendMargins = height * 0.2;
   const getRedirectLink = getMapRedirectLink(
     props.statVarInfo,
     props.placeInfo
@@ -134,7 +135,8 @@ function draw(
         props.mapDataValues,
         props.unit
       ),
-      zoomDcid
+      zoomDcid,
+      { top: legendMargins, bottom: legendMargins }
     );
   }
 }

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -114,7 +114,7 @@ function draw(
   const width = document.getElementById(SVG_CONTAINER_ID).offsetWidth;
   const height = (width * 2) / 5;
   const legendMargins = height * 0.2;
-  const getRedirectLink = getMapRedirectLink(
+  const redirectAction = getMapRedirectAction(
     props.statVarInfo,
     props.placeInfo
   );
@@ -141,7 +141,7 @@ function draw(
       "",
       props.statVarInfo.name,
       props.placeInfo.enclosedPlaceType in USA_CHILD_PLACE_TYPES,
-      getRedirectLink,
+      redirectAction,
       getTooltipHtml(
         props.metadata,
         props.statVarInfo,
@@ -187,9 +187,10 @@ function exploreTimelineOnClick(placeDcid: string, statVarDcid: string): void {
   window.open(`/tools/timeline#place=${placeDcid}&statsVar=${statVarDcid}`);
 }
 
-const getMapRedirectLink = (statVarInfo: StatVarInfo, placeInfo: PlaceInfo) => (
-  geoProperties: GeoJsonFeatureProperties
-) => {
+const getMapRedirectAction = (
+  statVarInfo: StatVarInfo,
+  placeInfo: PlaceInfo
+) => (geoProperties: GeoJsonFeatureProperties) => {
   let hash = updateHashStatVarInfo("", statVarInfo);
   const selectedPlace = {
     dcid: geoProperties.geoDcid,
@@ -205,7 +206,8 @@ const getMapRedirectLink = (statVarInfo: StatVarInfo, placeInfo: PlaceInfo) => (
     selectedPlace,
     parentPlaces: [],
   });
-  return `${MAP_REDIRECT_PREFIX}#${encodeURIComponent(hash)}`;
+  const redirectLink = `${MAP_REDIRECT_PREFIX}#${encodeURIComponent(hash)}`;
+  window.open(redirectLink, "_self");
 };
 
 const getTooltipHtml = (
@@ -222,11 +224,13 @@ const getTooltipHtml = (
     hasValue = true;
   }
   if (!hasValue || !(place.dcid in metadataMapping)) {
-    return titleHtml + `${statVarInfo.name}: ${value}<br />`;
+    return titleHtml + `${statVarInfo.name}: <wbr>${value}<br />`;
   }
   const metadata = metadataMapping[place.dcid];
   if (!_.isEmpty(metadata.errorMessage)) {
-    return titleHtml + `${statVarInfo.name}: ${metadata.errorMessage}<br />`;
+    return (
+      titleHtml + `${statVarInfo.name}: <wbr>${metadata.errorMessage}<br />`
+    );
   }
   let sources = urlToDomain(metadata.statVarSource);
   if (statVarInfo.perCapita && !_.isEmpty(metadata.popSource)) {
@@ -241,11 +245,11 @@ const getTooltipHtml = (
     !metadata.statVarDate.includes(metadata.popDate) &&
     !metadata.popDate.includes(metadata.statVarDate);
   const popDateHtml = showPopDateMessage
-    ? `<sup>*</sup> Uses population data from: ${metadata.popDate}`
+    ? `<sup>*</sup> Uses population data from: <wbr>${metadata.popDate}`
     : "";
   const html =
     titleHtml +
-    `${statVarInfo.name} (${metadata.statVarDate}): ${value}<br />` +
-    `<footer>Data from: ${sources} <br/>${popDateHtml}</footer>`;
+    `${statVarInfo.name} (${metadata.statVarDate}): <wbr>${value}<br />` +
+    `<footer>Data from: <wbr>${sources} <br/>${popDateHtml}</footer>`;
   return html;
 };

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -176,7 +176,7 @@ function updateEnclosedPlaceTypes(
       if (!hasEnclosedPlaceTypes) {
         alert(
           `Sorry, we don't support maps for ${selectedPlace.name}.` +
-            `Please select a different place.`
+            "Please select a different place."
         );
         setEnclosedPlaceTypes([]);
       }


### PR DESCRIPTION
- when zooming and panning, disable hover action
- make tooltip stay in map boundary
- show alert when user selects a place we don't have maps for [issue 977](https://github.com/datacommonsorg/website/issues/977)
- on map click, open the page in the same window [issue 978](https://github.com/datacommonsorg/website/issues/978)
- only push hash to history if it's new. With this change, user only has to click back once to get to the last state

dev updated (http://dev.datacommons.org/tools/map#%26sv%3DCumulativeCount_MedicalConditionIncident_COVID_19_PatientDeceased%26pc%3D1)