### PR TITLE
[tree widget] various updates

### DIFF
--- a/static/css/tools/stat_var_widget.scss
+++ b/static/css/tools/stat_var_widget.scss
@@ -42,7 +42,6 @@ $transparent-red: rgba(240, 230, 231, 0.2);
 
 #stat-var-hierarchy-section {
   height: 100%;
-  position: relative;
   overflow-y: hidden;
 }
 
@@ -125,6 +124,8 @@ form.node-title {
   border: 0.5px solid #dee2e6;
   padding: 0.3rem;
   overflow-wrap: anywhere;
+  z-index: 5;
+  min-width: 12rem;
 }
 
 #tree-widget-info i {

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -41,8 +41,6 @@ import {
   TOOLTIP_ID,
 } from "./util";
 
-const SORTED_FIRST_SVG_ID = "dc/g/Demographics";
-const SORTED_LAST_SVG_ID = "dc/g/Uncategorized";
 const ROOT_SVG = "dc/g/Root";
 const TOOLTIP_TOP_OFFSET = 30;
 const TOOLTIP_MARGIN = 5;
@@ -120,25 +118,7 @@ export class StatVarHierarchy extends React.Component<
       // rendering them again after the componentDidUpdate hook.
       return null;
     }
-    // Do not want to change the state here.
-    let rootSVGs = _.cloneDeep(this.state.rootSVGs);
-    if (!_.isEmpty(rootSVGs)) {
-      rootSVGs.sort((a, b) => {
-        if (a.id === SORTED_FIRST_SVG_ID) {
-          return -1;
-        }
-        if (b.id === SORTED_FIRST_SVG_ID) {
-          return 1;
-        }
-        if (a.id === SORTED_LAST_SVG_ID) {
-          return 1;
-        }
-        if (b.id === SORTED_LAST_SVG_ID) {
-          return -1;
-        }
-        return a > b ? 1 : -1;
-      });
-    }
+    let rootSVGs = this.state.rootSVGs;
     if (this.props.type === StatVarHierarchyType.BROWSER) {
       rootSVGs = rootSVGs.filter((svg) => svg.numDescendentStatVars > 0);
     }

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -147,10 +147,11 @@ export class StatVarHierarchy extends React.Component<
         {this.props.type !== StatVarHierarchyType.BROWSER && (
           <div
             id="tree-widget-info"
+          >
+            <i 
             onMouseOver={this.onMouseOverInfoIcon}
             onMouseOut={() => hideTooltip()}
-          >
-            <i className="material-icons-outlined">info</i>
+            className="material-icons-outlined">info</i>
           </div>
         )}
         {!_.isEmpty(this.state.errorMessage) && (

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -145,13 +145,14 @@ export class StatVarHierarchy extends React.Component<
     return (
       <div id={SV_HIERARCHY_SECTION_ID} className="loading-spinner-container">
         {this.props.type !== StatVarHierarchyType.BROWSER && (
-          <div
-            id="tree-widget-info"
-          >
-            <i 
-            onMouseOver={this.onMouseOverInfoIcon}
-            onMouseOut={() => hideTooltip()}
-            className="material-icons-outlined">info</i>
+          <div id="tree-widget-info">
+            <i
+              onMouseOver={this.onMouseOverInfoIcon}
+              onMouseOut={() => hideTooltip()}
+              className="material-icons-outlined"
+            >
+              info
+            </i>
           </div>
         )}
         {!_.isEmpty(this.state.errorMessage) && (

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -77,12 +77,14 @@ export class StatVarHierarchySearch extends React.Component<
             placeholder="Search Statistical Variables"
             onBlur={() => this.setState({ showNoResultsMessage: false })}
           />
-          {!_.isEmpty(this.state.query) &&<span
-            className="material-icons clear-search"
-            onClick={this.onInputClear}
-          >
-            clear
-          </span>}
+          {!_.isEmpty(this.state.query) && (
+            <span
+              className="material-icons clear-search"
+              onClick={this.onInputClear}
+            >
+              clear
+            </span>
+          )}
         </div>
         {renderResults && (
           <div className="statvar-hierarchy-search-results">

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -203,7 +203,7 @@ export class StatVarHierarchySearch extends React.Component<
         }
       }
     }
-    if (displayName == "" && this.state.svgResults) {
+    if (displayName === "" && this.state.svgResults) {
       for (const svg of this.state.svgResults) {
         if (svg.dcid == selectedID) {
           displayName = svg.name;

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -195,13 +195,15 @@ export class StatVarHierarchySearch extends React.Component<
   private onResultSelected = (selectedID: string) => () => {
     this.props.onSelectionChange(selectedID);
     let displayName = "";
-    for (const sv of this.state.svResults) {
-      if (sv.dcid == selectedID) {
-        displayName = sv.name;
-        break;
+    if (this.state.svResults) {
+      for (const sv of this.state.svResults) {
+        if (sv.dcid == selectedID) {
+          displayName = sv.name;
+          break;
+        }
       }
     }
-    if (displayName == "") {
+    if (displayName == "" && this.state.svgResults) {
       for (const svg of this.state.svgResults) {
         if (svg.dcid == selectedID) {
           displayName = svg.name;

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -74,15 +74,15 @@ export class StatVarHierarchySearch extends React.Component<
             type="text"
             value={this.state.query}
             onChange={this.onInputChanged}
-            placeholder="Filter Statistical Variables"
+            placeholder="Search Statistical Variables"
             onBlur={() => this.setState({ showNoResultsMessage: false })}
           />
-          <span
+          {!_.isEmpty(this.state.query) &&<span
             className="material-icons clear-search"
             onClick={this.onInputClear}
           >
             clear
-          </span>
+          </span>}
         </div>
         {renderResults && (
           <div className="statvar-hierarchy-search-results">

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -208,7 +208,7 @@ export class StatVarSectionInput extends React.Component<
   private getTooltipHtml(hasData: boolean): string {
     let html = hasData
       ? ""
-      : "This variable has no data for any of the chosen places.";
+      : "This statistical variable has no data for any of the chosen places.";
     if (_.isEmpty(this.props.summary)) {
       return html;
     }
@@ -216,10 +216,10 @@ export class StatVarSectionInput extends React.Component<
     if (_.isEmpty(placeTypeToPlaceNames)) {
       return hasData
         ? ""
-        : "Sorry, this variable is not supported by this tool.";
+        : "Sorry, this statistical variable is not supported by this tool.";
     } else {
       html += hasData
-        ? "This variable is available for these types of places:<ul>"
+        ? "This statistical variable is available for these types of places:<ul>"
         : "You can try these types of places instead:<ul>";
     }
     for (const placeType in placeTypeToPlaceNames) {

--- a/static/js/tools/map/info.tsx
+++ b/static/js/tools/map/info.tsx
@@ -25,8 +25,8 @@ export function Info(): JSX.Element {
   return (
     <div id="placeholder-container">
       <p>
-        The map explorer helps you visualize how a variable from the pane to the
-        left can vary across geographic regions.
+        The map explorer helps you visualize how a statistical variable from the
+        pane to the left can vary across geographic regions.
       </p>
       <ol>
         <li>
@@ -34,8 +34,8 @@ export function Info(): JSX.Element {
           want to plot in the dropdown menu above.
         </li>
         <li>
-          Pick a variable in the left pane. There are thousands of variables to
-          choose from, arranged in a topical hierarchy.
+          Pick a statistical variable in the left pane. There are thousands of
+          statistical variables to choose from, arranged in a topical hierarchy.
         </li>
       </ol>
       <p>Or you can start your exploration from these interesting points ...</p>

--- a/static/js/tools/map/stat_var_chooser.tsx
+++ b/static/js/tools/map/stat_var_chooser.tsx
@@ -57,7 +57,7 @@ export function StatVarChooser(): JSX.Element {
         selectSV={(svDcid) => {
           selectStatVar(statVar, svDcid);
         }}
-        searchLabel="Select variables:"
+        searchLabel="Select statistical variables:"
       />
     </div>
   );

--- a/static/js/tools/scatter/app.test.tsx
+++ b/static/js/tools/scatter/app.test.tsx
@@ -541,7 +541,7 @@ test("all functionalities", async () => {
               .then(() => {
                 app.update();
                 expect(app.find(".modal-title").text()).toContain(
-                  "Only Two Variables Supported"
+                  "Only Two Statistical Variables Supported"
                 );
                 app.find(`input[id="y-radio-button"]`).simulate("click");
                 app.find(".modal-footer button").simulate("click");

--- a/static/js/tools/scatter/info.tsx
+++ b/static/js/tools/scatter/info.tsx
@@ -25,7 +25,7 @@ function Info(): JSX.Element {
     <div id="placeholder-container">
       <p>
         The scatter plot tool helps you visualize the correlation between two
-        variables that appear in the pane to the left.
+        statistical variables that appear in the pane to the left.
       </p>
       <ol>
         <li>
@@ -33,8 +33,9 @@ function Info(): JSX.Element {
           want to plot in the dropdown menu above.
         </li>
         <li>
-          Pick two variables in the left pane. There are thousands of variables
-          to choose from, arranged in a topical hierarchy.
+          Pick two statistical variables in the left pane. There are thousands
+          of statistical variables to choose from, arranged in a topical
+          hierarchy.
         </li>
       </ol>
       <p>Or you can start your exploration from these interesting points ...</p>

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -132,11 +132,11 @@ function StatVarChooser(): JSX.Element {
         selectedSVs={menuSelected}
         selectSV={(sv) => addStatVar(x, y, sv, setThirdStatVar, setModalOpen)}
         deselectSV={(sv) => removeStatVar(x, y, sv)}
-        searchLabel="Select variables:"
+        searchLabel="Select statistical variables:"
       ></StatVarHierarchy>
       <Modal isOpen={modalOpen} backdrop="static" id="statvar-modal">
         <ModalHeader toggle={closeModal}>
-          Only Two Variables Supported
+          Only Two Statistical Variables Supported
         </ModalHeader>
         <ModalBody>
           <Container>
@@ -145,7 +145,7 @@ function StatVarChooser(): JSX.Element {
               <b>{thirdStatVar.info.title || thirdStatVar.dcid}</b>
             </div>
             <div className="radio-selection-label">
-              Please choose 1 more variable to keep:
+              Please choose 1 more statistical variable to keep:
             </div>
             <div className="radio-selection-section">
               <FormGroup radio row>

--- a/static/js/tools/timeline/info.tsx
+++ b/static/js/tools/timeline/info.tsx
@@ -21,11 +21,11 @@ class Info extends Component {
     return (
       <div id="placeholder-container">
         <p>
-          The timelines tool helps you explore trends for the variables that
-          appear in the pane to the left. Enter a place --- city, state, zip,
-          county, country --- in the search box above and then pick one or more
-          variables in the pane. There are thousands of variables to choose
-          from, arranged in a topical hierarchy.
+          The timelines tool helps you explore trends for the statistical
+          variables that appear in the pane to the left. Enter a place --- city,
+          state, zip, county, country --- in the search box above and then pick
+          one or more statistical variables in the pane. There are thousands of
+          statistical variables to choose from, arranged in a topical hierarchy.
         </p>
         <p>
           Or you can start your exploration from these interesting points ...

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -94,7 +94,7 @@ class Page extends Component<unknown, PageStateType> {
             deselectSV={(sv) => {
               removeToken("statsVar", statVarSep, sv);
             }}
-            searchLabel="Select variables:"
+            searchLabel="Select statistical variables:"
           />
         </div>
         <div id="plot-container">


### PR DESCRIPTION
- standardize to use "statistical variables" everywhere [issue #1020](https://github.com/datacommonsorg/website/issues/1020)
- remove [x] in the search when there is no input and update place holder to "Search Statistical Variables" [issue #1022](https://github.com/datacommonsorg/website/issues/1022)
- prevent tooltip from getting squished [issue #1023](https://github.com/datacommonsorg/website/issues/1023)
- remove svg hierarchy sorting in the client code [issue #1025](https://github.com/datacommonsorg/website/issues/1025)
- bug where when there are no stat vars in the search results, choosing a stat var group will cause the results section to stay open [issue #1028](https://github.com/datacommonsorg/website/issues/1028)