### PR TITLE
Fix some null data issue

### DIFF
--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -118,6 +118,9 @@ export function computePerCapita(
   popSeries: TimeSeries,
   scaling = 1
 ): TimeSeries {
+  if (!popSeries.val) {
+    return {};
+  }
   const result = _.cloneDeep(statSeries);
   const popYears = Object.keys(popSeries.val);
   popYears.sort();

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -174,9 +174,8 @@ class Chart extends Component<ChartPropsType> {
       const placeData = Object.values(this.statData.data)[0];
       this.units = [];
       for (const series of Object.values(placeData.data)) {
-        const unit = series["metadata"].unit || "";
-        if (unit) {
-          this.units.push(unit);
+        if (series && series["metadata"] && series["metadata"].unit) {
+          this.units.push(series["metadata"].unit);
         }
       }
       this.props.onDataUpdate(this.props.mprop, statData);


### PR DESCRIPTION
Right now this link is broken: https://autopush.datacommons.org/tools/timeline#place=wikidataId%2FQ1445%2Ccountry%2FIND,asia&statsVar=Count_Person_Workers__Count_Person_NonWorke&pc=1&chart=%7B%22count%22%3Atrue%7D

As there is no population data for Asia