### PR TITLE
[scatter] add option for quadrant lines for scatterplots

### DIFF
--- a/static/css/tools/scatter.scss
+++ b/static/css/tools/scatter.scss
@@ -236,3 +236,8 @@ circle {
   stroke: red;
   stroke-dasharray: 1;
 }
+
+#scatterplot .quadrant-label {
+  fill: red;
+  font-size: .8em;
+}

--- a/static/css/tools/scatter.scss
+++ b/static/css/tools/scatter.scss
@@ -231,3 +231,8 @@ circle {
 .radio-selection-section {
   margin-left: 2rem;
 }
+
+#scatterplot .quadrant-line {
+  stroke: red;
+  stroke-dasharray: 1;
+}

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -199,7 +199,7 @@ function plot(
   );
 
   if (props.isQuadrants) {
-    const quadrant = g.append('g');
+    const quadrant = g.append("g");
     const xMean = d3.mean(props.points, (point) => point.xVal);
     const yMean = d3.mean(props.points, (point) => point.yVal);
     addQuadrants(quadrant, xScale, yScale, xMean, yMean, width, height);
@@ -281,7 +281,6 @@ function addXAxis(
       `translate(${width / 2},${height + marginBottom / 2 + 10})`
     )
     .text(xLabel + unitLabelString);
-
   return xScale;
 }
 
@@ -331,6 +330,9 @@ function addYAxis(
   return yScale;
 }
 
+/**
+ * Draw quadrant lines at the mean of the x and y values.
+ */
 function addQuadrants(
   quadrant: d3.Selection<SVGGElement, any, any, any>,
   xScale: d3.ScaleLinear<any, any>,
@@ -338,27 +340,30 @@ function addQuadrants(
   xMean: number,
   yMean: number,
   chartWidth: number,
-  chartHeight: number,
+  chartHeight: number
 ) {
-    quadrant.append('line')
-    .attr('x1', xScale(xMean))
-    .attr('x2', xScale(xMean))
-    .attr('y1', 0)
-    .attr('y2', chartHeight)
-    .attr('stroke', 'red')
-    .attr('class', 'quadrant-line')
+  quadrant
+    .append("line")
+    .attr("x1", xScale(xMean))
+    .attr("x2", xScale(xMean))
+    .attr("y1", 0)
+    .attr("y2", chartHeight)
+    .attr("stroke", "red")
+    .attr("class", "quadrant-line");
 
-    quadrant.append('line')
-    .attr('y1', yScale(yMean))
-    .attr('y2', yScale(yMean))
-    .attr('x1', 0)
-    .attr('x2', chartWidth)
-    .attr('class', 'quadrant-line')
+  quadrant
+    .append("line")
+    .attr("y1", yScale(yMean))
+    .attr("y2", yScale(yMean))
+    .attr("x1", 0)
+    .attr("x2", chartWidth)
+    .attr("class", "quadrant-line");
 
-    quadrant.append('text')
+  quadrant
+    .append("text")
     .text(`mean (${formatNumber(xMean)}, ${formatNumber(yMean)})`)
-    .attr('transform', `translate(${xScale(xMean) + 5}, 5)`)
-    .attr('class', 'quadrant-label')
+    .attr("transform", `translate(${xScale(xMean) + 5}, 5)`)
+    .attr("class", "quadrant-label");
 }
 
 /**

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -39,6 +39,7 @@ interface ChartPropsType {
   yStatVar: string;
   xUnits?: string;
   yUnits?: string;
+  isQuadrants: boolean;
 }
 
 const DOT_REDIRECT_PREFIX = "/tools/timeline";
@@ -197,6 +198,26 @@ function plot(
     props.yUnits
   );
 
+  console.log('is quadrants: ' + props.isQuadrants);
+  if (props.isQuadrants) {
+    const xMean = d3.mean(props.points, (point) => point.xVal);
+    g.append('line')
+    .attr('x1', xScale(xMean))
+    .attr('x2', xScale(xMean))
+    .attr('y1', 0)
+    .attr('y2', height)
+    .attr('stroke', 'red')
+    .attr('class', 'quadrant-line')
+
+    const yMean = d3.mean(props.points, (point) => point.yVal);
+    g.append('line')
+    .attr('y1', yScale(yMean))
+    .attr('y2', yScale(yMean))
+    .attr('x1', 0)
+    .attr('x2', width)
+    .attr('class', 'quadrant-line')
+  }
+
   g.append("text")
     .attr("class", "plot-title")
     .attr("transform", `translate(${width / 2},${-margin.top / 2})`)
@@ -273,6 +294,7 @@ function addXAxis(
       `translate(${width / 2},${height + marginBottom / 2 + 10})`
     )
     .text(xLabel + unitLabelString);
+
   return xScale;
 }
 

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -198,24 +198,11 @@ function plot(
     props.yUnits
   );
 
-  console.log('is quadrants: ' + props.isQuadrants);
   if (props.isQuadrants) {
+    const quadrant = g.append('g');
     const xMean = d3.mean(props.points, (point) => point.xVal);
-    g.append('line')
-    .attr('x1', xScale(xMean))
-    .attr('x2', xScale(xMean))
-    .attr('y1', 0)
-    .attr('y2', height)
-    .attr('stroke', 'red')
-    .attr('class', 'quadrant-line')
-
     const yMean = d3.mean(props.points, (point) => point.yVal);
-    g.append('line')
-    .attr('y1', yScale(yMean))
-    .attr('y2', yScale(yMean))
-    .attr('x1', 0)
-    .attr('x2', width)
-    .attr('class', 'quadrant-line')
+    addQuadrants(quadrant, xScale, yScale, xMean, yMean, width, height);
   }
 
   g.append("text")
@@ -342,6 +329,36 @@ function addYAxis(
     )
     .text(yLabel + unitLabelString);
   return yScale;
+}
+
+function addQuadrants(
+  quadrant: d3.Selection<SVGGElement, any, any, any>,
+  xScale: d3.ScaleLinear<any, any>,
+  yScale: d3.ScaleLinear<any, any>,
+  xMean: number,
+  yMean: number,
+  chartWidth: number,
+  chartHeight: number,
+) {
+    quadrant.append('line')
+    .attr('x1', xScale(xMean))
+    .attr('x2', xScale(xMean))
+    .attr('y1', 0)
+    .attr('y2', chartHeight)
+    .attr('stroke', 'red')
+    .attr('class', 'quadrant-line')
+
+    quadrant.append('line')
+    .attr('y1', yScale(yMean))
+    .attr('y2', yScale(yMean))
+    .attr('x1', 0)
+    .attr('x2', chartWidth)
+    .attr('class', 'quadrant-line')
+
+    quadrant.append('text')
+    .text(`mean (${formatNumber(xMean)}, ${formatNumber(yMean)})`)
+    .attr('transform', `translate(${xScale(xMean) + 5}, 5)`)
+    .attr('class', 'quadrant-label')
 }
 
 /**

--- a/static/js/tools/scatter/chart_loader.tsx
+++ b/static/js/tools/scatter/chart_loader.tsx
@@ -66,7 +66,7 @@ type Cache = {
 };
 
 function ChartLoader(): JSX.Element {
-  const { x, y, isLoading } = useContext(Context);
+  const { x, y, isLoading, isQuadrants } = useContext(Context);
   const cache = useCache();
   const points = usePoints(cache);
 
@@ -115,6 +115,7 @@ function ChartLoader(): JSX.Element {
                 yStatVar={yStatVar}
                 xUnits={xUnits}
                 yUnits={yUnits}
+                isQuadrants={isQuadrants.value}
               />
               <PlotOptions />
             </>

--- a/static/js/tools/scatter/context.ts
+++ b/static/js/tools/scatter/context.ts
@@ -91,6 +91,13 @@ const EmptyPlace: PlaceInfo = Object.freeze({
   upperBound: 1e10,
 });
 
+interface IsQuadrantWrapper {
+  value: boolean;
+
+  // Setters
+  set: Setter<boolean>;
+}
+
 interface DateInfo {
   year: number;
   month: number;
@@ -135,6 +142,8 @@ interface ContextType {
   y: AxisWrapper;
   // Places to plot
   place: PlaceInfoWrapper;
+  // Whether to plot in Quadrant mode
+  isQuadrants: IsQuadrantWrapper;
   // Whether there are currently active network tasks
   isLoading: IsLoadingWrapper;
 }
@@ -154,6 +163,9 @@ const FieldToAbbreviation = {
   enclosedPlaceType: "ept",
   lowerBound: "lb",
   upperBound: "ub",
+
+  // Quadrant fields
+  isQuadrant: "qd",
 };
 
 /**
@@ -163,6 +175,7 @@ function useContextStore(): ContextType {
   const [x, setX] = useState(EmptyAxis);
   const [y, setY] = useState(EmptyAxis);
   const [place, setPlace] = useState(EmptyPlace);
+  const [isQuadrants, setQuadrants] = useState(false);
   const [arePlacesLoading, setArePlacesLoading] = useState(false);
   const [areStatVarsLoading, setAreStatVarsLoading] = useState(false);
   const [areDataLoading, setAreDataLoading] = useState(false);
@@ -193,6 +206,10 @@ function useContextStore(): ContextType {
       setEnclosedPlaces: getSetEnclosedPlaces(place, setPlace),
       setLowerBound: getSetLowerBound(place, setPlace),
       setUpperBound: getSetUpperBound(place, setPlace),
+    },
+    isQuadrants: {
+      value: isQuadrants,
+      set: (isQuadrants) => setQuadrants(isQuadrants),
     },
     isLoading: {
       arePlacesLoading: arePlacesLoading,
@@ -359,6 +376,7 @@ export {
   DateInfo,
   DateInfoWrapper,
   IsLoadingWrapper,
+  IsQuadrantWrapper,
   EmptyAxis,
   EmptyPlace,
   EmptyDate,

--- a/static/js/tools/scatter/plot_options.tsx
+++ b/static/js/tools/scatter/plot_options.tsx
@@ -21,7 +21,12 @@
 
 import React, { useContext, useState } from "react";
 import { FormGroup, Label, Input, Card, Button } from "reactstrap";
-import { AxisWrapper, Context, IsQuadrantWrapper, PlaceInfoWrapper } from "./context";
+import {
+  AxisWrapper,
+  Context,
+  IsQuadrantWrapper,
+  PlaceInfoWrapper,
+} from "./context";
 
 import { Container, Row, Col } from "reactstrap";
 
@@ -201,7 +206,10 @@ function checkLog(
   axis.setLog(event.target.checked);
 }
 
-function checkQuadrants(isQuadrant: IsQuadrantWrapper, event: React.ChangeEvent<HTMLInputElement>): void {
+function checkQuadrants(
+  isQuadrant: IsQuadrantWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+): void {
   isQuadrant.set(event.target.checked);
 }
 

--- a/static/js/tools/scatter/plot_options.tsx
+++ b/static/js/tools/scatter/plot_options.tsx
@@ -21,7 +21,7 @@
 
 import React, { useContext, useState } from "react";
 import { FormGroup, Label, Input, Card, Button } from "reactstrap";
-import { AxisWrapper, Context, PlaceInfoWrapper } from "./context";
+import { AxisWrapper, Context, IsQuadrantWrapper, PlaceInfoWrapper } from "./context";
 
 import { Container, Row, Col } from "reactstrap";
 
@@ -29,7 +29,7 @@ import { Container, Row, Col } from "reactstrap";
 // returns the available dates for the statvar. Then, fill the datapicker with
 // the dates.
 function PlotOptions(): JSX.Element {
-  const { place, x, y } = useContext(Context);
+  const { place, x, y, isQuadrants } = useContext(Context);
   const [lowerBound, setLowerBound] = useState(
     place.value.lowerBound.toString()
   );
@@ -118,6 +118,24 @@ function PlotOptions(): JSX.Element {
           </Col>
         </Row>
         <Row className="plot-options-row centered-items-row">
+          <Col sm={1} className="plot-options-label">
+            Quadrants:
+          </Col>
+          <Col sm="auto">
+            <FormGroup check>
+              <Label check>
+                <Input
+                  id="quadrants"
+                  type="checkbox"
+                  checked={isQuadrants.value}
+                  onChange={(e) => checkQuadrants(isQuadrants, e)}
+                />
+                Show Quadrants
+              </Label>
+            </FormGroup>
+          </Col>
+        </Row>
+        <Row className="plot-options-row centered-items-row">
           <Col sm={2} className="plot-options-label">
             Filter by population:
           </Col>
@@ -181,6 +199,10 @@ function checkLog(
   event: React.ChangeEvent<HTMLInputElement>
 ): void {
   axis.setLog(event.target.checked);
+}
+
+function checkQuadrants(isQuadrant: IsQuadrantWrapper, event: React.ChangeEvent<HTMLInputElement>): void {
+  isQuadrant.set(event.target.checked);
 }
 
 /**

--- a/static/js/tools/scatter/util.test.ts
+++ b/static/js/tools/scatter/util.test.ts
@@ -55,9 +55,12 @@ const TestContext = ({
       upperBound: 99999,
     },
   },
+  isQuadrants: {
+    value: true
+  }
 } as unknown) as ContextType;
 const Hash =
-  "#%26svx%3DCount_Person%26lx%3D1%26svy%3DCount_HousingUnit%26pcy%3D1%26epd%3DgeoId%2F10%26epn%3DDelaware%26ept%3DCounty%26ub%3D99999";
+  "#%26svx%3DCount_Person%26lx%3D1%26svy%3DCount_HousingUnit%26pcy%3D1%26epd%3DgeoId%2F10%26epn%3DDelaware%26ept%3DCounty%26ub%3D99999%26qd%3D1";
 
 test("updateHash", () => {
   history.pushState = jest.fn();
@@ -70,10 +73,11 @@ test("updateHash", () => {
 });
 
 test("applyHash", () => {
-  const context = { x: {}, y: {}, place: {} } as ContextType;
+  const context = { x: {}, y: {}, place: {}, isQuadrants: {} } as ContextType;
   context.x.set = (value) => (context.x.value = value);
   context.y.set = (value) => (context.y.value = value);
   context.place.set = (value) => (context.place.value = value);
+  context.isQuadrants.set = (value) => (context.isQuadrants.value = value);
   location.hash = Hash;
   applyHash(context);
   expect(context.x.value).toEqual(TestContext.x.value);
@@ -82,4 +86,5 @@ test("applyHash", () => {
     ...TestContext.place.value,
     enclosedPlaces: [],
   });
+  expect(context.isQuadrants.value).toEqual(TestContext.isQuadrants.value);
 });

--- a/static/js/tools/scatter/util.test.ts
+++ b/static/js/tools/scatter/util.test.ts
@@ -56,8 +56,8 @@ const TestContext = ({
     },
   },
   isQuadrants: {
-    value: true
-  }
+    value: true,
+  },
 } as unknown) as ContextType;
 const Hash =
   "#%26svx%3DCount_Person%26lx%3D1%26svy%3DCount_HousingUnit%26pcy%3D1%26epd%3DgeoId%2F10%26epn%3DDelaware%26ept%3DCounty%26ub%3D99999%26qd%3D1";

--- a/static/js/tools/scatter/util.ts
+++ b/static/js/tools/scatter/util.ts
@@ -79,6 +79,7 @@ function applyHash(context: ContextType): void {
   context.x.set(applyHashAxis(params, true));
   context.y.set(applyHashAxis(params, false));
   context.place.set(applyHashPlace(params));
+  context.isQuadrants.set(applyHashQuadrants(params));
 }
 
 /**
@@ -139,6 +140,11 @@ function applyHashPlace(params: URLSearchParams): PlaceInfo {
   return place;
 }
 
+function applyHashQuadrants(params: URLSearchParams): boolean {
+  const isQuadrant = params.get(FieldToAbbreviation.isQuadrant);
+  return isQuadrant === '1';
+}
+
 /**
  * Updates the hash based on the context and returns the new hash.
  * If there are multiple denominators for a statvar, only the first
@@ -152,7 +158,9 @@ function updateHash(context: ContextType): void {
   let hash = updateHashAxis("", x, true);
   hash = updateHashAxis(hash, y, false);
   hash = updateHashPlace(hash, place);
-  const newHash = encodeURIComponent(hash);
+  hash = updateHashQuadrant(hash, context.isQuadrants.value);
+  // const newHash = encodeURIComponent(hash);
+  const newHash = hash;
   const currentHash = location.hash.replace("#", "");
   if (newHash && newHash !== currentHash) {
     history.pushState({}, "", `/tools/scatter#${newHash}`);
@@ -224,6 +232,11 @@ function updateHashPlace(hash: string, place: PlaceInfo): string {
     }
   }
   return hash;
+}
+
+function updateHashQuadrant(hash: string, isQuadrants: boolean) {
+  const val = isQuadrants ? '1' : '0';
+  return appendEntry(hash, FieldToAbbreviation.isQuadrant, val);
 }
 
 export {

--- a/static/js/tools/scatter/util.ts
+++ b/static/js/tools/scatter/util.ts
@@ -142,7 +142,7 @@ function applyHashPlace(params: URLSearchParams): PlaceInfo {
 
 function applyHashQuadrants(params: URLSearchParams): boolean {
   const isQuadrant = params.get(FieldToAbbreviation.isQuadrant);
-  return isQuadrant === '1';
+  return isQuadrant === "1";
 }
 
 /**
@@ -159,8 +159,7 @@ function updateHash(context: ContextType): void {
   hash = updateHashAxis(hash, y, false);
   hash = updateHashPlace(hash, place);
   hash = updateHashQuadrant(hash, context.isQuadrants.value);
-  // const newHash = encodeURIComponent(hash);
-  const newHash = hash;
+  const newHash = encodeURIComponent(hash);
   const currentHash = location.hash.replace("#", "");
   if (newHash && newHash !== currentHash) {
     history.pushState({}, "", `/tools/scatter#${newHash}`);
@@ -234,8 +233,11 @@ function updateHashPlace(hash: string, place: PlaceInfo): string {
   return hash;
 }
 
+/**
+ * Updates the hash for quadrant related parameters.
+ */
 function updateHashQuadrant(hash: string, isQuadrants: boolean) {
-  const val = isQuadrants ? '1' : '0';
+  const val = isQuadrants ? "1" : "0";
   return appendEntry(hash, FieldToAbbreviation.isQuadrant, val);
 }
 


### PR DESCRIPTION
quadrant lines are plotted based off the mean of both x and y values

![image](https://user-images.githubusercontent.com/6052978/128779105-b66819dd-230e-416b-9b79-111d67621095.png)

adds a new "qd" query parameter, with display option:

![image](https://user-images.githubusercontent.com/6052978/128779204-cdd89702-ce13-4a87-a428-37e123d25ac0.png)
