### PR TITLE
[map/scatter] Update capped date

### DIFF
--- a/static/js/shared/util.test.ts
+++ b/static/js/shared/util.test.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { isDateTooFar, shouldCapStatVarDate } from "./util";
+import { MAX_DATE, MAX_YEAR } from "./constants";
+import { getCappedStatVarDate, isDateTooFar } from "./util";
 
 test("isDateTooFar", () => {
   const data = {
@@ -28,13 +29,14 @@ test("isDateTooFar", () => {
   }
 });
 
-test("shouldCapStatVarDate", () => {
+test("getCappedStatVarDate", () => {
   const data = {
-    Count_Person: false,
-    DifferenceRelativeToBaseDate2006_PrecipitationRate_RCP26: true,
-    PrecipitationRate: false,
+    Count_Person: "",
+    DifferenceRelativeToBaseDate2006_PrecipitationRate_RCP26: MAX_DATE,
+    NumberOfMonths_WetBulbTemperature_35COrMore_RCP85: MAX_YEAR,
+    PrecipitationRate: "",
   };
   for (const date in data) {
-    expect(shouldCapStatVarDate(date)).toEqual(data[date]);
+    expect(getCappedStatVarDate(date)).toEqual(data[date]);
   }
 });

--- a/static/js/shared/util.ts
+++ b/static/js/shared/util.ts
@@ -16,7 +16,7 @@
 
 import _ from "lodash";
 
-import { MAX_YEAR } from "./constants";
+import { MAX_DATE, MAX_YEAR } from "./constants";
 
 // This has to be in sync with server/__init__.py
 export const placeExplorerCategories = [
@@ -81,8 +81,16 @@ export function isDateTooFar(date: string): boolean {
   return date.slice(0, 4) > MAX_YEAR;
 }
 
-export function shouldCapStatVarDate(statVar: string): boolean {
-  return statVar.includes("_RCP");
+export function getCappedStatVarDate(statVar: string): string {
+  // Only want to cap stat var date for stat vars with RCP.
+  if (!statVar.includes("_RCP")) {
+    return "";
+  }
+  // Wet bulb temperature is observed at P1Y, so need to use year for the date.
+  if (statVar.includes("WetBulbTemperature")) {
+    return MAX_YEAR;
+  }
+  return MAX_DATE;
 }
 
 /**

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -24,9 +24,8 @@ import _ from "lodash";
 import React, { useContext, useEffect, useState } from "react";
 
 import { GeoJsonData, MapPoint } from "../../chart/types";
-import { MAX_DATE, MAX_YEAR } from "../../shared/constants";
 import { StatApiResponse } from "../../shared/stat_types";
-import { shouldCapStatVarDate } from "../../shared/util";
+import { getCappedStatVarDate } from "../../shared/util";
 import { getPopulationDate, getUnit, PlacePointStat } from "../shared_util";
 import { Chart } from "./chart";
 import { Context, IsLoadingWrapper, PlaceInfo, StatVar } from "./context";
@@ -161,17 +160,13 @@ function fetchData(
     .then((resp) => resp.data);
 
   let dataDateParam = "";
+  const cappedDate = getCappedStatVarDate(statVar.dcid);
   // If there is a specified date, get the data for that date. If no specified
   // date, still need to cut data for prediction data that extends to 2099
   if (statVar.date) {
     dataDateParam = `&date=${statVar.date}`;
-  } else if (shouldCapStatVarDate(statVar.dcid)) {
-    // Wet bulb temperature is observed at P1Y, so need to use year for the date.
-    if (statVar.dcid.includes("WetBulbTemperature")) {
-      dataDateParam = `&date=${MAX_YEAR}`;
-    } else {
-      dataDateParam = `&date=${MAX_DATE}`;
-    }
+  } else if (cappedDate) {
+    dataDateParam = `&date=${cappedDate}`;
   }
   const statVarDataUrl = `/api/stats/within-place?parent_place=${placeInfo.enclosingPlace.dcid}&child_type=${placeInfo.enclosedPlaceType}&stat_vars=${statVar.dcid}${dataDateParam}`;
   const statVarDataPromise: Promise<PlacePointStat> = axios

--- a/static/js/tools/scatter/util.ts
+++ b/static/js/tools/scatter/util.ts
@@ -21,9 +21,8 @@
 import axios from "axios";
 import _ from "lodash";
 
-import { MAX_DATE } from "../../shared/constants";
 import { StatVarNode } from "../../shared/stat_var";
-import { shouldCapStatVarDate } from "../../shared/util";
+import { getCappedStatVarDate } from "../../shared/util";
 import { PlacePointStat } from "../shared_util";
 import {
   Axis,
@@ -65,8 +64,9 @@ async function getStatsWithinPlace(
   const promises: Promise<Record<string, PlacePointStat>>[] = [];
   for (const statVar of statVars) {
     statVarParams = `&stat_vars=${statVar}`;
-    if (shouldCapStatVarDate(statVar)) {
-      statVarParams += `&date=${MAX_DATE}`;
+    const cappedDate = getCappedStatVarDate(statVar);
+    if (cappedDate) {
+      statVarParams += `&date=${cappedDate}`;
     }
     promises.push(
       axios.get(


### PR DESCRIPTION
- wet bulb data wasn't being shown in map and scatter because the data has an observation period of P1Y but we were asking for data from a specific month. Update to get data for a specific year for wet bulb data