### PR TITLE
[timeline] fix a few issues with missing plots

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -1079,25 +1079,43 @@ function drawGroupLineChart(
   for (const place in dataGroupsDict) {
     dataGroups = dataGroupsDict[place];
     for (const dataGroup of dataGroups) {
-      const dataset = dataGroup.value.map((dp) => {
-        timePoints.add(dp.time);
-        return [dp.time, dp.value];
-      });
+      const dataset = dataGroup.value
+        .map((dp) => {
+          timePoints.add(dp.time);
+          return [dp.time, dp.value];
+        })
+        .filter((dp) => {
+          return dp[1] !== null;
+        });
       const line = d3
         .line()
-        .defined((d) => d[1] != null)
         .x((d) => xScale(d[0]))
         .y((d) => yScale(d[1]));
       const lineStyle = plotParams.lines[place + dataGroup.label];
-      chart
-        .append("path")
-        .datum(dataset)
-        .attr("class", "line")
-        .attr("d", line)
-        .style("fill", "none")
-        .style("stroke", lineStyle.color)
-        .style("stroke-width", "2px")
-        .style("stroke-dasharray", lineStyle.dash);
+      if (dataset.length > 1) {
+        chart
+          .append("path")
+          .datum(dataset)
+          .attr("class", "line")
+          .attr("d", line)
+          .style("fill", "none")
+          .style("stroke", lineStyle.color)
+          .style("stroke-width", "2px")
+          .style("stroke-dasharray", lineStyle.dash);
+      } else {
+        chart
+          .append("g")
+          .selectAll(".dot")
+          .data(dataGroup.value)
+          .enter()
+          .append("circle")
+          .attr("class", "dot")
+          .attr("cx", (d) => xScale(d.time))
+          .attr("cy", (d) => yScale(d.value))
+          .attr("r", (d) => (d.value === null ? 0 : 3))
+          .style("fill", lineStyle.color)
+          .style("stroke", "#fff");
+      }
     }
   }
   // add source info to the chart

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -90,7 +90,7 @@ export class StatData {
         continue;
       }
       const timeSeries = this.data[place].data[statVar];
-      if (Object.keys(timeSeries.val).length !== 0) {
+      if (timeSeries.val && Object.keys(timeSeries.val).length !== 0) {
         for (const date of this.dates) {
           dataPoints.push({
             label: date,
@@ -256,10 +256,12 @@ export function fetchStatData(
       }
       for (const statVar in placeData) {
         const timeSeries = placeData[statVar];
-        if (Object.keys(timeSeries.val).length > 0) {
+        if (timeSeries.val && Object.keys(timeSeries.val).length > 0) {
           numStatVarsPerPlace[place] = numStatVarsPerPlace[place] + 1;
         }
-        result.sources.add(timeSeries.metadata.provenanceUrl);
+        if (timeSeries.metadata) {
+          result.sources.add(timeSeries.metadata.provenanceUrl);
+        }
         for (const date in timeSeries.val) {
           if (date in numOccurencesPerDate) {
             numOccurencesPerDate[date] = numOccurencesPerDate[date] + 1;


### PR DESCRIPTION
Fixes #1031. The [line.defined](https://github.com/d3/d3-shape/blob/main/README.md#line_defined) call is meant for filtering out undefined points, but since we fill in null values for all timestamps across datasets, this causes issues with cases like this:
timeseries a
- 2000: 1.0, 2001: 1.0, 2002: 1.0
timeseries b
- 2000-01: 2.0, .... 2000-12: 2.0, ...

in the example above, we filled in timeseries a with null for all the dates in timeseries b. then, the call to "line.defined" will find the lines incomplete and plot disjoint dots that are not visible.

for another [example](http://localhost:8080/tools/timeline#statsVar=Count_Person_Employed__dc%2Fnm9hcklgg5zb3&place=nuts%2FES61%2CgeoId%2F56&chart=%7B%22consumption%22%3Afalse%7D), here it is without the call to line.defined:
![image](https://user-images.githubusercontent.com/6052978/125856395-26d02b74-94ea-470f-9c2f-773fc9d1f3ac.png)
with the fix:
![image](https://user-images.githubusercontent.com/6052978/125856445-5bd79a92-12ee-4a7d-9649-18c11daa88f3.png)

this is a bit of a compromise solution, where we manually filter out all the null values. this solves issues such as above, but also means we will interpolate missing points (such as in [this chart](https://autopush.datacommons.org/tools/timeline#&place=geoId/0606000,geoId/2511000,geoId/2603000,geoId/1777005,geoId/1225175,geoId/4815976&statsVar=Count_CriminalActivities_ViolentCrime)). i think that's ok, especially now that we have tooltips.

also included a fix for single points in datasets by drawing a circle, instead of showing a blank chart.

http://localhost:8080/tools/timeline#place=geoId%2F06&statsVar=LifeExpectancy_Person&chart=%7B%22genderIncomeInequality%22%3Afalse%7D
![image](https://user-images.githubusercontent.com/6052978/125856226-96d51291-c6f3-458e-aa0b-67acec8bdb90.png)
