### PR TITLE
Clean up GCP/GKE setup guide

### DIFF
--- a/docs/iap.md
+++ b/docs/iap.md
@@ -47,7 +47,7 @@ Deploy backend config and service
 
 ```bash
 # In <REPO_ROOT>/gke
-kubectl apply -f backendconfig.yaml
+kubectl apply -f backendconfig_iap.yaml
 kubectl apply -f mcs.yaml
 
 cp mci.yaml.tpl mci.yaml

--- a/docs/new_deployment.md
+++ b/docs/new_deployment.md
@@ -1,18 +1,17 @@
 # Add a New Deployment Instance
 
-This doc details the steps involved to bring up a new deployment instance named
+This doc details the steps involved to bring up a new Data Commons instance
 `<new_instance>`.
 
 ## Setup GCP and GKE
 
-Follow this [instruction](../gke/README.md) to set up a new GCP project and GKE
-clusters. After the process, rename and copy `config.yaml` to
-[deploy/gke](../deploy/gke).
+Follow the [GKE Setup Guide](../gke/README.md) to set up a new GCP project and GKE
+clusters. When all steps are completed, put `config.yaml` in [deploy/gke](../deploy/gke)
+and rename it as `<new_instance>.yaml`.
 
-## Setup deployment
+## Setup Deployment
 
-- Make a new folder `<new_instance>` under
-  [deploy/overlays](../deploy/overlays).
+- Make a new folder `<new_instance>` under [deploy/overlays](../deploy/overlays).
 
 - Copy the [kustomization.yaml
   template](../deploy/overlays/kustomization.yaml.tpl) to the new folder and
@@ -45,3 +44,7 @@ Then go to GCP Kubernetes page and check the workload, load balancer status and
 managed certificate status.
 
 If everything works, try to access the website from the configured domain.
+
+## Restrict Access
+
+Follow the [IAP setup](./iap.md) to use Cloud IAP to restrict access to the new instance.

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,5 +1,7 @@
 # Use Redis as memory cache
 
+## Deploy Redis
+
 If you would like to use [Cloud Memorystore](https://cloud.google.com/memorystore/docs/redis/quickstart-gcloud), run
 
 ```bash
@@ -13,3 +15,10 @@ found in config.yaml.
 Record the **host** and **port** as deployment config file
 ([example](../deploy/overlays/prod/redis.json)) and make a patch to the
 deployment ([example](../deploy/overlays/patch_deployment.yaml)).
+
+## Clear the cache
+
+Follow the instructions of [clear cache tool](../tools/clearcache/README.md) to clear Redis cache.
+
+Note the tool now only clears production Redis cache. You may need to update it
+to clear other Redis instance.

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,0 +1,15 @@
+# Use Redis as memory cache
+
+If you would like to use [Cloud Memorystore](https://cloud.google.com/memorystore/docs/redis/quickstart-gcloud), run
+
+```bash
+cd gke
+./create_redis.sh <REGION>
+```
+
+Need to run this for all the regions that the app is hosted. The regions can be
+found in config.yaml.
+
+Record the **host** and **port** as deployment config file
+([example](../deploy/overlays/prod/redis.json)) and make a patch to the
+deployment ([example](../deploy/overlays/patch_deployment.yaml)).

--- a/gke/README.md
+++ b/gke/README.md
@@ -4,81 +4,67 @@ You should have owner/editor role to perform the following tasks.
 
 ## Prerequisites
 
-- Make a copy of the `config.yaml.tpl` as `config.yaml`.
+- Register a website domain on Google Domain or other registrars.
 
-  ```bash
-  cp config.yaml.tpl config.yaml
-  ```
+- Make a copy of the `config.yaml.tpl` as `config.yaml` and fill out the following
+  fields
 
-- Add the GCP project id in `config.yaml`, **project** field.
+  - `project`: the hosting GCP website
+  - `domain`: domain of the the website
 
-- Enable GCP services.
+- Install the following tools:
 
-  ```bash
-  ./enable_services.sh
-  ```
+  - [`gcloud`](https://cloud.google.com/sdk/docs/install)
+  - [`Skaffold`](https://skaffold.dev/docs/install/)
+  - [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+  - [`kustomize`](https://kustomize.io/)
+  - [`yq` 4.x](https://github.com/mikefarah/yq#install)
 
-- Create a global static IP in GCP.
+## One time setup
 
-  - Run:
-
-    ```bash
-    ./create_ip.sh
-    ```
-
-  - Record the IP address and update it in `config.yaml`, **ip** field.
-
-- Update the domain in `cluster.yaml` **domain** field.
-
-- Create a GCS bucket, copy resource files (placeid2dcid.json, etc) to it and
-  update `config.yaml` **gcs_bucket** field.
-
-- Create api key for "Maps API" and "Place API" and put them in GCP "Secret
-  Manager" with name **maps-api-key**.
-
-## One Time Setup
+Run the following scripts sequentially. Retry any script if errors occur.
 
 ```bash
-./first_time_setup.sh
+# Update gcloud
+gcloud components update
+gcloud auth login
+
+# Enable GCP services
+./enable_services.sh
+
+# Create a static IP for the domain
+./create_ip.sh
+
+# Create api key for web client maps and places API
+./create_api_key.sh
+
+# Create robot account
+./create_robot_account.sh
+
+# Config robot account IAM in the project
+./add_policy_binding.sh
+
+# [Ask Data Commons team to run this] Get permission to read Data Commons data
+./get_storage_permission.sh
+
+# Create SSL certificate
+./setup_ssl.sh
+
+# Deploy esp service
+./setup_esp.sh
+
+# Create clusters
+./create_all_clusters
+
+# Set up multi-cluster ingress and service
+./setup_config_cluster.sh
 ```
-
-**NOTE** In IAM, Give the robot account
-`website-robot@PROJECT_ID.iam.gserviceaccount.com` "GCE Storage Lister" role.
-TODO(shifucun): Figure out how to do this with gcloud, without giving
-"objectAdmin" role.
-
-This step creates clusters and runs all the one time tasks, including:
-
-- Enable API in the project.
-- Create service account, set up roles and create service account key.
-- Create a cluster in each region
-- Setup the config cluster
-
-Each cluster is a regional cluster with 3 zones.
-
-Each node is a configured to e2-highmem-4 machine type that has 4 vCPU and 32G
-memory.
-
-If you would like to use [Cloud
-Memorystore](https://cloud.google.com/memorystore/docs/redis/quickstart-gcloud),
-run
-
-```bash
-./create_redis.sh <REGION>
-```
-
-Need to run this for all the regions that the app is hosted. The regions can be
-found in config.yaml.
-
-Record the **host** and **port** as deployment config file
-([example](../deploy/overlays/prod/redis.json)) and make a patch to the
-deployment ([example](../deploy/overlays/patch_deployment.yaml)).
 
 ## DNS setup
 
 - Make sure the managed SSL certificate is "ACTIVE" by checking ["Load
   balancing" in
-  GCP](https://pantheon.corp.google.com/net-services/loadbalancing/advanced/sslCertificates/list?project=PROJECT_ID&sslCertificateTablesize=50).
+  GCP](https://pantheon.corp.google.com/net-services/loadbalancing/advanced/sslCertificates/list?project=<PROJECT_ID>&sslCertificateTablesize=50).
   This can take minutes up to hours.
 
   **NOTE** Make sure the certificate is [associated with a target
@@ -92,7 +78,9 @@ deployment ([example](../deploy/overlays/patch_deployment.yaml)).
 
 ## Add a new cluster
 
+If new cluster is needed to scale, then run:
+
 ```bash
 ./create_cluster.sh <REGION>
-../scripts/deploy_gke.sh <"staging"|"prod"|"autopush"> <REGION>
+../scripts/deploy_gke.sh <ENV> <REGION>
 ```

--- a/gke/add_policy_binding.sh
+++ b/gke/add_policy_binding.sh
@@ -18,43 +18,19 @@ set -e
 PROJECT_ID=$(yq eval '.project' config.yaml)
 STORE_PROJECT_ID=$(yq eval '.storage_project' config.yaml)
 TMCF_CSV_BUCKET=$(yq eval '.tmcf_csv_bucket' config.yaml)
-GCS_BUCKET=$(yq eval '.gcs_bucket' config.yaml)
-
 
 NAME="website-robot"
 SERVICE_ACCOUNT="$NAME@$PROJECT_ID.iam.gserviceaccount.com"
 
-# Data store project roles
 declare -a roles=(
-    "roles/bigquery.admin"   # Query BigQuery
-    "roles/bigtable.reader" # Query Bigtable
-    "roles/storage.objectViewer" # Branch Cache Read
-    "roles/pubsub.editor" # Branch Cache subscription
-)
-for role in "${roles[@]}"
-do
-  gcloud projects add-iam-policy-binding $STORE_PROJECT_ID \
-    --member serviceAccount:$SERVICE_ACCOUNT \
-    --role $role
-done
-
-# Self project roles
-declare -a roles=(
-   # service control report for endpoints.
-    "roles/endpoints.serviceAgent"
-    # Website resource: placeid2dcid.json, etc...
-    "roles/storage.objectViewer"
-    "roles/storage.legacyBucketReader"
-    # Secret manager accessor
-    "roles/secretmanager.secretAccessor"
-    # Logging and monitoring
-    "roles/logging.logWriter"
+    "roles/endpoints.serviceAgent" # service control report for endpoints.
+    "roles/logging.logWriter" # Logging and monitoring
     "roles/monitoring.metricWriter"
     "roles/stackdriver.resourceMetadata.writer"
     "roles/compute.networkViewer"
     "roles/cloudtrace.agent"
     "roles/bigquery.jobUser"   # Query BigQuery
-    "roles/pubsub.editor" # Private DC data change subscription
+    "roles/pubsub.editor" # TMCF + CSV GCS data change subscription
 )
 for role in "${roles[@]}"
 do
@@ -63,8 +39,7 @@ do
     --role $role
 done
 
-gsutil iam ch serviceAccount:$SERVICE_ACCOUNT:roles/storage.legacyBucketReader gs://$GCS_BUCKET
-
+# Read CSV and TMCF from GCS
 if [[ $TMCF_CSV_BUCKET != 'null' ]]; then
   gsutil iam ch serviceAccount:$SERVICE_ACCOUNT:roles/storage.objectViewer gs://$TMCF_CSV_BUCKET
 fi

--- a/gke/backendconfig.yaml
+++ b/gke/backendconfig.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# BackendConfig for connection timeout and healthcheck
+
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:

--- a/gke/backendconfig_iap.yaml
+++ b/gke/backendconfig_iap.yaml
@@ -26,3 +26,7 @@ spec:
     port: 8080
     type: HTTP
     requestPath: /healthz
+  iap:
+    enabled: true
+    oauthclientCredentials:
+      secretName: iap-secret

--- a/gke/backendconfig_iap.yaml
+++ b/gke/backendconfig_iap.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# BackendConfig for connection timeout and healthcheck and IAP
+
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:

--- a/gke/config.yaml.tpl
+++ b/gke/config.yaml.tpl
@@ -17,12 +17,14 @@
 # Copy this file to `config.yaml` and use that.
 
 project:
-ip:
 domain:
+ip:
 region:
   primary:
   others:
     -
 nodes: 1
 storage_project:
-gcs_bucket:
+maps_api_key:
+tmcf_csv_bucket:
+tmcf_csv_folder:

--- a/gke/create_all_clusters.sh
+++ b/gke/create_all_clusters.sh
@@ -15,30 +15,6 @@
 
 set -e
 
-PROJECT_ID=$(yq eval '.project' config.yaml)
-
-# Update gcloud
-gcloud components update
-
-# Auth
-gcloud auth login
-
-# Project level setup
-./enable_services.sh
-
-# Create robot account
-./create_robot_account.sh
-
-# Config robot account IAM
-./setup_robot_account.sh
-
-# Create certificate
-# !! This is crucial to get the ingress external IP working.
-./setup_ssl.sh
-
-# Deploy esp service
-./setup_esp.sh
-
 # Setup cluster in primary region
 PRIMARY_REGION=$(yq eval '.region.primary' config.yaml)
 ./create_cluster.sh $PRIMARY_REGION
@@ -51,5 +27,3 @@ do
   REGION=$(yq eval '.region.others[env(index)]' config.yaml)
   ./create_cluster.sh $REGION
 done
-
-./setup_config_cluster.sh

--- a/gke/create_api_key.sh
+++ b/gke/create_api_key.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Create an API key for maps and places API and store it in the config.
+
 
 PROJECT_ID=$(yq eval '.project' config.yaml)
 DOMAIN=$(yq eval '.project' domain.yaml)

--- a/gke/create_api_key.sh
+++ b/gke/create_api_key.sh
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,21 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
-REGION=$1
-if [[ $REGION == "" ]]; then
-  REGION=$(yq eval '.region.primary' config.yaml)
-fi
 
 PROJECT_ID=$(yq eval '.project' config.yaml)
+DOMAIN=$(yq eval '.project' domain.yaml)
 
 gcloud config set project $PROJECT_ID
 
-gcloud services enable redis.googleapis.com
+# Create API key for maps and places API
+gcloud alpha services api-keys create \
+  --display-name=maps-api-key \
+  --allowed-referrers=$DOMAIN \
+  --api-target=service=maps_backend \
+  --api-target=service=places_backend
 
-# Create 10G redis cache
-gcloud redis instances create webserver-cache --size=10 --region=$REGION \
-    --redis-version=redis_5_0
+API_KEY_NAME=$(gcloud alpha services api-keys list --filter='displayName=maps-api-key' --format='value(name)')
+export KEY_STRING=$(gcloud alpha services api-keys get-key-string $API_KEY_NAME)
 
-gcloud redis instances describe webserver-cache --region=$REGION
+yq eval -i '.maps_api_key = env(KEY_STRING)' config.yaml

--- a/gke/create_ip.sh
+++ b/gke/create_ip.sh
@@ -22,4 +22,6 @@ gcloud config set project $PROJECT_ID
 gcloud compute addresses create website-ip --global
 
 # Record the IP address.
-echo $(gcloud compute addresses list --global --filter='name:website-ip' --format='value(ADDRESS)')
+export IP=$(gcloud compute addresses list --global --filter='name:website-ip' --format='value(ADDRESS)')
+
+yq eval -i '.ip = env(IP)' config.yaml

--- a/gke/get_storage_permission.sh
+++ b/gke/get_storage_permission.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+PROJECT_ID=$1
+if [[ $PROJECT_ID == "" ]]; then
+  PROJECT_ID=$(yq eval '.project' config.yaml)
+fi
+
+STORE_PROJECT_ID=$2
+if [[ $STORE_PROJECT_ID == "" ]]; then
+  STORE_PROJECT_ID=$(yq eval '.storage_project' config.yaml)
+fi
+
+NAME="website-robot"
+SERVICE_ACCOUNT="$NAME@$PROJECT_ID.iam.gserviceaccount.com"
+
+# Data store project roles
+declare -a roles=(
+    "roles/bigquery.admin"   # BigQuery
+    "roles/bigtable.reader" # Bigtable
+    "roles/storage.objectViewer" # Branch Cache Read
+    "roles/pubsub.editor" # Branch Cache Subscription
+)
+for role in "${roles[@]}"
+do
+  gcloud projects add-iam-policy-binding $STORE_PROJECT_ID \
+    --member serviceAccount:$SERVICE_ACCOUNT \
+    --role $role
+done

--- a/gke/get_storage_permission.sh
+++ b/gke/get_storage_permission.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# Grant service account permission to access Data Commons data storage, including
+# Cloud BigTable and BigQuery.
+
 set -e
 
 PROJECT_ID=$1


### PR DESCRIPTION
Some manual steps and inconsistencies have accumulated since last version.

Clean up and update the doc to reflect the latest steps. This will help for simplify private Data Commons deployment.