### PR TITLE
[tree widget] small fixes/updates

### DIFF
--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -207,7 +207,10 @@ export class StatVarSectionInput extends React.Component<
    * string.
    */
   private getTooltipHtml(hasData: boolean): string {
-    let html = hasData
+    let html = `<b>${
+      this.props.statVar.displayName || this.props.statVar.id
+    }</b></br>`;
+    html += hasData
       ? ""
       : "This statistical variable has no data for any of the chosen places.";
     if (_.isEmpty(this.props.summary)) {


### PR DESCRIPTION
- include stat var name in tooltip
- expand tree for pre-selected stat var for Map [(issue #1036)](https://github.com/datacommonsorg/website/issues/1036)
![screen-recording-_43_](https://user-images.githubusercontent.com/69875368/146810529-8e0dd815-0719-47b4-bf9e-ceb983b493b8.gif)