### PR TITLE
Update chart sorting in place page

### DIFF
--- a/static/js/place/main.tsx
+++ b/static/js/place/main.tsx
@@ -90,7 +90,9 @@ class MainPane extends React.Component<MainPanePropType> {
     const currentPageTopic = this.props.topic;
     const isOverview = currentPageTopic === "Overview";
     const topics = Object.keys(topicData);
-    topics.sort();
+    if (!isOverview) {
+      topics.sort();
+    }
     return (
       <RawIntlProvider value={intl}>
         {this.props.isUsaPlace &&
@@ -128,6 +130,14 @@ class MainPane extends React.Component<MainPanePropType> {
           } else {
             subtopicHeader = <h3 id={topic}>{topic}</h3>;
           }
+          const data = topicData[topic];
+          data.sort((a, b) => {
+            if (a.title < b.title) {
+              return -1;
+            } else {
+              return 1;
+            }
+          });
           return (
             <section className="subtopic col-12" key={topic}>
               {subtopicHeader}

--- a/static/js/place/topic_menu.tsx
+++ b/static/js/place/topic_menu.tsx
@@ -100,7 +100,9 @@ class Menu extends React.Component<MenuPropsType> {
         )}
         {categories.map((category: string) => {
           let topics = Object.keys(this.props.pageChart[category]);
-          topics.sort();
+          if (!showOverviewSubmenu) {
+            topics.sort();
+          }
           if (category === "Overview") {
             topics = topics.map((t) => this.props.categories[t]);
           }


### PR DESCRIPTION
* "Overview" tab contains sections of "categories", the order of the section should in the original order.
* "non Overview" tab contains sections of "chart groups", the order of the chart groups should be based on the title.