### PR TITLE
[scatter] Add date param

### DIFF
--- a/server/webdriver_tests/scatter_test.py
+++ b/server/webdriver_tests/scatter_test.py
@@ -75,8 +75,8 @@ class TestScatter(WebdriverBaseTest):
         chart_title_x = self.driver.find_element_by_xpath(
             '//*[@id="no-padding"]/div[1]/h3[2]')
         self.assertEqual(chart_title_y.text,
-                         "Asian Alone Population Per Capita")
-        self.assertEqual(chart_title_x.text, "Median Income")
+                         "Asian Alone Population Per Capita (2020)")
+        self.assertEqual(chart_title_x.text, "Median Income (2019)")
         chart = self.driver.find_element_by_xpath('//*[@id="scatterplot"]')
         circles = chart.find_elements_by_tag_name('circle')
         self.assertGreater(len(circles), 20)
@@ -149,8 +149,8 @@ class TestScatter(WebdriverBaseTest):
             '//*[@id="no-padding"]/div[1]/h3[1]')
         chart_title_x = self.driver.find_element_by_xpath(
             '//*[@id="no-padding"]/div[1]/h3[2]')
-        self.assertEqual(chart_title_y.text, "Median Income")
-        self.assertEqual(chart_title_x.text, "Median Age")
+        self.assertEqual(chart_title_y.text, "Median Income (2019)")
+        self.assertEqual(chart_title_x.text, "Median Age (2019)")
         chart = self.driver.find_element_by_xpath('//*[@id="scatterplot"]')
         circles = chart.find_elements_by_tag_name('circle')
         self.assertGreater(len(circles), 20)

--- a/static/css/tools/scatter.scss
+++ b/static/css/tools/scatter.scss
@@ -326,10 +326,6 @@ circle {
   margin-bottom: 0.5rem;
 }
 
-.subtitle h3 {
-  color: var(--gray);
-  padding: 0px 2px;
-}
 .scatter-chart-container {
   position: relative;
 }

--- a/static/css/tools/scatter.scss
+++ b/static/css/tools/scatter.scss
@@ -326,6 +326,10 @@ circle {
   margin-bottom: 0.5rem;
 }
 
+.subtitle h3 {
+  color: var(--gray);
+  padding: 0px 2px;
+}
 .scatter-chart-container {
   position: relative;
 }

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -51,7 +51,8 @@ interface ChartPropsType {
   yUnits?: string;
   placeInfo: PlaceInfo;
   display: DisplayOptionsWrapper;
-  date: string;
+  xDate: string;
+  yDate: string;
 }
 
 const DOT_REDIRECT_PREFIX = "/place/";
@@ -201,12 +202,15 @@ function Chart(props: ChartPropsType): JSX.Element {
       <Row>
         <Card id="no-padding">
           <div className="chart-title">
-            <h3>{props.yLabel}</h3>
+            <h3>
+              {props.yLabel}
+              {props.yDate && ` (${props.yDate})`}
+            </h3>
             <span>vs</span>
-            <h3>{props.xLabel}</h3>
-            <span className="subtitle">
-              {props.date && <h3>({props.date})</h3>}
-            </span>
+            <h3>
+              {props.xLabel}
+              {props.xDate && ` (${props.xDate})`}
+            </h3>
           </div>
           <div className="scatter-chart-container">
             <div id={SVG_CONTAINER_ID} ref={svgContainerRef}></div>

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -51,6 +51,7 @@ interface ChartPropsType {
   yUnits?: string;
   placeInfo: PlaceInfo;
   display: DisplayOptionsWrapper;
+  date: string;
 }
 
 const DOT_REDIRECT_PREFIX = "/place/";
@@ -203,6 +204,9 @@ function Chart(props: ChartPropsType): JSX.Element {
             <h3>{props.yLabel}</h3>
             <span>vs</span>
             <h3>{props.xLabel}</h3>
+            <span className="subtitle">
+              {props.date && <h3>({props.date})</h3>}
+            </span>
           </div>
           <div className="scatter-chart-container">
             <div id={SVG_CONTAINER_ID} ref={svgContainerRef}></div>

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -51,8 +51,6 @@ interface ChartPropsType {
   yUnits?: string;
   placeInfo: PlaceInfo;
   display: DisplayOptionsWrapper;
-  xDate: string;
-  yDate: string;
 }
 
 const DOT_REDIRECT_PREFIX = "/place/";
@@ -112,12 +110,16 @@ function Chart(props: ChartPropsType): JSX.Element {
   const svgContainerRef = useRef<HTMLDivElement>();
   const tooltipRef = useRef<HTMLDivElement>();
   const chartContainerRef = useRef<HTMLDivElement>();
-  const sources: Set<string> = new Set();
   const [geoJson, setGeoJson] = useState(null);
   const [geoJsonFetched, setGeoJsonFetched] = useState(false);
+  const sources: Set<string> = new Set();
+  const xDates: Set<string> = new Set();
+  const yDates: Set<string> = new Set();
   Object.values(props.points).forEach((point) => {
     sources.add(point.xSource);
     sources.add(point.ySource);
+    xDates.add(point.xDate);
+    yDates.add(point.yDate);
     if (props.xPerCapita && point.xPopSource) {
       sources.add(point.xPopSource);
     }
@@ -125,21 +127,9 @@ function Chart(props: ChartPropsType): JSX.Element {
       sources.add(point.yPopSource);
     }
   });
-  const sourceList: string[] = Array.from(sources);
-  const seenSourceDomains = new Set();
-  const sourcesJsx = sourceList.map((source, index) => {
-    const domain = urlToDomain(source);
-    if (seenSourceDomains.has(domain)) {
-      return null;
-    }
-    seenSourceDomains.add(domain);
-    return (
-      <span key={source}>
-        {index > 0 ? ", " : ""}
-        <a href={source}>{domain}</a>
-      </span>
-    );
-  });
+  const sourcesJsx = getSourcesJsx(sources);
+  const xTitle = getTitle(Array.from(xDates), props.xLabel);
+  const yTitle = getTitle(Array.from(yDates), props.yLabel);
   // Tooltip needs to start off hidden
   d3.select(tooltipRef.current)
     .style("visibility", "hidden")
@@ -202,15 +192,9 @@ function Chart(props: ChartPropsType): JSX.Element {
       <Row>
         <Card id="no-padding">
           <div className="chart-title">
-            <h3>
-              {props.yLabel}
-              {props.yDate && ` (${props.yDate})`}
-            </h3>
+            <h3>{yTitle}</h3>
             <span>vs</span>
-            <h3>
-              {props.xLabel}
-              {props.xDate && ` (${props.xDate})`}
-            </h3>
+            <h3>{xTitle}</h3>
           </div>
           <div className="scatter-chart-container">
             <div id={SVG_CONTAINER_ID} ref={svgContainerRef}></div>
@@ -581,6 +565,33 @@ function drawMapLegend(
 function redirectAction(placeDcid: string): void {
   const uri = `${DOT_REDIRECT_PREFIX}${placeDcid}`;
   window.open(uri);
+}
+
+function getTitle(dates: string[], statVarLabel: string) {
+  const minDate = _.min(dates);
+  const maxDate = _.max(dates);
+  const dateRange =
+    minDate === maxDate ? `(${minDate})` : `(${minDate} to ${maxDate})`;
+  return `${statVarLabel} ${dateRange}`;
+}
+
+function getSourcesJsx(sources: Set<string>): JSX.Element[] {
+  const sourceList: string[] = Array.from(sources);
+  const seenSourceDomains = new Set();
+  const sourcesJsx = sourceList.map((source, index) => {
+    const domain = urlToDomain(source);
+    if (seenSourceDomains.has(domain)) {
+      return null;
+    }
+    seenSourceDomains.add(domain);
+    return (
+      <span key={source}>
+        {index > 0 ? ", " : ""}
+        <a href={source}>{domain}</a>
+      </span>
+    );
+  });
+  return sourcesJsx;
 }
 
 const getMapTooltipHtml = (

--- a/static/js/tools/scatter/chart_loader.tsx
+++ b/static/js/tools/scatter/chart_loader.tsx
@@ -127,8 +127,6 @@ function ChartLoader(): JSX.Element {
                 yUnits={yUnits}
                 placeInfo={place.value}
                 display={display}
-                xDate={cache.xDate}
-                yDate={cache.yDate}
               />
               <PlotOptions points={points} />
             </>

--- a/static/js/tools/scatter/context.ts
+++ b/static/js/tools/scatter/context.ts
@@ -111,28 +111,6 @@ interface DisplayOptionsWrapper {
   setRegression: Setter<boolean>;
 }
 
-interface DateInfo {
-  year: number;
-  month: number;
-  day: number;
-}
-
-interface DateInfoWrapper {
-  value: DateInfo;
-
-  // Setters
-  set: Setter<DateInfo>;
-  setYear: Setter<number>;
-  setMonth: Setter<number>;
-  setDay: Setter<number>;
-}
-
-const EmptyDate: DateInfo = Object.freeze({
-  year: 0,
-  month: 0,
-  day: 0,
-});
-
 interface IsLoadingWrapper {
   // Whether child places and their names are being retrieved
   arePlacesLoading: boolean;
@@ -147,6 +125,13 @@ interface IsLoadingWrapper {
   setAreDataLoading: Setter<boolean>;
 }
 
+interface DateWrapper {
+  value: string;
+
+  // Setter
+  set: Setter<string>;
+}
+
 // Global app state
 interface ContextType {
   // X axis
@@ -157,6 +142,8 @@ interface ContextType {
   place: PlaceInfoWrapper;
   // Plot display options
   display: DisplayOptionsWrapper;
+  // Date of the data to plot
+  date: DateWrapper;
   // Whether there are currently active network tasks
   isLoading: IsLoadingWrapper;
 }
@@ -182,6 +169,9 @@ const FieldToAbbreviation = {
   chartType: "ct",
   showDensity: "dd",
   showRegression: "rg",
+
+  // Date fields
+  date: "date",
 };
 
 /**
@@ -199,6 +189,7 @@ function useContextStore(): ContextType {
   const [areDataLoading, setAreDataLoading] = useState(false);
   const [chartType, setChartType] = useState(ScatterChartType.SCATTER);
   const [showRegression, setRegression] = useState(false);
+  const [date, setDate] = useState("");
   return {
     x: {
       value: x,
@@ -239,6 +230,10 @@ function useContextStore(): ContextType {
       setDensity: (showDensity) => setDensity(showDensity),
       showRegression: showRegression,
       setRegression: (showRegression) => setRegression(showRegression),
+    },
+    date: {
+      value: date,
+      set: (date) => setDate(date),
     },
     isLoading: {
       arePlacesLoading: arePlacesLoading,
@@ -401,11 +396,8 @@ export {
   AxisWrapper,
   Context,
   ContextType,
-  DateInfo,
-  DateInfoWrapper,
   DisplayOptionsWrapper,
   EmptyAxis,
-  EmptyDate,
   EmptyPlace,
   FieldToAbbreviation,
   IsLoadingWrapper,

--- a/static/js/tools/scatter/context.ts
+++ b/static/js/tools/scatter/context.ts
@@ -35,6 +35,8 @@ interface Axis {
   log: boolean;
   // Whether to plot per capita values
   perCapita: boolean;
+  // The date of the StatVar data to plot for this axis
+  date: string;
 }
 
 const EmptyAxis: Axis = Object.freeze({
@@ -42,6 +44,7 @@ const EmptyAxis: Axis = Object.freeze({
   statVarDcid: "",
   log: false,
   perCapita: false,
+  date: "",
 });
 
 interface AxisWrapper {
@@ -54,6 +57,7 @@ interface AxisWrapper {
   setStatVarInfo: Setter<StatVarInfo>;
   setLog: Setter<boolean>;
   setPerCapita: Setter<boolean>;
+  setDate: Setter<string>;
 }
 
 interface PlaceInfo {
@@ -125,13 +129,6 @@ interface IsLoadingWrapper {
   setAreDataLoading: Setter<boolean>;
 }
 
-interface DateWrapper {
-  value: string;
-
-  // Setter
-  set: Setter<string>;
-}
-
 // Global app state
 interface ContextType {
   // X axis
@@ -142,8 +139,6 @@ interface ContextType {
   place: PlaceInfoWrapper;
   // Plot display options
   display: DisplayOptionsWrapper;
-  // Date of the data to plot
-  date: DateWrapper;
   // Whether there are currently active network tasks
   isLoading: IsLoadingWrapper;
 }
@@ -156,6 +151,7 @@ const FieldToAbbreviation = {
   statVarDcid: "sv",
   log: "l",
   perCapita: "pc",
+  date: "date",
 
   // PlaceInfo fields
   enclosingPlaceDcid: "epd",
@@ -169,9 +165,6 @@ const FieldToAbbreviation = {
   chartType: "ct",
   showDensity: "dd",
   showRegression: "rg",
-
-  // Date fields
-  date: "date",
 };
 
 /**
@@ -189,7 +182,6 @@ function useContextStore(): ContextType {
   const [areDataLoading, setAreDataLoading] = useState(false);
   const [chartType, setChartType] = useState(ScatterChartType.SCATTER);
   const [showRegression, setRegression] = useState(false);
-  const [date, setDate] = useState("");
   return {
     x: {
       value: x,
@@ -199,6 +191,7 @@ function useContextStore(): ContextType {
       setStatVarInfo: getSetStatVarInfo(x, setX),
       setLog: getSetLog(x, setX),
       setPerCapita: getSetPerCapita(x, setX),
+      setDate: getSetDate(x, setX),
     },
     y: {
       value: y,
@@ -208,6 +201,7 @@ function useContextStore(): ContextType {
       setStatVarInfo: getSetStatVarInfo(y, setY),
       setLog: getSetLog(y, setY),
       setPerCapita: getSetPerCapita(y, setY),
+      setDate: getSetDate(y, setY),
     },
     place: {
       value: place,
@@ -230,10 +224,6 @@ function useContextStore(): ContextType {
       setDensity: (showDensity) => setDensity(showDensity),
       showRegression: showRegression,
       setRegression: (showRegression) => setRegression(showRegression),
-    },
-    date: {
-      value: date,
-      set: (date) => setDate(date),
     },
     isLoading: {
       arePlacesLoading: arePlacesLoading,
@@ -365,6 +355,18 @@ function getSetPerCapita(
     setAxis({
       ...axis,
       perCapita: perCapita,
+    });
+  };
+}
+
+function getSetDate(
+  axis: Axis,
+  setAxis: React.Dispatch<React.SetStateAction<Axis>>
+): Setter<string> {
+  return (date) => {
+    setAxis({
+      ...axis,
+      date,
     });
   };
 }

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -298,7 +298,7 @@ function addStatVarHelper(
       statVarDcid: svDcid,
       log: x.value.log,
       perCapita: x.value.perCapita,
-      date: x.value.date
+      date: x.value.date,
     });
   } else if (_.isEmpty(y.value.statVarDcid)) {
     y.set({
@@ -306,7 +306,7 @@ function addStatVarHelper(
       statVarDcid: svDcid,
       log: y.value.log,
       perCapita: y.value.perCapita,
-      date: y.value.date
+      date: y.value.date,
     });
   } else {
     setThirdStatVar({ info: svInfo, dcid: svDcid });

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -298,6 +298,7 @@ function addStatVarHelper(
       statVarDcid: svDcid,
       log: x.value.log,
       perCapita: x.value.perCapita,
+      date: x.value.date
     });
   } else if (_.isEmpty(y.value.statVarDcid)) {
     y.set({
@@ -305,6 +306,7 @@ function addStatVarHelper(
       statVarDcid: svDcid,
       log: y.value.log,
       perCapita: y.value.perCapita,
+      date: y.value.date
     });
   } else {
     setThirdStatVar({ info: svInfo, dcid: svDcid });

--- a/static/js/tools/scatter/util.test.ts
+++ b/static/js/tools/scatter/util.test.ts
@@ -64,6 +64,9 @@ const TestContext = ({
     chartType: ScatterChartType.SCATTER,
     showRegression: true,
   },
+  date: {
+    value: "",
+  },
 } as unknown) as ContextType;
 const Hash =
   "#%26svx%3DCount_Person%26lx%3D1%26svy%3DCount_HousingUnit%26pcy%3D1%26epd%3DgeoId%2F10%26ept%3DCounty%26ub%3D99999%26qd%3D1%26ld%3D1%26dd%3D1%26rg%3D1";
@@ -79,7 +82,13 @@ test("updateHash", () => {
 });
 
 test("applyHash", () => {
-  const context = { x: {}, y: {}, place: {}, display: {} } as ContextType;
+  const context = {
+    x: {},
+    y: {},
+    place: {},
+    display: {},
+    date: {},
+  } as ContextType;
   context.x.set = (value) => (context.x.value = value);
   context.y.set = (value) => (context.y.value = value);
   context.place.set = (value) => (context.place.value = value);
@@ -90,6 +99,7 @@ test("applyHash", () => {
   context.display.setDensity = (value) => (context.display.showDensity = value);
   context.display.setRegression = (value) =>
     (context.display.showRegression = value);
+  context.date.set = (value) => (context.date.value = value);
   location.hash = Hash;
   applyHash(context);
   expect(context.x.value).toEqual(TestContext.x.value);

--- a/static/js/tools/scatter/util.test.ts
+++ b/static/js/tools/scatter/util.test.ts
@@ -24,6 +24,7 @@ const TestContext = ({
       statVarInfo: null,
       log: true,
       perCapita: false,
+      date: "",
     },
   },
   y: {
@@ -32,6 +33,7 @@ const TestContext = ({
       statVarInfo: null,
       log: false,
       perCapita: true,
+      date: "",
     },
   },
   place: {
@@ -64,9 +66,6 @@ const TestContext = ({
     chartType: ScatterChartType.SCATTER,
     showRegression: true,
   },
-  date: {
-    value: "",
-  },
 } as unknown) as ContextType;
 const Hash =
   "#%26svx%3DCount_Person%26lx%3D1%26svy%3DCount_HousingUnit%26pcy%3D1%26epd%3DgeoId%2F10%26ept%3DCounty%26ub%3D99999%26qd%3D1%26ld%3D1%26dd%3D1%26rg%3D1";
@@ -82,13 +81,7 @@ test("updateHash", () => {
 });
 
 test("applyHash", () => {
-  const context = {
-    x: {},
-    y: {},
-    place: {},
-    display: {},
-    date: {},
-  } as ContextType;
+  const context = { x: {}, y: {}, place: {}, display: {} } as ContextType;
   context.x.set = (value) => (context.x.value = value);
   context.y.set = (value) => (context.y.value = value);
   context.place.set = (value) => (context.place.value = value);
@@ -99,7 +92,6 @@ test("applyHash", () => {
   context.display.setDensity = (value) => (context.display.showDensity = value);
   context.display.setRegression = (value) =>
     (context.display.showRegression = value);
-  context.date.set = (value) => (context.date.value = value);
   location.hash = Hash;
   applyHash(context);
   expect(context.x.value).toEqual(TestContext.x.value);


### PR DESCRIPTION
- Add date url param to control the date for the data for each axis in the plot. (param keys are "datex" and "datey")
- If date is specified, include it in the title

Notes
- not sure if including the dates in the title is useful or confusing (would love some thoughts)
    - Could be useful to quickly see that all the data will be from this specific date. Otherwise, will need to hover over the points on the graph to see the date of the data in the tooltip.
    - Could be confusing if sometimes there is a date in the title and sometimes there isn't

<img width="1678" alt="Screen Shot 2022-01-06 at 2 05 28 PM" src="https://user-images.githubusercontent.com/69875368/148458802-433d5de8-6a3d-44ec-9951-bc36f0c6a738.png">

