### PR TITLE
small ui updates

### DIFF
--- a/static/css/draw.scss
+++ b/static/css/draw.scss
@@ -39,8 +39,8 @@
 }
 
 #draw-tooltip {
-  background-color: var(--dc-white);
-  color: var(--dc-gray);
+  background-color: rgb(59, 59, 59, 0.7);
+  color: var(--dc-white);
   font-size: 0.8rem;
   border-radius: 3px;
   border: 0.5px solid var(--dc-gray-lite);

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -235,13 +235,17 @@ export function Chart(props: ChartProps): JSX.Element {
           </div>
           <div className="map-footer">
             <div className="sources">Data from {sourcesJsx}</div>
-            <div
-              className="explore-timeline-link"
-              onClick={() => exploreTimelineOnClick(placeDcid, statVarDcid)}
-            >
-              <span className="explore-timeline-text">Explore timeline</span>
-              <i className="material-icons">keyboard_arrow_right</i>
-            </div>
+            {(props.placeInfo.selectedPlace.dcid in props.mapDataValues ||
+              props.placeInfo.selectedPlace.dcid in
+                props.breadcrumbDataValues) && (
+              <div
+                className="explore-timeline-link"
+                onClick={() => exploreTimelineOnClick(placeDcid, statVarDcid)}
+              >
+                <span className="explore-timeline-text">Explore timeline</span>
+                <i className="material-icons">keyboard_arrow_right</i>
+              </div>
+            )}
           </div>
         </div>
         <div id="map-chart-screen" className="screen">


### PR DESCRIPTION
- remove explore more link when there's no data for the selected place: 
<img width="1766" alt="Screen Shot 2021-10-29 at 8 02 52 AM" src="https://user-images.githubusercontent.com/69875368/139458093-93ba5cdd-1278-4234-99ad-89577de89c61.png">

- update the timeline tooltip so that the background is a little transparent so you can faintly see the lines/points in the background even when the tooltip is covering them. It's a little confusing when the data shows "N/A" for a place that shows a line (but there's just no data at that specific point). With this slight bit of transparency, can kind of see whether or not there's a point for each line
    - original: 
<img width="1346" alt="Screen Shot 2021-10-29 at 8 13 24 AM" src="https://user-images.githubusercontent.com/69875368/139459638-a9f10caa-876f-4ba6-9692-cd5752d986ca.png">
    - with this change:
<img width="1352" alt="Screen Shot 2021-10-29 at 8 15 46 AM" src="https://user-images.githubusercontent.com/69875368/139459978-aa469b02-800b-4165-a5ff-e0b4b7002db9.png">
