### PR TITLE
[map] resize legend separately from the map

### DIFF
--- a/static/css/tools/map.scss
+++ b/static/css/tools/map.scss
@@ -139,6 +139,7 @@
 #choropleth-map {
   overflow-x: hidden;
   overflow-y: hidden;
+  flex-grow: 1;
 }
 
 .legend rect {
@@ -178,4 +179,14 @@
 
 .zoom-button i {
   font-size: 1.3rem;
+}
+
+#chart-container {
+  width: 100%;
+  display: flex;
+}
+
+#choropleth-legend {
+  display: flex;
+  align-items: center;
 }

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -44,8 +44,7 @@ const NUM_TICKS = 5;
 const HIGHLIGHTED_CLASS_NAME = "highlighted";
 const REGULAR_SCALE_AMOUNT = 1;
 const ZOOMED_SCALE_AMOUNT = 0.7;
-const LEGEND_BACKGROUND_MARGIN_LEFT = 30;
-const LEGEND_BACKGROUND_FILL = "white";
+const LEGEND_CLASS_NAME = "legend";
 
 /**
  * From https://bl.ocks.org/HarryStevens/0e440b73fbd88df7c6538417481c9065
@@ -68,45 +67,20 @@ function fitSize(
   projection.scale(s).translate([translateX, translateY]);
 }
 
-/** Draws a choropleth chart
+/** Generates a color scale to be used for drawing choropleth map and legend.
  *
- * @param containerId id of the div to draw the choropleth in
- * @param geoJson the geojson data for drawing choropleth
- * @param chartHeight height for the chart
- * @param chartWidth width for the chart
- * @param dataValues data values for plotting
- * @param unit the unit of measurement
- * @param statVar the stat var the choropleth is showing
- * @param canClick whether the regions on the map should be clickable
- * @param getRedirectLink function to get the link to redirect to when region on
- *                        the map is clicked
- * @param getTooltipHtml function to get the html content for the tooltip
- * @param zoomDcid the dcid of the region to zoom in on when drawing the chart
- * @param zoomInButtonId the id of the zoom in button
- * @param zoomOutButtonId the id of the zoom out button
- * @param legendMargins the top and bottom margins for the legend
+ * @param statVar name of the stat var we are drawing choropleth for
+ * @param dataValues the values we are using to plot our choropleth
  */
-function drawChoropleth(
-  containerId: string,
-  geoJson: GeoJsonData,
-  chartHeight: number,
-  chartWidth: number,
+function getColorScale(
+  statVar: string,
   dataValues: {
     [placeDcid: string]: number;
-  },
-  unit: string,
-  statVar: string,
-  canClick: boolean,
-  getRedirectLink: (geoDcid: GeoJsonFeatureProperties) => string,
-  getTooltipHtml: (place: NamedPlace) => string,
-  zoomDcid?: string,
-  zoomInButtonId?: string,
-  zoomOutButtonId?: string,
-  legendMargins?: { top: number; bottom: number }
-): void {
+  }
+): d3.ScaleLinear<number, number> {
   const label = getStatsVarLabel(statVar);
   const maxColor = d3.color(getColorFn([label])(label));
-  const colorScale = d3
+  return d3
     .scaleLinear()
     .domain(d3.extent(Object.values(dataValues)))
     .nice()
@@ -117,7 +91,44 @@ function drawChoropleth(
         b: unknown
       ) => (t: number) => number
     );
+}
 
+/** Draws a choropleth chart
+ *
+ * @param containerId id of the div to draw the choropleth in
+ * @param geoJson the geojson data for drawing choropleth
+ * @param chartHeight height for the chart
+ * @param chartWidth width for the chart
+ * @param dataValues data values for plotting
+ * @param unit the unit of measurement
+ * @param colorScale the color scale to use for drawing the map and legend
+ * @param canClick whether the regions on the map should be clickable
+ * @param getRedirectLink function to get the link to redirect to when region on
+ *                        the map is clicked
+ * @param getTooltipHtml function to get the html content for the tooltip
+ * @param shouldGenerateLegend whether legend needs to be generated
+ * @param zoomDcid the dcid of the region to zoom in on when drawing the chart
+ * @param zoomInButtonId the id of the zoom in button
+ * @param zoomOutButtonId the id of the zoom out button
+ */
+function drawChoropleth(
+  containerId: string,
+  geoJson: GeoJsonData,
+  chartHeight: number,
+  chartWidth: number,
+  dataValues: {
+    [placeDcid: string]: number;
+  },
+  unit: string,
+  colorScale: d3.ScaleLinear<number, number>,
+  canClick: boolean,
+  getRedirectLink: (geoDcid: GeoJsonFeatureProperties) => string,
+  getTooltipHtml: (place: NamedPlace) => string,
+  shouldGenerateLegend: boolean,
+  zoomDcid?: string,
+  zoomInButtonId?: string,
+  zoomOutButtonId?: string
+): void {
   // Add svg for the map to the div holding the chart.
   const domContainerId = `#${containerId}`;
   const svg = d3
@@ -132,14 +143,15 @@ function drawChoropleth(
 
   const projection = geo.geoAlbersUsaTerritories();
   const geomap = d3.geoPath().projection(projection);
-  const legendWidth = generateLegend(
-    svg,
-    chartWidth,
-    chartHeight,
-    colorScale,
-    unit,
-    legendMargins
-  );
+
+  if (shouldGenerateLegend) {
+    const legendHeight = chartHeight - LEGEND_MARGIN_BOTTOM - LEGEND_MARGIN_TOP;
+    const legendWidth = generateLegend(svg, legendHeight, colorScale, unit);
+    chartWidth -= legendWidth;
+    svg
+      .select(`.${LEGEND_CLASS_NAME}`)
+      .attr("transform", `translate(${chartWidth}, ${LEGEND_MARGIN_TOP})`);
+  }
 
   // Scale and center the map
   let isMapFitted = false;
@@ -149,7 +161,7 @@ function drawChoropleth(
     );
     if (geoJsonFeature) {
       fitSize(
-        chartWidth - legendWidth,
+        chartWidth,
         chartHeight,
         geoJsonFeature,
         projection,
@@ -161,7 +173,7 @@ function drawChoropleth(
   }
   if (!isMapFitted) {
     fitSize(
-      chartWidth - legendWidth,
+      chartWidth,
       chartHeight,
       geoJson,
       projection,
@@ -306,31 +318,23 @@ function addTooltip(domContainerId: string) {
  * Draw a color scale legend.
  * @param color The d3 linearScale that encodes the color gradient to be
  *        plotted.
- * @param margins Optional object that holds the margin top and margin bottom
- *        of the legend to be plotted
  *
  * @return the width of the legend
  */
 function generateLegend(
   svg: d3.Selection<SVGElement, any, any, any>,
-  chartWidth: number,
-  chartHeight: number,
+  height: number,
   color: d3.ScaleLinear<number, number>,
-  unit: string,
-  margins?: { top: number; bottom: number }
-) {
-  const marginTop = margins ? margins.top : LEGEND_MARGIN_TOP;
-  const marginBottom = margins ? margins.bottom : LEGEND_MARGIN_BOTTOM;
-  const height = chartHeight - marginTop - marginBottom;
+  unit: string
+): number {
   const n = Math.min(color.domain().length, color.range().length);
 
-  const legend = svg.append("g").attr("class", "legend");
-  const background = legend.append("rect");
+  const legend = svg.append("g").attr("class", LEGEND_CLASS_NAME);
   legend
     .append("image")
     .attr("id", "legend-img")
     .attr("x", 0)
-    .attr("y", marginTop)
+    .attr("y", 0)
     .attr("width", LEGEND_IMG_WIDTH)
     .attr("height", height)
     .attr("preserveAspectRatio", "none")
@@ -344,7 +348,6 @@ function generateLegend(
   const yScale = d3.scaleLinear().domain(color.domain()).range([0, height]);
   legend
     .append("g")
-    .attr("transform", `translate(0, ${marginTop})`)
     .call(
       d3
         .axisRight(yScale)
@@ -369,12 +372,34 @@ function generateLegend(
     .call((g) => g.select(".domain").remove());
 
   const legendWidth = legend.node().getBBox().width;
-  background
-    .attr("height", "100%")
-    .attr("width", legendWidth + LEGEND_BACKGROUND_MARGIN_LEFT)
-    .attr("fill", LEGEND_BACKGROUND_FILL)
-    .attr("transform", `translate(-${LEGEND_BACKGROUND_MARGIN_LEFT}, 0)`);
-  legend.attr("transform", `translate(${chartWidth - legendWidth}, 0)`);
+  return legendWidth;
+}
+
+/** Generate a svg that contains a color scale legend
+ *
+ * @param containerId id of the container to draw the legend in
+ * @param height height of the legend
+ * @param colorScale the color scale to use for the legend
+ * @param unit unit of measurement
+ * @param marginLeft left margin of the legend
+ *
+ * @return width of the svg
+ */
+function generateLegendSvg(
+  containerId: string,
+  height: number,
+  colorScale: d3.ScaleLinear<number, number>,
+  unit: string,
+  marginLeft: number
+): number {
+  const svg = d3.select(`#${containerId}`).append("svg");
+  const legendWidth =
+    generateLegend(svg, height, colorScale, unit) + marginLeft;
+  svg
+    .attr("width", legendWidth)
+    .attr("height", height + LEGEND_MARGIN_BOTTOM)
+    .select(`.${LEGEND_CLASS_NAME}`)
+    .attr("transform", `translate(${marginLeft}, 0)`);
   return legendWidth;
 }
 
@@ -393,4 +418,4 @@ const genScaleImg = (
   return canvas;
 };
 
-export { drawChoropleth };
+export { drawChoropleth, getColorScale, generateLegendSvg };

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -32,7 +32,7 @@ import {
 } from "../chart/types";
 import { updatePageLayoutState } from "./place";
 import { ChartEmbed } from "./chart_embed";
-import { drawChoropleth } from "../chart/draw_choropleth";
+import { drawChoropleth, getColorScale } from "../chart/draw_choropleth";
 import _ from "lodash";
 import { FormattedMessage } from "react-intl";
 import { getStatsVarLabel } from "../shared/stats_var_labels";
@@ -391,6 +391,10 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         }
         return place.name + ": " + value;
       };
+      const colorScale = getColorScale(
+        this.props.statsVars[0],
+        this.state.choroplethDataGroup.data
+      );
       drawChoropleth(
         this.props.id,
         this.state.geoJson,
@@ -398,10 +402,11 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         elem.offsetWidth,
         this.state.choroplethDataGroup.data,
         this.props.unit,
-        this.props.statsVars[0],
+        colorScale,
         true,
         getRedirectLink,
-        getTooltipHtml
+        getTooltipHtml,
+        true
       );
     }
   }

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -18,12 +18,16 @@
  * Chart component for drawing a choropleth.
  */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { GeoJsonData, GeoJsonFeatureProperties } from "../../chart/types";
 import { PlaceInfo, StatVarInfo } from "./context";
 import { Container } from "reactstrap";
 import _ from "lodash";
-import { drawChoropleth } from "../../chart/draw_choropleth";
+import {
+  drawChoropleth,
+  getColorScale,
+  generateLegendSvg,
+} from "../../chart/draw_choropleth";
 import {
   MAP_REDIRECT_PREFIX,
   updateHashPlaceInfo,
@@ -49,18 +53,39 @@ interface ChartProps {
 }
 
 const SVG_CONTAINER_ID = "choropleth-map";
+const LEGEND_CONTAINER_ID = "choropleth-legend";
+const CHART_CONTAINER_ID = "chart-container";
 const ZOOM_IN_BUTTON_ID = "zoom-in-button";
 const ZOOM_OUT_BUTTON_ID = "zoom-out-button";
+const LEGEND_MARGIN_LEFT = 30;
+const LEGEND_HEIGHT_SCALING = 0.6;
 
 export function Chart(props: ChartProps): JSX.Element {
   const [errorMessage, setErrorMessage] = useState("");
-  useEffect(() => {
-    draw(props, setErrorMessage);
-  }, [props]);
   const title = getTitle(Array.from(props.dates), props.statVarInfo.name);
   const sourcesJsx = getSourcesJsx(props.sources);
   const placeDcid = props.placeInfo.enclosingPlace.dcid;
   const statVarDcid = _.findKey(props.statVarInfo.statVar);
+  const [chartWidth, setChartWidth] = useState(0);
+  useEffect(() => {
+    draw(props, setErrorMessage, true);
+  }, [props]);
+  useEffect(() => {
+    function _handleWindowResize() {
+      const chartContainer = document.getElementById(CHART_CONTAINER_ID);
+      if (chartContainer) {
+        const width = chartContainer.offsetWidth;
+        if (width !== chartWidth) {
+          setChartWidth(width);
+          draw(props, setErrorMessage, false);
+        }
+      }
+    }
+    window.addEventListener("resize", _handleWindowResize);
+    return () => {
+      window.removeEventListener("resize", _handleWindowResize);
+    };
+  }, [props]);
   return (
     <>
       <Container>
@@ -71,19 +96,21 @@ export function Chart(props: ChartProps): JSX.Element {
           {errorMessage ? (
             <div className="error-message">{errorMessage}</div>
           ) : (
-            <div id={SVG_CONTAINER_ID}></div>
-          )}
-          <div className="map-section-container">
-            <div id={SVG_CONTAINER_ID}></div>
-            <div className="zoom-button-section">
-              <div id={ZOOM_IN_BUTTON_ID} className="zoom-button">
-                <i className="material-icons">add</i>
+            <div className="map-section-container">
+              <div id={CHART_CONTAINER_ID}>
+                <div id={SVG_CONTAINER_ID}></div>
+                <div id={LEGEND_CONTAINER_ID}></div>
               </div>
-              <div id={ZOOM_OUT_BUTTON_ID} className="zoom-button">
-                <i className="material-icons">remove</i>
+              <div className="zoom-button-section">
+                <div id={ZOOM_IN_BUTTON_ID} className="zoom-button">
+                  <i className="material-icons">add</i>
+                </div>
+                <div id={ZOOM_OUT_BUTTON_ID} className="zoom-button">
+                  <i className="material-icons">remove</i>
+                </div>
               </div>
             </div>
-          </div>
+          )}
           <ChartOptions
             dataValues={props.breadcrumbDataValues}
             placeInfo={props.placeInfo}
@@ -108,12 +135,12 @@ export function Chart(props: ChartProps): JSX.Element {
 
 function draw(
   props: ChartProps,
-  setErrorMessage: (errorMessage: string) => void
+  setErrorMessage: (errorMessage: string) => void,
+  shouldDrawMap: boolean
 ): void {
-  document.getElementById(SVG_CONTAINER_ID).innerHTML = "";
-  const width = document.getElementById(SVG_CONTAINER_ID).offsetWidth;
+  document.getElementById(LEGEND_CONTAINER_ID).innerHTML = "";
+  const width = document.getElementById(CHART_CONTAINER_ID).offsetWidth;
   const height = (width * 2) / 5;
-  const legendMargins = height * 0.2;
   const getRedirectLink = getMapRedirectLink(
     props.statVarInfo,
     props.placeInfo
@@ -131,15 +158,28 @@ function draw(
       return;
     }
   }
-  if (!_.isEmpty(props.geoJsonData) && !_.isEmpty(props.mapDataValues)) {
+  const colorScale = getColorScale(props.statVarInfo.name, props.mapDataValues);
+  const legendHeight = height * LEGEND_HEIGHT_SCALING;
+  const legendWidth = generateLegendSvg(
+    LEGEND_CONTAINER_ID,
+    legendHeight,
+    colorScale,
+    props.unit,
+    LEGEND_MARGIN_LEFT
+  );
+  if (
+    shouldDrawMap &&
+    !_.isEmpty(props.geoJsonData) &&
+    !_.isEmpty(props.mapDataValues)
+  ) {
     drawChoropleth(
       SVG_CONTAINER_ID,
       props.geoJsonData,
       height,
-      width,
+      width - legendWidth,
       props.mapDataValues,
       "",
-      props.statVarInfo.name,
+      colorScale,
       props.placeInfo.enclosedPlaceType in USA_CHILD_PLACE_TYPES,
       getRedirectLink,
       getTooltipHtml(
@@ -148,10 +188,10 @@ function draw(
         props.mapDataValues,
         props.unit
       ),
+      false,
       zoomDcid,
       ZOOM_IN_BUTTON_ID,
-      ZOOM_OUT_BUTTON_ID,
-      { top: legendMargins, bottom: legendMargins }
+      ZOOM_OUT_BUTTON_ID
     );
   }
 }


### PR DESCRIPTION
Separate how window resize is handled for the legend from how it's handled for the map. Otherwise, going from small screen to large screen will cause the legend to become too large. 
![screen-recording (18)](https://user-images.githubusercontent.com/69875368/123167384-4ddddd00-d42b-11eb-8e5e-afb5c7af297b.gif)
