### PR TITLE
Website update for scatter and stat var widget

### DIFF
--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -120,9 +120,12 @@ export class StatVarGroupNode extends React.Component<
   }
 
   render(): JSX.Element {
-    const triggerTitle = this.props.data.specializedEntity
+    let triggerTitle = this.props.data.specializedEntity
       ? this.props.data.specializedEntity
       : this.props.data.displayName;
+    if (this.props.data.id == "dc/g/Private") {
+      triggerTitle = "[PRIVATE] " + triggerTitle;
+    }
 
     const level = this.props.path.length;
     this.selectionCount = 0;

--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -123,7 +123,7 @@ export class StatVarGroupNode extends React.Component<
     let triggerTitle = this.props.data.specializedEntity
       ? this.props.data.specializedEntity
       : this.props.data.displayName;
-    if (this.props.data.id == "dc/g/Private") {
+    if (this.props.data.id === "dc/g/Private") {
       triggerTitle = "[PRIVATE] " + triggerTitle;
     }
 

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -41,7 +41,10 @@ import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
 
 // Number of enclosed places to sample when filtering the stat vars in the
 // stat var menu
-const SAMPLE_SIZE = 3;
+// Use a large sample size here. Performance wise this is okay. When the filtered
+// stat vars are set, mixer can use the existence cache to check if stat vars
+// exist for the place, which is only a point read.
+const SAMPLE_SIZE = 50;
 
 interface StatVar {
   // Always contains a single statvar.


### PR DESCRIPTION
- Use more samples for scatter plot places. This is to allow stat var with sparse data of some place type to work properly.
- Highlight private dc section