### PR TITLE
[timeline] only show all model data for projections

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -1211,7 +1211,7 @@ function drawGroupLineChart(
           .attr("d", line)
           .style("fill", "none")
           .style("stroke", lineStyle.color)
-          .style("stroke-width", "1.5px")
+          .style("stroke-width", "2px")
           .style("stroke-dasharray", lineStyle.dash)
           .style("stroke-linecap", "round")
           .style("stroke-linejoin", "round");

--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -101,6 +101,8 @@ export function getUnit(placePointStat: PlacePointStat): string {
  */
 export function isIpccStatVarWithMultipleModels(statVar: string) {
   return (
-    statVar.indexOf("_Temperature") > 0 && statVar.indexOf("Difference") < 0
+    statVar.indexOf("_Temperature") > 0 &&
+    statVar.indexOf("Difference") < 0 &&
+    !statVar.endsWith("Temperature")
   );
 }

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -222,11 +222,6 @@ class Chart extends Component<ChartPropsType> {
             means[date] = _.mean(means[date]);
           }
           this.statData.data[place].data[sv].val = means;
-          // TODO: This date munging shouldn't be necessary if GetStatAll returns only P1Y data.
-          this.statData.dates = _.union(
-            this.statData.dates,
-            Object.keys(means)
-          );
         }
       }
     }

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -195,7 +195,6 @@ class Chart extends Component<ChartPropsType> {
       data: {},
       sources: new Set<string>(),
     };
-    this.statData.dates = [];
     for (const place in ipccData.placeData) {
       const placeData = ipccData.placeData[place];
       modelData.places.push(place);
@@ -223,6 +222,7 @@ class Chart extends Component<ChartPropsType> {
             means[date] = _.mean(means[date]);
           }
           this.statData.data[place].data[sv].val = means;
+          // TODO: This date munging shouldn't be necessary if GetStatAll returns only P1Y data.
           this.statData.dates = _.union(
             this.statData.dates,
             Object.keys(means)


### PR DESCRIPTION
this will be temporarily broken until the next mixer autopush with https://github.com/datacommonsorg/mixer/pull/641