### PR TITLE
[scatter] Fix bug when there is no StatVarInfo available

### DIFF
--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -106,12 +106,14 @@ function StatVarChooser(): JSX.Element {
     }
     getStatVarInfo(statVarsToGetInfo)
       .then((info) => {
-        if (x.value.statVarDcid in info) {
-          x.setStatVarInfo(info[x.value.statVarDcid]);
-        }
-        if (y.value.statVarDcid in info) {
-          y.setStatVarInfo(info[y.value.statVarDcid]);
-        }
+        statVarsToGetInfo.forEach((sv) => {
+          const svInfo = sv in info ? info[sv] : {};
+          if (sv === x.value.statVarDcid) {
+            x.setStatVarInfo(svInfo);
+          } else {
+            y.setStatVarInfo(svInfo);
+          }
+        });
       })
       .catch(() => {
         if (statVarsToGetInfo.indexOf(x.value.statVarDcid) > -1) {


### PR DESCRIPTION
- fix bug causing scatter chart to not show up when one of the chosen stat vars doesn't have StatVarInfo