### PR TITLE
[scatter] Various small updates

### DIFF
--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -145,35 +145,36 @@ def geojson():
     if place_dcid == 'geoId/72':
         geojson_prop = 'geoJsonCoordinatesDP1'
     names_by_geo = place_api.get_display_name('^'.join(geos), g.locale)
-    geojson_by_geo = dc_service.get_property_values(geos, geojson_prop)
     features = []
-    for geo_id, json_text in geojson_by_geo.items():
-        if json_text and geo_id in names_by_geo:
-            geo_feature = {
-                "type": "Feature",
-                "geometry": {
-                    "type": "MultiPolygon",
-                },
-                "id": geo_id,
-                "properties": {
-                    "name": names_by_geo.get(geo_id, "Unnamed Area"),
-                    "geoDcid": geo_id,
+    if geojson_prop:
+        geojson_by_geo = dc_service.get_property_values(geos, geojson_prop)
+        for geo_id, json_text in geojson_by_geo.items():
+            if json_text and geo_id in names_by_geo:
+                geo_feature = {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "MultiPolygon",
+                    },
+                    "id": geo_id,
+                    "properties": {
+                        "name": names_by_geo.get(geo_id, "Unnamed Area"),
+                        "geoDcid": geo_id,
+                    }
                 }
-            }
-            # Load, simplify, and add geoJSON coordinates.
-            # Exclude geo if no or multiple renderings are present.
-            if len(json_text) != 1:
-                continue
-            geojson = json.loads(json_text[0])
-            # The geojson data for each country varies in whether it follows the
-            # righthand rule or not. We want to ensure geojsons for all countries
-            # does follow the righthand rule.
-            if place_type == "Country":
-                geojson = rewind(geojson)
-            geo_feature['geometry']['coordinates'] = (
-                reverse_geojson_righthand_rule(geojson['coordinates'],
-                                               geojson['type']))
-            features.append(geo_feature)
+                # Load, simplify, and add geoJSON coordinates.
+                # Exclude geo if no or multiple renderings are present.
+                if len(json_text) != 1:
+                    continue
+                geojson = json.loads(json_text[0])
+                # The geojson data for each country varies in whether it follows the
+                # righthand rule or not. We want to ensure geojsons for all countries
+                # does follow the righthand rule.
+                if place_type == "Country":
+                    geojson = rewind(geojson)
+                geo_feature['geometry']['coordinates'] = (
+                    reverse_geojson_righthand_rule(geojson['coordinates'],
+                                                   geojson['type']))
+                features.append(geo_feature)
     return Response(json.dumps({
         "type": "FeatureCollection",
         "features": features,

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -23,7 +23,7 @@ import * as geo from "geo-albers-usa-territories";
 import _ from "lodash";
 
 import { formatNumber } from "../i18n/i18n";
-import { EARTH_NAMED_TYPED_PLACE, USA_PLACE_DCID } from "../shared/constants";
+import { EARTH_NAMED_TYPED_PLACE } from "../shared/constants";
 import { getStatsVarLabel } from "../shared/stats_var_labels";
 import { NamedPlace } from "../shared/types";
 import { getColorFn } from "./base";
@@ -205,7 +205,7 @@ function addMapPoints(
  * @param colorScale the color scale to use for drawing the map and legend
  * @param redirectAction function that runs when region on map is clicked
  * @param getTooltipHtml function to get the html content for the tooltip
- * @param canClick whether the regions on the map should be clickable
+ * @param canClickRegion function to determine if a region on the map is clickable
  * @param shouldGenerateLegend whether legend needs to be generated
  * @param shouldShowBoundaryLines whether each region should have boundary lines shown
  * @param mapPoints list of points to add onto the map
@@ -227,7 +227,7 @@ function drawChoropleth(
   colorScale: d3.ScaleLinear<number | string, number>,
   redirectAction: (geoDcid: GeoJsonFeatureProperties) => void,
   getTooltipHtml: (place: NamedPlace) => string,
-  canClick: boolean,
+  canClickRegion: (placeDcid: string) => boolean,
   shouldGenerateLegend: boolean,
   shouldShowBoundaryLines: boolean,
   mapPoints?: Array<MapPoint>,
@@ -330,23 +330,21 @@ function drawChoropleth(
     .attr("id", (_, index) => {
       return "geoPath" + index;
     })
-    .on("mouseover", onMouseOver(enclosingPlaceDcid, domContainerId, canClick))
+    .on("mouseover", onMouseOver(canClickRegion, domContainerId))
     .on("mouseout", onMouseOut(domContainerId))
     .on(
       "mousemove",
-      onMouseMove(enclosingPlaceDcid, domContainerId, getTooltipHtml, canClick)
+      onMouseMove(canClickRegion, domContainerId, getTooltipHtml)
     );
   if (shouldShowBoundaryLines) {
     mapObjects
       .attr("stroke-width", STROKE_WIDTH)
       .attr("stroke", GEO_STROKE_COLOR);
   }
-  if (canClick) {
-    mapObjects.on(
-      "click",
-      onMapClick(enclosingPlaceDcid, domContainerId, redirectAction)
-    );
-  }
+  mapObjects.on(
+    "click",
+    onMapClick(canClickRegion, domContainerId, redirectAction)
+  );
 
   // style highlighted region and bring to the front
   d3.select(domContainerId)
@@ -387,17 +385,9 @@ function drawChoropleth(
         mapObjects
           .on(
             "mousemove",
-            onMouseMove(
-              enclosingPlaceDcid,
-              domContainerId,
-              getTooltipHtml,
-              canClick
-            )
+            onMouseMove(canClickRegion, domContainerId, getTooltipHtml)
           )
-          .on(
-            "mouseover",
-            onMouseOver(enclosingPlaceDcid, domContainerId, canClick)
-          );
+          .on("mouseover", onMouseOver(canClickRegion, domContainerId));
       });
     svg.call(zoom);
     if (zoomInButtonId) {
@@ -414,16 +404,14 @@ function drawChoropleth(
 }
 
 const onMouseOver = (
-  enclosingPlaceDcid: string,
-  domContainerId: string,
-  canClick: boolean
+  canClickRegion: (placeDcid: string) => boolean,
+  domContainerId: string
 ) => (e, index): void => {
   const geoProperties = e["properties"];
   mouseHoverAction(
     domContainerId,
     index,
-    canClick &&
-      !shouldDisableRegionClick(enclosingPlaceDcid, geoProperties.geoDcid)
+    canClickRegion(geoProperties.geoDcid)
   );
 };
 
@@ -432,18 +420,13 @@ const onMouseOut = (domContainerId: string) => (_, index): void => {
 };
 
 const onMouseMove = (
-  enclosingPlaceDcid: string,
+  canClickRegion: (placeDcid: string) => boolean,
   domContainerId: string,
-  getTooltipHtml: (place: NamedPlace) => string,
-  canClick: boolean
+  getTooltipHtml: (place: NamedPlace) => string
 ) => (e, index) => {
   const geoProperties = e["properties"];
   const placeDcid = geoProperties.geoDcid;
-  mouseHoverAction(
-    domContainerId,
-    index,
-    canClick && !shouldDisableRegionClick(enclosingPlaceDcid, placeDcid)
-  );
+  mouseHoverAction(domContainerId, index, canClickRegion(placeDcid));
   const place = {
     dcid: placeDcid,
     name: geoProperties.name,
@@ -452,16 +435,11 @@ const onMouseMove = (
 };
 
 const onMapClick = (
-  enclosingPlaceDcid: string,
+  canClickRegion: (placeDcid: string) => boolean,
   domContainerId: string,
   redirectAction: (properties: GeoJsonFeatureProperties) => void
 ) => (geo: GeoJsonFeature, index) => {
-  if (
-    enclosingPlaceDcid === EARTH_NAMED_TYPED_PLACE.dcid &&
-    geo.properties.geoDcid !== USA_PLACE_DCID
-  ) {
-    return;
-  }
+  if (!canClickRegion(geo.properties.geoDcid)) return;
   redirectAction(geo.properties);
   mouseOutAction(domContainerId, index);
 };
@@ -597,15 +575,5 @@ const genScaleImg = (
   }
   return canvas;
 };
-
-function shouldDisableRegionClick(
-  enclosingPlaceDcid: string,
-  placeDcid: string
-): boolean {
-  return (
-    enclosingPlaceDcid === EARTH_NAMED_TYPED_PLACE.dcid &&
-    placeDcid !== USA_PLACE_DCID
-  );
-}
 
 export { drawChoropleth, generateLegendSvg, getColorScale };

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -413,7 +413,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         colorScale,
         redirectAction,
         getTooltipHtml,
-        true,
+        () => true,
         true,
         true
       );

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -34,6 +34,10 @@ import {
   MapPoint,
 } from "../../chart/types";
 import { formatNumber } from "../../i18n/i18n";
+import {
+  EARTH_NAMED_TYPED_PLACE,
+  USA_PLACE_DCID,
+} from "../../shared/constants";
 import { NamedPlace } from "../../shared/types";
 import { urlToDomain } from "../../shared/util";
 import { shouldShowMapBoundaries } from "../shared_util";
@@ -220,7 +224,7 @@ function draw(
         props.mapPointValues,
         props.unit
       ),
-      props.placeInfo.enclosedPlaceType in CHILD_PLACE_TYPES,
+      canClickRegion(props.placeInfo),
       false,
       shouldShowMapBoundaries(
         props.placeInfo.selectedPlace,
@@ -345,6 +349,15 @@ const onDateRangeMouseOver = () => {
     .style("visibility", "visible");
 };
 
+const canClickRegion = (placeInfo: PlaceInfo) => (placeDcid: string) => {
+  if (!(placeInfo.enclosedPlaceType in CHILD_PLACE_TYPES)) {
+    return false;
+  }
+  return (
+    placeInfo.enclosingPlace.dcid !== EARTH_NAMED_TYPED_PLACE.dcid ||
+    placeDcid === USA_PLACE_DCID
+  );
+};
 const onDateRangeMouseOut = () => {
   d3.select(`#${DATE_RANGE_INFO_TEXT_ID}`).style("visibility", "hidden");
 };

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -78,9 +78,9 @@ const MAP_COLORS = [
 // These values correspond to the index of the color from MAP_COLORS that should
 // be used as the fill for that cell in the legend.
 const MAP_LEGEND_GRID_VALUES = [
-  [8, 7, 6],
-  [5, 4, 3],
-  [2, 1, 0],
+  [8, 5, 2],
+  [7, 4, 1],
+  [6, 3, 0],
 ];
 
 function Chart(props: ChartPropsType): JSX.Element {
@@ -261,7 +261,7 @@ function plot(
         props.xPerCapita,
         props.yPerCapita
       ),
-      true,
+      () => true,
       false,
       shouldShowMapBoundaries(
         props.placeInfo.enclosingPlace,
@@ -443,38 +443,38 @@ function drawMapLegend(
   // draw the labels
   const xUnitString = xUnit ? ` (${xUnit})` : "";
   const yUnitString = yUnit ? ` (${yUnit})` : "";
-  const xLabelTitle = legendLabels
+  const yLabelTitle = legendLabels
     .append("tspan")
-    .text(xLabel + xUnitString)
+    .text(yLabel + yUnitString)
     .attr("x", 0)
     .attr("y", 0)
     .attr("font-weight", MAP_LEGEND_TITLE_FONT_WEIGHT);
-  const xLabelRange = legendLabels
+  const yLabelRange = legendLabels
     .append("tspan")
-    .text(`${getStringOrNA(xRange[0])} to ${getStringOrNA(xRange[1])}`)
+    .text(`${getStringOrNA(yRange[0])} to ${getStringOrNA(yRange[1])}`)
     .attr("x", 0)
     .attr("y", 15);
-  const xLabelLength = Math.max(
-    xLabelTitle.node().getBBox().width,
-    xLabelRange.node().getBBox().width
+  const yLabelLength = Math.max(
+    yLabelTitle.node().getBBox().width,
+    yLabelRange.node().getBBox().width
   );
   legendLabels
     .append("tspan")
-    .text(yLabel + yUnitString)
-    .attr("x", xLabelLength + 3 * legendCellSize)
+    .text(xLabel + xUnitString)
+    .attr("x", yLabelLength + 3 * legendCellSize)
     .attr("y", 0)
     .attr("font-weight", MAP_LEGEND_TITLE_FONT_WEIGHT);
   legendLabels
     .append("tspan")
-    .text(`${getStringOrNA(yRange[0])} to ${getStringOrNA(yRange[1])}`)
-    .attr("x", xLabelLength + 3 * legendCellSize)
+    .text(`${getStringOrNA(xRange[0])} to ${getStringOrNA(xRange[1])}`)
+    .attr("x", yLabelLength + 3 * legendCellSize)
     .attr("y", 15);
 
   // move the legend labels to the left and down so that the legend is in the
   // of the labels
   legendLabels.attr(
     "transform",
-    `translate(-${xLabelLength + 1.5 * legendCellSize}, ${
+    `translate(-${yLabelLength + 1.5 * legendCellSize}, ${
       legend.node().getBoundingClientRect().height
     })`
   );

--- a/static/js/tools/scatter/draw_scatter.ts
+++ b/static/js/tools/scatter/draw_scatter.ts
@@ -234,14 +234,14 @@ function addDensityLegend(
     .append("text")
     .attr("dominant-baseline", "hanging")
     .attr("font-size", DENSITY_LEGEND_FONT_SIZE)
-    .text("sparse");
+    .text("dense");
 
   legend
     .append("g")
     .append("text")
     .attr("dominant-baseline", "hanging")
     .attr("font-size", DENSITY_LEGEND_FONT_SIZE)
-    .text("dense")
+    .text("sparse")
     .attr(
       "transform",
       `translate(0, ${
@@ -255,7 +255,7 @@ function addDensityLegend(
   canvas.height = contours.length + 1;
   const context = canvas.getContext("2d");
   for (let i = 0; i <= contours.length; i++) {
-    context.fillStyle = colorScale(contours.length - i);
+    context.fillStyle = colorScale(i);
     context.fillRect(0, i, 1, 1);
   }
   legend

--- a/static/js/tools/scatter/place_and_type_options.tsx
+++ b/static/js/tools/scatter/place_and_type_options.tsx
@@ -25,8 +25,14 @@ import { Container, CustomInput } from "reactstrap";
 import { Card } from "reactstrap";
 
 import { EARTH_NAMED_TYPED_PLACE } from "../../shared/constants";
+import { CHILD_PLACE_TYPES } from "../map/util";
 import { SearchBar } from "../timeline/search";
-import { Context, IsLoadingWrapper, PlaceInfoWrapper } from "./context";
+import {
+  Context,
+  IsLoadingWrapper,
+  PlaceInfo,
+  PlaceInfoWrapper,
+} from "./context";
 import { isPlacePicked, ScatterChartType } from "./util";
 
 const USA_CITY_CHILD_TYPES = ["CensusZipCodeTabulationArea", "City"];
@@ -81,6 +87,23 @@ function PlaceAndTypeOptions(): JSX.Element {
       loadPlaces(place, isLoading);
     }
   }, [place.value]);
+
+  /**
+   * If map view is selected, check that map view is possible before rendering
+   * the view. If map view is not possible, alert and render scatter view.
+   */
+  useEffect(() => {
+    if (
+      isPlacePicked(place.value) &&
+      display.chartType === ScatterChartType.MAP &&
+      !hasMapView(place.value)
+    ) {
+      display.setChartType(ScatterChartType.SCATTER);
+      alert(
+        `Sorry, map view is not supported for places in ${place.value.enclosingPlace.name} of type ${place.value.enclosedPlaceType}`
+      );
+    }
+  }, [place.value, display.chartType]);
 
   return (
     <Card className="place-and-type-options-card">
@@ -154,6 +177,18 @@ function PlaceAndTypeOptions(): JSX.Element {
       </Container>
     </Card>
   );
+}
+
+function hasMapView(place: PlaceInfo): boolean {
+  const allowedEnclosingPlaceTypes = place.enclosingPlace.types.filter(
+    (type) => type in CHILD_PLACE_TYPES
+  );
+  for (const type of allowedEnclosingPlaceTypes) {
+    if (CHILD_PLACE_TYPES[type].indexOf(place.enclosedPlaceType) > -1) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/static/js/tools/scatter/plot_options.tsx
+++ b/static/js/tools/scatter/plot_options.tsx
@@ -53,21 +53,6 @@ function PlotOptions(): JSX.Element {
             <FormGroup check>
               <Label check>
                 <Input
-                  id="per-capita-x"
-                  type="checkbox"
-                  checked={x.value.perCapita}
-                  onChange={(e) => checkPerCapita(x, e)}
-                />
-                {display.chartType === ScatterChartType.SCATTER
-                  ? "X-axis"
-                  : x.value.statVarInfo.title || x.value.statVarDcid}
-              </Label>
-            </FormGroup>
-          </Col>
-          <Col sm="auto">
-            <FormGroup check>
-              <Label check>
-                <Input
                   id="per-capita-y"
                   type="checkbox"
                   checked={y.value.perCapita}
@@ -76,6 +61,21 @@ function PlotOptions(): JSX.Element {
                 {display.chartType === ScatterChartType.SCATTER
                   ? "Y-axis"
                   : y.value.statVarInfo.title || y.value.statVarDcid}
+              </Label>
+            </FormGroup>
+          </Col>
+          <Col sm="auto">
+            <FormGroup check>
+              <Label check>
+                <Input
+                  id="per-capita-x"
+                  type="checkbox"
+                  checked={x.value.perCapita}
+                  onChange={(e) => checkPerCapita(x, e)}
+                />
+                {display.chartType === ScatterChartType.SCATTER
+                  ? "X-axis"
+                  : x.value.statVarInfo.title || x.value.statVarDcid}
               </Label>
             </FormGroup>
           </Col>
@@ -90,12 +90,12 @@ function PlotOptions(): JSX.Element {
                 <FormGroup check>
                   <Label check>
                     <Input
-                      id="log-x"
+                      id="log-y"
                       type="checkbox"
-                      checked={x.value.log}
-                      onChange={(e) => checkLog(x, e)}
+                      checked={y.value.log}
+                      onChange={(e) => checkLog(y, e)}
                     />
-                    X-axis
+                    Y-axis
                   </Label>
                 </FormGroup>
               </Col>
@@ -103,12 +103,12 @@ function PlotOptions(): JSX.Element {
                 <FormGroup check>
                   <Label check>
                     <Input
-                      id="log-y"
+                      id="log-x"
                       type="checkbox"
-                      checked={y.value.log}
-                      onChange={(e) => checkLog(y, e)}
+                      checked={x.value.log}
+                      onChange={(e) => checkLog(x, e)}
                     />
-                    Y-axis
+                    X-axis
                   </Label>
                 </FormGroup>
               </Col>


### PR DESCRIPTION
- flip the legend for scatter density charts so that dense is at the top and sparse is at the bottom
<img width="1364" alt="Screen Shot 2021-10-18 at 3 58 45 PM" src="https://user-images.githubusercontent.com/69875368/137817662-1ebf3f1b-54c5-42d7-b6f6-e7b8f1e9cf01.png">
 
- for bivariate choropleth legend, move xlabel to right side and ylabel to left side to match the title
<img width="1369" alt="Screen Shot 2021-10-18 at 4 00 00 PM" src="https://user-images.githubusercontent.com/69875368/137817801-b7b212a7-d37a-4e04-abc3-ff77578650c5.png">

- for bivariate choropleth maps world view, allow all countries to be clickable
- when a combination of place and place type doesn't have choropleth map support, show alert and switch back to scatter view

dev updated