### PR TITLE
[timeline] various updates

### DIFF
--- a/static/css/timeline.scss
+++ b/static/css/timeline.scss
@@ -169,3 +169,7 @@ sup {
 .search-icon {
   padding: 0.5rem;
 }
+
+.mdl-chip__text {
+  cursor: pointer;
+}

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -16,6 +16,7 @@
 
 import * as d3 from "d3";
 import { urlToDomain } from "../shared/util";
+import _ from "lodash";
 
 import {
   DataGroup,
@@ -180,7 +181,7 @@ function getTooltipContent(
         if (places.length > 1) {
           rowLabel += ` ${place}`;
         }
-        const value = dataPoint.value
+        const value = !_.isNull(dataPoint.value)
           ? formatNumber(dataPoint.value, unit)
           : "N/A";
         tooltipContent += `${rowLabel}: ${value}<br/>`;

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -161,7 +161,7 @@ function getTooltipContent(
   dataGroupsDict: { [place: string]: DataGroup[] },
   highlightedTime: number,
   unit?: string,
-  statsVarInfo?: { [key: string]: StatVarInfo }
+  statVarInfo?: { [key: string]: StatVarInfo }
 ): string {
   let tooltipDate = "";
   let tooltipContent = "";
@@ -178,9 +178,9 @@ function getTooltipContent(
           dataGroups.length === 1 && places.length === 1 ? dataPoint.label : "";
         if (dataGroups.length > 1) {
           let statVarLabel = dataGroup.label;
-          if (statsVarInfo && dataGroup.label in statsVarInfo) {
+          if (statVarInfo && dataGroup.label in statVarInfo) {
             statVarLabel =
-              statsVarInfo[dataGroup.label].title || dataGroup.label;
+              statVarInfo[dataGroup.label].title || dataGroup.label;
           }
           rowLabel += statVarLabel;
         }
@@ -251,7 +251,7 @@ function addHighlightOnHover(
   highlightArea: d3.Selection<SVGGElement, any, any, any>,
   chartAreaBoundary: Boundary,
   unit?: string,
-  statsVarInfo?: { [key: string]: StatVarInfo }
+  statVarInfo?: { [key: string]: StatVarInfo }
 ): void {
   const listOfTimePoints: number[] = Array.from(setOfTimePoints);
   listOfTimePoints.sort((a, b) => a - b);
@@ -320,7 +320,7 @@ function addHighlightOnHover(
         dataGroupsDict,
         highlightedTime,
         unit,
-        statsVarInfo
+        statVarInfo
       );
       showTooltip(
         tooltipContent,
@@ -983,7 +983,7 @@ function computeRanges(dataGroupsDict: { [geoId: string]: DataGroup[] }) {
  * @param id: DOM id.
  * @param width: width for the chart.
  * @param height: height for the chart.
- * @param statsVarInfo: object from stat var dcid to its info struct.
+ * @param statVarInfo: object from stat var dcid to its info struct.
  * @param dataGroupsDict: data groups for plotting.
  * @param plotParams: contains all plot params for chart.
  * @param sources: an array of source domain.
@@ -993,7 +993,7 @@ function drawGroupLineChart(
   selector: string | HTMLDivElement,
   width: number,
   height: number,
-  statsVarInfo: { [key: string]: StatVarInfo },
+  statVarInfo: { [key: string]: StatVarInfo },
   dataGroupsDict: { [place: string]: DataGroup[] },
   plotParams: PlotParams,
   ylabel?: string,
@@ -1008,7 +1008,7 @@ function drawGroupLineChart(
   const legendTextdWidth = Math.max(width * LEGEND.ratio, LEGEND.minTextWidth);
   const legendWidth =
     Object.keys(dataGroupsDict).length > 1 &&
-    Object.keys(statsVarInfo).length > 1
+    Object.keys(statVarInfo).length > 1
       ? LEGEND.dashWidth + legendTextdWidth
       : legendTextdWidth;
 
@@ -1128,7 +1128,7 @@ function drawGroupLineChart(
         LEGEND.marginTop
       })`
     );
-  buildInChartLegend(legend, plotParams.legend, legendTextdWidth, statsVarInfo);
+  buildInChartLegend(legend, plotParams.legend, legendTextdWidth, statVarInfo);
 
   // Add highlight on hover
   const chartAreaBoundary = {
@@ -1150,7 +1150,7 @@ function drawGroupLineChart(
     highlight,
     chartAreaBoundary,
     unit,
-    statsVarInfo
+    statVarInfo
   );
 }
 

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -160,7 +160,8 @@ function showTooltip(
 function getTooltipContent(
   dataGroupsDict: { [place: string]: DataGroup[] },
   highlightedTime: number,
-  unit?: string
+  unit?: string,
+  statsVarInfo?: { [key: string]: StatVarInfo }
 ): string {
   let tooltipDate = "";
   let tooltipContent = "";
@@ -176,10 +177,15 @@ function getTooltipContent(
         let rowLabel =
           dataGroups.length === 1 && places.length === 1 ? dataPoint.label : "";
         if (dataGroups.length > 1) {
-          rowLabel += dataGroup.label;
+          let statVarLabel = dataGroup.label;
+          if (statsVarInfo && dataGroup.label in statsVarInfo) {
+            statVarLabel =
+              statsVarInfo[dataGroup.label].title || dataGroup.label;
+          }
+          rowLabel += statVarLabel;
         }
         if (places.length > 1) {
-          rowLabel += ` ${place}`;
+          rowLabel += _.isEmpty(rowLabel) ? ` ${place}` : ` - ${place}`;
         }
         const value = !_.isNull(dataPoint.value)
           ? formatNumber(dataPoint.value, unit)
@@ -244,7 +250,8 @@ function addHighlightOnHover(
   setOfTimePoints: Set<number>,
   highlightArea: d3.Selection<SVGGElement, any, any, any>,
   chartAreaBoundary: Boundary,
-  unit?: string
+  unit?: string,
+  statsVarInfo?: { [key: string]: StatVarInfo }
 ): void {
   const listOfTimePoints: number[] = Array.from(setOfTimePoints);
   listOfTimePoints.sort((a, b) => a - b);
@@ -312,7 +319,8 @@ function addHighlightOnHover(
       const tooltipContent = getTooltipContent(
         dataGroupsDict,
         highlightedTime,
-        unit
+        unit,
+        statsVarInfo
       );
       showTooltip(
         tooltipContent,
@@ -1141,7 +1149,8 @@ function drawGroupLineChart(
     timePoints,
     highlight,
     chartAreaBoundary,
-    unit
+    unit,
+    statsVarInfo
   );
 }
 

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -135,7 +135,7 @@ class StatsData {
           dataPoints.push({
             label: date,
             time: new Date(date).getTime(),
-            value: timeSeries.data[date] || null,
+            value: date in timeSeries.data ? timeSeries.data[date] : null,
           });
         }
         result.push(new DataGroup(statsVar, dataPoints));

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -42,7 +42,15 @@ class StatVarChip extends Component<StatVarChipPropsType> {
         className="pv-chip mdl-chip--deletable"
         style={{ backgroundColor: this.props.color }}
       >
-        <span className="mdl-chip__text">{this.props.title}</span>
+        <span
+          className="mdl-chip__text"
+          onClick={() => {
+            // TODO(chejennifer): open stat var explorer page once that's ready.
+            window.open(`/browser/${this.props.statVar}`);
+          }}
+        >
+          {this.props.title}
+        </span>
         <button className="mdl-chip__action">
           <i
             className="material-icons"


### PR DESCRIPTION
- plot zero values [issue #1030](https://github.com/datacommonsorg/website/issues/1030)
- link to browser page when click on chip [issue #1032](https://github.com/datacommonsorg/website/issues/1032)
- make tooltip labeling consistent with legend [issue #1032](https://github.com/datacommonsorg/website/issues/1033)

plot zero values:
![Screen Shot 2021-07-15 at 9 55 34 AM](https://user-images.githubusercontent.com/69875368/125827236-619ac8fc-0857-404e-8205-95e87b453605.png)

make tooltip labelling consistent with legend:
![Screen Shot 2021-07-15 at 9 54 17 AM](https://user-images.githubusercontent.com/69875368/125827089-cd6fc8ce-3bf6-44aa-8dc6-27d8f5b8dd6b.png)