### PR TITLE
[browser] small change in dcid refs

### DIFF
--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -210,4 +210,6 @@
 
 .dcid-text {
   font-weight: 300;
+  color: var(--gray);
+  padding-left: 1em;
 }

--- a/static/js/browser/arc_table_row.tsx
+++ b/static/js/browser/arc_table_row.tsx
@@ -59,7 +59,7 @@ export class ArcTableRow extends React.Component<
           <>
             <a href={HREF_PREFIX + value.dcid}>{value.text}</a>
             {value.dcid !== value.text && (
-              <span className="dcid-text"> ({value.dcid})</span>
+              <span className="dcid-text"> (dcid: {value.dcid})</span>
             )}
           </>
         ) : (


### PR DESCRIPTION
made it even lighter, and added dcid: prefix

![image](https://user-images.githubusercontent.com/6052978/141390101-7bf9cdd5-267a-4e84-998b-fee314c0a427.png)
