### PR TITLE
[Place Page] Only process data for the current topic

### DIFF
--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -21,14 +21,7 @@ class Config:
     SCHEME = 'https'
     # Additional stat vars that need to be fetched for place page data.
     # This is only needed for local development when cache is not up to date.
-    NEW_STAT_VARS = [
-        "Mean_Concentration_AirPollutant_Ozone",
-        "Mean_Concentration_AirPollutant_DieselPM",
-        "Annual_Emissions_CarbonDioxide_NonBiogenic",
-        "Annual_Emissions_Methane_NonBiogenic",
-        "Annual_Emissions_NitrousOxide_NonBiogenic",
-        "WithdrawalRate_Water",
-    ]
+    NEW_STAT_VARS = []
     ENABLE_BLOCKLIST = False
     # If the deployment is a private instance
     PRIVATE = False

--- a/server/main.py
+++ b/server/main.py
@@ -221,4 +221,4 @@ if __name__ == '__main__':
     # a webserver process such as Gunicorn will serve the app.
     logging.info("Run web server in local mode")
     port = sys.argv[1] if len(sys.argv) >= 2 else 8080
-    app.run(host='127.0.0.1', port=port)
+    app.run(host='127.0.0.1', port=port, debug=True)

--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -41,11 +41,11 @@ OVERVIEW = 'Overview'
 
 
 def get_landing_page_data(dcid, new_stat_vars):
-    return get_landing_page_data_helpfer(dcid, '^'.join(new_stat_vars))
+    return get_landing_page_data_helper(dcid, '^'.join(new_stat_vars))
 
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def get_landing_page_data_helpfer(dcid, stat_vars_string):
+def get_landing_page_data_helper(dcid, stat_vars_string):
     data = {'place': dcid}
     if stat_vars_string:
         data['newStatVars'] = '^'.split(stat_vars_string)

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -143,10 +143,11 @@ async function getChoroplethData(
  */
 async function getLandingPageData(
   dcid: string,
+  category: string,
   locale: string
 ): Promise<PageData> {
   return axios
-    .get(`/api/landingpage/data/${dcid}?hl=${locale}`)
+    .get(`/api/landingpage/data/${dcid}?category=${category}&hl=${locale}`)
     .then((resp) => {
       return resp.data;
     });
@@ -167,7 +168,7 @@ function renderPage(): void {
   const placeName = document.getElementById("place-name").dataset.pn;
   const placeType = document.getElementById("place-type").dataset.pt;
   const locale = document.getElementById("locale").dataset.lc;
-  const landingPagePromise = getLandingPageData(dcid, locale);
+  const landingPagePromise = getLandingPageData(dcid, category, locale);
   const chartGeoJsonPromise = getGeoJsonData(dcid, placeType, locale);
   const choroplethDataPromise = getChoroplethData(dcid, placeType);
 


### PR DESCRIPTION
The entire cache data is still load once in the web server, however only the data for the current category is processed.

This also removes the previous behavior that merges all the categories into overview when total number of charts is too small.

Some other updates:

- Removes the new stat vars for place page as they are already in cache.