### PR TITLE
[map] increase dynamic range of map colors

### DIFF
--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -80,11 +80,12 @@ function getColorScale(
 ): d3.ScaleLinear<number, number> {
   const label = getStatsVarLabel(statVar);
   const maxColor = d3.color(getColorFn([label])(label));
+  const extent = d3.extent(Object.values(dataValues));
   return d3
     .scaleLinear()
-    .domain(d3.extent(Object.values(dataValues)))
+    .domain([extent[0], d3.mean(extent), extent[1]])
     .nice()
-    .range(([MIN_COLOR, maxColor, maxColor.darker(2)] as unknown) as number[])
+    .range(([MIN_COLOR, maxColor, maxColor.darker(1.5)] as unknown) as number[])
     .interpolate(
       (d3.interpolateHslLong as unknown) as (
         a: unknown,

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -389,10 +389,10 @@ function generateLegend(
       d3
         .axisRight(yScale)
         .tickSize(TICK_SIZE)
-        .ticks(NUM_TICKS)
         .tickFormat((d) => {
           return formatNumber(d.valueOf(), unit);
         })
+        .tickValues(color.ticks(NUM_TICKS).concat(yScale.domain()))
     )
     .call((g) =>
       g


### PR DESCRIPTION
domain and range must match -- we were setting domain only with extent, but range with 3 values, so the third (darkest color) was ignored. increased the range, making it darker at the end, using the max color for the median instead.

also fixed the legends to always include the min and max values.

![image](https://user-images.githubusercontent.com/6052978/128912030-499f9649-5cee-4dbe-b492-4ba657d3fc92.png)
