### PR TITLE
Add Block componenet and get topic page working end to end

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -23,6 +23,7 @@ from flask import Flask, request, g
 from flask_babel import Babel
 from google.cloud import storage
 from google.protobuf import text_format
+from google.protobuf.json_format import MessageToJson
 
 from google.cloud import secretmanager
 from opencensus.ext.flask.flask_middleware import FlaskMiddleware
@@ -91,7 +92,7 @@ def load_topic_page_config():
     with open('topic_page_config.textproto', 'r') as f:
         data = f.read()
     text_format.Parse(data, topic_page_config)
-    return topic_page_config
+    return MessageToJson(topic_page_config)
 
 
 def create_app():

--- a/server/main.py
+++ b/server/main.py
@@ -40,8 +40,9 @@ app.jinja_env.globals['GA_ACCOUNT'] = app.config['GA_ACCOUNT']
 app.jinja_env.globals['FEEDING_AMERICA'] = app.config['FEEDING_AMERICA']
 app.jinja_env.globals['SUSTAINABILITY'] = app.config['SUSTAINABILITY']
 app.jinja_env.globals['NAME'] = app.config['NAME']
-app.jinja_env.globals['BASE_HTML'] = 'sustainability/base.html' if app.config[
-    'SUSTAINABILITY'] else 'base.html'
+app.jinja_env.globals['TOPIC_PAGE_CONFIG'] = app.config['TOPIC_PAGE_CONFIG']
+app.jinja_env.globals['BASE_HTML'] = (
+    'sustainability/base.html' if app.config['SUSTAINABILITY'] else 'base.html')
 
 GCS_BUCKET = app.config['GCS_BUCKET']
 _MAX_SEARCH_RESULTS = 1000

--- a/server/templates/topic_page.html
+++ b/server/templates/topic_page.html
@@ -36,7 +36,7 @@
           <h3 id="locale" data-lc="{{ locale }}"></h3>
         </div>
       </div>
-      <div id="main-pane" class="row"></div>
+      <div id="main-pane" class="row" data-config="{{ TOPIC_PAGE_CONFIG }}"></div>
     </div>
   </div>
 </div>

--- a/static/js/topic_page/block.tsx
+++ b/static/js/topic_page/block.tsx
@@ -32,6 +32,7 @@ export interface BlockPropType {
   placeDcid: string;
   enclosedPlaceType: string;
   title: string;
+  description: string;
   leftTiles: Tile[];
   rightTiles: Tile[];
   statVarMetadata: StatVarMetadata;

--- a/static/js/topic_page/block.tsx
+++ b/static/js/topic_page/block.tsx
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Component for rendering a block.
+ */
+
+import React from "react";
+
+import { randDomId } from "../shared/util";
+import { StatVarMetadata } from "../types/stat_var";
+import { LineTile } from "./line_tile";
+import { MapTile } from "./map_tile";
+import { RankingTile } from "./ranking_tile";
+import { Tile } from "./tile";
+
+export interface BlockPropType {
+  id: string;
+  placeDcid: string;
+  enclosedPlaceType: string;
+  title: string;
+  leftTiles: Tile[];
+  rightTiles: Tile[];
+  statVarMetadata: StatVarMetadata;
+}
+
+export function Block(props: BlockPropType): JSX.Element {
+  return (
+    <div className="block">
+      <span className="block-title">{props.title}</span>
+      <div className="block-body">
+        <div className="left-tiles">{renderTiles(props.leftTiles, props)}</div>
+        <div className="right-tiles">
+          {renderTiles(props.rightTiles, props)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
+  const tilesJsx = tiles.map((tile) => {
+    const id = randDomId();
+    switch (tile.type) {
+      case "MAP":
+        return (
+          <MapTile
+            key={id}
+            id={id}
+            title={tile.title}
+            placeDcid={props.placeDcid}
+            enclosedPlaceType={props.enclosedPlaceType}
+            isUsaPlace={true}
+            statVarMetadata={props.statVarMetadata}
+          />
+        );
+      case "LINE":
+        return (
+          <LineTile
+            key={id}
+            id={id}
+            title={tile.title}
+            placeDcid={props.placeDcid}
+            statVarMetadata={props.statVarMetadata}
+          />
+        );
+      case "RANKING":
+        return (
+          <RankingTile
+            key={id}
+            id={id}
+            title={tile.title}
+            statVarMetadata={props.statVarMetadata}
+          />
+        );
+      default:
+        console.log("Tile type not supported:" + tile.type);
+    }
+  });
+  return <>{tilesJsx}</>;
+}

--- a/static/js/topic_page/line_tile.tsx
+++ b/static/js/topic_page/line_tile.tsx
@@ -20,7 +20,7 @@
 
 import axios from "axios";
 import _ from "lodash";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { DataGroup, DataPoint, expandDataPoints } from "../chart/base";
 import { drawLineChart } from "../chart/draw";
@@ -28,8 +28,6 @@ import { StatApiResponse } from "../shared/stat_types";
 import { getStatsVarLabel } from "../shared/stats_var_labels";
 import { StatVarMetadata } from "../types/stat_var";
 import { CHART_HEIGHT } from "./constants";
-
-const SVG_CONTAINER_ELEMENT: React.RefObject<HTMLDivElement> = React.createRef();
 
 interface LineTilePropType {
   id: string;
@@ -39,6 +37,7 @@ interface LineTilePropType {
 }
 
 export function LineTile(props: LineTilePropType): JSX.Element {
+  const svgContainer = useRef(null);
   const [rawData, setRawData] = useState<StatApiResponse | undefined>(null);
   const [chartData, setChartData] = useState<DataGroup[] | undefined>(null);
 
@@ -54,7 +53,7 @@ export function LineTile(props: LineTilePropType): JSX.Element {
 
   useEffect(() => {
     if (chartData) {
-      draw(props, chartData);
+      draw(props, chartData, svgContainer);
     }
   }, [props, chartData]);
 
@@ -65,11 +64,7 @@ export function LineTile(props: LineTilePropType): JSX.Element {
           <div className="line-title">
             <h4>{props.title}</h4>
           </div>
-          <div
-            id={props.id}
-            className="svg-container"
-            ref={SVG_CONTAINER_ELEMENT}
-          ></div>
+          <div id={props.id} className="svg-container" ref={svgContainer}></div>
         </>
       )}
     </div>
@@ -111,7 +106,11 @@ function processData(
   setChartData(trendData);
 }
 
-function draw(props: LineTilePropType, chartData: DataGroup[]): void {
+function draw(
+  props: LineTilePropType,
+  chartData: DataGroup[],
+  svgContainer: React.RefObject<HTMLElement>
+): void {
   const elem = document.getElementById(props.id);
   // TODO: Remove all cases of setting innerHTML directly.
   elem.innerHTML = "";
@@ -125,9 +124,8 @@ function draw(props: LineTilePropType, chartData: DataGroup[]): void {
     props.statVarMetadata.unit
   );
   if (!isCompleteLine) {
-    SVG_CONTAINER_ELEMENT.current.querySelectorAll(
-      ".dotted-warning"
-    )[0].className += " d-inline";
+    svgContainer.current.querySelectorAll(".dotted-warning")[0].className +=
+      " d-inline";
   }
 }
 

--- a/static/js/topic_page/main_pane.tsx
+++ b/static/js/topic_page/main_pane.tsx
@@ -62,6 +62,7 @@ export function MainPane(props: MainPanePropType): JSX.Element {
             placeDcid={props.dcid}
             enclosedPlaceType={"State"}
             title={block.title}
+            description={block.description}
             leftTiles={block.leftTiles}
             rightTiles={block.rightTiles}
             statVarMetadata={block.statVarMetadata}

--- a/static/js/topic_page/main_pane.tsx
+++ b/static/js/topic_page/main_pane.tsx
@@ -15,9 +15,13 @@
  */
 import React from "react";
 
-import { StatVarMetadata } from "../types/stat_var";
-import { LineTile } from "./line_tile";
-import { MapTile } from "./map_tile";
+import { randDomId } from "../shared/util";
+import { Block, BlockPropType } from "./block";
+
+export interface PageConfig {
+  overviewBlock: BlockPropType;
+  blocks: BlockPropType[];
+}
 
 interface MainPanePropType {
   /**
@@ -36,74 +40,34 @@ interface MainPanePropType {
    * The topic of the current page.
    */
   topic: string;
+  /**
+   * Config of the page
+   */
+  pageConfig: PageConfig;
 }
 
-class MainPane extends React.Component<MainPanePropType> {
-  constructor(props: MainPanePropType) {
-    super(props);
-  }
-  render(): JSX.Element {
-    const lineId = "line-1";
-    const lineTitle = "line-title";
-    const mapId = "map-1";
-    const mapTitle = "map-title";
-    const statVarMetadata: StatVarMetadata = {
-      statVars: [
-        {
-          main:
-            "Count_Person_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone",
-          denom: "Count_Person_AmericanIndianOrAlaskaNativeAlone",
-        },
-        {
-          main: "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone",
-          denom: "Count_Person_AsianAlone",
-        },
-        {
-          main:
-            "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone",
-          denom: "Count_Person_BlackOrAfricanAmericanAlone",
-        },
-        {
-          main:
-            "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
-          denom: "Count_Person_HispanicOrLatino",
-        },
-        {
-          main:
-            "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
-          denom: "Count_Person_NativeHawaiianOrOtherPacificIslanderAlone",
-        },
-        {
-          main: "Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone",
-          denom: "Count_Person_WhiteAlone",
-        },
-      ],
-      unit: "%",
-      scaling: 100,
-    };
-    return (
-      <>
-        <div>{this.props.dcid}</div>
-        <div>{this.props.placeName}</div>
-        <div>{this.props.placeType}</div>
-        <div>{this.props.topic}</div>
-        <LineTile
-          id={lineId}
-          title={lineTitle}
-          placeDcid={this.props.dcid}
-          statVarMetadata={statVarMetadata}
-        />
-        <MapTile
-          id={mapId}
-          title={mapTitle}
-          placeDcid={this.props.dcid}
-          enclosedPlaceType={"State"}
-          isUsaPlace={true}
-          statVarMetadata={statVarMetadata}
-        />
-      </>
-    );
-  }
+export function MainPane(props: MainPanePropType): JSX.Element {
+  return (
+    <>
+      <div>{props.dcid}</div>
+      <div>{props.placeName}</div>
+      <div>{props.placeType}</div>
+      <div>{props.topic}</div>
+      {props.pageConfig.blocks.map((block) => {
+        const id = randDomId();
+        return (
+          <Block
+            key={id}
+            id={id}
+            placeDcid={props.dcid}
+            enclosedPlaceType={"State"}
+            title={block.title}
+            leftTiles={block.leftTiles}
+            rightTiles={block.rightTiles}
+            statVarMetadata={block.statVarMetadata}
+          />
+        );
+      })}
+    </>
+  );
 }
-
-export { MainPane };

--- a/static/js/topic_page/map_tile.tsx
+++ b/static/js/topic_page/map_tile.tsx
@@ -20,7 +20,7 @@
 
 import axios from "axios";
 import _ from "lodash";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { drawChoropleth, getColorScale } from "../chart/draw_choropleth";
 import { GeoJsonData } from "../chart/types";
@@ -40,8 +40,6 @@ import {
 } from "../tools/shared_util";
 import { StatVarMetadata } from "../types/stat_var";
 import { CHART_HEIGHT } from "./constants";
-
-const SVG_CONTAINER_ELEMENT: React.RefObject<HTMLDivElement> = React.createRef();
 
 interface MapTilePropType {
   id: string;
@@ -68,6 +66,7 @@ interface ChartData {
 }
 
 export function MapTile(props: MapTilePropType): JSX.Element {
+  const svgContainer = useRef(null);
   const [rawData, setRawData] = useState<RawData | undefined>(null);
   const [chartData, setChartData] = useState<ChartData | undefined>(null);
   const sourcesJsx = chartData ? getSourcesJsx(chartData.sources) : [];
@@ -100,7 +99,7 @@ export function MapTile(props: MapTilePropType): JSX.Element {
 
   useEffect(() => {
     if (chartData) {
-      draw(chartData, props);
+      draw(chartData, props, svgContainer);
     }
   }, [chartData, props]);
 
@@ -111,11 +110,7 @@ export function MapTile(props: MapTilePropType): JSX.Element {
           <div className="map-title">
             <h4>{chartData.chartTitle}</h4>
           </div>
-          <div
-            id={props.id}
-            className="svg-container"
-            ref={SVG_CONTAINER_ELEMENT}
-          ></div>
+          <div id={props.id} className="svg-container" ref={svgContainer}></div>
           <div className="map-footer">
             <div className="sources">Data from {sourcesJsx}</div>
           </div>
@@ -211,9 +206,13 @@ function processData(
   });
 }
 
-function draw(chartData: ChartData, props: MapTilePropType): void {
+function draw(
+  chartData: ChartData,
+  props: MapTilePropType,
+  svgContainer: React.RefObject<HTMLElement>
+): void {
   const mainStatVar = props.statVarMetadata.statVars[0].main;
-  const width = SVG_CONTAINER_ELEMENT.current.offsetWidth;
+  const width = svgContainer.current.offsetWidth;
   const colorScale = getColorScale(mainStatVar, chartData.dataValues);
   const getTooltipHtml = (place: NamedPlace) => {
     let value = "Data Missing";

--- a/static/js/topic_page/tile.tsx
+++ b/static/js/topic_page/tile.tsx
@@ -13,46 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "./base";
-@import "./draw";
-@import "./draw_choropleth";
 
-.chart-container h4 {
-  color: var(--dc-gray);
-  font-weight: 600;
-  font-size: 1rem;
+import { StatVarMetadata } from "../types/stat_var";
+
+interface RankingMetadata {
+  showHighlight: boolean;
+  showLowlight: boolean;
+  showIncrease: boolean;
+  showDecrease: boolean;
+  diffBaseDate: string;
 }
 
-#main-pane {
-  flex-direction: column;
+interface HighlightMetadata {
+  description: string;
 }
 
-.chart-container {
-  padding: 10px;
-  display: flex;
-  flex-grow: 1;
-  flex-direction: column;
-  position: relative;
-  width: 100%;
-}
-
-.svg-container {
-  flex: 1 1 auto;
-  width: 100%;
-}
-
-.map-title {
-  display: flex;
-  justify-content: center;
-  position: relative;
-}
-
-.block-body {
-  display: flex;
-}
-
-.left-tiles,
-.right-tiles {
-  display: flex;
-  flex-direction: column;
+export interface Tile {
+  title: string;
+  description: string;
+  type: string;
+  statVarOverride?: StatVarMetadata;
+  rankingMetadata?: RankingMetadata;
+  highlightMetadata?: HighlightMetadata;
 }

--- a/static/js/topic_page/topic_page.ts
+++ b/static/js/topic_page/topic_page.ts
@@ -30,6 +30,9 @@ function renderPage(): void {
   const dcid = document.getElementById("title").dataset.dcid;
   const placeName = document.getElementById("place-name").dataset.pn;
   const placeType = document.getElementById("place-type").dataset.pt;
+  const pageConfig = JSON.parse(
+    document.getElementById("main-pane").dataset.config
+  );
 
   ReactDOM.render(
     React.createElement(MainPane, {
@@ -37,6 +40,7 @@ function renderPage(): void {
       dcid,
       placeName,
       placeType,
+      pageConfig,
     }),
     document.getElementById("main-pane")
   );


### PR DESCRIPTION
Page config is stored in initial page load as an html data field. Then each block (tile) renders async with their own data fetching.

Things to add later:
- real css
- ranking tile
- bar tile
- better config for place type, child place type and similar place type; place based stat vars..