### PR TITLE
[tree widget] tooltip updates

### DIFF
--- a/server/routes/api/stats.py
+++ b/server/routes/api/stats.py
@@ -231,7 +231,6 @@ def get_statvar_summary():
     """Gets the summaries for a list of stat vars.
     """
     stat_vars = request.json.get("statVars")
-    print(stat_vars)
     result = dc.get_statvar_summary(stat_vars)
     return Response(json.dumps(result.get("statVarSummary", {})),
                     200,

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -161,7 +161,7 @@ export class StatVarSectionInput extends React.Component<
       html = "Sorry, this variable is not supported by this tool.";
     } else {
       html += hasData
-        ? "You can also try these types of places:<ul>"
+        ? "This variable is available for these types of places:<ul>"
         : "You can try these types of places instead:<ul>";
     }
     // Some place types are considered equivalent, so need to consolidate the

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -34,12 +34,20 @@ import { USA_CHILD_PLACE_TYPES } from "../tools/map/util";
 
 const TOOLTIP_TOP_OFFSET = 10;
 const TOOLTIP_RIGHT_MARGIN = 20;
+const STATE_OR_EQUIVALENT = "State or equivalent";
+const COUNTY_OR_EQUIVALENT = "County or equivalent";
+const CITY_OR_EQUIVALENT = "City or equivalent";
 const PLACE_TYPE_MAPPING = {
-  EurostatNUTS1: "State",
-  EurostatNUTS2: "State",
-  Town: "City",
-  Village: "City",
-  Borough: "City",
+  EurostatNUTS1: STATE_OR_EQUIVALENT,
+  EurostatNUTS2: STATE_OR_EQUIVALENT,
+  State: STATE_OR_EQUIVALENT,
+  AdministrativeArea1: STATE_OR_EQUIVALENT,
+  AdministrativeArea2: COUNTY_OR_EQUIVALENT,
+  County: COUNTY_OR_EQUIVALENT,
+  Town: CITY_OR_EQUIVALENT,
+  Village: CITY_OR_EQUIVALENT,
+  Borough: CITY_OR_EQUIVALENT,
+  City: CITY_OR_EQUIVALENT,
 };
 const IGNORED_PLACE_TYPES = new Set([
   "Continent",
@@ -56,6 +64,7 @@ const IGNORED_PLACE_TYPES = new Set([
   "CensusCoreBasedStatisticalArea",
   "CensusTract",
   "CensusCountyDivision",
+  "CensusBlockGroup",
 ]);
 const IGNORED_PLACE_DCIDS = new Set(["Earth"]);
 
@@ -158,7 +167,9 @@ export class StatVarSectionInput extends React.Component<
       return !IGNORED_PLACE_TYPES.has(placeType);
     });
     if (availablePlaceTypes.length === 0) {
-      html = "Sorry, this variable is not supported by this tool.";
+      return hasData
+        ? ""
+        : "Sorry, this variable is not supported by this tool.";
     } else {
       html += hasData
         ? "This variable is available for these types of places:<ul>"
@@ -177,6 +188,9 @@ export class StatVarSectionInput extends React.Component<
         continue;
       }
       const placeNames = placeList.map((place) => place.name);
+      if (_.isEmpty(placeNames)) {
+        continue;
+      }
       placeType =
         placeType in PLACE_TYPE_MAPPING
           ? PLACE_TYPE_MAPPING[placeType]
@@ -186,6 +200,11 @@ export class StatVarSectionInput extends React.Component<
       } else {
         placeTypeToPlaceNames[placeType] = placeNames;
       }
+    }
+    if (_.isEmpty(placeTypeToPlaceNames)) {
+      return hasData
+        ? ""
+        : "Sorry, this variable is not supported by this tool.";
     }
     for (const placeType in placeTypeToPlaceNames) {
       // We only want to show a unique list of 3 items as examples.
@@ -205,6 +224,9 @@ export class StatVarSectionInput extends React.Component<
 
   private mouseMoveAction = (hasData: boolean) => (e) => {
     const html = this.getTooltipHtml(hasData);
+    if (_.isEmpty(html)) {
+      return;
+    }
     const left = e.pageX;
     const containerY = (d3
       .select(`#${SV_HIERARCHY_SECTION_ID}`)

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -121,7 +121,7 @@ export class StatVarSectionInput extends React.Component<
   }
 
   private mouseMoveAction = (e) => {
-    let html = "loading stat var summary...";
+    let html = "This stat var has no data for any of the chosen places.";
     if (!_.isEmpty(this.props.summary)) {
       let availablePlaceTypes = Object.keys(
         this.props.summary.placeTypeSummary
@@ -132,11 +132,11 @@ export class StatVarSectionInput extends React.Component<
             placeType in USA_CHILD_PLACE_TYPES && placeType !== "Country"
         );
       }
-      html =
-        availablePlaceTypes.length > 0
-          ? "This stat var has no data for any of the chosen places." +
-            "You can try these types of places instead. <ul>"
-          : "Sorry, this stat var is not supported by this tool.";
+      if (availablePlaceTypes.length === 0) {
+        html = "Sorry, this stat var is not supported by this tool.";
+      } else {
+        html += " You can try these types of places instead. <ul>";
+      }
       for (const placeType of availablePlaceTypes) {
         const placeSummary = this.props.summary.placeTypeSummary[placeType];
         const placeList = placeSummary.topPlaces.map((place) => place.name);


### PR DESCRIPTION
- don't show certain place types that can't be searched
- show tooltip for stat vars that have data
- rename certain place types (eg. NUTS2) to more recognizable place type