### PR TITLE
Fix website docker image build issue

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -27,12 +27,12 @@ COPY static/package-lock.json /workspace/static/package-lock.json
 WORKDIR /workspace/static
 RUN npm install
 
+# Flask
+COPY server/. /workspace/server/
+
 # NPM
 COPY static/. /workspace/static/
 RUN npm run-script build
-
-# Flask
-COPY server/. /workspace/server/
 
 # Run server
 WORKDIR /workspace/server


### PR DESCRIPTION
This change https://github.com/datacommonsorg/website/pull/1044/files#diff-540d39fbd8b0774c2d96e42b981dce59d51849ec7878f9cd447ae08f954e286f included test files in tsconfig.json. Some of the test files refer to chart_config.json which resides in "/server" folder.

By swapping the order, we make sure "npm run-script build" can see the "/server" folder