### PR TITLE
[place] fix layout for charts without comparisons

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -258,7 +258,7 @@ the same region.
 1. Run these commands:
    ```bash
    ./scripts/extract_messages.sh
-   ./scripts/compiled_messages.sh
+   ./scripts/compile_messages.sh
    ```
 
 1. **IMPORTANT**: Manually restart the flask or minikube instance to reload the config and translations.

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -438,9 +438,9 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
       }
     }
     return (
-      <div className="row row-cols-xl-3 row-cols-md-2 row-cols-1">
+      <>
         {chartElements}
-      </div>
+      </>
     );
   }
 }

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -437,11 +437,7 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
         );
       }
     }
-    return (
-      <>
-        {chartElements}
-      </>
-    );
+    return <>{chartElements}</>;
   }
 }
 

--- a/static/js/place/main.tsx
+++ b/static/js/place/main.tsx
@@ -141,26 +141,28 @@ class MainPane extends React.Component<MainPanePropType> {
           return (
             <section className="subtopic col-12" key={topic}>
               {subtopicHeader}
-              {topicData[topic].map((data: ChartBlockData) => {
-                return (
-                  <ChartBlock
-                    key={data.title}
-                    isOverview={isOverview}
-                    dcid={this.props.dcid}
-                    placeName={this.props.placeName}
-                    placeType={this.props.placeType}
-                    isUsaPlace={this.props.isUsaPlace}
-                    names={this.props.names}
-                    data={data}
-                    locale={this.props.locale}
-                    geoJsonData={this.props.geoJsonData}
-                    choroplethData={this.props.choroplethData}
-                    childPlaceType={this.props.childPlacesType}
-                    parentPlaces={this.props.parentPlaces}
-                    topic={currentPageTopic}
-                  />
-                );
-              })}
+              <div className="row row-cols-xl-3 row-cols-md-2 row-cols-1">
+                {topicData[topic].map((data: ChartBlockData) => {
+                  return (
+                    <ChartBlock
+                      key={data.title}
+                      isOverview={isOverview}
+                      dcid={this.props.dcid}
+                      placeName={this.props.placeName}
+                      placeType={this.props.placeType}
+                      isUsaPlace={this.props.isUsaPlace}
+                      names={this.props.names}
+                      data={data}
+                      locale={this.props.locale}
+                      geoJsonData={this.props.geoJsonData}
+                      choroplethData={this.props.choroplethData}
+                      childPlaceType={this.props.childPlacesType}
+                      parentPlaces={this.props.parentPlaces}
+                      topic={currentPageTopic}
+                    />
+                  );
+                })}
+              </div>
             </section>
           );
         })}


### PR DESCRIPTION
We were adding div's around each chart block, which creates an entire row (even if there could be opportunity for a chart on the next row to float up).

Before:
![image](https://user-images.githubusercontent.com/6052978/135174704-a3962d67-fb85-4012-8fd8-45babe8ab7e7.png)


After: 
![image](https://user-images.githubusercontent.com/6052978/135174674-d18149aa-e22b-4373-b026-b7732800eb8c.png)
