### PR TITLE
[scatter] fix jumpiness option changes

### DIFF
--- a/static/css/tools/scatter.scss
+++ b/static/css/tools/scatter.scss
@@ -49,6 +49,10 @@
   display: block;
 }
 
+#scatter-plot-container {
+  height: 60vh;
+}
+
 .no-padding {
   padding: 0;
 }
@@ -271,7 +275,7 @@ circle {
 .chart-type-option, .selected-chart-option {
   display: flex;
   align-items: center;
-  min-width: 4rem;
+  min-width: 3.5rem;
   height: 2.4rem;
   justify-content: center;
   cursor: pointer;

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -257,18 +257,12 @@ function plot(
   geoJsonData: GeoJsonData
 ): void {
   const svgContainerRealWidth = svgContainerRef.current.offsetWidth;
-  // TODO: Use CSS to set the height of the chart so it's visible (< 1 vh).
-  const scatterHeight = Math.min(
-    window.innerHeight * 0.6,
-    svgContainerRealWidth
-  );
-  const scatterWidth = svgContainerRealWidth;
-  const chartHeight = scatterHeight;
+  const chartHeight = svgContainerRef.current.offsetHeight;
   if (props.display.chartType === ScatterChartType.SCATTER) {
     drawScatter(
       svgContainerRef,
       tooltipRef,
-      scatterWidth,
+      svgContainerRealWidth,
       chartHeight,
       props,
       redirectAction,

--- a/static/js/tools/scatter/chart_loader.tsx
+++ b/static/js/tools/scatter/chart_loader.tsx
@@ -89,7 +89,7 @@ function ChartLoader(): JSX.Element {
     yUnits = yStatData ? getUnit(yStatData) : null;
   }
   return (
-    <div>
+    <>
       {shouldRenderChart && (
         <>
           {cache.noDataError ? (
@@ -125,7 +125,7 @@ function ChartLoader(): JSX.Element {
           )}
         </>
       )}
-    </div>
+    </>
   );
 }
 

--- a/static/js/tools/scatter/place_and_type_options.tsx
+++ b/static/js/tools/scatter/place_and_type_options.tsx
@@ -115,7 +115,7 @@ function PlaceAndTypeOptions(): JSX.Element {
 
   return (
     <Card className="place-and-type-options-card">
-      <Container className="place-and-type-options">
+      <Container className="place-and-type-options" fluid={true}>
         <div
           className="place-and-type-options-section"
           id="place-search-section"

--- a/static/js/tools/scatter/plot_options.tsx
+++ b/static/js/tools/scatter/plot_options.tsx
@@ -44,7 +44,7 @@ function PlotOptions(): JSX.Element {
   );
   return (
     <Card id="plot-options">
-      <Container>
+      <Container fluid={true}>
         <Row className="plot-options-row">
           <Col sm={1} className="plot-options-label">
             Per capita:


### PR DESCRIPTION
use css to set size of the chart drawing area, to reduce jumpiness on replotting.
also updated container to fluid for some options that were left out with earlier layout fixes.

will work on debouncing next..