### PR TITLE
Use simple-import-sort package for import lint and auto-fix

### DIFF
--- a/static/.eslintrc.json
+++ b/static/.eslintrc.json
@@ -7,13 +7,14 @@
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended"
   ],
-  "plugins": ["react", "prettier"],
+  "plugins": ["react", "prettier", "simple-import-sort"],
   "rules": {
     "prettier/prettier": ["error"],
     "semi": ["error", "always"],
     "@typescript-eslint/no-explicit-any": "off",
     "no-fallthrough": "off",
-    "sort-imports": "warn"
+    "simple-import-sort/exports": "error",
+    "simple-import-sort/imports": "error"
   },
   "settings": {
     "react": {

--- a/static/js/browser/arc_table_row.tsx
+++ b/static/js/browser/arc_table_row.tsx
@@ -19,9 +19,10 @@
  * the property, value, and provenance of an arc.
  */
 
-import { ArcValue } from "./types";
-import React from "react";
 import _ from "lodash";
+import React from "react";
+
+import { ArcValue } from "./types";
 
 const HREF_PREFIX = "/browser/";
 const NUM_VALUES_UNEXPANDED = 5;

--- a/static/js/browser/browser.ts
+++ b/static/js/browser/browser.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { PageDisplayType, getPageDisplayType } from "./types";
-
-import { BrowserPage } from "./browser_page";
+import axios from "axios";
+import _ from "lodash";
 import React from "react";
 import ReactDOM from "react-dom";
-import _ from "lodash";
-import axios from "axios";
+
+import { BrowserPage } from "./browser_page";
+import { getPageDisplayType, PageDisplayType } from "./types";
 
 const TYPE_OF_UNKNOWN = "Unknown";
 const TYPE_OF_STAT_VAR = "StatisticalVariable";

--- a/static/js/browser/browser_page.tsx
+++ b/static/js/browser/browser_page.tsx
@@ -18,18 +18,19 @@
  * Main component for browser.
  */
 
+import axios from "axios";
+import _ from "lodash";
+import React from "react";
 import Collapsible from "react-collapsible";
+
+import { StatVarHierarchyType } from "../shared/types";
+import { StatVarHierarchy } from "../stat_var_hierarchy/stat_var_hierarchy";
 import { ImageSection } from "./image_section";
 import { InArcSection } from "./in_arc_section";
 import { ObservationChartSection } from "./observation_chart_section";
 import { OutArcSection } from "./out_arc_section";
 import { PageDisplayType } from "./types";
-import React from "react";
-import { StatVarHierarchy } from "../stat_var_hierarchy/stat_var_hierarchy";
-import { StatVarHierarchyType } from "../shared/types";
 import { WeatherChartSection } from "./weather_chart_section";
-import _ from "lodash";
-import axios from "axios";
 
 const URL_PREFIX = "/browser/";
 const PLACE_STAT_VAR_PROPERTIES_HEADER = "Statistical Variable Properties";

--- a/static/js/browser/image_section.tsx
+++ b/static/js/browser/image_section.tsx
@@ -18,11 +18,11 @@
  * Component for rendering the image for the imageUrl property value.
  */
 
-import { loadSpinner, removeSpinner } from "./util";
-
-import React from "react";
-import _ from "lodash";
 import axios from "axios";
+import _ from "lodash";
+import React from "react";
+
+import { loadSpinner, removeSpinner } from "./util";
 
 const IMAGE_URL_PROPERTY_LABEL = "imageUrl";
 const LOADING_CONTAINER_ID = "browser-image-section";

--- a/static/js/browser/in_arc_section.tsx
+++ b/static/js/browser/in_arc_section.tsx
@@ -18,13 +18,13 @@
  * Component for rendering all the groups of in arcs grouped by parentType and predicate.
  */
 
-import { loadSpinner, removeSpinner } from "./util";
+import axios from "axios";
+import _ from "lodash";
+import React from "react";
 
 import { InArcSubsection } from "./in_arc_subsection";
 import { InArcValue } from "./types";
-import React from "react";
-import _ from "lodash";
-import axios from "axios";
+import { loadSpinner, removeSpinner } from "./util";
 
 const IGNORED_PARENT_TYPES = new Set(["StatisticalPopulation"]);
 const LOADING_CONTAINER_ID = "browser-in-arc-section";

--- a/static/js/browser/in_arc_subsection.tsx
+++ b/static/js/browser/in_arc_subsection.tsx
@@ -18,9 +18,10 @@
  * Component for displaying a single group of in arcs of the same parentType and property.
  */
 
+import React from "react";
+
 import { ArcTableRow } from "./arc_table_row";
 import { InArcValue } from "./types";
-import React from "react";
 
 interface InArcSubsectionPropType {
   nodeName: string;

--- a/static/js/browser/observation_chart.tsx
+++ b/static/js/browser/observation_chart.tsx
@@ -18,15 +18,15 @@
  * Component for displaying a line chart for a single source series.
  */
 
-import { DataGroup, DataPoint } from "../chart/base";
-
-import React from "react";
-import { SourceSeries } from "./types";
-import { URI_PREFIX } from "./constants";
 import axios from "axios";
+import React from "react";
+
+import { DataGroup, DataPoint } from "../chart/base";
 import { drawLineChart } from "../chart/draw";
-import { getUnit } from "./util";
 import { randDomId } from "../shared/util";
+import { URI_PREFIX } from "./constants";
+import { SourceSeries } from "./types";
+import { getUnit } from "./util";
 
 // Chart size
 const HEIGHT = 220;

--- a/static/js/browser/observation_chart_section.tsx
+++ b/static/js/browser/observation_chart_section.tsx
@@ -18,14 +18,14 @@
  * Component for rendering the observation charts for a place stat var.
  */
 
-import { getUnit, loadSpinner, removeSpinner } from "./util";
-
-import { ObservationChart } from "./observation_chart";
-import React from "react";
-import { SourceSeries } from "./types";
-import _ from "lodash";
 import axios from "axios";
+import _ from "lodash";
+import React from "react";
+
 import { randDomId } from "../shared/util";
+import { ObservationChart } from "./observation_chart";
+import { SourceSeries } from "./types";
+import { getUnit, loadSpinner, removeSpinner } from "./util";
 
 const IGNORED_SOURCE_SERIES_MMETHODS = new Set([
   "GoogleKGHumanCurated",

--- a/static/js/browser/out_arc_section.tsx
+++ b/static/js/browser/out_arc_section.tsx
@@ -18,13 +18,13 @@
  * Component for displaying the out arcs.
  */
 
-import { loadSpinner, removeSpinner } from "./util";
+import axios from "axios";
+import _ from "lodash";
+import React from "react";
 
 import { ArcTableRow } from "./arc_table_row";
 import { ArcValue } from "./types";
-import React from "react";
-import _ from "lodash";
-import axios from "axios";
+import { loadSpinner, removeSpinner } from "./util";
 
 const DCID_PREDICATE = "dcid";
 const TYPEOF_PREDICATE = "typeOf";

--- a/static/js/browser/stat_var_charts.tsx
+++ b/static/js/browser/stat_var_charts.tsx
@@ -18,14 +18,14 @@
  * Component for rendering a stat var with charts in the stat var hierarchy.
  */
 
-import { StatVarHierarchyNodeType, StatVarInfo } from "../shared/types";
-
-import Collapsible from "react-collapsible";
-import { NamedPlace } from "../shared/types";
-import { ObservationChartSection } from "./observation_chart_section";
 import React from "react";
+import Collapsible from "react-collapsible";
+
+import { StatVarHierarchyNodeType, StatVarInfo } from "../shared/types";
+import { NamedPlace } from "../shared/types";
 import { StatVarHierarchyNodeHeader } from "../stat_var_hierarchy/node_header";
 import { URI_PREFIX } from "./constants";
+import { ObservationChartSection } from "./observation_chart_section";
 
 interface StatVarChartsPropType {
   place: NamedPlace;

--- a/static/js/browser/util.test.ts
+++ b/static/js/browser/util.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { PageDisplayType, getPageDisplayType } from "./types";
+import { getPageDisplayType, PageDisplayType } from "./types";
 import { getUnit } from "./util";
 
 test("getPageDisplayType", () => {

--- a/static/js/browser/util.ts
+++ b/static/js/browser/util.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { SourceSeries } from "./types";
 import _ from "lodash";
+
+import { SourceSeries } from "./types";
 
 /**
  * Utility functions shared across different components of graph browser.

--- a/static/js/browser/weather_chart_section.tsx
+++ b/static/js/browser/weather_chart_section.tsx
@@ -18,13 +18,13 @@
  * Component for rendering charts for various weather related properties.
  */
 
-import { getUnit, loadSpinner, removeSpinner } from "./util";
+import axios from "axios";
+import _ from "lodash";
+import React from "react";
 
 import { ObservationChart } from "./observation_chart";
-import React from "react";
 import { SourceSeries } from "./types";
-import _ from "lodash";
-import axios from "axios";
+import { getUnit, loadSpinner, removeSpinner } from "./util";
 
 const WEATHER_PROPERTY_NAMES = [
   "temperature",

--- a/static/js/chart/base.ts
+++ b/static/js/chart/base.ts
@@ -16,8 +16,8 @@
 
 import * as d3 from "d3";
 
-import { StatVarInfo } from "../shared/stat_var";
 import { translateVariableString } from "../i18n/i18n";
+import { StatVarInfo } from "../shared/stat_var";
 
 const DEFAULT_COLOR = "#000";
 
@@ -378,15 +378,15 @@ interface Range {
 }
 
 export {
-  DataGroup,
-  DataPoint,
-  Range,
-  PlotParams,
-  Style,
   computePlotParams,
+  DataGroup,
   dataGroupsToCsv,
+  DataPoint,
   getColorFn,
   getDashes,
+  PlotParams,
+  Range,
   shouldFillInValues,
+  Style,
   wrap,
 };

--- a/static/js/chart/draw.test.ts
+++ b/static/js/chart/draw.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { getColorFn, getDashes } from "./base";
-
 import { appendLegendElem } from "./draw";
 
 test("svg test", () => {

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -15,24 +15,23 @@
  */
 
 import * as d3 from "d3";
+import _ from "lodash";
 
+import { formatNumber } from "../i18n/i18n";
+import { StatVarInfo } from "../shared/stat_var";
+import { Boundary } from "../shared/types";
+import { urlToDomain } from "../shared/util";
+import { isProjection } from "../tools/shared_util";
 import {
   DataGroup,
   DataPoint,
-  PlotParams,
-  Style,
   getColorFn,
+  PlotParams,
   shouldFillInValues,
+  Style,
   wrap,
 } from "./base";
-
-import { Boundary } from "../shared/types";
 import { DotDataPoint } from "./types";
-import { StatVarInfo } from "../shared/stat_var";
-import _ from "lodash";
-import { formatNumber } from "../i18n/i18n";
-import { isProjection } from "../tools/shared_util";
-import { urlToDomain } from "../shared/util";
 
 const NUM_X_TICKS = 5;
 const NUM_Y_TICKS = 5;

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -20,20 +20,19 @@
 
 import * as d3 from "d3";
 import * as geo from "geo-albers-usa-territories";
+import _ from "lodash";
 
+import { formatNumber } from "../i18n/i18n";
 import { EARTH_NAMED_TYPED_PLACE, USA_PLACE_DCID } from "../shared/constants";
+import { getStatsVarLabel } from "../shared/stats_var_labels";
+import { NamedPlace } from "../shared/types";
+import { getColorFn } from "./base";
 import {
   GeoJsonData,
   GeoJsonFeature,
   GeoJsonFeatureProperties,
   MapPoint,
 } from "./types";
-
-import { NamedPlace } from "../shared/types";
-import _ from "lodash";
-import { formatNumber } from "../i18n/i18n";
-import { getColorFn } from "./base";
-import { getStatsVarLabel } from "../shared/stats_var_labels";
 
 const MISSING_DATA_COLOR = "#999";
 const DOT_COLOR = "black";
@@ -603,4 +602,4 @@ function shouldDisableRegionClick(
   );
 }
 
-export { drawChoropleth, getColorScale, generateLegendSvg };
+export { drawChoropleth, generateLegendSvg, getColorScale };

--- a/static/js/dev.ts
+++ b/static/js/dev.ts
@@ -18,9 +18,10 @@
  * @fileoverview dev page.
  */
 
-import { DevPage } from "./dev_page";
 import React from "react";
 import ReactDOM from "react-dom";
+
+import { DevPage } from "./dev_page";
 
 window.onload = () => {
   ReactDOM.render(

--- a/static/js/dev_page.tsx
+++ b/static/js/dev_page.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import React from "react";
+
 import {
+  computePlotParams,
   DataGroup,
   DataPoint,
   PlotParams,
-  computePlotParams,
 } from "./chart/base";
 import {
   drawGroupBarChart,
@@ -27,13 +29,11 @@ import {
   drawLineChart,
   drawStackBarChart,
 } from "./chart/draw";
-
-import React from "react";
-import { StatVarHierarchy } from "./stat_var_hierarchy/stat_var_hierarchy";
-import { StatVarHierarchyType } from "./shared/types";
-import { StatVarInfo } from "./shared/stat_var";
 import { chartTypeEnum } from "./chart/types";
+import { StatVarInfo } from "./shared/stat_var";
+import { StatVarHierarchyType } from "./shared/types";
 import { randDomId } from "./shared/util";
+import { StatVarHierarchy } from "./stat_var_hierarchy/stat_var_hierarchy";
 
 interface DevChartPropType {
   id: string;

--- a/static/js/i18n/i18n.tsx
+++ b/static/js/i18n/i18n.tsx
@@ -19,9 +19,8 @@
  * NOTE: Messages in this file will not be extracted for translation.
  */
 
-import { IntlCache, IntlShape, createIntl, createIntlCache } from "react-intl";
-
 import React from "react";
+import { createIntl, createIntlCache, IntlCache, IntlShape } from "react-intl";
 
 // A single cache instance can be shared for all locales.
 // TODO(beets): might not be necessary since we create one intl object.
@@ -295,11 +294,11 @@ function translateUnit(unit: string): string {
 
 export {
   formatNumber,
+  intl,
+  loadLocaleData,
   LocalizedLink,
   localizeLink,
   localizeSearchParams,
-  loadLocaleData,
-  intl,
   translateUnit,
   translateVariableString,
 };

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -14,36 +14,36 @@
  * limitations under the License.
  */
 
-import {
-  CachedChoroplethData,
-  ChoroplethDataGroup,
-  GeoJsonData,
-  GeoJsonFeatureProperties,
-  SnapshotData,
-  TrendData,
-  chartTypeEnum,
-} from "../chart/types";
-import { DataGroup, DataPoint, dataGroupsToCsv } from "../chart/base";
-import {
-  LocalizedLink,
-  formatNumber,
-  intl,
-  localizeSearchParams,
-} from "../i18n/i18n";
-import { drawChoropleth, getColorScale } from "../chart/draw_choropleth";
+import _ from "lodash";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { DataGroup, dataGroupsToCsv, DataPoint } from "../chart/base";
 import {
   drawGroupBarChart,
   drawLineChart,
   drawStackBarChart,
 } from "../chart/draw";
-import { isDateTooFar, urlToDomain } from "../shared/util";
-
-import { ChartEmbed } from "./chart_embed";
-import { FormattedMessage } from "react-intl";
-import { NamedPlace } from "../shared/types";
-import React from "react";
-import _ from "lodash";
+import { drawChoropleth, getColorScale } from "../chart/draw_choropleth";
+import {
+  CachedChoroplethData,
+  chartTypeEnum,
+  ChoroplethDataGroup,
+  GeoJsonData,
+  GeoJsonFeatureProperties,
+  SnapshotData,
+  TrendData,
+} from "../chart/types";
+import {
+  formatNumber,
+  intl,
+  LocalizedLink,
+  localizeSearchParams,
+} from "../i18n/i18n";
 import { getStatsVarLabel } from "../shared/stats_var_labels";
+import { NamedPlace } from "../shared/types";
+import { isDateTooFar, urlToDomain } from "../shared/util";
+import { ChartEmbed } from "./chart_embed";
 import { updatePageLayoutState } from "./place";
 
 const CHART_HEIGHT = 194;

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
+import _ from "lodash";
+import React from "react";
+import { defineMessages } from "react-intl";
+
 import {
   CachedChoroplethData,
   ChartBlockData,
-  GeoJsonData,
   chartTypeEnum,
+  GeoJsonData,
 } from "../chart/types";
 import { intl, localizeSearchParams } from "../i18n/i18n";
-
-import { Chart } from "./chart";
-import React from "react";
-import _ from "lodash";
-import { defineMessages } from "react-intl";
-import { displayNameForPlaceType } from "./util";
 import { randDomId } from "../shared/util";
+import { Chart } from "./chart";
+import { displayNameForPlaceType } from "./util";
 
 interface ChartBlockPropType {
   /**

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -15,13 +15,12 @@
  */
 
 import * as d3 from "d3";
-
-import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
-import { randDomId, saveToFile, urlToDomain } from "../shared/util";
-
 import React from "react";
-import { intl } from "../i18n/i18n";
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+
 import { wrap } from "../chart/base";
+import { intl } from "../i18n/i18n";
+import { randDomId, saveToFile, urlToDomain } from "../shared/util";
 
 // SVG adjustment related constants
 const TITLE_Y = 20;

--- a/static/js/place/child_places_menu.tsx
+++ b/static/js/place/child_places_menu.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { LocalizedLink, intl } from "../i18n/i18n";
-
 import React from "react";
+
+import { intl, LocalizedLink } from "../i18n/i18n";
 import { displayNameForPlaceType } from "./util";
 
 interface ChildPlacePropType {

--- a/static/js/place/main.tsx
+++ b/static/js/place/main.tsx
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
+import React from "react";
+import { RawIntlProvider } from "react-intl";
+
 import {
   CachedChoroplethData,
   ChartBlockData,
   GeoJsonData,
   PageChart,
 } from "../chart/types";
-import { LocalizedLink, intl } from "../i18n/i18n";
-
+import { intl, LocalizedLink } from "../i18n/i18n";
 import { ChartBlock } from "./chart_block";
 import { Overview } from "./overview";
-import { RawIntlProvider } from "react-intl";
-import React from "react";
 
 interface MainPanePropType {
   /**

--- a/static/js/place/map.tsx
+++ b/static/js/place/map.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React from "react";
 import axios from "axios";
+import React from "react";
 
 interface MapPropType {
   /**

--- a/static/js/place/overview.tsx
+++ b/static/js/place/overview.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import React from "react";
+
 import { Map } from "./map";
 import { Ranking } from "./ranking";
-import React from "react";
 
 interface OverviewPropType {
   /**

--- a/static/js/place/page_subtitle.tsx
+++ b/static/js/place/page_subtitle.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { LocalizedLink, intl } from "../i18n/i18n";
-
 import React from "react";
+
+import { intl, LocalizedLink } from "../i18n/i18n";
 
 interface PageSubtitlePropsType {
   category: string;

--- a/static/js/place/parent_breadcrumbs.tsx
+++ b/static/js/place/parent_breadcrumbs.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { FormattedMessage, RawIntlProvider } from "react-intl";
-import { LocalizedLink, intl } from "../i18n/i18n";
-
 import React from "react";
+import { FormattedMessage, RawIntlProvider } from "react-intl";
+
+import { intl, LocalizedLink } from "../i18n/i18n";
 import { displayNameForPlaceType } from "./util";
 
 interface ParentPlacePropsType {

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { CachedChoroplethData, GeoJsonData, PageData } from "../chart/types";
+import axios from "axios";
+import _ from "lodash";
+import React from "react";
+import ReactDOM from "react-dom";
 
+import { CachedChoroplethData, GeoJsonData, PageData } from "../chart/types";
+import { loadLocaleData } from "../i18n/i18n";
+import { USA_PLACE_DCID } from "../shared/constants";
 import { ChildPlace } from "./child_places_menu";
 import { MainPane } from "./main";
-import { Menu } from "./topic_menu";
 import { PageSubtitle } from "./page_subtitle";
 import { ParentPlace } from "./parent_breadcrumbs";
 import { PlaceHighlight } from "./place_highlight";
-import React from "react";
-import ReactDOM from "react-dom";
-import { USA_PLACE_DCID } from "../shared/constants";
-import _ from "lodash";
-import axios from "axios";
 import { initSearchAutocomplete } from "./search";
+import { Menu } from "./topic_menu";
 import { isPlaceInUsa } from "./util";
-import { loadLocaleData } from "../i18n/i18n";
 
 // Window scroll position to start fixing the sidebar.
 let yScrollLimit = 0;

--- a/static/js/place/place_highlight.tsx
+++ b/static/js/place/place_highlight.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { PageHighlight } from "../chart/types";
-import React from "react";
 import _ from "lodash";
+import React from "react";
+
+import { PageHighlight } from "../chart/types";
 import { intl } from "../i18n/i18n";
 import { urlToDomain } from "../shared/util";
 

--- a/static/js/place/place_landing.ts
+++ b/static/js/place/place_landing.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { initSearchAutocomplete } from "./search";
 import { loadLocaleData } from "../i18n/i18n";
+import { initSearchAutocomplete } from "./search";
 
 window.onload = () => {
   const locale = document.getElementById("locale").dataset.lc;

--- a/static/js/place/ranking.tsx
+++ b/static/js/place/ranking.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { LocalizedLink, intl } from "../i18n/i18n";
-
-import { FormattedMessage } from "react-intl";
-import React from "react";
 import axios from "axios";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { intl, LocalizedLink } from "../i18n/i18n";
 
 interface RankingPropsType {
   dcid: string;

--- a/static/js/place/search.ts
+++ b/static/js/place/search.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { intl, localizeLink } from "../i18n/i18n";
-
 import axios from "axios";
+
+import { intl, localizeLink } from "../i18n/i18n";
 let ac: google.maps.places.Autocomplete;
 let acs: google.maps.places.AutocompleteService;
 

--- a/static/js/place/topic_menu.tsx
+++ b/static/js/place/topic_menu.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { LocalizedLink, intl } from "../i18n/i18n";
+import React from "react";
 
 import { PageChart } from "../chart/types";
-import React from "react";
+import { intl, LocalizedLink } from "../i18n/i18n";
 
 interface MenuCategoryPropsType {
   dcid: string;

--- a/static/js/place/util.ts
+++ b/static/js/place/util.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { USA_PLACE_DCID } from "../shared/constants";
 import { defineMessages } from "react-intl";
+
 import { intl } from "../i18n/i18n";
+import { USA_PLACE_DCID } from "../shared/constants";
 
 /**
  * Given a list of parent places, return true if the place is in USA.

--- a/static/js/protein/page.tsx
+++ b/static/js/protein/page.tsx
@@ -18,9 +18,10 @@
  * Main component for bio.
  */
 
-import { GraphNode } from "../shared/types";
-import React from "react";
 import axios from "axios";
+import React from "react";
+
+import { GraphNode } from "../shared/types";
 import { drawTissueScoreChart } from "./chart";
 
 interface PagePropType {

--- a/static/js/protein/protein.ts
+++ b/static/js/protein/protein.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { Page } from "./page";
 import React from "react";
 import ReactDOM from "react-dom";
+
+import { Page } from "./page";
 
 window.onload = () => {
   const dcid = document.getElementById("node").dataset.dcid;

--- a/static/js/ranking/ranking.ts
+++ b/static/js/ranking/ranking.ts
@@ -18,10 +18,11 @@
  * @fileoverview Entry point for Ranking pages
  */
 
-import { Page } from "./ranking_page";
 import React from "react";
 import ReactDOM from "react-dom";
+
 import { loadLocaleData } from "../i18n/i18n";
+import { Page } from "./ranking_page";
 
 window.onload = () => {
   const withinPlace = document.getElementById("within-place-dcid").dataset.pwp;

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { RankInfo, Ranking } from "./ranking_types";
+import React from "react";
 
 import { DataPoint } from "../chart/base";
-import React from "react";
 import { drawHistogram } from "../chart/draw";
+import { RankInfo, Ranking } from "./ranking_types";
 
 interface RankingHistogramPropType {
   ranking: Ranking;

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { LocalizedLink, intl } from "../i18n/i18n";
-
-import { LocationRankData } from "./ranking_types";
-import { RankingHistogram } from "./ranking_histogram";
-import { RankingTable } from "./ranking_table";
-import React from "react";
 import axios from "axios";
+import React from "react";
 import { defineMessages } from "react-intl";
+
+import { intl, LocalizedLink } from "../i18n/i18n";
 import { displayNameForPlaceType } from "../place/util";
 import { getStatsVarTitle } from "../shared/stats_var_titles";
+import { RankingHistogram } from "./ranking_histogram";
+import { RankingTable } from "./ranking_table";
+import { LocationRankData } from "./ranking_types";
 
 const GET_BOTTOM_PARAM = "bottom";
 const RANK_SIZE = 100;

--- a/static/js/ranking/ranking_table.tsx
+++ b/static/js/ranking/ranking_table.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { LocalizedLink, intl, translateUnit } from "../i18n/i18n";
-import { RankInfo, Ranking } from "./ranking_types";
-
 import React from "react";
+
+import { intl, LocalizedLink, translateUnit } from "../i18n/i18n";
 import { displayNameForPlaceType } from "../place/util";
+import { RankInfo, Ranking } from "./ranking_types";
 
 interface RankingTablePropType {
   ranking: Ranking;

--- a/static/js/ranking/ranking_types.ts
+++ b/static/js/ranking/ranking_types.ts
@@ -31,4 +31,4 @@ interface LocationRankData {
   rankBottom1000: Ranking;
 }
 
-export { LocationRankData, Ranking, RankInfo };
+export { LocationRankData, RankInfo, Ranking };

--- a/static/js/shared/stat_var.ts
+++ b/static/js/shared/stat_var.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import _ from "lodash";
 import axios from "axios";
+import _ from "lodash";
 
 interface StatVarInfo {
   // measurementDenominator
@@ -75,4 +75,4 @@ interface StatVarNode {
   [key: string]: { paths: string[][]; denominators?: string[] };
 }
 
-export { StatVarInfo, getStatVarInfo, getStatVar, StatVarNode };
+export { getStatVar, getStatVarInfo, StatVarInfo, StatVarNode };

--- a/static/js/shared/stats_var_labels.test.ts
+++ b/static/js/shared/stats_var_labels.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import { loadLocaleData } from "../i18n/i18n";
 import enLabels from "../i18n/strings/en/stats_var_labels.json";
 import { getStatsVarLabel } from "./stats_var_labels";
-import { loadLocaleData } from "../i18n/i18n";
 import { placeExplorerCategories } from "./util";
 
 test("stats var label: marked for translation", async () => {

--- a/static/js/shared/stats_var_titles.test.ts
+++ b/static/js/shared/stats_var_titles.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import { loadLocaleData } from "../i18n/i18n";
 import enTitles from "../i18n/strings/en/stats_var_titles.json";
 import { getStatsVarTitle } from "./stats_var_titles";
-import { loadLocaleData } from "../i18n/i18n";
 import { placeExplorerCategories } from "./util";
 
 test("stats var label: marked for translation", async () => {

--- a/static/js/stat_var_hierarchy/node_header.tsx
+++ b/static/js/stat_var_hierarchy/node_header.tsx
@@ -18,9 +18,9 @@
  * Component for rendering the header of a stat var node.
  */
 
-import { Context, ContextType } from "../shared/context";
-
 import React from "react";
+
+import { Context, ContextType } from "../shared/context";
 import { StatVarHierarchyNodeType } from "../shared/types";
 import { StatVarHierarchyType } from "../shared/types";
 

--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -18,6 +18,11 @@
  * Component for rendering a stat var group node in the stat var hierarchy
  */
 
+import axios from "axios";
+import _ from "lodash";
+import React from "react";
+import Collapsible from "react-collapsible";
+
 import { Context, ContextType } from "../shared/context";
 import {
   StatVarGroupInfo,
@@ -25,15 +30,10 @@ import {
   StatVarHierarchyType,
   StatVarInfo,
 } from "../shared/types";
-
-import Collapsible from "react-collapsible";
 import { NamedPlace } from "../shared/types";
-import React from "react";
-import { StatVarGroupSection } from "./stat_var_group_section";
 import { StatVarHierarchyNodeHeader } from "./node_header";
+import { StatVarGroupSection } from "./stat_var_group_section";
 import { StatVarSection } from "./stat_var_section";
-import _ from "lodash";
-import axios from "axios";
 
 const SCROLL_DELAY = 400;
 

--- a/static/js/stat_var_hierarchy/stat_var_group_section.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_section.tsx
@@ -19,11 +19,11 @@
  * in the stat var hierarchy.
  */
 
-import { NamedPlace, StatVarGroupInfo } from "../shared/types";
-
-import React from "react";
-import { StatVarGroupNode } from "./stat_var_group_node";
 import _ from "lodash";
+import React from "react";
+
+import { NamedPlace, StatVarGroupInfo } from "../shared/types";
+import { StatVarGroupNode } from "./stat_var_group_node";
 
 const VARIABLES_STATVAR_GROUP_PREFIX = "dc/g/Variables_";
 

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -19,27 +19,26 @@
  * section and the hierarchy section.
  */
 
+import axios from "axios";
 import * as d3 from "d3";
+import _ from "lodash";
+import React from "react";
 
+import { loadSpinner, removeSpinner } from "../browser/util";
+import { Context } from "../shared/context";
 import {
   NamedPlace,
   StatVarGroupInfo,
   StatVarHierarchyType,
 } from "../shared/types";
-import {
-  SV_HIERARCHY_SECTION_ID,
-  TOOLTIP_ID,
-  hideTooltip,
-  showTooltip,
-} from "./util";
-import { loadSpinner, removeSpinner } from "../browser/util";
-
-import { Context } from "../shared/context";
-import React from "react";
 import { StatVarGroupNode } from "./stat_var_group_node";
 import { StatVarHierarchySearch } from "./stat_var_search";
-import _ from "lodash";
-import axios from "axios";
+import {
+  hideTooltip,
+  showTooltip,
+  SV_HIERARCHY_SECTION_ID,
+  TOOLTIP_ID,
+} from "./util";
 
 const ROOT_SVG = "dc/g/Root";
 const TOOLTIP_TOP_OFFSET = 30;

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -19,10 +19,11 @@
  * the search input and dropdown results.
  */
 
-import { NamedNode } from "../shared/types";
-import React from "react";
-import _ from "lodash";
 import axios from "axios";
+import _ from "lodash";
+import React from "react";
+
+import { NamedNode } from "../shared/types";
 
 interface StatVarHierarchySearchPropType {
   places: string[];

--- a/static/js/stat_var_hierarchy/stat_var_section.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section.tsx
@@ -19,14 +19,14 @@
  * region with chart, or a checkbox.
  */
 
+import axios from "axios";
+import React from "react";
+
+import { StatVarCharts } from "../browser/stat_var_charts";
+import { Context } from "../shared/context";
 import { NamedPlace, StatVarHierarchyType } from "../shared/types";
 import { StatVarInfo, StatVarSummary } from "../shared/types";
-
-import { Context } from "../shared/context";
-import React from "react";
-import { StatVarCharts } from "../browser/stat_var_charts";
 import { StatVarSectionInput } from "./stat_var_section_input";
-import axios from "axios";
 
 interface StatVarSectionPropType {
   path: string[];

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -20,18 +20,17 @@
  */
 
 import * as d3 from "d3";
+import _ from "lodash";
+import React from "react";
 
 import { Context, ContextType } from "../shared/context";
-import { SV_HIERARCHY_SECTION_ID, hideTooltip, showTooltip } from "./util";
 import {
   StatVarHierarchyType,
   StatVarInfo,
   StatVarSummary,
 } from "../shared/types";
-
 import { CHILD_PLACE_TYPES } from "../tools/map/util";
-import React from "react";
-import _ from "lodash";
+import { hideTooltip, showTooltip, SV_HIERARCHY_SECTION_ID } from "./util";
 
 const TOOLTIP_TOP_OFFSET = 10;
 const TOOLTIP_RIGHT_MARGIN = 20;

--- a/static/js/stat_var_hierarchy/util.ts
+++ b/static/js/stat_var_hierarchy/util.ts
@@ -19,6 +19,7 @@
  */
 
 import * as d3 from "d3";
+
 import { Boundary } from "../shared/types";
 
 export const TOOLTIP_ID = "tree-widget-tooltip";

--- a/static/js/tools/commons.ts
+++ b/static/js/tools/commons.ts
@@ -55,8 +55,8 @@ class NoopStatsVarFilter implements StatsVarFilterInterface {
 }
 
 export {
-  StatsVarFilterInterface,
-  TimelineStatsVarFilter,
   ChoroplethStatsVarFilter,
   NoopStatsVarFilter,
+  StatsVarFilterInterface,
+  TimelineStatsVarFilter,
 };

--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -18,22 +18,22 @@
  * Main app component for map explorer.
  */
 
-import { Container, Row } from "reactstrap";
-import { Context, ContextType, getInitialContext } from "./context";
-import {
-  MAP_REDIRECT_PREFIX,
-  applyHashPlaceInfo,
-  applyHashStatVar,
-  updateHashPlaceInfo,
-  updateHashStatVar,
-} from "./util";
+import _ from "lodash";
 import React, { useContext, useEffect } from "react";
+import { Container, Row } from "reactstrap";
 
 import { ChartLoader } from "./chart_loader";
+import { Context, ContextType, getInitialContext } from "./context";
 import { Info } from "./info";
 import { PlaceOptions } from "./place_options";
 import { StatVarChooser } from "./stat_var_chooser";
-import _ from "lodash";
+import {
+  applyHashPlaceInfo,
+  applyHashStatVar,
+  MAP_REDIRECT_PREFIX,
+  updateHashPlaceInfo,
+  updateHashStatVar,
+} from "./util";
 
 function App(): JSX.Element {
   const { statVar, placeInfo, isLoading } = useContext(Context);

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -19,34 +19,33 @@
  */
 
 import * as d3 from "d3";
-
-import {
-  CHILD_PLACE_TYPES,
-  MAP_REDIRECT_PREFIX,
-  USA_PLACE_HIERARCHY,
-  updateHashPlaceInfo,
-  updateHashStatVar,
-} from "./util";
-import {
-  GeoJsonData,
-  GeoJsonFeatureProperties,
-  MapPoint,
-} from "../../chart/types";
-import { PlaceInfo, StatVar } from "./context";
+import _ from "lodash";
 import React, { useEffect, useState } from "react";
+import { Container } from "reactstrap";
+
 import {
   drawChoropleth,
   generateLegendSvg,
   getColorScale,
 } from "../../chart/draw_choropleth";
-
-import { ChartOptions } from "./chart_options";
-import { Container } from "reactstrap";
-import { DataPointMetadata } from "./chart_loader";
-import { NamedPlace } from "../../shared/types";
-import _ from "lodash";
+import {
+  GeoJsonData,
+  GeoJsonFeatureProperties,
+  MapPoint,
+} from "../../chart/types";
 import { formatNumber } from "../../i18n/i18n";
+import { NamedPlace } from "../../shared/types";
 import { urlToDomain } from "../../shared/util";
+import { DataPointMetadata } from "./chart_loader";
+import { ChartOptions } from "./chart_options";
+import { PlaceInfo, StatVar } from "./context";
+import {
+  CHILD_PLACE_TYPES,
+  MAP_REDIRECT_PREFIX,
+  updateHashPlaceInfo,
+  updateHashStatVar,
+  USA_PLACE_HIERARCHY,
+} from "./util";
 
 interface ChartProps {
   geoJsonData: GeoJsonData;

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -19,17 +19,17 @@
  * and passing the data to a `Chart` component that draws the choropleth.
  */
 
-import { Context, IsLoadingWrapper, PlaceInfo, StatVar } from "./context";
-import { GeoJsonData, MapPoint } from "../../chart/types";
-import { PlacePointStat, getPopulationDate, getUnit } from "../shared_util";
+import axios from "axios";
+import _ from "lodash";
 import React, { useContext, useEffect, useState } from "react";
 
-import { Chart } from "./chart";
+import { GeoJsonData, MapPoint } from "../../chart/types";
 import { MAX_DATE } from "../../shared/constants";
 import { StatApiResponse } from "../../shared/stat_types";
-import _ from "lodash";
-import axios from "axios";
 import { shouldCapStatVarDate } from "../../shared/util";
+import { getPopulationDate, getUnit, PlacePointStat } from "../shared_util";
+import { Chart } from "./chart";
+import { Context, IsLoadingWrapper, PlaceInfo, StatVar } from "./context";
 
 interface ChartRawData {
   geoJsonData: GeoJsonData;

--- a/static/js/tools/map/chart_options.tsx
+++ b/static/js/tools/map/chart_options.tsx
@@ -18,19 +18,19 @@
  * Component to allow per capita toggling and navigating to a parent place map.
  */
 
+import _ from "lodash";
+import React, { useContext } from "react";
+import { FormGroup, Input, Label } from "reactstrap";
+
+import { formatNumber } from "../../i18n/i18n";
+import { DataPointMetadata } from "./chart_loader";
+import { Context, NamedTypedPlace, PlaceInfo, StatVar } from "./context";
 import {
   CHILD_PLACE_TYPES,
   MAP_REDIRECT_PREFIX,
   updateHashPlaceInfo,
   updateHashStatVar,
 } from "./util";
-import { Context, NamedTypedPlace, PlaceInfo, StatVar } from "./context";
-import { FormGroup, Input, Label } from "reactstrap";
-import React, { useContext } from "react";
-
-import { DataPointMetadata } from "./chart_loader";
-import _ from "lodash";
-import { formatNumber } from "../../i18n/i18n";
 
 const NO_PER_CAPITA_TYPES = ["medianValue"];
 

--- a/static/js/tools/map/context.ts
+++ b/static/js/tools/map/context.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { applyHashPlaceInfo, applyHashStatVar } from "./util";
 import { createContext, useState } from "react";
 
-import { NamedPlace } from "../../shared/types";
 import { StatVarInfo } from "../../shared/stat_var";
+import { NamedPlace } from "../../shared/types";
+import { applyHashPlaceInfo, applyHashStatVar } from "./util";
 
 /**
  * Global app context for map explorer tool.

--- a/static/js/tools/map/map.ts
+++ b/static/js/tools/map/map.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { AppWithContext } from "./app";
 import React from "react";
 import ReactDOM from "react-dom";
+
+import { AppWithContext } from "./app";
 
 window.onload = () => {
   ReactDOM.render(

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -18,15 +18,15 @@
  * Place options for selecting the enclosing place and enclosed place type.
  */
 
-import { Card, Container, CustomInput } from "reactstrap";
-import { Context, IsLoadingWrapper, PlaceInfoWrapper } from "./context";
+import axios from "axios";
+import _ from "lodash";
 import React, { useContext, useEffect, useState } from "react";
+import { Card, Container, CustomInput } from "reactstrap";
 
-import { CHILD_PLACE_TYPES } from "./util";
 import { EARTH_NAMED_TYPED_PLACE } from "../../shared/constants";
 import { SearchBar } from "../timeline/search";
-import _ from "lodash";
-import axios from "axios";
+import { Context, IsLoadingWrapper, PlaceInfoWrapper } from "./context";
+import { CHILD_PLACE_TYPES } from "./util";
 
 export function PlaceOptions(): JSX.Element {
   const { placeInfo, isLoading } = useContext(Context);

--- a/static/js/tools/map/stat_var_chooser.tsx
+++ b/static/js/tools/map/stat_var_chooser.tsx
@@ -18,19 +18,19 @@
  * Component to pick statvar for map.
  */
 
+import axios from "axios";
+import _ from "lodash";
+import React, { useContext, useEffect, useState } from "react";
+
+import { getStatVarInfo } from "../../shared/stat_var";
+import { StatVarHierarchyType } from "../../shared/types";
+import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
 import { Context, StatVarWrapper } from "./context";
 import {
   MAP_REDIRECT_PREFIX,
   updateHashPlaceInfo,
   updateHashStatVar,
 } from "./util";
-import React, { useContext, useEffect, useState } from "react";
-
-import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
-import { StatVarHierarchyType } from "../../shared/types";
-import _ from "lodash";
-import axios from "axios";
-import { getStatVarInfo } from "../../shared/stat_var";
 
 const SAMPLE_SIZE = 3;
 

--- a/static/js/tools/map/util.test.ts
+++ b/static/js/tools/map/util.test.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
+import { ContextType } from "./context";
 import {
   applyHashPlaceInfo,
   applyHashStatVar,
   updateHashPlaceInfo,
   updateHashStatVar,
 } from "./util";
-
-import { ContextType } from "./context";
 
 const TestContext = ({
   placeInfo: {

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -18,8 +18,9 @@
  * Utility functions shared across different components of map explorer.
  */
 
-import { PlaceInfo, StatVar } from "./context";
 import _ from "lodash";
+
+import { PlaceInfo, StatVar } from "./context";
 
 const USA_STATE_CHILD_TYPES = ["County"];
 const USA_COUNTRY_CHILD_TYPES = ["State", ...USA_STATE_CHILD_TYPES];

--- a/static/js/tools/mock_functions.tsx
+++ b/static/js/tools/mock_functions.tsx
@@ -16,11 +16,11 @@
 
 jest.mock("axios");
 
-import * as d3 from "d3";
-
 import axios from "axios";
-import { drawGroupLineChart } from "../chart/draw";
+import * as d3 from "d3";
 import { when } from "jest-when";
+
+import { drawGroupLineChart } from "../chart/draw";
 
 export function axios_mock(): void {
   // Mock all the async axios call.

--- a/static/js/tools/scatter/app.test.tsx
+++ b/static/js/tools/scatter/app.test.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { Context, EmptyPlace, useContextStore } from "./context";
+import { waitFor } from "@testing-library/react";
+import axios from "axios";
+import Cheerio from "cheerio";
 import Enzyme, { mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import { when } from "jest-when";
 import React, { useEffect } from "react";
 
-import Adapter from "enzyme-adapter-react-16";
 import { App } from "./app";
-import Cheerio from "cheerio";
-import axios from "axios";
-import { waitFor } from "@testing-library/react";
-import { when } from "jest-when";
+import { Context, EmptyPlace, useContextStore } from "./context";
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/static/js/tools/scatter/app.tsx
+++ b/static/js/tools/scatter/app.tsx
@@ -18,6 +18,10 @@
  * Main app component for scatter.
  */
 
+import React, { useContext, useEffect } from "react";
+import { Container, Row } from "reactstrap";
+
+import { ChartLoader } from "./chart_loader";
 import {
   Axis,
   Context,
@@ -25,20 +29,16 @@ import {
   PlaceInfo,
   useContextStore,
 } from "./context";
-import { Container, Row } from "reactstrap";
-import React, { useContext, useEffect } from "react";
+import { Info } from "./info";
+import { PlaceOptions } from "./place_options";
+import { Spinner } from "./spinner";
+import { StatVarChooser } from "./statvar";
 import {
   applyHash,
   areStatVarsPicked,
   isPlacePicked,
   updateHash,
 } from "./util";
-
-import { ChartLoader } from "./chart_loader";
-import { Info } from "./info";
-import { PlaceOptions } from "./place_options";
-import { Spinner } from "./spinner";
-import { StatVarChooser } from "./statvar";
 
 function App(): JSX.Element {
   const { x, y, place, isLoading } = useContext(Context);

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -19,16 +19,15 @@
  */
 
 import * as d3 from "d3";
-
-import { Card, Container, Row } from "reactstrap";
-import React, { useEffect, useRef, useState } from "react";
-
-import { Point } from "./chart_loader";
-import ReactDOM from "react-dom";
 import _ from "lodash";
+import React, { useEffect, useRef, useState } from "react";
+import ReactDOM from "react-dom";
+import { Card, Container, Row } from "reactstrap";
+
+import { wrap } from "../../chart/base";
 import { formatNumber } from "../../i18n/i18n";
 import { urlToDomain } from "../../shared/util";
-import { wrap } from "../../chart/base";
+import { Point } from "./chart_loader";
 
 interface ChartPropsType {
   points: Array<Point>;

--- a/static/js/tools/scatter/chart_loader.tsx
+++ b/static/js/tools/scatter/chart_loader.tsx
@@ -19,6 +19,15 @@
  * and passing the data to a `Chart` component that plots the scatter plot.
  */
 
+import axios from "axios";
+import _ from "lodash";
+import React, { useContext, useEffect, useState } from "react";
+
+import { StatApiResponse } from "../../shared/stat_types";
+import { NamedPlace } from "../../shared/types";
+import { saveToFile } from "../../shared/util";
+import { getPopulationDate, getUnit, PlacePointStat } from "../shared_util";
+import { Chart } from "./chart";
 import {
   Axis,
   AxisWrapper,
@@ -26,17 +35,8 @@ import {
   IsLoadingWrapper,
   PlaceInfo,
 } from "./context";
-import { PlacePointStat, getPopulationDate, getUnit } from "../shared_util";
-import React, { useContext, useEffect, useState } from "react";
-import { arePlacesLoaded, getStatsWithinPlace } from "./util";
-
-import { Chart } from "./chart";
-import { NamedPlace } from "../../shared/types";
 import { PlotOptions } from "./plot_options";
-import { StatApiResponse } from "../../shared/stat_types";
-import _ from "lodash";
-import axios from "axios";
-import { saveToFile } from "../../shared/util";
+import { arePlacesLoaded, getStatsWithinPlace } from "./util";
 
 /**
  * Represents a point in the scatter plot.

--- a/static/js/tools/scatter/context.ts
+++ b/static/js/tools/scatter/context.ts
@@ -18,9 +18,9 @@
  * Global app context.
  */
 
-import { StatVarInfo, StatVarNode } from "../../shared/stat_var";
 import { createContext, useState } from "react";
 
+import { StatVarInfo, StatVarNode } from "../../shared/stat_var";
 import { NamedPlace } from "../../shared/types";
 
 interface Axis {
@@ -379,19 +379,19 @@ function getSetUpperBound(
 }
 
 export {
-  Context,
-  useContextStore,
-  ContextType,
   Axis,
   AxisWrapper,
-  PlaceInfo,
-  PlaceInfoWrapper,
+  Context,
+  ContextType,
   DateInfo,
   DateInfoWrapper,
-  IsLoadingWrapper,
   DisplayOptionsWrapper,
   EmptyAxis,
-  EmptyPlace,
   EmptyDate,
+  EmptyPlace,
   FieldToAbbreviation,
+  IsLoadingWrapper,
+  PlaceInfo,
+  PlaceInfoWrapper,
+  useContextStore,
 };

--- a/static/js/tools/scatter/place_options.tsx
+++ b/static/js/tools/scatter/place_options.tsx
@@ -18,15 +18,15 @@
  * Place options for selecting the child place type and the enclosing place.
  */
 
-import { Container, CustomInput } from "reactstrap";
-import { Context, IsLoadingWrapper, PlaceInfoWrapper } from "./context";
-import React, { useContext, useEffect, useState } from "react";
-
-import { Card } from "reactstrap";
-import { SearchBar } from "../timeline/search";
-import _ from "lodash";
 import axios from "axios";
+import _ from "lodash";
+import React, { useContext, useEffect, useState } from "react";
+import { Container, CustomInput } from "reactstrap";
+import { Card } from "reactstrap";
+
+import { SearchBar } from "../timeline/search";
 import { getPlaceNames } from "../timeline/util";
+import { Context, IsLoadingWrapper, PlaceInfoWrapper } from "./context";
 import { isPlacePicked } from "./util";
 
 const USA_CITY_CHILD_TYPES = ["CensusZipCodeTabulationArea", "City"];

--- a/static/js/tools/scatter/plot_options.tsx
+++ b/static/js/tools/scatter/plot_options.tsx
@@ -19,15 +19,16 @@
  * lower and upper bounds for populations.
  */
 
+import React, { useContext, useState } from "react";
+import { Button, Card, FormGroup, Input, Label } from "reactstrap";
+import { Col, Container, Row } from "reactstrap";
+
 import {
   AxisWrapper,
   Context,
   DisplayOptionsWrapper,
   PlaceInfoWrapper,
 } from "./context";
-import { Button, Card, FormGroup, Input, Label } from "reactstrap";
-import { Col, Container, Row } from "reactstrap";
-import React, { useContext, useState } from "react";
 
 // TODO: Add a new API that given a statvar, a parent place, and a child type,
 // returns the available dates for the statvar. Then, fill the datapicker with

--- a/static/js/tools/scatter/scatter.ts
+++ b/static/js/tools/scatter/scatter.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { AppWithContext } from "./app";
 import React from "react";
 import ReactDOM from "react-dom";
+
+import { AppWithContext } from "./app";
 
 window.onload = () => {
   ReactDOM.render(

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -20,7 +20,9 @@
  * two of the three.
  */
 
-import { Axis, AxisWrapper, Context, EmptyAxis } from "./context";
+import axios from "axios";
+import _ from "lodash";
+import React, { useContext, useEffect, useState } from "react";
 import {
   Button,
   Container,
@@ -32,13 +34,11 @@ import {
   ModalFooter,
   ModalHeader,
 } from "reactstrap";
-import React, { useContext, useEffect, useState } from "react";
-import { StatVarInfo, getStatVarInfo } from "../../shared/stat_var";
 
-import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
+import { getStatVarInfo, StatVarInfo } from "../../shared/stat_var";
 import { StatVarHierarchyType } from "../../shared/types";
-import _ from "lodash";
-import axios from "axios";
+import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
+import { Axis, AxisWrapper, Context, EmptyAxis } from "./context";
 
 // Number of enclosed places to sample when filtering the stat vars in the
 // stat var menu

--- a/static/js/tools/scatter/util.test.ts
+++ b/static/js/tools/scatter/util.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { applyHash, updateHash } from "./util";
 import { ContextType } from "./context";
+import { applyHash, updateHash } from "./util";
 
 const TestContext = ({
   x: {

--- a/static/js/tools/scatter/util.ts
+++ b/static/js/tools/scatter/util.ts
@@ -18,6 +18,13 @@
  * Functions for making API calls and updating and applying URL hash.
  */
 
+import axios from "axios";
+import _ from "lodash";
+
+import { MAX_DATE } from "../../shared/constants";
+import { StatVarNode } from "../../shared/stat_var";
+import { shouldCapStatVarDate } from "../../shared/util";
+import { PlacePointStat } from "../shared_util";
 import {
   Axis,
   ContextType,
@@ -27,13 +34,6 @@ import {
   FieldToAbbreviation,
   PlaceInfo,
 } from "./context";
-
-import { MAX_DATE } from "../../shared/constants";
-import { PlacePointStat } from "../shared_util";
-import { StatVarNode } from "../../shared/stat_var";
-import _ from "lodash";
-import axios from "axios";
-import { shouldCapStatVarDate } from "../../shared/util";
 
 async function getPlacesInNames(
   dcid: string,
@@ -304,9 +304,9 @@ export function areStatVarsPicked(x: Axis, y: Axis): boolean {
 }
 
 export {
+  applyHash,
   getPlacesInNames,
   getStatsWithinPlace,
   nodeGetStatVar,
   updateHash,
-  applyHash,
 };

--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import * as d3 from "d3";
-
-import { StatVarInfo } from "../shared/stat_var";
-import { TimeSeries } from "../shared/stat_types";
 import _ from "lodash";
+
+import { TimeSeries } from "../shared/stat_types";
+import { StatVarInfo } from "../shared/stat_var";
 
 /**
  * Functions and interfaces shared between tools components

--- a/static/js/tools/stat_var/explorer.tsx
+++ b/static/js/tools/stat_var/explorer.tsx
@@ -18,12 +18,12 @@
  * Component that contains the content for the Stat Var Explorer.
  */
 
-import { Provenance, ProvenancePropType } from "./provenance";
 import React, { Component } from "react";
 
-import { Places } from "./places";
-import { StatVarSummary } from "../../shared/types";
 import { formatNumber } from "../../i18n/i18n";
+import { StatVarSummary } from "../../shared/types";
+import { Places } from "./places";
+import { Provenance, ProvenancePropType } from "./provenance";
 
 interface ExplorerPropType {
   description: string;

--- a/static/js/tools/stat_var/page.tsx
+++ b/static/js/tools/stat_var/page.tsx
@@ -18,13 +18,13 @@
  * Top-level wrapper component for Stat Var Explorer page.
  */
 
+import axios from "axios";
 import React, { Component } from "react";
-import { StatVarHierarchyType, StatVarSummary } from "../../shared/types";
 
+import { StatVarHierarchyType, StatVarSummary } from "../../shared/types";
+import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
 import { Explorer } from "./explorer";
 import { Info } from "./info";
-import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
-import axios from "axios";
 
 interface PageStateType {
   description: string;

--- a/static/js/tools/stat_var/places.tsx
+++ b/static/js/tools/stat_var/places.tsx
@@ -20,8 +20,8 @@
 
 import React, { Component } from "react";
 
-import { PlaceTypeSummary } from "../../shared/types";
 import { formatNumber } from "../../i18n/i18n";
+import { PlaceTypeSummary } from "../../shared/types";
 
 interface PlacesPropType {
   statVar: string;

--- a/static/js/tools/stat_var/provenance.tsx
+++ b/static/js/tools/stat_var/provenance.tsx
@@ -20,8 +20,8 @@
 
 import React, { Component } from "react";
 
-import { ProvenanceSummary } from "../../shared/types";
 import { formatNumber } from "../../i18n/i18n";
+import { ProvenanceSummary } from "../../shared/types";
 import { urlToDomain } from "../../shared/util";
 
 interface ProvenancePropType {

--- a/static/js/tools/stat_var/stat_var.ts
+++ b/static/js/tools/stat_var/stat_var.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { Page } from "./page";
 import React from "react";
 import ReactDOM from "react-dom";
+
+import { Page } from "./page";
 
 window.onload = () => {
   ReactDOM.render(

--- a/static/js/tools/timeline/bulk_download.ts
+++ b/static/js/tools/timeline/bulk_download.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import axios from "axios";
-import { getTokensFromUrl } from "./util";
+
 import { saveToFile } from "../../shared/util";
+import { getTokensFromUrl } from "./util";
 
 /* Start the loading spinner and gray out the background. */
 function loadSpinner(): void {

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { PlotParams, computePlotParams } from "../../chart/base";
 import React, { Component } from "react";
+
+import { computePlotParams, PlotParams } from "../../chart/base";
+import { drawGroupLineChart } from "../../chart/draw";
+import { StatVarInfo } from "../../shared/stat_var";
 import {
-  StatData,
   fetchStatData,
   getStatVarGroupWithTime,
+  StatData,
 } from "./data_fetcher";
-
-import { StatVarInfo } from "../../shared/stat_var";
-import { drawGroupLineChart } from "../../chart/draw";
 import { setChartOption } from "./util";
 
 const CHART_HEIGHT = 300;

--- a/static/js/tools/timeline/chart_region.tsx
+++ b/static/js/tools/timeline/chart_region.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+import _ from "lodash";
 import React, { Component } from "react";
-import { getChartOption, removeToken, statVarSep } from "./util";
 
+import { StatVarInfo } from "../../shared/stat_var";
+import { saveToFile } from "../../shared/util";
 import { Chart } from "./chart";
 import { StatData } from "./data_fetcher";
-import { StatVarInfo } from "../../shared/stat_var";
-import _ from "lodash";
-import { saveToFile } from "../../shared/util";
+import { getChartOption, removeToken, statVarSep } from "./util";
 
 interface ChartGroupInfo {
   chartOrder: string[];
@@ -216,4 +216,4 @@ class ChartRegion extends Component<ChartRegionPropsType> {
   }
 }
 
-export { ChartRegionPropsType, ChartRegion, StatVarInfo };
+export { ChartRegion, ChartRegionPropsType, StatVarInfo };

--- a/static/js/tools/timeline/data_fetcher.test.ts
+++ b/static/js/tools/timeline/data_fetcher.test.ts
@@ -21,11 +21,11 @@ import { DataGroup } from "../../chart/base";
 import { loadLocaleData } from "../../i18n/i18n";
 import { StatApiResponse, TimeSeries } from "../../shared/stat_types";
 import {
-  StatData,
   computePerCapita,
   convertToDelta,
   fetchStatData,
   getStatVarGroupWithTime,
+  StatData,
 } from "./data_fetcher";
 
 jest.mock("axios");

--- a/static/js/tools/timeline/page.test.tsx
+++ b/static/js/tools/timeline/page.test.tsx
@@ -18,12 +18,12 @@ jest.mock("axios");
 jest.mock("../../chart/draw");
 
 import Enzyme, { mount } from "enzyme";
-import { axios_mock, drawGroupLineChart_mock } from "../mock_functions";
-
 import Adapter from "enzyme-adapter-react-16";
-import { Page } from "./page";
-import React from "react";
 import pretty from "pretty";
+import React from "react";
+
+import { axios_mock, drawGroupLineChart_mock } from "../mock_functions";
+import { Page } from "./page";
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-import { NamedPlace, StatVarHierarchyType } from "../../shared/types";
+import axios from "axios";
+import _ from "lodash";
 import React, { Component } from "react";
-import { StatVarInfo, getStatVarInfo } from "../../shared/stat_var";
+
+import { getStatVarInfo, StatVarInfo } from "../../shared/stat_var";
+import { NamedPlace, StatVarHierarchyType } from "../../shared/types";
+import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
+import { ChartRegion } from "./chart_region";
+import { Info } from "./info";
+import { SearchBar } from "./search";
 import {
   addToken,
   getPlaceNames,
@@ -26,13 +33,6 @@ import {
   setTokensToUrl,
   statVarSep,
 } from "./util";
-
-import { ChartRegion } from "./chart_region";
-import { Info } from "./info";
-import { SearchBar } from "./search";
-import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
-import _ from "lodash";
-import axios from "axios";
 
 interface PageStateType {
   placeName: Record<string, string>;

--- a/static/js/tools/timeline/search.tsx
+++ b/static/js/tools/timeline/search.tsx
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import {} from "googlemaps";
-
-import React, { Component, PureComponent } from "react";
-
 import axios from "axios";
+import {} from "googlemaps";
+import React, { Component, PureComponent } from "react";
 
 interface ChipPropType {
   placeName: string;

--- a/static/js/tools/timeline/timeline.ts
+++ b/static/js/tools/timeline/timeline.ts
@@ -18,9 +18,10 @@
  * @fileoverview entrance of timeline page.
  */
 
-import { Page } from "./page";
 import React from "react";
 import ReactDOM from "react-dom";
+
+import { Page } from "./page";
 
 window.onload = () => {
   ReactDOM.render(

--- a/static/js/translator/page.tsx
+++ b/static/js/translator/page.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { Binding, Constraint, Translation } from "./translation";
-
-import React from "react";
 import axios from "axios";
+import React from "react";
+
 import { input } from "./constants";
+import { Binding, Constraint, Translation } from "./translation";
 
 interface PagePropType {
   mapping: string;

--- a/static/js/translator/translator.ts
+++ b/static/js/translator/translator.ts
@@ -18,10 +18,11 @@
  * @fileoverview Translator javascript.
  */
 
-import { Page } from "./page";
 import React from "react";
 import ReactDOM from "react-dom";
+
 import { input } from "./constants";
+import { Page } from "./page";
 
 /**
  * Update translation results when schema mapping or query changes.

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -7241,6 +7241,12 @@
         }
       }
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/static/package.json
+++ b/static/package.json
@@ -75,6 +75,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "full-icu": "^1.3.1",
     "jest": "^25.5.4",
     "jest-each": "^26.4.2",


### PR DESCRIPTION
This package provides the fix option. Now the import can be fixed by running:
`npm run lint`

This package apparently uses different rules compared with sort-imports.