### PR TITLE
[scatter] don't reset options when switching sv

### DIFF
--- a/static/js/tools/scatter/plot_options.tsx
+++ b/static/js/tools/scatter/plot_options.tsx
@@ -50,6 +50,14 @@ function PlotOptions(props: PlotOptionsProps): JSX.Element {
   );
   const xMinMax = d3.extent(Object.values(props.points), (point) => point.xVal);
   const yMinMax = d3.extent(Object.values(props.points), (point) => point.yVal);
+  const xLogDisabled = xMinMax[0] * xMinMax[1] <= 0;
+  const yLogDisabled = yMinMax[0] * yMinMax[1] <= 0;
+  if (xLogDisabled && x.value.log) {
+    x.setLog(false);
+  }
+  if (yLogDisabled && y.value.log) {
+    y.setLog(false);
+  }
   return (
     <Card id="plot-options">
       <Container fluid={true}>
@@ -96,40 +104,38 @@ function PlotOptions(props: PlotOptionsProps): JSX.Element {
           <Col sm={1} className="plot-options-label">
             Log scale:
           </Col>
-          {yMinMax[0] * yMinMax[1] > 0 && (
-            <Col sm="auto">
-              <FormGroup check>
-                <Label check>
-                  <Input
-                    id="log-y"
-                    type="checkbox"
-                    checked={y.value.log}
-                    onChange={(e) => checkLog(y, e)}
-                  />
-                  {display.chartType === ScatterChartType.SCATTER
-                    ? "Y-axis"
-                    : y.value.statVarInfo.title || y.value.statVarDcid}
-                </Label>
-              </FormGroup>
-            </Col>
-          )}
-          {xMinMax[0] * xMinMax[1] > 0 && (
-            <Col sm="auto">
-              <FormGroup check>
-                <Label check>
-                  <Input
-                    id="log-x"
-                    type="checkbox"
-                    checked={x.value.log}
-                    onChange={(e) => checkLog(x, e)}
-                  />
-                  {display.chartType === ScatterChartType.SCATTER
-                    ? "X-axis"
-                    : x.value.statVarInfo.title || x.value.statVarDcid}
-                </Label>
-              </FormGroup>
-            </Col>
-          )}
+          <Col sm="auto">
+            <FormGroup check>
+              <Input
+                id="log-y"
+                type="checkbox"
+                checked={y.value.log}
+                onChange={(e) => checkLog(y, e)}
+                disabled={yLogDisabled}
+              />
+              <Label check>
+                {display.chartType === ScatterChartType.SCATTER
+                  ? "Y-axis"
+                  : y.value.statVarInfo.title || y.value.statVarDcid}
+              </Label>
+            </FormGroup>
+          </Col>
+          <Col sm="auto">
+            <FormGroup check>
+              <Input
+                id="log-x"
+                type="checkbox"
+                checked={x.value.log}
+                onChange={(e) => checkLog(x, e)}
+                disabled={xLogDisabled}
+              />
+              <Label check>
+                {display.chartType === ScatterChartType.SCATTER
+                  ? "X-axis"
+                  : x.value.statVarInfo.title || x.value.statVarDcid}
+              </Label>
+            </FormGroup>
+          </Col>
         </Row>
         {display.chartType === ScatterChartType.SCATTER && (
           <>

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -39,7 +39,7 @@ import { getStatVarInfo, StatVarInfo } from "../../shared/stat_var";
 import { StatVarHierarchyType } from "../../shared/types";
 import { DrawerToggle } from "../../stat_var_hierarchy/drawer_toggle";
 import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
-import { AxisWrapper, Context, EmptyAxis } from "./context";
+import { AxisWrapper, Context } from "./context";
 
 // Number of enclosed places to sample when filtering the stat vars in the
 // stat var menu
@@ -351,13 +351,13 @@ function confirmStatVars(
 ): void {
   if (modalSelected.y) {
     x.set({
-      ...EmptyAxis,
+      ...x.value,
       statVarInfo: thirdStatVar.info,
       statVarDcid: thirdStatVar.dcid,
     });
   } else if (modalSelected.x) {
     y.set({
-      ...EmptyAxis,
+      ...y.value,
       statVarInfo: thirdStatVar.info,
       statVarDcid: thirdStatVar.dcid,
     });


### PR DESCRIPTION
- revert resetting options when switching sv
- if log is picked for an axes that can't have log, un-choose log
- disable log options instead of hiding them
![Screen Shot 2021-11-02 at 9 01 10 AM](https://user-images.githubusercontent.com/69875368/139891747-3c4db9a4-b73f-4e3f-9ac9-5d4bda8a05c9.png)


