### PR TITLE
[timeline] fix regression in non-model ipcc colors

### DIFF
--- a/static/js/chart/base.ts
+++ b/static/js/chart/base.ts
@@ -18,7 +18,7 @@ import * as d3 from "d3";
 
 import { translateVariableString } from "../i18n/i18n";
 import { StatVarInfo } from "../shared/stat_var";
-import { isIpccStatVarWithMultipleModels } from "../tools/shared_util";
+import { isIpccStatVar } from "../tools/shared_util";
 
 const DEFAULT_COLOR = "#000";
 
@@ -233,7 +233,7 @@ interface PlotParams {
  * Returns undefined if the stat var is not IPCC Temperature related.
  */
 function temperatureColorMap(statVar: string): string {
-  if (!isIpccStatVarWithMultipleModels(statVar)) {
+  if (!isIpccStatVar(statVar)) {
     return undefined;
   }
   if (statVar.indexOf("RCP") > 0) {

--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -104,7 +104,15 @@ export function isIpccStatVarWithMultipleModels(statVar: string): boolean {
   return (
     statVar.indexOf("_Temperature") > 0 &&
     statVar.indexOf("Difference") < 0 &&
-    !statVar.endsWith("Temperature")
+    statVar.indexOf("RCP") > 0
+  );
+}
+
+export function isIpccStatVar(statVar: string): boolean {
+  return (
+    isIpccStatVarWithMultipleModels(statVar) ||
+    statVar == "Min_Temperature" ||
+    statVar == "Max_Temperature"
   );
 }
 


### PR DESCRIPTION
I introduced a regression in the line colors for historical temperatures when we turned off displaying all the models for them.

![image](https://user-images.githubusercontent.com/6052978/138040089-ed56bc5f-4cda-41e7-829d-0fdf311dcfe4.png)
