### PR TITLE
Add denominator to timeline page url

### DIFF
--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -58,11 +58,11 @@ def build_url(dcids, statvar_to_denom, is_scaled=False):
     for statvar, denom in statvar_to_denom.items():
         part = statvar
         if denom:
-            part += ',' + denom
+            part += '|' + denom
         parts.append(part)
     anchor += ('&statsVar=' + '__'.join(parts))
     if is_scaled:
-        anchor = anchor + '&pc=1'
+        anchor = anchor + '&pc'
     return urllib.parse.unquote(url_for('tools.timeline', _anchor=anchor))
 
 

--- a/server/webdriver_tests/place_landing_test.py
+++ b/server/webdriver_tests/place_landing_test.py
@@ -17,8 +17,6 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 
-import time
-
 
 class TestPlaceLanding(WebdriverBaseTest):
     """Tests for Place Landing page."""

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -228,7 +228,12 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
                 />
               </a>
               {intl.locale != "en" ? null : (
-                <a className="explore-more" href={exploreUrl}>
+                <a
+                  className="explore-more"
+                  href={exploreUrl}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <FormattedMessage
                     id="chart_metadata-explore_more"
                     defaultMessage="Explore More ›"

--- a/static/js/shared/data_fetcher.test.ts
+++ b/static/js/shared/data_fetcher.test.ts
@@ -653,7 +653,7 @@ test("Per capita with specified denominators test", () => {
   return fetchStatData(
     ["geoId/05", "geoId/06"],
     ["Count_Person_Male", "Count_Person_Female"],
-    false,
+    true,
     1,
     {
       Count_Person_Male: "Count_Person",

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -173,7 +173,6 @@ export function fetchStatData(
   let denomStatVars = [];
   if (perCapita) {
     denomStatVars.push(TOTAL_POPULATION_SV);
-  } else {
     for (const sv in denominators) {
       denomStatVars.push(denominators[sv]);
     }
@@ -231,17 +230,19 @@ export function fetchStatData(
       const placeData = statResp[place].data;
       for (const statVar in placeData) {
         if (perCapita) {
-          placeData[statVar] = computePerCapita(
-            placeData[statVar],
-            denomResp[place].data[TOTAL_POPULATION_SV],
-            scaling
-          );
-        } else if (statVar in denominators) {
-          placeData[statVar] = computePerCapita(
-            placeData[statVar],
-            denomResp[place].data[denominators[statVar]],
-            scaling
-          );
+          if (Object.keys(denominators).length == 0) {
+            placeData[statVar] = computePerCapita(
+              placeData[statVar],
+              denomResp[place].data[TOTAL_POPULATION_SV],
+              scaling
+            );
+          } else if (statVar in denominators) {
+            placeData[statVar] = computePerCapita(
+              placeData[statVar],
+              denomResp[place].data[denominators[statVar]],
+              scaling
+            );
+          }
         }
       }
       // Build the dates collection, get the union of available dates for all data

--- a/static/js/shared/data_fetcher.ts
+++ b/static/js/shared/data_fetcher.ts
@@ -230,7 +230,7 @@ export function fetchStatData(
       const placeData = statResp[place].data;
       for (const statVar in placeData) {
         if (perCapita) {
-          if (Object.keys(denominators).length == 0) {
+          if (Object.keys(denominators).length === 0) {
             placeData[statVar] = computePerCapita(
               placeData[statVar],
               denomResp[place].data[TOTAL_POPULATION_SV],

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -69,6 +69,7 @@ interface ChartPropsType {
   placeName: Record<string, string>; // An array of place dcids.
   statVarInfo: Record<string, StatVarInfo>;
   perCapita: boolean;
+  denomMap: Record<string, string>;
   removeStatVar: (statVar: string) => void;
   onDataUpdate: (mprop: string, data: StatData) => void;
 }
@@ -166,7 +167,8 @@ class Chart extends Component<ChartPropsType> {
       Object.keys(this.props.placeName),
       Object.keys(this.props.statVarInfo),
       this.props.perCapita,
-      1
+      1,
+      this.props.denomMap
     ).then((statData) => {
       this.statData = statData;
       // Get from all stat vars. In most cases there should be only one

--- a/static/js/tools/timeline/chart_region.tsx
+++ b/static/js/tools/timeline/chart_region.tsx
@@ -27,6 +27,8 @@ interface ChartRegionPropsType {
   placeName: Record<string, string>;
   // Map from stat var dcid to info.
   statVarInfo: { [key: string]: StatVarInfo };
+  // Map from stat var dcid to denominator dcid.
+  denomMap: Record<string, string>;
 }
 
 class ChartRegion extends Component<ChartRegionPropsType> {
@@ -79,6 +81,7 @@ class ChartRegion extends Component<ChartRegionPropsType> {
               placeName={this.props.placeName}
               statVarInfo={_.pick(this.props.statVarInfo, groups[mprop])}
               perCapita={getChartPerCapita(mprop)}
+              denomMap={this.props.denomMap}
               onDataUpdate={this.onDataUpdate.bind(this)}
               removeStatVar={(statVar) => {
                 removeToken("statsVar", statVarSep, statVar);

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -71,6 +71,8 @@ class Page extends Component<unknown, PageStateType> {
         const parts = token.split("|");
         statVars.push(parts[0]);
         denomMap[parts[0]] = parts[1];
+      } else {
+        statVars.push(token);
       }
     }
 

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -37,6 +37,7 @@ import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
 interface PageStateType {
   placeName: Record<string, string>;
   statVarInfo: Record<string, StatVarInfo>;
+  denomMap: Record<string, string>;
 }
 
 class Page extends Component<unknown, PageStateType> {
@@ -47,6 +48,7 @@ class Page extends Component<unknown, PageStateType> {
     this.state = {
       placeName: {},
       statVarInfo: {},
+      denomMap: {},
     };
   }
 
@@ -56,8 +58,21 @@ class Page extends Component<unknown, PageStateType> {
   }
 
   private fetchDataAndRender(): void {
-    const statVars = Array.from(getTokensFromUrl("statsVar", statVarSep));
     const places = Array.from(getTokensFromUrl("place", placeSep));
+    // A stat var token could also have a denominator attached to it  by "|".
+    // Ex: Count_Person_Female|Count_Person
+    const statVarsAndDenoms = Array.from(
+      getTokensFromUrl("statsVar", statVarSep)
+    );
+    const statVars: string[] = [];
+    const denomMap: Record<string, string> = {};
+    for (const token of statVarsAndDenoms) {
+      if (token.includes("|")) {
+        const parts = token.split("|");
+        statVars.push(parts[0]);
+        denomMap[parts[0]] = parts[1];
+      }
+    }
 
     let statVarInfoPromise = Promise.resolve({});
     if (statVars.length !== 0) {
@@ -72,6 +87,7 @@ class Page extends Component<unknown, PageStateType> {
         this.setState({
           statVarInfo,
           placeName,
+          denomMap,
         });
       }
     );
@@ -121,6 +137,7 @@ class Page extends Component<unknown, PageStateType> {
                 <ChartRegion
                   placeName={this.state.placeName}
                   statVarInfo={this.state.statVarInfo}
+                  denomMap={this.state.denomMap}
                 ></ChartRegion>
               </div>
             )}

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -46,9 +46,9 @@ class Page extends Component<unknown, PageStateType> {
     this.fetchDataAndRender = this.fetchDataAndRender.bind(this);
     this.addPlaceAction = this.addPlaceAction.bind(this);
     this.state = {
+      denomMap: {},
       placeName: {},
       statVarInfo: {},
-      denomMap: {},
     };
   }
 

--- a/static/js/tools/timeline/util.ts
+++ b/static/js/tools/timeline/util.ts
@@ -56,7 +56,8 @@ export function setTokensToUrl(tokens: TokenInfo[]): void {
   window.location.hash = urlParams.toString();
 }
 
-// add one statVar
+// Add a token to the url. A token could either be a place dcid, a stat var or
+// a [stat var,denominator] pair separated by comma.
 export function addToken(name: string, sep: string, token: string): void {
   const tokens = getTokensFromUrl(name, sep);
   if (tokens.has(token)) {
@@ -66,7 +67,7 @@ export function addToken(name: string, sep: string, token: string): void {
   setTokensToUrl([{ name, sep, tokens }]);
 }
 
-// remove one statVar
+// Remove a token from the url.
 export function removeToken(name: string, sep: string, token: string): void {
   const tokens = getTokensFromUrl(name, sep);
   if (!tokens.has(token)) {
@@ -85,11 +86,18 @@ export function setChartPerCapita(mprop: string, pc: boolean): void {
   }
   chartOptions[mprop] = pc;
   urlParams.set("chart", JSON.stringify(chartOptions));
+  if (!pc) {
+    // "&pc" means per capita for all charts.
+    urlParams.delete("pc");
+  }
   window.location.hash = urlParams.toString();
 }
 
 export function getChartPerCapita(mprop: string): boolean {
   const urlParams = new URLSearchParams(window.location.hash.split("#")[1]);
+  if (urlParams.get("pc")) {
+    return true;
+  }
   const chartOptions = JSON.parse(urlParams.get("chart"));
   if (!chartOptions) {
     return false;


### PR DESCRIPTION
This was removed in recent stat var hierarchy change, where stat var denominator was removed and only Count_Person is used.

However, place page uses specific denominator for stat vars and that carries over in the explore more link. This fixes the broken link. Also fixes the "per capita" checkbox bug