### PR TITLE
[timeline] fix a few deref errors for null series

### DIFF
--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -90,7 +90,7 @@ export class StatData {
         continue;
       }
       const timeSeries = this.data[place].data[statVar];
-      if (Object.keys(timeSeries.val).length !== 0) {
+      if (timeSeries.val && Object.keys(timeSeries.val).length !== 0) {
         for (const date of this.dates) {
           dataPoints.push({
             label: date,
@@ -256,10 +256,12 @@ export function fetchStatData(
       }
       for (const statVar in placeData) {
         const timeSeries = placeData[statVar];
-        if (Object.keys(timeSeries.val).length > 0) {
+        if (timeSeries.val && Object.keys(timeSeries.val).length > 0) {
           numStatVarsPerPlace[place] = numStatVarsPerPlace[place] + 1;
         }
-        result.sources.add(timeSeries.metadata.provenanceUrl);
+        if (timeSeries.metadata) {
+          result.sources.add(timeSeries.metadata.provenanceUrl);
+        }
         for (const date in timeSeries.val) {
           if (date in numOccurencesPerDate) {
             numOccurencesPerDate[date] = numOccurencesPerDate[date] + 1;


### PR DESCRIPTION
follow up from #1044 - there are cases where a place will not have data for one of the stat vars, e.g.
https://autopush.datacommons.org/tools/timeline#statsVar=Count_Person_Employed__dc%2Fnm9hcklgg5zb3&place=nuts%2FES61%2CgeoId%2F56&chart=%7B%22consumption%22%3Afalse%7D