### PR TITLE
[map] remove boundary lines for granularities 2 levels down from the selected place

### DIFF
--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -124,6 +124,7 @@ function drawChoropleth(
   redirectAction: (geoDcid: GeoJsonFeatureProperties) => void,
   getTooltipHtml: (place: NamedPlace) => string,
   shouldGenerateLegend: boolean,
+  shouldShowBoundaryLines: boolean,
   zoomDcid?: string,
   zoomInButtonId?: string,
   zoomOutButtonId?: string
@@ -209,11 +210,14 @@ function drawChoropleth(
     .attr("id", (_, index) => {
       return "geoPath" + index;
     })
-    .attr("stroke-width", STROKE_WIDTH)
-    .attr("stroke", GEO_STROKE_COLOR)
     .on("mouseover", onMouseOver(domContainerId, canClick))
     .on("mouseout", onMouseOut(domContainerId))
     .on("mousemove", onMouseMove(domContainerId, getTooltipHtml, canClick));
+  if (shouldShowBoundaryLines) {
+    mapObjects
+      .attr("stroke-width", STROKE_WIDTH)
+      .attr("stroke", GEO_STROKE_COLOR);
+  }
   if (canClick) {
     mapObjects.on("click", onMapClick(domContainerId, redirectAction));
   }

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -412,6 +412,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         true,
         redirectAction,
         getTooltipHtml,
+        true,
         true
       );
     }

--- a/static/js/tools/map/chart.test.ts
+++ b/static/js/tools/map/chart.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PlaceInfo } from "../map/context";
+import { shouldShowBoundary } from "./chart";
+
+test("shouldShowBoundary", () => {
+  const basePlaceInfo: PlaceInfo = {
+    enclosedPlaceType: "County",
+    enclosedPlaces: [],
+    enclosingPlace: {
+      dcid: "country/USA",
+      name: "United States of America",
+    },
+    parentPlaces: [],
+    selectedPlace: {
+      dcid: "country/USA",
+      name: "United States of America",
+      types: ["Country"],
+    },
+  };
+  expect(shouldShowBoundary(basePlaceInfo)).toEqual(false);
+  const placeInfoWithBoundary = {
+    ...basePlaceInfo,
+    enclosedPlaceType: "State",
+  };
+  expect(shouldShowBoundary(placeInfoWithBoundary)).toEqual(true);
+});

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -219,7 +219,7 @@ function draw(
   }
 }
 
-function shouldShowBoundary(placeInfo: PlaceInfo): boolean {
+export function shouldShowBoundary(placeInfo: PlaceInfo): boolean {
   const selectedPlaceTypes = placeInfo.selectedPlace.types;
   let selectedPlaceTypeIdx = -1;
   if (selectedPlaceTypes) {

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -34,6 +34,7 @@ import {
   updateHashPlaceInfo,
   updateHashStatVar,
   USA_CHILD_PLACE_TYPES,
+  USA_PLACE_HIERARCHY,
 } from "./util";
 import { urlToDomain } from "../../shared/util";
 import { ChartOptions } from "./chart_options";
@@ -210,11 +211,27 @@ function draw(
         props.unit
       ),
       false,
+      shouldShowBoundary(props.placeInfo),
       zoomDcid,
       ZOOM_IN_BUTTON_ID,
       ZOOM_OUT_BUTTON_ID
     );
   }
+}
+
+function shouldShowBoundary(placeInfo: PlaceInfo): boolean {
+  const selectedPlaceTypes = placeInfo.selectedPlace.types;
+  let selectedPlaceTypeIdx = -1;
+  if (selectedPlaceTypes) {
+    selectedPlaceTypeIdx = USA_PLACE_HIERARCHY.indexOf(selectedPlaceTypes[0]);
+  }
+  const enclosedPlaceTypeIdx = USA_PLACE_HIERARCHY.indexOf(
+    placeInfo.enclosedPlaceType
+  );
+  if (selectedPlaceTypeIdx < 0 || enclosedPlaceTypeIdx < 0) {
+    return true;
+  }
+  return enclosedPlaceTypeIdx - selectedPlaceTypeIdx < 2;
 }
 
 function getTitle(statVarDates: string[], statVarName: string): string {

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -30,6 +30,8 @@ export const USA_CHILD_PLACE_TYPES = {
   County: ["County"],
 };
 
+export const USA_PLACE_HIERARCHY = ["Country", "State", "County"];
+
 const URL_PARAM_VALUE_SEPARATOR = "-";
 
 const URL_PARAM_KEYS = {

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -30,6 +30,7 @@ export const USA_CHILD_PLACE_TYPES = {
   County: ["County"],
 };
 
+// list of place types in the US in the order of high to low granularity.
 export const USA_PLACE_HIERARCHY = ["Country", "State", "County"];
 
 const URL_PARAM_VALUE_SEPARATOR = "-";


### PR DESCRIPTION
eg. counties in USA (country) will have its boundary lines removed

<img width="1381" alt="Screen Shot 2021-08-09 at 1 45 44 PM" src="https://user-images.githubusercontent.com/69875368/128772700-21448038-cb09-46c8-8598-14451f7e9821.png">

but counties in California (State) will keep its boundary lines
<img width="1371" alt="Screen Shot 2021-08-09 at 1 46 07 PM" src="https://user-images.githubusercontent.com/69875368/128772708-5a2ed573-1ddd-4aad-97a1-841d925b8fa9.png">
