### PR TITLE
[scatter] various updates/fixes

### DIFF
--- a/static/css/tools/scatter.scss
+++ b/static/css/tools/scatter.scss
@@ -104,6 +104,8 @@
   opacity: 0.9;
   z-index: 2;
   border: 0.5px solid var(--dc-gray-lite);
+  word-break: break-word;  
+  white-space: normal;
 }
 
 #tooltip header {
@@ -312,4 +314,8 @@ circle {
 .chart-title span {
   font-size: 1rem;
   margin-bottom: 0.5rem;
+}
+
+.scatter-chart-container {
+  position: relative;
 }

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -179,7 +179,7 @@ function showTooltip(
   );
   if (left < 0) {
     left = 0;
-    tooltipSelect.style("width", containerWidth + "px"); 
+    tooltipSelect.style("width", containerWidth + "px");
   } else {
     tooltipSelect.style("width", "fit-content");
   }

--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -173,10 +173,16 @@ function showTooltip(
   const offset = 5;
   const leftOffset = offset;
   const topOffset = -tooltipHeight - offset;
-  const left = Math.min(
+  let left = Math.min(
     d3.event.offsetX + leftOffset,
     containerWidth - tooltipWidth
   );
+  if (left < 0) {
+    left = 0;
+    tooltipSelect.style("width", containerWidth + "px"); 
+  } else {
+    tooltipSelect.style("width", "fit-content");
+  }
   let top = d3.event.offsetY + topOffset;
   if (top < 0) {
     top = d3.event.offsetY + offset;

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -140,7 +140,7 @@ function Chart(props: ChartPropsType): JSX.Element {
   // Tooltip needs to start off hidden
   d3.select(tooltipRef.current)
     .style("visibility", "hidden")
-    .style("position", "fixed");
+    .style("position", "absolute");
 
   // Fetch geojson in the background when component is first mounted.
   useEffect(() => {
@@ -207,11 +207,11 @@ function Chart(props: ChartPropsType): JSX.Element {
             <span>vs</span>
             <h3>{props.xLabel}</h3>
           </div>
-          <div>
+          <div className="scatter-chart-container">
             <div id={SVG_CONTAINER_ID} ref={svgContainerRef}></div>
             <div id={MAP_LEGEND_CONTAINER_ID}></div>
+            <div id="tooltip" ref={tooltipRef} />
           </div>
-          <div id="tooltip" ref={tooltipRef} />
           <div className="provenance">Data from {sourcesJsx}</div>
         </Card>
       </Row>

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -53,7 +53,7 @@ interface ChartPropsType {
   display: DisplayOptionsWrapper;
 }
 
-const DOT_REDIRECT_PREFIX = "/tools/timeline";
+const DOT_REDIRECT_PREFIX = "/place/";
 const SVG_CONTAINER_ID = "scatter-plot-container";
 const MAP_LEGEND_CONTAINER_ID = "legend-container";
 const MAP_LEGEND_ARROW_LENGTH = 5;
@@ -316,7 +316,7 @@ function plot(
       "",
       colorScale,
       (geoDcid: GeoJsonFeatureProperties) => {
-        redirectAction(props.xStatVar, props.yStatVar, geoDcid.geoDcid);
+        redirectAction(geoDcid.geoDcid);
       },
       getMapTooltipHtml(
         props.points,
@@ -578,11 +578,9 @@ function drawMapLegend(
 }
 
 function redirectAction(
-  xStatVar: string,
-  yStatVar: string,
   placeDcid: string
 ): void {
-  const uri = `${DOT_REDIRECT_PREFIX}#place=${placeDcid}&statsVar=${xStatVar}__${yStatVar}`;
+  const uri = `${DOT_REDIRECT_PREFIX}${placeDcid}`;
   window.open(uri);
 }
 

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -577,9 +577,7 @@ function drawMapLegend(
   );
 }
 
-function redirectAction(
-  placeDcid: string
-): void {
+function redirectAction(placeDcid: string): void {
   const uri = `${DOT_REDIRECT_PREFIX}${placeDcid}`;
   window.open(uri);
 }

--- a/static/js/tools/scatter/draw_scatter.ts
+++ b/static/js/tools/scatter/draw_scatter.ts
@@ -377,13 +377,20 @@ function addTooltip(
     );
 
     ReactDOM.render(element, tooltip.current);
-    let tooltipHeight = (div.node() as HTMLDivElement).getBoundingClientRect().height;
-    let tooltipWidth = (div.node() as HTMLDivElement).getBoundingClientRect().width;
-    const containerWidth = (d3.select(svgContainerRef.current).node() as HTMLDivElement).getBoundingClientRect().width;
-    let left = Math.min(d3.event.offsetX + TOOLTIP_OFFSET, containerWidth - tooltipWidth);
+    const tooltipHeight = (div.node() as HTMLDivElement).getBoundingClientRect()
+      .height;
+    const tooltipWidth = (div.node() as HTMLDivElement).getBoundingClientRect()
+      .width;
+    const containerWidth = (d3
+      .select(svgContainerRef.current)
+      .node() as HTMLDivElement).getBoundingClientRect().width;
+    let left = Math.min(
+      d3.event.offsetX + TOOLTIP_OFFSET,
+      containerWidth - tooltipWidth
+    );
     if (left < 0) {
       left = 0;
-      div.style("width", containerWidth + "px"); 
+      div.style("width", containerWidth + "px");
     } else {
       div.style("width", "fit-content");
     }
@@ -414,9 +421,7 @@ export function drawScatter(
   chartWidth: number,
   chartHeight: number,
   props: ChartPropsType,
-  redirectAction: (
-    placeDcid: string
-  ) => void,
+  redirectAction: (placeDcid: string) => void,
   getTooltipElement: (
     point: Point,
     xLabel: string,
@@ -493,9 +498,7 @@ export function drawScatter(
     .attr("cy", (point) => yScale(point.yVal))
     .attr("stroke", "rgb(147, 0, 0)")
     .style("opacity", "0.7")
-    .on("click", (point: Point) =>
-      redirectAction(point.place.dcid)
-    );
+    .on("click", (point: Point) => redirectAction(point.place.dcid));
 
   if (props.display.showDensity) {
     addDensity(

--- a/static/js/tools/scatter/draw_scatter.ts
+++ b/static/js/tools/scatter/draw_scatter.ts
@@ -415,8 +415,6 @@ export function drawScatter(
   chartHeight: number,
   props: ChartPropsType,
   redirectAction: (
-    xStatVar: string,
-    yStatVar: string,
     placeDcid: string
   ) => void,
   getTooltipElement: (
@@ -496,7 +494,7 @@ export function drawScatter(
     .attr("stroke", "rgb(147, 0, 0)")
     .style("opacity", "0.7")
     .on("click", (point: Point) =>
-      redirectAction(props.xStatVar, props.yStatVar, point.place.dcid)
+      redirectAction(point.place.dcid)
     );
 
   if (props.display.showDensity) {

--- a/static/js/tools/scatter/draw_scatter.ts
+++ b/static/js/tools/scatter/draw_scatter.ts
@@ -40,6 +40,7 @@ const DENSITY_LEGEND_TEXT_HEIGHT = 15;
 const DENSITY_LEGEND_TEXT_PADDING = 5;
 const DENSITY_LEGEND_IMAGE_WIDTH = 10;
 const DENSITY_LEGEND_WIDTH = 75;
+const TOOLTIP_OFFSET = 5;
 
 /**
  * Adds a label for the y-axis
@@ -350,6 +351,7 @@ function addDensity(
  * @param yLabel
  */
 function addTooltip(
+  svgContainerRef: React.MutableRefObject<HTMLDivElement>,
   tooltip: React.MutableRefObject<HTMLDivElement>,
   dots: d3.Selection<SVGCircleElement, Point, SVGGElement, unknown>,
   xLabel: string,
@@ -375,9 +377,23 @@ function addTooltip(
     );
 
     ReactDOM.render(element, tooltip.current);
+    let tooltipHeight = (div.node() as HTMLDivElement).getBoundingClientRect().height;
+    let tooltipWidth = (div.node() as HTMLDivElement).getBoundingClientRect().width;
+    const containerWidth = (d3.select(svgContainerRef.current).node() as HTMLDivElement).getBoundingClientRect().width;
+    let left = Math.min(d3.event.offsetX + TOOLTIP_OFFSET, containerWidth - tooltipWidth);
+    if (left < 0) {
+      left = 0;
+      div.style("width", containerWidth + "px"); 
+    } else {
+      div.style("width", "fit-content");
+    }
+    let top = d3.event.offsetY - tooltipHeight - TOOLTIP_OFFSET;
+    if (top < 0) {
+      top = d3.event.offsetY + TOOLTIP_OFFSET;
+    }
     div
-      .style("left", d3.event.pageX + 15 + "px")
-      .style("top", d3.event.pageY - 28 + "px")
+      .style("left", left + "px")
+      .style("top", top + "px")
       .style("visibility", "visible");
   };
   const onTooltipMouseout = () => {
@@ -515,6 +531,7 @@ export function drawScatter(
   }
 
   addTooltip(
+    svgContainerRef,
     tooltipRef,
     dots,
     props.xLabel,

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -349,47 +349,22 @@ function confirmStatVars(
   setModalSelected: (modalSelected: ModalSelected) => void,
   setModalOpened: (open: boolean) => void
 ): void {
-  const values: Array<Axis> = [];
-  const axes = [x, y];
-  if (modalSelected.x) {
-    values.push(x.value);
-  } else {
-    values.push({
-      ...EmptyAxis,
-      statVarInfo: thirdStatVar.info,
-      statVarDcid: thirdStatVar.dcid,
-    });
-  }
   if (modalSelected.y) {
-    values.push(y.value);
-  } else {
-    values.push({
+    x.set({
+      ...EmptyAxis,
+      statVarInfo: thirdStatVar.info,
+      statVarDcid: thirdStatVar.dcid,
+    });
+  } else if (modalSelected.x) {
+    y.set({
       ...EmptyAxis,
       statVarInfo: thirdStatVar.info,
       statVarDcid: thirdStatVar.dcid,
     });
   }
-  assignAxes(axes, values);
-  assignAxes(axes, values);
   setThirdStatVar(emptyStatVar);
   setModalSelected(defaultModalSelected);
   setModalOpened(false);
-}
-
-/**
- * Assigns the first `Axis` in `values` to the first `AxisWrapper` in axes while
- * keeping the log and per capita options in the original `AxisWrapper`.
- * The `Axis` and `AxisWrapper` involved are removed from the arrays.
- * @param axes
- * @param values
- */
-function assignAxes(axes: Array<AxisWrapper>, values: Array<Axis>) {
-  const axis = axes.shift();
-  axis.set({
-    ...values.shift(),
-    log: axis.value.log,
-    perCapita: axis.value.perCapita,
-  });
 }
 
 export { StatVarChooser };

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -39,7 +39,7 @@ import { getStatVarInfo, StatVarInfo } from "../../shared/stat_var";
 import { StatVarHierarchyType } from "../../shared/types";
 import { DrawerToggle } from "../../stat_var_hierarchy/drawer_toggle";
 import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
-import { Axis, AxisWrapper, Context, EmptyAxis } from "./context";
+import { AxisWrapper, Context, EmptyAxis } from "./context";
 
 // Number of enclosed places to sample when filtering the stat vars in the
 // stat var menu


### PR DESCRIPTION
- add text wrap for tooltip
<img width="877" alt="Screen Shot 2021-11-01 at 7 27 53 AM" src="https://user-images.githubusercontent.com/69875368/139687833-bd403db2-aa0f-4df6-a0ce-337eb77dbf77.png">

- on dot click, go to place page
- when switching to new stat var, reset per capita and scale log for that axis