### PR TITLE
[cleanup] move types out of data_fetcher, and remove some dead code

### DIFF
--- a/static/.eslintrc.json
+++ b/static/.eslintrc.json
@@ -13,7 +13,7 @@
     "semi": ["error", "always"],
     "@typescript-eslint/no-explicit-any": "off",
     "no-fallthrough": "off",
-    "sort-imports": "error"
+    "sort-imports": "warn"
   },
   "settings": {
     "react": {

--- a/static/js/shared/stat_types.ts
+++ b/static/js/shared/stat_types.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Stat API related types.
+ */
+
+export interface TimeSeries {
+  val?: {
+    [date: string]: number; // Date might be "latest" if it's from the cache
+  };
+  metadata?: {
+    importName?: string;
+    measurementMethod?: string;
+    provenanceUrl?: string;
+    unit?: string;
+  };
+}
+
+export interface StatApiResponse {
+  [place: string]: {
+    data: {
+      [statVar: string]: TimeSeries | null;
+    };
+    name?: string;
+  };
+}
+
+export interface DisplayNameApiResponse {
+  [placeDcid: string]: string;
+}

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -26,7 +26,7 @@ import React, { useContext, useEffect, useState } from "react";
 
 import { Chart } from "./chart";
 import { MAX_DATE } from "../../shared/constants";
-import { StatApiResponse } from "../../shared/data_fetcher";
+import { StatApiResponse } from "../../shared/stat_types";
 import _ from "lodash";
 import axios from "axios";
 import { shouldCapStatVarDate } from "../../shared/util";

--- a/static/js/tools/scatter/chart_loader.tsx
+++ b/static/js/tools/scatter/chart_loader.tsx
@@ -33,7 +33,7 @@ import { arePlacesLoaded, getStatsWithinPlace } from "./util";
 import { Chart } from "./chart";
 import { NamedPlace } from "../../shared/types";
 import { PlotOptions } from "./plot_options";
-import { StatApiResponse } from "../../shared/data_fetcher";
+import { StatApiResponse } from "../../shared/stat_types";
 import _ from "lodash";
 import axios from "axios";
 import { saveToFile } from "../../shared/util";

--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -16,7 +16,7 @@
 import * as d3 from "d3";
 
 import { StatVarInfo } from "../shared/stat_var";
-import { TimeSeries } from "../shared/data_fetcher";
+import { TimeSeries } from "../shared/stat_types";
 import _ from "lodash";
 
 /**

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -20,7 +20,7 @@ import {
   StatData,
   fetchStatData,
   getStatVarGroupWithTime,
-} from "../../shared/data_fetcher";
+} from "./data_fetcher";
 
 import { StatVarInfo } from "../../shared/stat_var";
 import { drawGroupLineChart } from "../../chart/draw";

--- a/static/js/tools/timeline/chart_region.tsx
+++ b/static/js/tools/timeline/chart_region.tsx
@@ -18,7 +18,7 @@ import React, { Component } from "react";
 import { getChartOption, removeToken, statVarSep } from "./util";
 
 import { Chart } from "./chart";
-import { StatData } from "../../shared/data_fetcher";
+import { StatData } from "./data_fetcher";
 import { StatVarInfo } from "../../shared/stat_var";
 import _ from "lodash";
 import { saveToFile } from "../../shared/util";

--- a/static/js/tools/timeline/data_fetcher.test.ts
+++ b/static/js/tools/timeline/data_fetcher.test.ts
@@ -168,7 +168,6 @@ test("fetch stats data", () => {
       places: ["geoId/05", "geoId/06"],
       statVars: ["Count_Person", "Count_Person_Male"],
       sources: new Set(["source1", "source2"]),
-      latestCommonDate: "2012",
     });
 
     expect(getStatVarGroupWithTime(data, "geoId/06")).toEqual([
@@ -272,7 +271,6 @@ test("fetch stats data with state code", () => {
         places: ["geoId/05", "geoId/06085"],
         statVars: ["Count_Person"],
         sources: new Set(["source1", "source2"]),
-        latestCommonDate: "2012",
       });
     }
   );
@@ -339,7 +337,6 @@ test("fetch stats data where latest date with data for all stat vars is not the 
         places: ["geoId/05", "geoId/06"],
         statVars: ["Count_Person"],
         sources: new Set(["source1", "source2"]),
-        latestCommonDate: "2011",
       });
 
       expect(getStatVarGroupWithTime(data, "geoId/06")).toEqual([
@@ -414,7 +411,6 @@ test("fetch stats data where there is no date with data for all stat vars", () =
         places: ["geoId/05", "geoId/06"],
         statVars: ["Count_Person"],
         sources: new Set(["source1", "source2"]),
-        latestCommonDate: "2013",
       });
 
       expect(getStatVarGroupWithTime(data, "geoId/06")).toEqual([
@@ -513,7 +509,6 @@ test("fetch stats data with per capita with population size 0", () => {
         places: ["geoId/05"],
         sources: new Set(["source1"]),
         statVars: ["Count_Person_Male"],
-        latestCommonDate: "2012",
       });
     }
   );
@@ -540,7 +535,6 @@ test("StatsData test", () => {
     },
     dates: [],
     sources: new Set(),
-    latestCommonDate: "",
   };
   expect(getStatVarGroupWithTime(statData, "geoId/01")).toEqual([]);
 });
@@ -716,7 +710,6 @@ test("Per capita with specified denominators test", () => {
       places: ["geoId/05", "geoId/06"],
       statVars: ["Count_Person_Male", "Count_Person_Female"],
       sources: new Set(["source1", "source2"]),
-      latestCommonDate: "2012",
     });
 
     expect(getStatVarGroupWithTime(data, "geoId/06")).toEqual([
@@ -833,7 +826,6 @@ test("Per capita with specified denominators test - missing place data", () => {
         "UnemploymentRate_Person_Female",
       ],
       sources: new Set(["source2", "source1"]),
-      latestCommonDate: "2012",
     });
 
     expect(getStatVarGroupWithTime(data, "geoId/05")).toEqual([
@@ -909,7 +901,6 @@ test("convert to delta", () => {
       "UnemploymentRate_Person_Female",
     ],
     sources: new Set(["source2", "source1"]),
-    latestCommonDate: "2012",
   };
 
   const expected: StatData = {
@@ -948,7 +939,6 @@ test("convert to delta", () => {
       "UnemploymentRate_Person_Female",
     ],
     sources: new Set(["source2", "source1"]),
-    latestCommonDate: "2012",
   };
 
   statData = convertToDelta(statData);

--- a/static/js/tools/timeline/data_fetcher.test.ts
+++ b/static/js/tools/timeline/data_fetcher.test.ts
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
+import axios from "axios";
+import _ from "lodash";
+
+import { DataGroup } from "../../chart/base";
+import { loadLocaleData } from "../../i18n/i18n";
+import { StatApiResponse, TimeSeries } from "../../shared/stat_types";
 import {
-  StatApiResponse,
   StatData,
-  TimeSeries,
   computePerCapita,
   convertToDelta,
   fetchStatData,
   getStatVarGroupWithTime,
 } from "./data_fetcher";
-
-import { DataGroup } from "../chart/base";
-import _ from "lodash";
-import axios from "axios";
-import { loadLocaleData } from "../i18n/i18n";
 
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;

--- a/static/js/tools/timeline/data_fetcher.ts
+++ b/static/js/tools/timeline/data_fetcher.ts
@@ -14,39 +14,19 @@
  * limitations under the License.
  */
 
-import { DataGroup, DataPoint } from "../chart/base";
-
-import _ from "lodash";
 import axios from "axios";
-import { isDateTooFar } from "./util";
+import _ from "lodash";
+
+import { DataGroup, DataPoint } from "../../chart/base";
+import {
+  DisplayNameApiResponse,
+  StatApiResponse,
+  TimeSeries,
+} from "../../shared/stat_types";
+import { isDateTooFar } from "../../shared/util";
 
 const TOTAL_POPULATION_SV = "Count_Person";
 const ZERO_POPULATION = 0;
-
-export interface TimeSeries {
-  val?: {
-    [date: string]: number; // Date might be "latest" if it's from the cache
-  };
-  metadata?: {
-    importName?: string;
-    measurementMethod?: string;
-    provenanceUrl?: string;
-    unit?: string;
-  };
-}
-
-export interface StatApiResponse {
-  [place: string]: {
-    data: {
-      [statVar: string]: TimeSeries | null;
-    };
-    name?: string;
-  };
-}
-
-interface DisplayNameApiResponse {
-  [placeDcid: string]: string;
-}
 
 /**
  * Stats Data is keyed by statistical variable, then keyed by place dcid, with


### PR DESCRIPTION
data fetcher is included in most tools, so changes there are slow to compile, even though all imports except for timeline are only for types

also downgraded sort-import to a warning