### PR TITLE
[map] add support for europe

### DIFF
--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -43,7 +43,7 @@ CHOROPLETH_GEOJSON_PROPERTY_MAP = {
     "AdministrativeArea2": "geoJsonCoordinatesDP1",
     "EurostatNUTS1": "geoJsonCoordinatesDP2",
     "EurostatNUTS2": "geoJsonCoordinatesDP2",
-    "EurostatNUTS3": "geoJsonCoordinatesDP2",
+    "EurostatNUTS3": "geoJsonCoordinatesDP1",
 }
 
 

--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -41,6 +41,9 @@ CHOROPLETH_GEOJSON_PROPERTY_MAP = {
     "AdministrativeArea1": "geoJsonCoordinatesDP3",
     "County": "geoJsonCoordinatesDP1",
     "AdministrativeArea2": "geoJsonCoordinatesDP1",
+    "EurostatNUTS1": "geoJsonCoordinatesDP2",
+    "EurostatNUTS2": "geoJsonCoordinatesDP2",
+    "EurostatNUTS3": "geoJsonCoordinatesDP2",
 }
 
 

--- a/static/js/shared/constants.ts
+++ b/static/js/shared/constants.ts
@@ -18,6 +18,7 @@ import { NamedTypedPlace } from "../tools/map/context";
 
 export const USA_PLACE_DCID = "country/USA";
 export const INDIA_PLACE_DCID = "country/IND";
+export const EUROPE_PLACE_DCID = "europe";
 
 export const EARTH_NAMED_TYPED_PLACE: NamedTypedPlace = {
   dcid: "Earth",

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -36,6 +36,7 @@ import {
 import { formatNumber } from "../../i18n/i18n";
 import {
   EARTH_NAMED_TYPED_PLACE,
+  EUROPE_PLACE_DCID,
   INDIA_PLACE_DCID,
   USA_PLACE_DCID,
 } from "../../shared/constants";
@@ -381,7 +382,12 @@ const canClickRegion = (placeInfo: PlaceInfo) => (placeDcid: string) => {
   return (
     placeInfo.enclosingPlace.dcid !== EARTH_NAMED_TYPED_PLACE.dcid ||
     placeDcid === USA_PLACE_DCID ||
-    placeDcid === INDIA_PLACE_DCID
+    placeDcid === INDIA_PLACE_DCID ||
+    isChildPlaceOf(
+      placeInfo.selectedPlace.dcid,
+      EUROPE_PLACE_DCID,
+      placeInfo.parentPlaces
+    )
   );
 };
 const onDateRangeMouseOut = () => {

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -379,15 +379,11 @@ const canClickRegion = (placeInfo: PlaceInfo) => (placeDcid: string) => {
   if (!(placeInfo.enclosedPlaceType in CHILD_PLACE_TYPES)) {
     return false;
   }
+  // Add European countries to this list.
   return (
     placeInfo.enclosingPlace.dcid !== EARTH_NAMED_TYPED_PLACE.dcid ||
     placeDcid === USA_PLACE_DCID ||
-    placeDcid === INDIA_PLACE_DCID ||
-    isChildPlaceOf(
-      placeInfo.selectedPlace.dcid,
-      EUROPE_PLACE_DCID,
-      placeInfo.parentPlaces
-    )
+    placeDcid === INDIA_PLACE_DCID
   );
 };
 const onDateRangeMouseOut = () => {

--- a/static/js/tools/map/place_details.tsx
+++ b/static/js/tools/map/place_details.tsx
@@ -24,7 +24,12 @@ import { Card } from "reactstrap";
 
 import { GeoJsonFeature } from "../../chart/types";
 import { formatNumber } from "../../i18n/i18n";
-import { INDIA_PLACE_DCID, USA_PLACE_DCID } from "../../shared/constants";
+import {
+  EUROPE_PLACE_DCID,
+  INDIA_PLACE_DCID,
+  USA_PLACE_DCID,
+} from "../../shared/constants";
+import { isChildPlaceOf } from "../shared_util";
 import { DataPointMetadata } from "./chart_loader";
 import { NamedTypedPlace, PlaceInfo, StatVar } from "./context";
 import { getRedirectLink } from "./util";
@@ -136,7 +141,8 @@ function getListItemElement(
   const shouldBeClickable =
     place.types.indexOf("Country") === -1 ||
     place.dcid === USA_PLACE_DCID ||
-    place.dcid === INDIA_PLACE_DCID;
+    place.dcid === INDIA_PLACE_DCID ||
+    isChildPlaceOf(place.dcid, EUROPE_PLACE_DCID, props.placeInfo.parentPlaces);
   return (
     <div key={place.dcid}>
       {itemNumber && `${itemNumber}. `}

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -25,6 +25,7 @@ import { Card, Container, CustomInput } from "reactstrap";
 
 import {
   EARTH_NAMED_TYPED_PLACE,
+  EUROPE_PLACE_DCID,
   INDIA_PLACE_DCID,
   USA_PLACE_DCID,
 } from "../../shared/constants";
@@ -33,6 +34,7 @@ import { SearchBar } from "../timeline/search";
 import { Context, IsLoadingWrapper, PlaceInfoWrapper } from "./context";
 import {
   CHILD_PLACE_TYPES,
+  EUROPE_CHILD_PLACE_TYPES,
   getAllChildPlaceTypes,
   INDIA_PLACE_TYPES,
 } from "./util";
@@ -100,7 +102,7 @@ export function PlaceOptions(): JSX.Element {
                 unselectPlace(placeInfo, setEnclosedPlaceTypes)
               }
               numPlacesLimit={1}
-              countryRestrictions={["us", "ind"]}
+              countryRestrictions={["us", "ind", "fr", "gb", "de"]} // API only allows 5 countries.
               customPlaceHolder={"Enter a country or state to get started"}
             />
           </div>
@@ -201,12 +203,21 @@ function updateEnclosedPlaceTypes(
         INDIA_PLACE_DCID,
         parents
       );
+      const isEuropePlace =
+        isChildPlaceOf(
+          place.value.selectedPlace.dcid,
+          EUROPE_PLACE_DCID,
+          parents
+        ) ||
+        placeType.indexOf("Eurostat") == 0 ||
+        place.value.selectedPlace.dcid == EUROPE_PLACE_DCID;
       let hasEnclosedPlaceTypes = false;
-      if (isUSPlace || isIndPlace) {
+      if (isUSPlace || isIndPlace || isEuropePlace) {
         if (placeType in CHILD_PLACE_TYPES) {
           hasEnclosedPlaceTypes = true;
           let enclosedPlacetypes = CHILD_PLACE_TYPES[placeType];
           if (isIndPlace) {
+            // TODO: This should be statically built.
             const uniqueEnclosedPlaceTypes = new Set();
             enclosedPlacetypes.forEach((type) => {
               if (type in INDIA_PLACE_TYPES) {
@@ -214,6 +225,8 @@ function updateEnclosedPlaceTypes(
               }
             });
             enclosedPlacetypes = Array.from(uniqueEnclosedPlaceTypes);
+          } else if (isEuropePlace) {
+            enclosedPlacetypes = EUROPE_CHILD_PLACE_TYPES[placeType];
           }
           if (enclosedPlacetypes.length === 1) {
             place.setEnclosedPlaceType(enclosedPlacetypes[0]);
@@ -223,7 +236,7 @@ function updateEnclosedPlaceTypes(
       }
       if (!hasEnclosedPlaceTypes) {
         alert(
-          `Sorry, we don't support maps for ${place.value.selectedPlace.name}.` +
+          `Sorry, we don't support maps for ${place.value.selectedPlace.name}. ` +
             "Please select a different place."
         );
         setEnclosedPlaceTypes([]);

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -102,8 +102,10 @@ export function PlaceOptions(): JSX.Element {
                 unselectPlace(placeInfo, setEnclosedPlaceTypes)
               }
               numPlacesLimit={1}
-              countryRestrictions={["us", "ind", "fr", "gb", "de"]} // API only allows 5 countries.
               customPlaceHolder={"Enter a country or state to get started"}
+              // Don't apply country restrictions and rely on alerts for
+              // unsupported places since the API only allows 5 countries in the
+              // restrictions list.
             />
           </div>
         </div>
@@ -209,10 +211,15 @@ function updateEnclosedPlaceTypes(
           EUROPE_PLACE_DCID,
           parents
         ) ||
-        placeType.indexOf("Eurostat") == 0 ||
-        place.value.selectedPlace.dcid == EUROPE_PLACE_DCID;
+        placeType.indexOf("Eurostat") === 0 ||
+        place.value.selectedPlace.dcid === EUROPE_PLACE_DCID;
       let hasEnclosedPlaceTypes = false;
-      if (isUSPlace || isIndPlace || isEuropePlace) {
+      if (
+        isUSPlace ||
+        isIndPlace ||
+        isEuropePlace ||
+        placeType == "Continent"
+      ) {
         if (placeType in CHILD_PLACE_TYPES) {
           hasEnclosedPlaceTypes = true;
           let enclosedPlacetypes = CHILD_PLACE_TYPES[placeType];

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -30,11 +30,15 @@ const USA_COUNTRY_CHILD_TYPES = ["State", ...USA_STATE_CHILD_TYPES];
 
 export const CHILD_PLACE_TYPES = {
   Planet: ["Country"],
+  Continent: ["Country"],
   Country: USA_COUNTRY_CHILD_TYPES,
   State: USA_STATE_CHILD_TYPES,
   County: ["County"],
   AdministrativeArea1: ["AdministrativeArea2"],
   AdministrativeArea2: ["AdministrativeArea2"],
+  EurostatNUTS1: ["EurostatNUTS2", "EurostatNUTS3"],
+  EurostatNUTS2: ["EurostatNUTS3"],
+  EurostatNUTS3: ["EurostatNUTS3"],
 };
 
 export const INDIA_PLACE_TYPES = {
@@ -42,6 +46,14 @@ export const INDIA_PLACE_TYPES = {
   AdministrativeArea2: "AdministrativeArea2",
   County: "AdministrativeArea2",
   State: "AdministrativeArea1",
+};
+
+export const EUROPE_CHILD_PLACE_TYPES = {
+  Continent: ["Country", "EurostatNUTS1", "EurostatNUTS2", "EurostatNUTS3"],
+  Country: ["EurostatNUTS1", "EurostatNUTS2", "EurostatNUTS3"],
+  EurostatNUTS1: ["EurostatNUTS2", "EurostatNUTS3"],
+  EurostatNUTS2: ["EurostatNUTS3"],
+  EurostatNUTS3: ["EurostatNUTS3"],
 };
 
 // list of place types in the US in the order of high to low granularity.

--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -132,8 +132,8 @@ export function shouldShowMapBoundaries(
 ): boolean {
   const selectedPlaceTypes = selectedPlace.types;
   if (
-    enclosedPlaceType == "EurostatNUTS3" &&
-    selectedPlaceTypes[0] != "EurostatNUTS2"
+    enclosedPlaceType === "EurostatNUTS3" &&
+    selectedPlaceTypes[0] !== "EurostatNUTS2"
   ) {
     return false;
   }

--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -131,6 +131,12 @@ export function shouldShowMapBoundaries(
   enclosedPlaceType: string
 ): boolean {
   const selectedPlaceTypes = selectedPlace.types;
+  if (
+    enclosedPlaceType == "EurostatNUTS3" &&
+    selectedPlaceTypes[0] != "EurostatNUTS2"
+  ) {
+    return false;
+  }
   let selectedPlaceTypeIdx = -1;
   if (selectedPlaceTypes) {
     selectedPlaceTypeIdx = USA_PLACE_HIERARCHY.indexOf(selectedPlaceTypes[0]);


### PR DESCRIPTION
Add basic support for displaying sub-european maps.

I added continents back to the parent places list so that it will be possible to test for european countries on the client. So they'll start showing up in the "contained places" breadcrumbs on the bottom.

We'll need a better way to add support for other regions as they come, I tried to make the changes minimal.

Known issues:
- European countries aren't clickable from the Earth view
- Only France, Germany and UK are searchable (there is a Maps API limit of 5 country restrictions)
- Continent views, accessible via breadcrumbs from countries above + India + US, include territories that are far away from the physical continent (and Russia crosses the date line), so the views are rather skewed.

![image](https://user-images.githubusercontent.com/6052978/138638268-504b44bb-43ac-41c9-bed4-2990ec068b6a.png)
