### PR TITLE
[tree widget] Various fixes

### DIFF
--- a/static/css/stat_var_hierarchy.scss
+++ b/static/css/stat_var_hierarchy.scss
@@ -74,6 +74,7 @@ $horizontal-spacing: 15px;
 .statvar-search-input {
   border-radius: $border-radius;
   width: 100%;
+  padding-right: 1.7rem;
 }
 
 .clear-search {

--- a/static/css/tools/stat_var_widget.scss
+++ b/static/css/tools/stat_var_widget.scss
@@ -52,6 +52,7 @@ $transparent-red: rgba(240, 230, 231, 0.2);
 
 #stat-var-hierarchy-scroll-container {
   overflow: auto;
+  flex-grow: 1;
 }
 
 .statvar-hierarchy-search-section {

--- a/static/js/stat_var_hierarchy/node_header.tsx
+++ b/static/js/stat_var_hierarchy/node_header.tsx
@@ -51,8 +51,7 @@ export class StatVarHierarchyNodeHeader extends React.Component<
       prefixHtml = this.props.opened ? DOWN_ARROW_HTML : RIGHT_ARROW_HTML;
     }
     const showSelectionCount =
-      (this.context.statVarHierarchyType === StatVarHierarchyType.TIMELINE ||
-        this.context.statVarHierarchyType === StatVarHierarchyType.SCATTER) &&
+      this.context.statVarHierarchyType !== StatVarHierarchyType.BROWSER &&
       this.props.selectionCount > 0;
 
     let className = "node-title";

--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -27,6 +27,7 @@ import {
   StatVarInfo,
   StatVarGroupInfo,
   StatVarHierarchyNodeType,
+  StatVarHierarchyType,
 } from "../shared/types";
 import { StatVarHierarchyNodeHeader } from "./node_header";
 import { StatVarSection } from "./stat_var_section";
@@ -201,9 +202,17 @@ export class StatVarGroupNode extends React.Component<
       .get(url)
       .then((resp) => {
         const data = resp.data;
+        let childSV: StatVarInfo[] = data["childStatVars"] || [];
+        let childSVG: StatVarGroupInfo[] = data["childStatVarGroups"] || [];
+        if (
+          this.context.statVarHierarchyType === StatVarHierarchyType.BROWSER
+        ) {
+          childSV = childSV.filter((sv) => sv.hasData);
+          childSVG = childSVG.filter((svg) => svg.numDescendentStatVars > 0);
+        }
         this.setState({
-          childSV: data["childStatVars"],
-          childSVG: data["childStatVarGroups"],
+          childSV,
+          childSVG,
           dataFetched: true,
         });
       })

--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -27,7 +27,6 @@ import {
   StatVarInfo,
   StatVarGroupInfo,
   StatVarHierarchyNodeType,
-  StatVarHierarchyType,
 } from "../shared/types";
 import { StatVarHierarchyNodeHeader } from "./node_header";
 import { StatVarSection } from "./stat_var_section";
@@ -126,13 +125,9 @@ export class StatVarGroupNode extends React.Component<
     }
 
     const getTrigger = (opened: boolean) => {
-      const shouldHighlightForMap =
-        this.context.statVarHierarchyType === StatVarHierarchyType.MAP &&
-        selectionCount > 0 &&
-        !opened;
       return React.createElement(StatVarHierarchyNodeHeader, {
         childrenStatVarCount: this.props.data.numDescendentStatVars,
-        highlighted: this.props.isSelected || shouldHighlightForMap,
+        highlighted: this.props.isSelected,
         nodeType: StatVarHierarchyNodeType.STAT_VAR_GROUP,
         opened,
         selectionCount,

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -113,7 +113,7 @@ export class StatVarHierarchy extends React.Component<
       return null;
     }
     // Do not want to change the state here.
-    const rootSVGs = _.cloneDeep(this.state.rootSVGs);
+    let rootSVGs = _.cloneDeep(this.state.rootSVGs);
     if (!_.isEmpty(rootSVGs)) {
       rootSVGs.sort((a, b) => {
         if (a.id === SORTED_FIRST_SVG_ID) {
@@ -130,6 +130,9 @@ export class StatVarHierarchy extends React.Component<
         }
         return a > b ? 1 : -1;
       });
+    }
+    if (this.props.type === StatVarHierarchyType.BROWSER) {
+      rootSVGs = rootSVGs.filter((svg) => svg.numDescendentStatVars > 0);
     }
     return (
       <div id={LOADING_CONTAINER_ID} className="loading-spinner-container">

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -197,9 +197,14 @@ export class StatVarHierarchy extends React.Component<
         return resp.data["childStatVarGroups"];
       })
     );
+    const svPath = {};
     if (this.props.selectedSVs) {
       for (const sv of this.props.selectedSVs) {
-        allPromises.push(this.getPath(sv));
+        if (this.state.svPath && sv in this.state.svPath) {
+          svPath[sv] = this.state.svPath[sv];
+        } else {
+          allPromises.push(this.getPath(sv));
+        }
       }
     }
     Promise.all(allPromises)
@@ -207,7 +212,6 @@ export class StatVarHierarchy extends React.Component<
         removeSpinner(LOADING_CONTAINER_ID);
         const rootSVGs = allResult[0] as StatVarGroupInfo[];
         const paths = allResult.slice(1) as string[][];
-        const svPath = {};
         for (const path of paths) {
           // In this case, the stat var is not in hierarchy.
           if (path.length == 1) {

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -244,15 +244,6 @@ export class StatVarHierarchy extends React.Component<
         focusPath: path,
         searchSelectionCleared,
       });
-      // If selection is stat var, added it to svPath.
-      if (selection != "" && !selection.startsWith("dc/g")) {
-        if (this.props.selectSV) {
-          this.props.selectSV(selection);
-        }
-        this.setState({
-          svPath: Object.assign({ [selection]: path }, this.state.svPath),
-        });
-      }
     });
   }
 

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -94,7 +94,12 @@ export class StatVarSectionInput extends React.Component<
           onChange={this.handleInputChange}
           disabled={!this.props.statVar.hasData}
         />
-        <label htmlFor={sectionId}>{this.props.statVar.displayName}</label>
+        <label
+          className={this.state.checked ? "selected-node-title" : ""}
+          htmlFor={sectionId}
+        >
+          {this.props.statVar.displayName}
+        </label>
       </form>
     );
   }

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -62,7 +62,7 @@ export class StatVarSectionInput extends React.Component<
   }
 
   private isChecked(): boolean {
-    return this.props.selected || this.props.statVar.id in this.context.svPath;
+    return this.props.statVar.id in this.context.svPath;
   }
 
   private handleInputChange(): void {

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -71,6 +71,12 @@ function StatVarChooser(): JSX.Element {
   // Records which two of the three statvars are wanted if a third statvar is selected.
   const [modalSelected, setModalSelected] = useState(defaultModalSelected);
   const [modalOpen, setModalOpen] = useState(false);
+  const [samplePlaces, setSamplePlaces] = useState(
+    _.sampleSize(place.value.enclosedPlaces, SAMPLE_SIZE)
+  );
+  useEffect(() => {
+    setSamplePlaces(_.sampleSize(place.value.enclosedPlaces, SAMPLE_SIZE));
+  }, [place.value.enclosedPlaces]);
   const menuSelected = [
     x.value.statVarDcid,
     y.value.statVarDcid,
@@ -122,7 +128,7 @@ function StatVarChooser(): JSX.Element {
     <div className="explore-menu-container" id="explore">
       <StatVarHierarchy
         type={StatVarHierarchyType.SCATTER}
-        places={_.sampleSize(place.value.enclosedPlaces, SAMPLE_SIZE)}
+        places={samplePlaces}
         selectedSVs={menuSelected}
         selectSV={(sv) => addStatVar(x, y, sv, setThirdStatVar, setModalOpen)}
         deselectSV={(sv) => removeStatVar(x, y, sv)}

--- a/static/js/tools/timeline/__snapshots__/page.test.tsx.snap
+++ b/static/js/tools/timeline/__snapshots__/page.test.tsx.snap
@@ -24,10 +24,10 @@ exports[`Single place and single stats var 3`] = `
   <div class=\\"Collapsible__contentInner\\">
     <div class=\\"svg-node-child\\">
       <div>
-        <form class=\\"node-title node-no-data\\"><input id=\\"Count_Persondc/g/Demographics-Count_Person\\" name=\\"stat-var-hierarchy\\" type=\\"checkbox\\" disabled=\\"\\"><label for=\\"Count_Persondc/g/Demographics-Count_Person\\">Count Of Person</label></form>
+        <form class=\\"node-title node-no-data\\"><input id=\\"Count_Persondc/g/Demographics-Count_Person\\" name=\\"stat-var-hierarchy\\" type=\\"checkbox\\" disabled=\\"\\"><label class=\\"selected-node-title\\" for=\\"Count_Persondc/g/Demographics-Count_Person\\">Count Of Person</label></form>
       </div>
       <div>
-        <form class=\\"node-title node-no-data\\"><input id=\\"Median_Age_Persondc/g/Demographics-Median_Age_Person\\" name=\\"stat-var-hierarchy\\" type=\\"checkbox\\" disabled=\\"\\"><label for=\\"Median_Age_Persondc/g/Demographics-Median_Age_Person\\">Median age of person</label></form>
+        <form class=\\"node-title node-no-data\\"><input id=\\"Median_Age_Persondc/g/Demographics-Median_Age_Person\\" name=\\"stat-var-hierarchy\\" type=\\"checkbox\\" disabled=\\"\\"><label class=\\"\\" for=\\"Median_Age_Persondc/g/Demographics-Median_Age_Person\\">Median age of person</label></form>
       </div>
     </div>
     <div class=\\"svg-node-child\\">


### PR DESCRIPTION
- fixed [issue 1005](https://github.com/datacommonsorg/website/issues/1005):  entire path not highlighted. This was actually because a different path that goes to the same variable was being highlighted. Fixed this by making sure the path that user took to get to a stat var is the path that gets highlighted
- fixed [issue 1006](https://github.com/datacommonsorg/website/issues/1006): browser should only show available nodes
- fixed problem where when a tree widget section had been opened and then there was a places change, the contents of the opened section didn't update. 
- fixed problem where when the input in the search box was longer than the width of search box, it would overlay over the clear search button
- removed auto selecting the option user selects from the list of search results when user uses the search

dev updated with these changes