### PR TITLE
[place] use topic ordering from config, display topics on place pages

### DIFF
--- a/server/webdriver_tests/place_explorer_i18n_test.py
+++ b/server/webdriver_tests/place_explorer_i18n_test.py
@@ -92,7 +92,7 @@ class TestPlaceI18nExplorer(WebdriverBaseTest):
         # Find and click on the Demographics URL.
         demographics = self.driver.find_element_by_xpath(
             '//*[@id="Demographics"]/a')
-        self.assertEqual(demographics.text, 'DONNÉES DÉMOGRAPHIQUES')
+        self.assertEqual(demographics.text, 'Données démographiques')
         demographics.click()
 
         # Wait until the new page has loaded.

--- a/static/css/place/place.scss
+++ b/static/css/place/place.scss
@@ -89,16 +89,23 @@ h3 {
 }
 
 #menu .nav-item .nav-item a {
-  font-weight: 300;
   padding: 0.25rem 0 0.25rem 0.5rem;
   font-size: 0.8rem;
+}
+
+#menu .nav-item .nav-item a.topic {
+  font-weight: 600;
+}
+
+#menu .nav-item .nav-item a {
+  font-weight: 300;
 }
 
 #menu a.active {
   color: var(--link-color);
 }
 
-#main h2 {
+#main h2.category {
   color: var(--dc-gray);
   font-weight: 600;
   font-size: 1.1rem;
@@ -319,4 +326,12 @@ h3 {
   font-style: italic;
   text-align: right;
   text-decoration: none !important;
+}
+
+.block.topic-header {
+  margin-bottom: -1rem;
+}
+
+.block h3 {
+  color: inherit;
 }

--- a/static/css/shared/story_block.scss
+++ b/static/css/shared/story_block.scss
@@ -17,7 +17,7 @@
 $subtopic-background: rgba(0, 0, 0, 0.05);
 $subtopic-color: #222;
 
-.block h3 {
+.block h2 {
   color: $subtopic-color;
   font-weight: 600;
   font-size: 1rem;

--- a/static/js/place/main_pane.tsx
+++ b/static/js/place/main_pane.tsx
@@ -150,7 +150,9 @@ class MainPane extends React.Component<MainPanePropType> {
             // UI.
             return [
               <section className="block topic-header col-12" key={topic}>
-                <h2 key={topic} id={topic} className="topic">{topic}</h2>
+                <h2 key={topic} id={topic} className="topic">
+                  {topic}
+                </h2>
               </section>,
               categoryData[topic].map((data: ChartBlockData, index) => {
                 return (

--- a/static/js/place/main_pane.tsx
+++ b/static/js/place/main_pane.tsx
@@ -149,11 +149,13 @@ class MainPane extends React.Component<MainPanePropType> {
             // The topic is only used for grouping, which is not displayed on
             // UI.
             return [
-              <section className="block topic-header col-12" key={topic}>
-                <h2 key={topic} id={topic} className="topic">
-                  {topic}
-                </h2>
-              </section>,
+              topic && (
+                <section className="block topic-header col-12" key={topic}>
+                  <h2 key={topic} id={topic} className="topic">
+                    {topic}
+                  </h2>
+                </section>
+              ),
               categoryData[topic].map((data: ChartBlockData, index) => {
                 return (
                   <section className="block col-12" key={index + data.title}>

--- a/static/js/place/main_pane.tsx
+++ b/static/js/place/main_pane.tsx
@@ -122,9 +122,6 @@ class MainPane extends React.Component<MainPanePropType> {
     const categoryData = this.props.pageChart[this.props.category];
     const isOverview = this.props.category === "Overview";
     const topics = Object.keys(categoryData);
-    if (!isOverview) {
-      topics.sort();
-    }
     return (
       <RawIntlProvider value={intl}>
         {this.showOverview() && (
@@ -152,6 +149,9 @@ class MainPane extends React.Component<MainPanePropType> {
             // The topic is only used for grouping, which is not displayed on
             // UI.
             return [
+              <section className="block topic-header col-12" key={topic}>
+                <h2 key={topic} id={topic} className="topic">{topic}</h2>
+              </section>,
               categoryData[topic].map((data: ChartBlockData, index) => {
                 return (
                   <section className="block col-12" key={index + data.title}>

--- a/static/js/place/menu.tsx
+++ b/static/js/place/menu.tsx
@@ -56,24 +56,24 @@ class MenuCategory extends React.Component<MenuCategoryPropsType> {
             {this.props.topics.map((topic: string) => {
               return (
                 <React.Fragment key={topic}>
-                <li className="nav-item">
-                  <LocalizedLink
-                    href={`${hrefString}#${topic.replace(/ /g, "-")}`}
-                    className="nav-link topic"
-                    text={topic}
-                  />
-                </li>
-                {items[topic].map((block: string) => {
-                  return (
-                    <li className="nav-item" key={block}>
-                      <LocalizedLink
-                        href={`${hrefString}#${block.replace(/ /g, "-")}`}
-                        className="nav-link"
-                        text={block}
-                      />
-                    </li>
-                  );
-                })}
+                  <li className="nav-item">
+                    <LocalizedLink
+                      href={`${hrefString}#${topic.replace(/ /g, "-")}`}
+                      className="nav-link topic"
+                      text={topic}
+                    />
+                  </li>
+                  {items[topic].map((block: string) => {
+                    return (
+                      <li className="nav-item" key={block}>
+                        <LocalizedLink
+                          href={`${hrefString}#${block.replace(/ /g, "-")}`}
+                          className="nav-link"
+                          text={block}
+                        />
+                      </li>
+                    );
+                  })}
                 </React.Fragment>
               );
             })}

--- a/static/js/place/menu.tsx
+++ b/static/js/place/menu.tsx
@@ -23,7 +23,8 @@ interface MenuCategoryPropsType {
   dcid: string;
   selectCategory: string;
   category: string;
-  items: string[];
+  items: string[][];
+  topics: string[];
   categoryDisplayStr: string;
 }
 
@@ -52,15 +53,28 @@ class MenuCategory extends React.Component<MenuCategoryPropsType> {
           data-parent="#nav-topics"
         >
           <div className="d-block">
-            {items.map((topic: string) => {
+            {this.props.topics.map((topic: string) => {
               return (
-                <li className="nav-item" key={topic}>
+                <React.Fragment key={topic}>
+                <li className="nav-item">
                   <LocalizedLink
                     href={`${hrefString}#${topic.replace(/ /g, "-")}`}
-                    className="nav-link"
+                    className="nav-link topic"
                     text={topic}
                   />
                 </li>
+                {items[topic].map((block: string) => {
+                  return (
+                    <li className="nav-item" key={block}>
+                      <LocalizedLink
+                        href={`${hrefString}#${block.replace(/ /g, "-")}`}
+                        className="nav-link"
+                        text={block}
+                      />
+                    </li>
+                  );
+                })}
+                </React.Fragment>
               );
             })}
           </div>
@@ -100,16 +114,17 @@ class Menu extends React.Component<MenuPropsType> {
           </li>
         )}
         {categories.map((category: string) => {
-          let items: string[] = [];
+          let items: string[][] = [];
+          let topics: string[] = [];
           if (category === "Overview") {
             items = Object.keys(this.props.pageChart[category]).map(
               (t) => this.props.categories[t]
             );
           } else {
-            const topics = Object.keys(this.props.pageChart[category]);
-            topics.sort();
+            topics = Object.keys(this.props.pageChart[category]);
             for (const topic of topics) {
-              items.push(
+              items[topic] = [];
+              items[topic].push(
                 ...this.props.pageChart[category][topic].map((c) => c.title)
               );
             }
@@ -123,6 +138,7 @@ class Menu extends React.Component<MenuPropsType> {
                 selectCategory={selectCategory}
                 category={category}
                 items={items}
+                topics={topics}
                 categoryDisplayStr={categoryDisplayStr}
               />
             );

--- a/static/js/place/menu.tsx
+++ b/static/js/place/menu.tsx
@@ -56,13 +56,15 @@ class MenuCategory extends React.Component<MenuCategoryPropsType> {
             {this.props.topics.map((topic: string) => {
               return (
                 <React.Fragment key={topic}>
-                  <li className="nav-item">
-                    <LocalizedLink
-                      href={`${hrefString}#${topic.replace(/ /g, "-")}`}
-                      className="nav-link topic"
-                      text={topic}
-                    />
-                  </li>
+                  {topic && (
+                    <li className="nav-item">
+                      <LocalizedLink
+                        href={`${hrefString}#${topic.replace(/ /g, "-")}`}
+                        className="nav-link topic"
+                        text={topic}
+                      />
+                    </li>
+                  )}
                   {items[topic].map((block: string) => {
                     return (
                       <li className="nav-item" key={block}>

--- a/static/js/place/page_subtitle.tsx
+++ b/static/js/place/page_subtitle.tsx
@@ -41,7 +41,7 @@ class PageSubtitle extends React.Component<PageSubtitlePropsType> {
       );
     } else {
       elem = (
-        <h2 className="col-12 pt-2">
+        <h2 className="category col-12 pt-2">
           {this.props.categoryDisplayStr}
           <span className="more">
             <LocalizedLink

--- a/static/js/topic_page/block.tsx
+++ b/static/js/topic_page/block.tsx
@@ -43,7 +43,7 @@ export interface BlockPropType {
 export function Block(props: BlockPropType): JSX.Element {
   return (
     <section className="block subtopic col-12">
-      {props.title && <h3 className="block-title">{props.title}</h3>}
+      {props.title && <h2 className="block-title">{props.title}</h2>}
       <div className="block-body row">
         <div className="left-tiles col-6">
           {renderTiles(props.leftTiles, props)}


### PR DESCRIPTION
guha requested that we show income first for equity category pages. i think keeping the ordering from the config allows us the most flexibility to configure this.
also picking up our old todo of displaying the topics on the place page so the ordering isn't confusing..
the strings for the topics still need to be sent for translation.

![image](https://user-images.githubusercontent.com/6052978/149248989-16c405d1-dc3e-4304-8bdb-e5a1767f1b55.png)
