### PR TITLE
Do not cache for private instance and update local private instance API_ROOT

### DIFF
--- a/deploy/overlays/karnataka/kustomization.yaml
+++ b/deploy/overlays/karnataka/kustomization.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -20,25 +19,25 @@ nameSuffix: -karnataka
 namespace: website
 
 resources:
-- ../../base
+  - ../../base
 
 configMapGenerator:
-- behavior: create
-  literals:
-  - flaskEnv=autopush
-  - secretProject=datcom-karnataka
-  name: website-configmap
-- behavior: create
-  literals:
-  - mixerProject=datcom-karnataka
-  - serviceName=website-esp.endpoints.datcom-karnataka.cloud.goog
-  name: mixer-configmap
+  - behavior: create
+    literals:
+      - flaskEnv=private
+      - secretProject=datcom-karnataka
+    name: website-configmap
+  - behavior: create
+    literals:
+      - mixerProject=datcom-karnataka
+      - serviceName=website-esp.endpoints.datcom-karnataka.cloud.goog
+    name: mixer-configmap
 
 patchesStrategicMerge:
-- |-
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: website-app
-  spec:
-    replicas: 6
+  - |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: website-app
+    spec:
+      replicas: 6

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -104,8 +104,10 @@ def create_app():
     app.config.from_object(cfg)
 
     # Init extentions
+    from cache import cache
     if app.config['PRIVATE']:
-        from cache import cache
+        cache.init_app(app, {'CACHE_TYPE': 'null'})
+    else:
         cache.init_app(app)
 
     register_routes_common(app)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -104,8 +104,9 @@ def create_app():
     app.config.from_object(cfg)
 
     # Init extentions
-    from cache import cache
-    cache.init_app(app)
+    if app.config['PRIVATE']:
+        from cache import cache
+        cache.init_app(app)
 
     register_routes_common(app)
     if cfg.SUSTAINABILITY:

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -72,7 +72,7 @@ class FeedingAmericaConfig(PrivateConfig):
     FEEDING_AMERICA = True
 
 
-class TidalConfig(Config):
+class TidalConfig(PrivateConfig):
     NAME = "Tidal"
 
 

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -63,20 +63,17 @@ class DevConfig(Config):
     pass
 
 
-class FeedingAmericaConfig(Config):
+class PrivateConfig(Config):
+    PRIVATE = True
+
+
+class FeedingAmericaConfig(PrivateConfig):
     NAME = "Feeding America"
     FEEDING_AMERICA = True
-    PRIVATE = True
 
 
 class TidalConfig(Config):
     NAME = "Tidal"
-    PRIVATE = True
-
-
-class MinikubeConfig(Config):
-    LOCAL = True
-    SCHEME = 'http'
 
 
 ######
@@ -85,6 +82,11 @@ class MinikubeConfig(Config):
 # like  `SECRET_PROJECT`
 #
 #####
+
+
+class MinikubeConfig(Config):
+    LOCAL = True
+    SCHEME = 'http'
 
 
 class LocalConfig(Config):
@@ -99,16 +101,14 @@ class LocalSustainabilityConfig(LocalConfig):
     SUSTAINABILITY = True
 
 
-class LocalPrivateConfig(Config):
+class LocalPrivateConfig(PrivateConfig):
     # This needs to talk to local mixer that is setup as a private mixer, which
     # loads csv + tmcf files from GCS
-    # API_ROOT = 'http://127.0.0.1:8081'
-    API_ROOT = 'https://autopush.api.datacommons.org'
+    API_ROOT = 'https://mixer.endpoints.datcom-mixer-statvar.cloud.goog'
     RECON_API_ROOT = 'https://autopush.recon.datacommons.org'
     LOCAL = True
     SECRET_PROJECT = 'datcom-website-private'
     NAME = "Feeding America"
-    PRIVATE = True
     SCHEME = 'http'
 
 


### PR DESCRIPTION
As private instance will have frequent data refresh, disable caching so it won't have stale data in the frontend.

To bring up a local private instance, run

`run_server.sh -e private`