### PR TITLE
[tree widget] Add tooltips

### DIFF
--- a/server/routes/api/stats.py
+++ b/server/routes/api/stats.py
@@ -224,3 +224,15 @@ def get_stats_all():
     return Response(json.dumps(dc.get_stats_all(dcids, stat_vars)),
                     200,
                     mimetype="application/json")
+
+
+@bp.route('/api/stats/stat-var-summary', methods=["POST"])
+@cache.cached(timeout=3600 * 24, query_string=True)
+def get_statvar_summary():
+    """Gets the summaries for a list of stat vars.
+    """
+    stat_vars = request.json.get("statVars")
+    result = dc.get_statvar_summary(stat_vars)
+    return Response(json.dumps(result.get("statVarSummary", {})),
+                    200,
+                    mimetype='application/json')

--- a/server/routes/api/stats.py
+++ b/server/routes/api/stats.py
@@ -227,11 +227,11 @@ def get_stats_all():
 
 
 @bp.route('/api/stats/stat-var-summary', methods=["POST"])
-@cache.cached(timeout=3600 * 24, query_string=True)
 def get_statvar_summary():
     """Gets the summaries for a list of stat vars.
     """
     stat_vars = request.json.get("statVars")
+    print(stat_vars)
     result = dc.get_statvar_summary(stat_vars)
     return Response(json.dumps(result.get("statVarSummary", {})),
                     200,

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -53,6 +53,7 @@ API_ENDPOINTS = {
     'get_statvar_group': '/stat-var/group',
     'get_statvar_path': '/stat-var/path',
     'search_statvar': '/stat-var/search',
+    'get_statvar_summary': '/stat-var/summary',
 }
 
 # The default value to limit to
@@ -362,6 +363,14 @@ def get_statvar_path(id):
     url = API_ROOT + API_ENDPOINTS['get_statvar_path']
     req_json = {
         'id': id,
+    }
+    return send_request(url, req_json, has_payload=False)
+
+
+def get_statvar_summary(dcids):
+    url = API_ROOT + API_ENDPOINTS['get_statvar_summary']
+    req_json = {
+        'stat_vars': dcids,
     }
     return send_request(url, req_json, has_payload=False)
 

--- a/server/templates/tools/scatter.html
+++ b/server/templates/tools/scatter.html
@@ -24,6 +24,7 @@
 {% block head %}
 <link rel="stylesheet" href={{url_for('static', filename='css/scatter.min.css', t=config['VERSION'])}}>
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
 {% endblock %}
 
 {% block content %}

--- a/server/templates/tools/timeline.html
+++ b/server/templates/tools/timeline.html
@@ -24,6 +24,7 @@
 {% block head %}
 <link rel="stylesheet" href={{url_for('static', filename='css/timeline.min.css', t=config['VERSION'])}}>
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
 {% endblock %}
 
 {% block content %}

--- a/static/css/tools/stat_var_widget.scss
+++ b/static/css/tools/stat_var_widget.scss
@@ -42,6 +42,8 @@ $transparent-red: rgba(240, 230, 231, 0.2);
 
 #stat-var-hierarchy-section {
   height: 100%;
+  position: relative;
+  overflow-y: hidden;
 }
 
 .stat-var-hierarchy-container {
@@ -122,6 +124,7 @@ form.node-title {
   border-radius: 3px;
   border: 0.5px solid #dee2e6;
   padding: 0.3rem;
+  overflow-wrap: anywhere;
 }
 
 #tree-widget-info i {

--- a/static/css/tools/stat_var_widget.scss
+++ b/static/css/tools/stat_var_widget.scss
@@ -119,7 +119,7 @@ form.node-title {
   visibility: hidden;
   position: absolute;
   background-color: #fff;
-  color: #3b3b3b;;
+  color: #3b3b3b;
   font-size: 0.8rem;
   border-radius: 3px;
   border: 0.5px solid #dee2e6;

--- a/static/css/tools/stat_var_widget.scss
+++ b/static/css/tools/stat_var_widget.scss
@@ -112,3 +112,28 @@ form.node-title {
   font-size: .9rem;
   line-height: 2em;
 }
+
+#tree-widget-tooltip {
+  visibility: hidden;
+  position: absolute;
+  background-color: #fff;
+  color: #3b3b3b;;
+  font-size: 0.8rem;
+  border-radius: 3px;
+  border: 0.5px solid #dee2e6;
+  padding: 0.3rem;
+}
+
+#tree-widget-info i {
+  position: absolute;
+  right: 0;
+  padding: 0.3rem;
+  color: white;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+
+#tree-widget-tooltip ul {
+  padding-left: 1rem;
+  margin-bottom: 0;
+}

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -29,6 +29,7 @@ import {
 import { StatVarInfo } from "../tools/statvar_menu/util";
 import { formatNumber } from "../i18n/i18n";
 import { DotDataPoint } from "./types";
+import { Boundary } from "../shared/types";
 
 const NUM_X_TICKS = 5;
 const NUM_Y_TICKS = 5;
@@ -75,13 +76,6 @@ const HIGHLIGHTING_DOT_R = 5;
 // if building a datagroup dictionary and the place for a datagroup is
 // unknown, use this as the place.
 const DATAGROUP_UNKNOWN_PLACE = "unknown";
-
-interface Boundary {
-  top: number;
-  bottom: number;
-  left: number;
-  right: number;
-}
 
 function appendLegendElem(
   elem: string,

--- a/static/js/shared/types.ts
+++ b/static/js/shared/types.ts
@@ -78,3 +78,18 @@ export interface Boundary {
   left?: number;
   right?: number;
 }
+
+interface PlaceSummary {
+  dcid: string;
+  name: string;
+  personCount: number;
+}
+
+interface PlaceTypeSummary {
+  numPlaces: number;
+  topPlaces: PlaceSummary[];
+}
+
+export interface StatVarSummary {
+  placeTypeSummary: { [placeType: string]: PlaceTypeSummary };
+}

--- a/static/js/shared/types.ts
+++ b/static/js/shared/types.ts
@@ -71,3 +71,10 @@ export enum StatVarHierarchyNodeType {
   STAT_VAR_GROUP,
   STAT_VAR,
 }
+
+export interface Boundary {
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+}

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -302,7 +302,7 @@ export class StatVarHierarchy extends React.Component<
     const html =
       "<ul><li>The number in parentheses represents the number of available" +
       "stat vars within the group that we have for the chosen place(s).</li>" +
-      "<li>Greyed out stat var groups have no available stat vars for the" +
+      "<li>Greyed out stat var groups have no available stat vars for the " +
       "chosen place(s), but can still be expanded for you to explore.</li></ul>";
     const topOffset = 30;
     const margin = 5;

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -44,6 +44,8 @@ import {
 const SORTED_FIRST_SVG_ID = "dc/g/Demographics";
 const SORTED_LAST_SVG_ID = "dc/g/Miscellaneous";
 const ROOT_SVG = "dc/g/Root";
+const TOOLTIP_TOP_OFFSET = 30;
+const TOOLTIP_MARGIN = 5;
 
 interface StatVarHierarchyPropType {
   type: string;
@@ -300,12 +302,10 @@ export class StatVarHierarchy extends React.Component<
 
   private onMouseOverInfoIcon = () => {
     const html =
-      "<ul><li>The number in parentheses represents the number of available" +
-      "stat vars within the group that we have for the chosen place(s).</li>" +
+      "<ul><li>The number in parentheses represents the number of stat vars " +
+      "within the group where we have data for the chosen place(s).</li>" +
       "<li>Greyed out stat var groups have no available stat vars for the " +
       "chosen place(s), but can still be expanded for you to explore.</li></ul>";
-    const topOffset = 30;
-    const margin = 5;
     const containerY = (d3
       .select("#explore")
       .node() as HTMLElement).getBoundingClientRect().y;
@@ -313,9 +313,9 @@ export class StatVarHierarchy extends React.Component<
       .select("#tree-widget-info i")
       .node() as HTMLElement).getBoundingClientRect().y;
     showTooltip(html, {
-      left: margin,
-      right: margin,
-      top: iconY - containerY + topOffset,
+      left: TOOLTIP_MARGIN,
+      right: TOOLTIP_MARGIN,
+      top: iconY - containerY + TOOLTIP_TOP_OFFSET,
     });
   };
 }

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -34,9 +34,13 @@ import {
 
 import { loadSpinner, removeSpinner } from "../browser/util";
 import { Context } from "../shared/context";
-import { hideTooltip, showTooltip, TOOLTIP_ID } from "./util";
+import {
+  hideTooltip,
+  SV_HIERARCHY_SECTION_ID,
+  showTooltip,
+  TOOLTIP_ID,
+} from "./util";
 
-const LOADING_CONTAINER_ID = "stat-var-hierarchy-section";
 const SORTED_FIRST_SVG_ID = "dc/g/Demographics";
 const SORTED_LAST_SVG_ID = "dc/g/Miscellaneous";
 const ROOT_SVG = "dc/g/Root";
@@ -137,7 +141,7 @@ export class StatVarHierarchy extends React.Component<
       rootSVGs = rootSVGs.filter((svg) => svg.numDescendentStatVars > 0);
     }
     return (
-      <div id={LOADING_CONTAINER_ID} className="loading-spinner-container">
+      <div id={SV_HIERARCHY_SECTION_ID} className="loading-spinner-container">
         <div
           id="tree-widget-info"
           onMouseOver={this.onMouseOverInfoIcon}
@@ -199,7 +203,7 @@ export class StatVarHierarchy extends React.Component<
   }
 
   private fetchData(): void {
-    loadSpinner(LOADING_CONTAINER_ID);
+    loadSpinner(SV_HIERARCHY_SECTION_ID);
     let url = `/api/browser/statvar/group?stat_var_group=${ROOT_SVG}`;
     for (const place of this.props.places) {
       url += `&places=${place.dcid}`;
@@ -222,7 +226,7 @@ export class StatVarHierarchy extends React.Component<
     }
     Promise.all(allPromises)
       .then((allResult) => {
-        removeSpinner(LOADING_CONTAINER_ID);
+        removeSpinner(SV_HIERARCHY_SECTION_ID);
         const rootSVGs = allResult[0] as StatVarGroupInfo[];
         const paths = allResult.slice(1) as string[][];
         for (const path of paths) {
@@ -238,7 +242,7 @@ export class StatVarHierarchy extends React.Component<
         });
       })
       .catch(() => {
-        removeSpinner(LOADING_CONTAINER_ID);
+        removeSpinner(SV_HIERARCHY_SECTION_ID);
         this.setState({
           errorMessage: "Error retrieving stat var group root nodes",
         });

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -22,6 +22,7 @@
 import React from "react";
 import axios from "axios";
 import _ from "lodash";
+import * as d3 from "d3";
 
 import { StatVarHierarchySearch } from "./stat_var_search";
 import { StatVarGroupNode } from "./stat_var_group_node";
@@ -33,6 +34,7 @@ import {
 
 import { loadSpinner, removeSpinner } from "../browser/util";
 import { Context } from "../shared/context";
+import { hideTooltip, showTooltip, TOOLTIP_ID } from "./util";
 
 const LOADING_CONTAINER_ID = "stat-var-hierarchy-section";
 const SORTED_FIRST_SVG_ID = "dc/g/Demographics";
@@ -136,6 +138,13 @@ export class StatVarHierarchy extends React.Component<
     }
     return (
       <div id={LOADING_CONTAINER_ID} className="loading-spinner-container">
+        <div
+          id="tree-widget-info"
+          onMouseOver={this.onMouseOverInfoIcon}
+          onMouseOut={() => hideTooltip()}
+        >
+          <i className="material-icons-outlined">info</i>
+        </div>
         {!_.isEmpty(this.state.errorMessage) && (
           <div className="error-message">{this.state.errorMessage}</div>
         )}
@@ -184,6 +193,7 @@ export class StatVarHierarchy extends React.Component<
         <div id="browser-screen" className="screen">
           <div id="spinner"></div>
         </div>
+        <div id={TOOLTIP_ID}></div>
       </div>
     );
   }
@@ -283,4 +293,25 @@ export class StatVarHierarchy extends React.Component<
         return _.cloneDeep(resp.data["path"]).reverse();
       });
   }
+
+  private onMouseOverInfoIcon = () => {
+    const html =
+      "<ul><li>The number in parentheses represents the number of available" +
+      "stat vars within the group that we have for the chosen place(s).</li>" +
+      "<li>Greyed out stat var groups have no available stat vars for the" +
+      "chosen place(s), but can still be expanded for you to explore.</li></ul>";
+    const topOffset = 30;
+    const margin = 5;
+    const containerY = (d3
+      .select("#explore")
+      .node() as HTMLElement).getBoundingClientRect().y;
+    const iconY = (d3
+      .select("#tree-widget-info i")
+      .node() as HTMLElement).getBoundingClientRect().y;
+    showTooltip(html, {
+      left: margin,
+      right: margin,
+      top: iconY - containerY + topOffset,
+    });
+  };
 }

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -144,13 +144,15 @@ export class StatVarHierarchy extends React.Component<
     }
     return (
       <div id={SV_HIERARCHY_SECTION_ID} className="loading-spinner-container">
-        <div
-          id="tree-widget-info"
-          onMouseOver={this.onMouseOverInfoIcon}
-          onMouseOut={() => hideTooltip()}
-        >
-          <i className="material-icons-outlined">info</i>
-        </div>
+        {this.props.type !== StatVarHierarchyType.BROWSER && (
+          <div
+            id="tree-widget-info"
+            onMouseOver={this.onMouseOverInfoIcon}
+            onMouseOut={() => hideTooltip()}
+          >
+            <i className="material-icons-outlined">info</i>
+          </div>
+        )}
         {!_.isEmpty(this.state.errorMessage) && (
           <div className="error-message">{this.state.errorMessage}</div>
         )}

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -21,15 +21,22 @@
 
 import React from "react";
 import * as d3 from "d3";
+import _ from "lodash";
 
-import { StatVarHierarchyType, StatVarInfo } from "../shared/types";
+import {
+  StatVarHierarchyType,
+  StatVarInfo,
+  StatVarSummary,
+} from "../shared/types";
 import { Context, ContextType } from "../shared/context";
-import { hideTooltip, showTooltip } from "./util";
+import { hideTooltip, SV_HIERARCHY_SECTION_ID, showTooltip } from "./util";
+import { USA_CHILD_PLACE_TYPES } from "../tools/map/util";
 
 interface StatVarSectionInputPropType {
   path: string[];
   statVar: StatVarInfo;
   selected: boolean;
+  summary: StatVarSummary;
 }
 
 interface StatVarSectionInputStateType {
@@ -111,17 +118,40 @@ export class StatVarSectionInput extends React.Component<
   }
 
   private mouseMoveAction = (e) => {
-    if (this.props.statVar.hasData) {
-      return;
+    let html = "loading stat var summary...";
+    if (!_.isEmpty(this.props.summary)) {
+      let availablePlaceTypes = Object.keys(
+        this.props.summary.placeTypeSummary
+      );
+      if (this.context.statVarHierarchyType === StatVarHierarchyType.MAP) {
+        availablePlaceTypes = availablePlaceTypes.filter(
+          (placeType) =>
+            placeType in USA_CHILD_PLACE_TYPES && placeType !== "Country"
+        );
+      }
+      html =
+        availablePlaceTypes.length > 0
+          ? "This stat var has no data for any of the chosen places." +
+            "You can try these types of places instead. <ul>"
+          : "Sorry, this stat var is not supported by this tool.";
+      for (const placeType of availablePlaceTypes) {
+        const placeSummary = this.props.summary.placeTypeSummary[placeType];
+        const placeList = placeSummary.topPlaces.map((place) => place.name);
+        html +=
+          this.context.statVarHierarchyType === StatVarHierarchyType.TIMELINE
+            ? `<li>${placeType} (eg. ${placeList.join(", ")})</li>`
+            : `<li>${placeType}</li>`;
+      }
+      html += "</ul>";
     }
-    const html = "placeholder";
     const left = e.pageX;
     const topOffset = 10;
     const containerY = (d3
-      .select("#explore")
+      .select(`#${SV_HIERARCHY_SECTION_ID}`)
       .node() as HTMLElement).getBoundingClientRect().y;
     const top = e.pageY - containerY + topOffset;
-    showTooltip(html, { left, top });
+    const right = 20;
+    showTooltip(html, { left, top, right });
   };
 }
 

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -32,6 +32,9 @@ import { Context, ContextType } from "../shared/context";
 import { hideTooltip, SV_HIERARCHY_SECTION_ID, showTooltip } from "./util";
 import { USA_CHILD_PLACE_TYPES } from "../tools/map/util";
 
+const TOOLTIP_TOP_OFFSET = 10;
+const TOOLTIP_RIGHT_MARGIN = 20;
+
 interface StatVarSectionInputPropType {
   path: string[];
   statVar: StatVarInfo;
@@ -145,13 +148,11 @@ export class StatVarSectionInput extends React.Component<
       html += "</ul>";
     }
     const left = e.pageX;
-    const topOffset = 10;
     const containerY = (d3
       .select(`#${SV_HIERARCHY_SECTION_ID}`)
       .node() as HTMLElement).getBoundingClientRect().y;
-    const top = e.pageY - containerY + topOffset;
-    const right = 20;
-    showTooltip(html, { left, top, right });
+    const top = e.pageY - containerY + TOOLTIP_TOP_OFFSET;
+    showTooltip(html, { left, top, right: TOOLTIP_RIGHT_MARGIN });
   };
 }
 

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -20,9 +20,11 @@
  */
 
 import React from "react";
+import * as d3 from "d3";
 
 import { StatVarHierarchyType, StatVarInfo } from "../shared/types";
 import { Context, ContextType } from "../shared/context";
+import { hideTooltip, showTooltip } from "./util";
 
 interface StatVarSectionInputPropType {
   path: string[];
@@ -97,12 +99,30 @@ export class StatVarSectionInput extends React.Component<
         <label
           className={this.state.checked ? "selected-node-title" : ""}
           htmlFor={sectionId}
+          onMouseMove={
+            !this.props.statVar.hasData ? this.mouseMoveAction : null
+          }
+          onMouseOut={() => hideTooltip()}
         >
           {this.props.statVar.displayName}
         </label>
       </form>
     );
   }
+
+  private mouseMoveAction = (e) => {
+    if (this.props.statVar.hasData) {
+      return;
+    }
+    const html = "placeholder";
+    const left = e.pageX;
+    const topOffset = 10;
+    const containerY = (d3
+      .select("#explore")
+      .node() as HTMLElement).getBoundingClientRect().y;
+    const top = e.pageY - containerY + topOffset;
+    showTooltip(html, { left, top });
+  };
 }
 
 StatVarSectionInput.contextType = Context;

--- a/static/js/stat_var_hierarchy/util.ts
+++ b/static/js/stat_var_hierarchy/util.ts
@@ -22,6 +22,8 @@ import * as d3 from "d3";
 import { Boundary } from "../shared/types";
 
 export const TOOLTIP_ID = "tree-widget-tooltip";
+// id value of the div that holds this stat var hierarchy section.
+export const SV_HIERARCHY_SECTION_ID = "stat-var-hierarchy-section";
 
 /** Function to make tooltip show up given the html for the tooltip and position
  * to display the tooltip at.

--- a/static/js/stat_var_hierarchy/util.ts
+++ b/static/js/stat_var_hierarchy/util.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility functions shared across different components of stat var hierarchy.
+ */
+
+import * as d3 from "d3";
+import { Boundary } from "../shared/types";
+
+export const TOOLTIP_ID = "tree-widget-tooltip";
+
+/** Function to make tooltip show up given the html for the tooltip and position
+ * to display the tooltip at.
+ */
+export function showTooltip(html: string, position: Boundary): void {
+  d3.select(`#${TOOLTIP_ID}`)
+    .style("visibility", "visible")
+    .style("left", position.left ? position.left + "px" : null)
+    .style("right", position.right ? position.right + "px" : null)
+    .style("top", position.top ? position.top + "px" : null)
+    .style("bottom", position.bottom ? position.bottom + "px" : null)
+    .html(html);
+}
+
+/** Function to hide the tooltip.
+ */
+export function hideTooltip(): void {
+  d3.select("#tree-widget-tooltip").style("visibility", "hidden");
+}

--- a/static/js/tools/mock_functions.tsx
+++ b/static/js/tools/mock_functions.tsx
@@ -237,6 +237,32 @@ export function axios_mock(): void {
         path: ["NotInTheTree"],
       },
     });
+  when(axios.post)
+    .calledWith("/api/stats/stat-var-summary", {
+      statVars: ["Count_Person", "Median_Age_Person"],
+    })
+    .mockResolvedValue({
+      data: {
+        statVarSummary: {
+          Count_Person: {
+            placeTypeSummary: {
+              type1: {
+                numPlaces: 0,
+                topPlaces: [],
+              },
+            },
+          },
+          Median_Age_Person: {
+            placeTypeSummary: {
+              type1: {
+                numPlaces: 0,
+                topPlaces: [],
+              },
+            },
+          },
+        },
+      },
+    });
 }
 
 export function mock_hierarchy_complete(): void {

--- a/static/js/tools/scatter/app.test.tsx
+++ b/static/js/tools/scatter/app.test.tsx
@@ -406,6 +406,44 @@ function mockAxios(): () => void {
     .calledWith("/api/browser/statvar/path?id=Count_Person_Employed")
     .mockResolvedValue({ data: pathsData.Count_Person_Employed });
 
+  when(axios.post)
+    .calledWith("/api/stats/stat-var-summary", {
+      statVars: [
+        "Count_Person_Employed",
+        "Count_HousingUnit",
+        "Count_Establishment",
+      ],
+    })
+    .mockResolvedValue({
+      data: {
+        statVarSummary: {
+          Count_Person_Employed: {
+            placeTypeSummary: {
+              type1: {
+                numPlaces: 0,
+                topPlaces: [],
+              },
+            },
+          },
+          Count_HousingUnit: {
+            placeTypeSummary: {
+              type1: {
+                numPlaces: 0,
+                topPlaces: [],
+              },
+            },
+          },
+          Count_Establishment: {
+            placeTypeSummary: {
+              type1: {
+                numPlaces: 0,
+                topPlaces: [],
+              },
+            },
+          },
+        },
+      },
+    });
   return () => {
     axios.get = get;
     axios.post = post;


### PR DESCRIPTION
- add an info tooltip to explain the count and the greyed out stat var groups ([issue 1008](https://github.com/datacommonsorg/website/issues/1008))
- add tooltip for greyed out stat vars that gives list of placetypes and/or place names that have data for this stat var

dev updated with these changes

<img width="552" alt="Screen Shot 2021-07-07 at 2 19 51 PM" src="https://user-images.githubusercontent.com/69875368/124830406-ab475300-df2e-11eb-8af0-87b64e7243f6.png">
<img width="477" alt="Screen Shot 2021-07-07 at 2 19 58 PM" src="https://user-images.githubusercontent.com/69875368/124830419-ada9ad00-df2e-11eb-841e-72aea5bb8e94.png">
