### PR TITLE
[map] url param to set the stat var for installations on a map

### DIFF
--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -92,9 +92,7 @@ export function Chart(props: ChartProps): JSX.Element {
   const [errorMessage, setErrorMessage] = useState("");
   const [denomInput, setDenomInput] = useState(props.statVar.value.denom);
   const mainSvInfo: StatVarInfo =
-  statVar.dcid in statVar.info
-      ? statVar.info[statVar.dcid]
-      : {};
+    statVar.dcid in statVar.info ? statVar.info[statVar.dcid] : {};
   const title = getTitle(
     Array.from(props.dates),
     mainSvInfo.title || statVar.dcid,

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -101,6 +101,7 @@ export function ChartLoader(): JSX.Element {
     statVar.value.dcid,
     statVar.value.info,
     statVar.value.denom,
+    statVar.value.mapPointSv,
   ]);
 
   useEffect(() => {
@@ -339,10 +340,11 @@ function fetchData(
       return resp.data;
     });
 
+  const mapPointSv = statVar.mapPointSv || statVar.dcid;
   const mapPointDataPromise: Promise<GetStatSetResponse> = placeInfo.mapPointPlaceType
     ? axios
         .get(
-          `/api/stats/within-place?parent_place=${placeInfo.enclosingPlace.dcid}&child_type=${placeInfo.mapPointPlaceType}&stat_vars=${statVar.dcid}${dateParam}`
+          `/api/stats/within-place?parent_place=${placeInfo.enclosingPlace.dcid}&child_type=${placeInfo.mapPointPlaceType}&stat_vars=${mapPointSv}`
         )
         .then((resp) => {
           return resp.data;
@@ -432,7 +434,7 @@ function fetchData(
           breadcrumbPlaceStat,
           metadataMap,
           population: { ...enclosedPlacesPop, ...breadcrumbPlacePop },
-          mapPointStat: mapPointData ? mapPointData.data[statVar.dcid] : null,
+          mapPointStat: mapPointData ? mapPointData.data[mapPointSv] : null,
           mapPointsPromise,
           europeanCountries,
         });
@@ -526,7 +528,6 @@ function loadChartData(
         continue;
       }
       mapPointValues[placeDcid] = placeChartData.value;
-      statVarDates.add(placeChartData.date);
       if (!_.isEmpty(placeChartData.metadata)) {
         metadata[placeDcid] = placeChartData.metadata;
       }

--- a/static/js/tools/map/context.ts
+++ b/static/js/tools/map/context.ts
@@ -32,8 +32,8 @@ import {
 
 // Information relating to the stat var to plot
 export interface StatVar {
-  // additional information about the chosen stat var
-  info: StatVarInfo;
+  // additional information about stat vars. key is stat var dcid.
+  info: Record<string, StatVarInfo>;
   // dcid of the chosen stat var
   dcid: string;
   // Whether to plot per capita values
@@ -42,6 +42,8 @@ export interface StatVar {
   denom: string;
   // date of the stat var data to get
   date: string;
+  // dcid of the stat var to use for map points
+  mapPointSv: string;
 }
 
 // Wraps StatVarInfo with its setters
@@ -49,11 +51,12 @@ export interface StatVarWrapper {
   value: StatVar;
 
   set: Setter<StatVar>;
-  setInfo: Setter<StatVarInfo>;
+  setInfo: Setter<Record<string, StatVarInfo>>;
   setDcid: Setter<string>;
   setPerCapita: Setter<boolean>;
   setDate: Setter<string>;
   setDenom: Setter<string>;
+  setMapPointSv: Setter<string>;
 }
 
 // Information relating to the places to plot
@@ -192,6 +195,7 @@ export function getInitialContext(params: URLSearchParams): ContextType {
       setPerCapita: (perCapita) => setStatVar({ ...statVar, perCapita }),
       setDate: (date) => setStatVar({ ...statVar, date }),
       setDenom: (denom) => setStatVar({ ...statVar, denom }),
+      setMapPointSv: (sv) => setStatVar({ ...statVar, mapPointSv: sv }),
     },
     display: {
       value: display,

--- a/static/js/tools/map/stat_var_chooser.tsx
+++ b/static/js/tools/map/stat_var_chooser.tsx
@@ -48,15 +48,21 @@ export function StatVarChooser(): JSX.Element {
     setSamplePlaces(_.sampleSize(placeInfo.value.enclosedPlaces, SAMPLE_SIZE));
   }, [placeInfo.value.enclosedPlaces]);
   useEffect(() => {
-    if (statVar.value.dcid && _.isNull(statVar.value.info)) {
-      getStatVarInfo([statVar.value.dcid])
+    const svWithInfo = _.isNull(statVar.value.info)
+      ? []
+      : Object.keys(statVar.value.info);
+    const svDcids = [statVar.value.dcid, statVar.value.mapPointSv].filter(
+      (svDcid) => !_.isEmpty(svDcid)
+    );
+    if (_.difference(svDcids, svWithInfo).length > 0) {
+      getStatVarInfo(svDcids)
         .then((info) => {
-          const statVarInfo =
-            statVar.value.dcid in info ? info[statVar.value.dcid] : {};
-          statVar.setInfo(statVarInfo);
+          statVar.setInfo(info);
         })
         .catch(() => {
-          statVar.setInfo({});
+          const emptyInfo = {};
+          svDcids.forEach((svDcid) => (emptyInfo[svDcid] = {}));
+          statVar.setInfo(emptyInfo);
         });
     }
   }, [statVar.value]);
@@ -93,5 +99,6 @@ function selectStatVar(
     denom: DEFAULT_DENOM,
     info: null,
     perCapita: false,
+    mapPointSv: "",
   });
 }

--- a/static/js/tools/map/util.test.ts
+++ b/static/js/tools/map/util.test.ts
@@ -57,6 +57,7 @@ const TestContext = ({
       info: null,
       date: "",
       denom: "Count_Person",
+      mapPointSv: "",
     },
   },
   display: {

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -52,6 +52,7 @@ const URL_PARAM_KEYS = {
   DOMAIN: "domain",
   DENOM: "denom",
   MAP_POINTS: "mp",
+  MAP_POINTS_SV: "mapsv",
 };
 const SV_REGEX_INSTALLATION_MAPPING = {
   Emissions: "EpaReportingFacility",
@@ -145,8 +146,16 @@ export function applyHashStatVar(params: URLSearchParams): StatVar {
   const dcid = params.get(URL_PARAM_KEYS.STAT_VAR_DCID);
   const date = params.get(URL_PARAM_KEYS.DATE);
   const denom = params.get(URL_PARAM_KEYS.DENOM);
+  const mapPointSv = params.get(URL_PARAM_KEYS.MAP_POINTS_SV);
   if (!dcid) {
-    return { dcid: "", perCapita: false, info: null, date: "", denom: "" };
+    return {
+      dcid: "",
+      perCapita: false,
+      info: null,
+      date: "",
+      denom: "",
+      mapPointSv: "",
+    };
   }
   const perCapita = params.get(URL_PARAM_KEYS.PER_CAPITA);
   return {
@@ -155,6 +164,7 @@ export function applyHashStatVar(params: URLSearchParams): StatVar {
     info: null,
     date: date ? date : "",
     denom: denom ? denom : DEFAULT_DENOM,
+    mapPointSv: mapPointSv ? mapPointSv : "",
   };
 }
 
@@ -216,11 +226,15 @@ export function updateHashStatVar(hash: string, statVar: StatVar): string {
   const dateParam = statVar.date
     ? `&${URL_PARAM_KEYS.DATE}=${statVar.date}`
     : "";
+  const mapPointParam = statVar.mapPointSv
+    ? `&${URL_PARAM_KEYS.MAP_POINTS_SV}=${statVar.mapPointSv}`
+    : "";
   const params =
     `&${URL_PARAM_KEYS.STAT_VAR_DCID}=${statVar.dcid}` +
     `&${URL_PARAM_KEYS.PER_CAPITA}=${perCapita}` +
     `&${URL_PARAM_KEYS.DENOM}=${statVar.denom}` +
-    dateParam;
+    dateParam +
+    mapPointParam;
   return hash + params;
 }
 


### PR DESCRIPTION
- add a url param to set the stat var used for the installations on a map. If no stat var set, will default to using the same stat var as being shown for the map regions.
- URL params to show glaciers: &mapsv=SurfaceArea&ppt=Glacier
- Now that installations can show a different stat var than the rest of the map, remove the dateParam when retrieving installations data because it can be hard to make the date work for both the map stat var and the installations stat var. For example, RCP stat vars use 2050 as the date, but not many other stat vars have data for 2050.
<img width="1343" alt="Screen Shot 2022-01-24 at 1 02 31 PM" src="https://user-images.githubusercontent.com/69875368/150864283-e551dbbb-57fe-4fc0-9ffa-f61be0713316.png">

