### PR TITLE
[map] update hover behaviour for dots

### DIFF
--- a/static/css/tools/map.scss
+++ b/static/css/tools/map.scss
@@ -239,4 +239,10 @@
 .dot {
   r: 4;
   stroke: var(--dc-gray-lite);
+  fill: black;
+}
+
+.dot:hover {
+  stroke: black;
+  fill: var(--dc-gray-lite);
 }


### PR DESCRIPTION
- on hover, make the dots outline and fill colors opposite that of the regular state

![screen-recording (21) (1)](https://user-images.githubusercontent.com/69875368/133317986-bb6f84b3-700b-43fd-a333-5c4aac1af6a3.gif)
