### PR TITLE
[map] add a min size for map installations

### DIFF
--- a/static/js/chart/draw_choropleth.ts
+++ b/static/js/chart/draw_choropleth.ts
@@ -79,6 +79,7 @@ const ZOOMED_SCALE_AMOUNT = 0.7;
 const LEGEND_CLASS_NAME = "legend";
 const MAP_ITEMS_GROUP_ID = "map-items";
 const LEGEND_TICK_LABEL_MARGIN = 10;
+const MIN_DOT_SIZE = 1.1;
 
 // Curated temperature domains.
 const TEMP_BASE_DIFF_DOMAIN = [-10, -5, 0, 5, 10];
@@ -491,7 +492,7 @@ function drawChoropleth(
         Math.pow(pathClientRect.height, 2) + Math.pow(pathClientRect.width, 2)
       );
     });
-    const minDotSize = minRegionDiagonal * 0.02;
+    const minDotSize = Math.max(minRegionDiagonal * 0.02, 1.1);
     addMapPoints(
       domContainerId,
       mapPoints,


### PR DESCRIPTION
- the min size of the installations on the map is calculated depending on the sizes of the regions on the map. For IPCCPlace50 placetype, the size of each region causes the installations to become too small to see. Therefore, we want to set a minimum size for map installation points
<img width="1339" alt="Screen Shot 2022-01-24 at 3 56 56 PM" src="https://user-images.githubusercontent.com/69875368/150885048-22cff951-10b0-4c01-ae01-c5bf8cdac4b8.png">
