### PR TITLE
[scatter] add option for text labels

### DIFF
--- a/static/css/tools/scatter.scss
+++ b/static/css/tools/scatter.scss
@@ -241,3 +241,8 @@ circle {
   fill: red;
   font-size: .8em;
 }
+
+#scatterplot .dot-label {
+  font-size: .8em;
+  
+}

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -39,7 +39,8 @@ interface ChartPropsType {
   yStatVar: string;
   xUnits?: string;
   yUnits?: string;
-  isQuadrants: boolean;
+  showQuadrants: boolean;
+  showLabels: boolean;
 }
 
 const DOT_REDIRECT_PREFIX = "/tools/timeline";
@@ -198,7 +199,7 @@ function plot(
     props.yUnits
   );
 
-  if (props.isQuadrants) {
+  if (props.showQuadrants) {
     const quadrant = g.append("g");
     const xMean = d3.mean(props.points, (point) => point.xVal);
     const yMean = d3.mean(props.points, (point) => point.yVal);
@@ -225,6 +226,19 @@ function plot(
     .attr("fill", "#FFFFFF")
     .style("opacity", "0.7")
     .on("click", handleDotClick(props.xStatVar, props.yStatVar));
+
+  if (props.showLabels) {
+    g.append("g")
+      .attr("class", "dot-label")
+      .selectAll("text")
+      .data(props.points)
+      .enter()
+      .append("text")
+      .attr("dy", "0.35em")
+      .attr("x", (point) => xScale(point.xVal) + 7)
+      .attr("y", (point) => yScale(point.yVal))
+      .text((point) => point.place.name);
+  }
 
   addTooltip(
     tooltip,

--- a/static/js/tools/scatter/chart_loader.tsx
+++ b/static/js/tools/scatter/chart_loader.tsx
@@ -66,7 +66,7 @@ type Cache = {
 };
 
 function ChartLoader(): JSX.Element {
-  const { x, y, isLoading, isQuadrants } = useContext(Context);
+  const { x, y, isLoading, display } = useContext(Context);
   const cache = useCache();
   const points = usePoints(cache);
 
@@ -115,7 +115,8 @@ function ChartLoader(): JSX.Element {
                 yStatVar={yStatVar}
                 xUnits={xUnits}
                 yUnits={yUnits}
-                isQuadrants={isQuadrants.value}
+                showQuadrants={display.showQuadrants}
+                showLabels={display.showLabels}
               />
               <PlotOptions />
             </>

--- a/static/js/tools/scatter/context.ts
+++ b/static/js/tools/scatter/context.ts
@@ -91,11 +91,13 @@ const EmptyPlace: PlaceInfo = Object.freeze({
   upperBound: 1e10,
 });
 
-interface IsQuadrantWrapper {
-  value: boolean;
+interface DisplayOptionsWrapper {
+  showQuadrants: boolean;
+  showLabels: boolean;
 
   // Setters
-  set: Setter<boolean>;
+  setQuadrants: Setter<boolean>;
+  setLabels: Setter<boolean>;
 }
 
 interface DateInfo {
@@ -142,8 +144,8 @@ interface ContextType {
   y: AxisWrapper;
   // Places to plot
   place: PlaceInfoWrapper;
-  // Whether to plot in Quadrant mode
-  isQuadrants: IsQuadrantWrapper;
+  // Plot display options
+  display: DisplayOptionsWrapper;
   // Whether there are currently active network tasks
   isLoading: IsLoadingWrapper;
 }
@@ -164,8 +166,9 @@ const FieldToAbbreviation = {
   lowerBound: "lb",
   upperBound: "ub",
 
-  // Quadrant fields
+  // DisplayOptions fields
   isQuadrant: "qd",
+  isLabels: "ld",
 };
 
 /**
@@ -176,6 +179,7 @@ function useContextStore(): ContextType {
   const [y, setY] = useState(EmptyAxis);
   const [place, setPlace] = useState(EmptyPlace);
   const [isQuadrants, setQuadrants] = useState(false);
+  const [isLabels, setLabels] = useState(false);
   const [arePlacesLoading, setArePlacesLoading] = useState(false);
   const [areStatVarsLoading, setAreStatVarsLoading] = useState(false);
   const [areDataLoading, setAreDataLoading] = useState(false);
@@ -207,9 +211,11 @@ function useContextStore(): ContextType {
       setLowerBound: getSetLowerBound(place, setPlace),
       setUpperBound: getSetUpperBound(place, setPlace),
     },
-    isQuadrants: {
-      value: isQuadrants,
-      set: (isQuadrants) => setQuadrants(isQuadrants),
+    display: {
+      showQuadrants: isQuadrants,
+      setQuadrants: (isQuadrants) => setQuadrants(isQuadrants),
+      showLabels: isLabels,
+      setLabels: (isLabels) => setLabels(isLabels),
     },
     isLoading: {
       arePlacesLoading: arePlacesLoading,
@@ -376,7 +382,7 @@ export {
   DateInfo,
   DateInfoWrapper,
   IsLoadingWrapper,
-  IsQuadrantWrapper,
+  DisplayOptionsWrapper,
   EmptyAxis,
   EmptyPlace,
   EmptyDate,

--- a/static/js/tools/scatter/context.ts
+++ b/static/js/tools/scatter/context.ts
@@ -167,8 +167,8 @@ const FieldToAbbreviation = {
   upperBound: "ub",
 
   // DisplayOptions fields
-  isQuadrant: "qd",
-  isLabels: "ld",
+  showQuadrant: "qd",
+  showLabels: "ld",
 };
 
 /**
@@ -178,8 +178,8 @@ function useContextStore(): ContextType {
   const [x, setX] = useState(EmptyAxis);
   const [y, setY] = useState(EmptyAxis);
   const [place, setPlace] = useState(EmptyPlace);
-  const [isQuadrants, setQuadrants] = useState(false);
-  const [isLabels, setLabels] = useState(false);
+  const [showQuadrants, setQuadrants] = useState(false);
+  const [showLabels, setLabels] = useState(false);
   const [arePlacesLoading, setArePlacesLoading] = useState(false);
   const [areStatVarsLoading, setAreStatVarsLoading] = useState(false);
   const [areDataLoading, setAreDataLoading] = useState(false);
@@ -212,10 +212,10 @@ function useContextStore(): ContextType {
       setUpperBound: getSetUpperBound(place, setPlace),
     },
     display: {
-      showQuadrants: isQuadrants,
-      setQuadrants: (isQuadrants) => setQuadrants(isQuadrants),
-      showLabels: isLabels,
-      setLabels: (isLabels) => setLabels(isLabels),
+      showQuadrants: showQuadrants,
+      setQuadrants: (showQuadrants) => setQuadrants(showQuadrants),
+      showLabels: showLabels,
+      setLabels: (showLabels) => setLabels(showLabels),
     },
     isLoading: {
       arePlacesLoading: arePlacesLoading,

--- a/static/js/tools/scatter/plot_options.tsx
+++ b/static/js/tools/scatter/plot_options.tsx
@@ -24,7 +24,7 @@ import { FormGroup, Label, Input, Card, Button } from "reactstrap";
 import {
   AxisWrapper,
   Context,
-  IsQuadrantWrapper,
+  DisplayOptionsWrapper,
   PlaceInfoWrapper,
 } from "./context";
 
@@ -34,7 +34,7 @@ import { Container, Row, Col } from "reactstrap";
 // returns the available dates for the statvar. Then, fill the datapicker with
 // the dates.
 function PlotOptions(): JSX.Element {
-  const { place, x, y, isQuadrants } = useContext(Context);
+  const { place, x, y, display } = useContext(Context);
   const [lowerBound, setLowerBound] = useState(
     place.value.lowerBound.toString()
   );
@@ -108,7 +108,7 @@ function PlotOptions(): JSX.Element {
         </Row>
         <Row className="plot-options-row centered-items-row">
           <Col sm={1} className="plot-options-label">
-            Swap:
+            Display:
           </Col>
           <Col sm="auto">
             <Button
@@ -121,10 +121,18 @@ function PlotOptions(): JSX.Element {
               Swap X and Y axes
             </Button>
           </Col>
-        </Row>
-        <Row className="plot-options-row centered-items-row">
-          <Col sm={1} className="plot-options-label">
-            Quadrants:
+          <Col sm="auto">
+            <FormGroup check>
+              <Label check>
+                <Input
+                  id="quadrants"
+                  type="checkbox"
+                  checked={display.showQuadrants}
+                  onChange={(e) => checkQuadrants(display, e)}
+                />
+                Show quadrants
+              </Label>
+            </FormGroup>
           </Col>
           <Col sm="auto">
             <FormGroup check>
@@ -132,10 +140,10 @@ function PlotOptions(): JSX.Element {
                 <Input
                   id="quadrants"
                   type="checkbox"
-                  checked={isQuadrants.value}
-                  onChange={(e) => checkQuadrants(isQuadrants, e)}
+                  checked={display.showLabels}
+                  onChange={(e) => checkLabels(display, e)}
                 />
-                Show Quadrants
+                Show labels
               </Label>
             </FormGroup>
           </Col>
@@ -206,11 +214,24 @@ function checkLog(
   axis.setLog(event.target.checked);
 }
 
+/**
+ * Toggles whether to show quadrant lines.
+ */
 function checkQuadrants(
-  isQuadrant: IsQuadrantWrapper,
+  display: DisplayOptionsWrapper,
   event: React.ChangeEvent<HTMLInputElement>
 ): void {
-  isQuadrant.set(event.target.checked);
+  display.setQuadrants(event.target.checked);
+}
+
+/**
+ * Toggles whether to show text labels for every dot.
+ */
+function checkLabels(
+  display: DisplayOptionsWrapper,
+  event: React.ChangeEvent<HTMLInputElement>
+): void {
+  display.setLabels(event.target.checked);
 }
 
 /**

--- a/static/js/tools/scatter/util.test.ts
+++ b/static/js/tools/scatter/util.test.ts
@@ -56,8 +56,8 @@ const TestContext = ({
     },
   },
   display: {
-    isQuadrants: true,
-    isLabels: true,
+    showQuadrants: true,
+    showLabels: true,
   },
 } as unknown) as ContextType;
 const Hash =

--- a/static/js/tools/scatter/util.test.ts
+++ b/static/js/tools/scatter/util.test.ts
@@ -55,12 +55,13 @@ const TestContext = ({
       upperBound: 99999,
     },
   },
-  isQuadrants: {
-    value: true,
+  display: {
+    isQuadrants: true,
+    isLabels: true,
   },
 } as unknown) as ContextType;
 const Hash =
-  "#%26svx%3DCount_Person%26lx%3D1%26svy%3DCount_HousingUnit%26pcy%3D1%26epd%3DgeoId%2F10%26epn%3DDelaware%26ept%3DCounty%26ub%3D99999%26qd%3D1";
+  "#%26svx%3DCount_Person%26lx%3D1%26svy%3DCount_HousingUnit%26pcy%3D1%26epd%3DgeoId%2F10%26epn%3DDelaware%26ept%3DCounty%26ub%3D99999%26qd%3D1%26ld%3D1";
 
 test("updateHash", () => {
   history.pushState = jest.fn();
@@ -73,11 +74,13 @@ test("updateHash", () => {
 });
 
 test("applyHash", () => {
-  const context = { x: {}, y: {}, place: {}, isQuadrants: {} } as ContextType;
+  const context = { x: {}, y: {}, place: {}, display: {} } as ContextType;
   context.x.set = (value) => (context.x.value = value);
   context.y.set = (value) => (context.y.value = value);
   context.place.set = (value) => (context.place.value = value);
-  context.isQuadrants.set = (value) => (context.isQuadrants.value = value);
+  context.display.setQuadrants = (value) =>
+    (context.display.showQuadrants = value);
+  context.display.setLabels = (value) => (context.display.showLabels = value);
   location.hash = Hash;
   applyHash(context);
   expect(context.x.value).toEqual(TestContext.x.value);
@@ -86,5 +89,7 @@ test("applyHash", () => {
     ...TestContext.place.value,
     enclosedPlaces: [],
   });
-  expect(context.isQuadrants.value).toEqual(TestContext.isQuadrants.value);
+  expect(context.display.showQuadrants).toEqual(
+    TestContext.display.showQuadrants
+  );
 });

--- a/static/js/tools/scatter/util.ts
+++ b/static/js/tools/scatter/util.ts
@@ -81,10 +81,10 @@ function applyHash(context: ContextType): void {
   context.y.set(applyHashAxis(params, false));
   context.place.set(applyHashPlace(params));
   context.display.setQuadrants(
-    applyHashBoolean(params, FieldToAbbreviation.isQuadrant)
+    applyHashBoolean(params, FieldToAbbreviation.showQuadrant)
   );
   context.display.setLabels(
-    applyHashBoolean(params, FieldToAbbreviation.isLabels)
+    applyHashBoolean(params, FieldToAbbreviation.showLabels)
   );
 }
 
@@ -165,8 +165,7 @@ function updateHash(context: ContextType): void {
   hash = updateHashAxis(hash, y, false);
   hash = updateHashPlace(hash, place);
   hash = updateHashDisplayOptions(hash, context.display);
-  // const newHash = encodeURIComponent(hash);
-  const newHash = hash;
+  const newHash = encodeURIComponent(hash);
   const currentHash = location.hash.replace("#", "");
   if (newHash && newHash !== currentHash) {
     history.pushState({}, "", `/tools/scatter#${newHash}`);
@@ -245,10 +244,10 @@ function updateHashDisplayOptions(
   display: DisplayOptionsWrapper
 ) {
   let val = display.showQuadrants ? "1" : "0";
-  hash = appendEntry(hash, FieldToAbbreviation.isQuadrant, val);
+  hash = appendEntry(hash, FieldToAbbreviation.showQuadrant, val);
 
   val = display.showLabels ? "1" : "0";
-  hash = appendEntry(hash, FieldToAbbreviation.isLabels, val);
+  hash = appendEntry(hash, FieldToAbbreviation.showLabels, val);
 
   return hash;
 }

--- a/static/js/tools/scatter/util.ts
+++ b/static/js/tools/scatter/util.ts
@@ -28,6 +28,7 @@ import {
   EmptyAxis,
   EmptyPlace,
   FieldToAbbreviation,
+  DisplayOptionsWrapper,
 } from "./context";
 import { PlacePointStat } from "../shared_util";
 
@@ -79,7 +80,12 @@ function applyHash(context: ContextType): void {
   context.x.set(applyHashAxis(params, true));
   context.y.set(applyHashAxis(params, false));
   context.place.set(applyHashPlace(params));
-  context.isQuadrants.set(applyHashQuadrants(params));
+  context.display.setQuadrants(
+    applyHashBoolean(params, FieldToAbbreviation.isQuadrant)
+  );
+  context.display.setLabels(
+    applyHashBoolean(params, FieldToAbbreviation.isLabels)
+  );
 }
 
 /**
@@ -140,9 +146,9 @@ function applyHashPlace(params: URLSearchParams): PlaceInfo {
   return place;
 }
 
-function applyHashQuadrants(params: URLSearchParams): boolean {
-  const isQuadrant = params.get(FieldToAbbreviation.isQuadrant);
-  return isQuadrant === "1";
+function applyHashBoolean(params: URLSearchParams, key: string): boolean {
+  const val = params.get(key);
+  return val === "1";
 }
 
 /**
@@ -158,8 +164,9 @@ function updateHash(context: ContextType): void {
   let hash = updateHashAxis("", x, true);
   hash = updateHashAxis(hash, y, false);
   hash = updateHashPlace(hash, place);
-  hash = updateHashQuadrant(hash, context.isQuadrants.value);
-  const newHash = encodeURIComponent(hash);
+  hash = updateHashDisplayOptions(hash, context.display);
+  // const newHash = encodeURIComponent(hash);
+  const newHash = hash;
   const currentHash = location.hash.replace("#", "");
   if (newHash && newHash !== currentHash) {
     history.pushState({}, "", `/tools/scatter#${newHash}`);
@@ -233,12 +240,17 @@ function updateHashPlace(hash: string, place: PlaceInfo): string {
   return hash;
 }
 
-/**
- * Updates the hash for quadrant related parameters.
- */
-function updateHashQuadrant(hash: string, isQuadrants: boolean) {
-  const val = isQuadrants ? "1" : "0";
-  return appendEntry(hash, FieldToAbbreviation.isQuadrant, val);
+function updateHashDisplayOptions(
+  hash: string,
+  display: DisplayOptionsWrapper
+) {
+  let val = display.showQuadrants ? "1" : "0";
+  hash = appendEntry(hash, FieldToAbbreviation.isQuadrant, val);
+
+  val = display.showLabels ? "1" : "0";
+  hash = appendEntry(hash, FieldToAbbreviation.isLabels, val);
+
+  return hash;
 }
 
 export {


### PR DESCRIPTION
v0 - no logic to control for text overlap
also added all the display options to a single row

![image](https://user-images.githubusercontent.com/6052978/128784595-f95b1dcb-c45c-4fd0-a3ea-b7d4ec4215f7.png)
