### PR TITLE
Topic page scatter updates

### DIFF
--- a/server/config/topic_page.proto
+++ b/server/config/topic_page.proto
@@ -26,7 +26,7 @@ message PageMetadata {
   // List of places supported by this config.
   repeated string place_dcid = 3;
   // Contained places to load for each parent place type.
-  // This might need to be overwritten by blocks.
+  // This can be overwritten by tiles.
   map<string, string> contained_place_types = 4;
 }
 
@@ -82,6 +82,8 @@ message Tile {
   repeated StatVarMetadata stat_var_override = 4;
   RankingMetadata ranking_metadata = 5;
   HighlightMetadata highlight_metadata = 6;
+  // Overrides the contained_place_types for the page.
+  map<string, string> contained_place_types = 7;
 }
 
 message Block {

--- a/server/config/topic_page/equity/USA.textproto
+++ b/server/config/topic_page/equity/USA.textproto
@@ -278,6 +278,52 @@ blocks {
 # }
 
 blocks {
+  title: "Median household income by race"
+  stat_var_metadata {
+    stat_var: "Median_Income_Household_HouseholderRaceAmericanIndianOrAlaskaNativeAlone"
+    unit: "$"
+    name: "American Indian or Alaska Native"
+  }
+  stat_var_metadata {
+    stat_var: "Median_Income_Household_HouseholderRaceAsianAlone"
+    unit: "$"
+    name: "Asian"
+  }
+  stat_var_metadata {
+    stat_var: "Median_Income_Household_HouseholderRaceBlackOrAfricanAmericanAlone"
+    unit: "$"
+    name: "Black or African American"
+  }
+  stat_var_metadata {
+    stat_var: "Median_Income_Household_HouseholderRaceHispanicOrLatino"
+    unit: "$"
+    name: "Hispanic or Latino"
+  }
+  stat_var_metadata {
+    stat_var: "Median_Income_Household_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+    unit: "$"
+    name: "Native Hawaiian or Pacific Islander"
+  }
+  stat_var_metadata {
+    stat_var: "Median_Income_Household_HouseholderRaceWhiteAlone"
+    unit: "$"
+    name: "White"
+  }
+  # TODO: This data is not available at the country level!
+  left_tiles {
+    type: BAR
+    title: "Median household income by race"
+  }
+  right_tiles {
+    type: RANKING
+    ranking_metadata {
+      show_highest: true
+      highest_title: "Highest among ${statVar}"
+    }
+  }
+}
+
+blocks {
   title: "Poverty rate by race"
   description: "Percentage of the population of each race living in poverty"
   stat_var_metadata {
@@ -330,7 +376,7 @@ blocks {
 }
 
 blocks {
-  title: "Juvenile facility residents by race"
+  title: "Correctional facility residents by race"
   # TODO(beets): investigate high numbes for this
   # stat_var_metadata {
   #   stat_var: "Count_Person_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone"
@@ -417,4 +463,52 @@ blocks {
       name: "White"
     }
   }
+}
+
+blocks {
+  title: "Health and poverty"
+  stat_var_metadata {
+    stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
+    denom: "Count_Person"
+    unit: "%"
+    scaling: 100
+    name: "Poverty rate"
+  }
+  stat_var_metadata {
+    stat_var: "Count_Person_NoHealthInsurance"
+    denom: "Count_Person"
+    unit: "%"
+    scaling: 100
+    name: "Uninsurance rate"
+  }
+  left_tiles {
+    type: SCATTER
+    title: "Poverty rate vs Uninsured rate"
+  }
+  right_tiles {
+    type: SCATTER
+    title: "Poverty rate vs Death from diseases of the digestive system"
+    stat_var_override {
+      stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
+      denom: "Count_Person"
+      unit: "%"
+      scaling: 100
+      name: "Poverty rate"
+    }
+    stat_var_override {
+      stat_var: "Count_Death_DiseasesOfTheDigestiveSystem"
+      denom: "Count_Person"
+      unit: "%"
+      scaling: 100
+      name: "Death from diseases of the digestive system per capita"
+    }
+  }
+  # right_tiles {
+  #   type: SCATTER
+  #   title: ""
+  #   stat_var_override {
+  #     stat_var: ""
+  #   }
+  # }
+  #   https://datacommons.org/tools/scatter#%26svx%3DInflationAdjustedGDP%26lx%3D1%26svy%3DCumulativeCount_MedicalConditionIncident_COVID_19_ConfirmedOrProbableCase%26epd%3Dcountry%2FUSA%26ept%3DState%26lb%3D10000
 }

--- a/server/config/topic_page/equity/USA.textproto
+++ b/server/config/topic_page/equity/USA.textproto
@@ -18,6 +18,10 @@ metadata {
   topic_id: 'equity'
   topic_name: 'Equity'
   place_dcid: 'country/USA'
+  contained_place_types {
+    key: 'Country'
+    value: 'State'
+  }
 }
 
 blocks {
@@ -39,6 +43,81 @@ blocks {
     title: "Gini index of economic activity for ${place}"
   }
   # TODO: Add rankings of other /Countries/
+}
+
+blocks {
+  title: "Health and poverty"
+  description: "Studies from CDC  and others have shown a correlation between obesity and poverty. Unfortunately, many other medical conditions are inversely correlated with economic well being."
+  stat_var_metadata {
+    stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
+    denom: "Count_Person"
+    unit: "%"
+    scaling: 100
+    name: "Poverty rate"
+  }
+  stat_var_metadata {
+    stat_var: "Count_Person_NoHealthInsurance"
+    denom: "Count_Person"
+    unit: "%"
+    scaling: 100
+    name: "Uninsurance rate"
+  }
+  left_tiles {
+    type: SCATTER
+    title: "Poverty rate vs. Uninsurance rate"
+  }
+  right_tiles {
+    type: SCATTER
+    title: "Inflation adjusted GDP vs. Death from Covid-19"
+    stat_var_override {
+      stat_var: "InflationAdjustedGDP"
+      unit: "$"
+      name: "Inflation adjusted GDP"
+    }
+    stat_var_override {
+      stat_var: "CumulativeCount_MedicalConditionIncident_COVID_19_PatientDeceased"
+      denom: "Count_Person"
+      unit: "%"
+      scaling: 100
+      name: "Cumulative death from Covid-19"
+    }
+  }
+  right_tiles {
+    type: SCATTER
+    title: "Poverty rate vs. Death from diseases of the circulatory system"
+    stat_var_override {
+      stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
+      denom: "Count_Person"
+      unit: "%"
+      scaling: 100
+      name: "Poverty rate"
+    }
+    stat_var_override {
+      stat_var: "Count_Death_DiseasesOfTheCirculatorySystem"
+      denom: "Count_Person"
+      unit: "%"
+      scaling: 100
+      name: "Death from diseases of the circulatory system"
+    }
+  }
+  left_tiles {
+    type: SCATTER
+    title: "Poverty rate vs. Death from diseases of the digestive system"
+    stat_var_override {
+      stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
+      denom: "Count_Person"
+      unit: "%"
+      scaling: 100
+      name: "Poverty rate"
+    }
+    stat_var_override {
+      stat_var: "Count_Death_DiseasesOfTheDigestiveSystem"
+      denom: "Count_Person"
+      unit: "%"
+      scaling: 100
+      name: "Death from diseases of the digestive system per capita"
+    }
+  }
 }
 
 blocks {
@@ -463,52 +542,4 @@ blocks {
       name: "White"
     }
   }
-}
-
-blocks {
-  title: "Health and poverty"
-  stat_var_metadata {
-    stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
-    denom: "Count_Person"
-    unit: "%"
-    scaling: 100
-    name: "Poverty rate"
-  }
-  stat_var_metadata {
-    stat_var: "Count_Person_NoHealthInsurance"
-    denom: "Count_Person"
-    unit: "%"
-    scaling: 100
-    name: "Uninsurance rate"
-  }
-  left_tiles {
-    type: SCATTER
-    title: "Poverty rate vs Uninsured rate"
-  }
-  right_tiles {
-    type: SCATTER
-    title: "Poverty rate vs Death from diseases of the digestive system"
-    stat_var_override {
-      stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
-      denom: "Count_Person"
-      unit: "%"
-      scaling: 100
-      name: "Poverty rate"
-    }
-    stat_var_override {
-      stat_var: "Count_Death_DiseasesOfTheDigestiveSystem"
-      denom: "Count_Person"
-      unit: "%"
-      scaling: 100
-      name: "Death from diseases of the digestive system per capita"
-    }
-  }
-  # right_tiles {
-  #   type: SCATTER
-  #   title: ""
-  #   stat_var_override {
-  #     stat_var: ""
-  #   }
-  # }
-  #   https://datacommons.org/tools/scatter#%26svx%3DInflationAdjustedGDP%26lx%3D1%26svy%3DCumulativeCount_MedicalConditionIncident_COVID_19_ConfirmedOrProbableCase%26epd%3Dcountry%2FUSA%26ept%3DState%26lb%3D10000
 }

--- a/server/config/topic_page/poverty/USA.textproto
+++ b/server/config/topic_page/poverty/USA.textproto
@@ -39,31 +39,6 @@ blocks {
   }
 }
 
-# blocks {
-#   description: "In the US, the Census Bureau uses a set of money income thresholds that vary by family size and composition to determine who is in poverty. If a family's total income is less than the family's threshold, then that family and every individual in it is considered in poverty. (US Census)"
-#   stat_var_metadata: {
-#     stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
-#     denom: "Count_Person"
-#     unit: "%"
-#     scaling: 100
-#     name: "Poverty rate"
-#   }
-#   left_tiles: {
-#     type: LINE
-#     title: "Poverty rate in ${place}"
-#   }
-#   right_tiles: {
-#     type: LINE
-#     title: "Population in poverty ${place}"
-#     stat_var_override {
-#       stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
-#     }
-#     stat_var_override {
-#       stat_var: "Count_Person"
-#     }
-#   }
-# }
-
 blocks {
   title: "Poverty across states"
   description: "Poverty thresholds are uniform across the country. There is a big range in terms of the percentage of the population who live in poverty (9 - 44%). Looking at the total number of people in poverty though, the rankings closely match state populations."

--- a/server/config/topic_page/poverty/USA.textproto
+++ b/server/config/topic_page/poverty/USA.textproto
@@ -39,6 +39,31 @@ blocks {
   }
 }
 
+# blocks {
+#   description: "In the US, the Census Bureau uses a set of money income thresholds that vary by family size and composition to determine who is in poverty. If a family's total income is less than the family's threshold, then that family and every individual in it is considered in poverty. (US Census)"
+#   stat_var_metadata: {
+#     stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
+#     denom: "Count_Person"
+#     unit: "%"
+#     scaling: 100
+#     name: "Poverty rate"
+#   }
+#   left_tiles: {
+#     type: LINE
+#     title: "Poverty rate in ${place}"
+#   }
+#   right_tiles: {
+#     type: LINE
+#     title: "Population in poverty ${place}"
+#     stat_var_override {
+#       stat_var: "Count_Person_BelowPovertyLevelInThePast12Months"
+#     }
+#     stat_var_override {
+#       stat_var: "Count_Person"
+#     }
+#   }
+# }
+
 blocks {
   title: "Poverty across states"
   description: "Poverty thresholds are uniform across the country. There is a big range in terms of the percentage of the population who live in poverty (9 - 44%). Looking at the total number of people in poverty though, the rankings closely match state populations."

--- a/server/config/topic_page_pb2.py
+++ b/server/config/topic_page_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10topic_page.proto\x12\x0b\x64\x61tacommons\"\xd7\x01\n\x0cPageMetadata\x12\x10\n\x08topic_id\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x01(\t\x12\x12\n\nplace_dcid\x18\x03 \x03(\t\x12Q\n\x15\x63ontained_place_types\x18\x04 \x03(\x0b\x32\x32.datacommons.PageMetadata.ContainedPlaceTypesEntry\x1a:\n\x18\x43ontainedPlaceTypesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"l\n\x0fStatVarMetadata\x12\x10\n\x08stat_var\x18\x01 \x01(\t\x12\r\n\x05\x64\x65nom\x18\x02 \x01(\t\x12\x0c\n\x04unit\x18\x03 \x01(\t\x12\x0f\n\x07scaling\x18\x04 \x01(\x01\x12\x0b\n\x03log\x18\x05 \x01(\x08\x12\x0c\n\x04name\x18\x06 \x01(\t\"\xdf\x01\n\x0fRankingMetadata\x12\x14\n\x0cshow_highest\x18\x01 \x01(\x08\x12\x13\n\x0bshow_lowest\x18\x02 \x01(\x08\x12\x15\n\rshow_increase\x18\x03 \x01(\x08\x12\x15\n\rshow_decrease\x18\x04 \x01(\x08\x12\x16\n\x0e\x64iff_base_date\x18\x05 \x01(\t\x12\x15\n\rhighest_title\x18\x06 \x01(\t\x12\x14\n\x0clowest_title\x18\x07 \x01(\t\x12\x16\n\x0eincrease_title\x18\x08 \x01(\t\x12\x16\n\x0e\x64\x65\x63rease_title\x18\t \x01(\t\"(\n\x11HighlightMetadata\x12\x13\n\x0b\x64\x65scription\x18\x01 \x01(\t\"\x81\x03\n\x04Tile\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12(\n\x04type\x18\x03 \x01(\x0e\x32\x1a.datacommons.Tile.TileType\x12\x37\n\x11stat_var_override\x18\x04 \x03(\x0b\x32\x1c.datacommons.StatVarMetadata\x12\x36\n\x10ranking_metadata\x18\x05 \x01(\x0b\x32\x1c.datacommons.RankingMetadata\x12:\n\x12highlight_metadata\x18\x06 \x01(\x0b\x32\x1e.datacommons.HighlightMetadata\"~\n\x08TileType\x12\r\n\tTYPE_NONE\x10\x00\x12\x08\n\x04LINE\x10\x01\x12\x07\n\x03\x42\x41R\x10\x02\x12\x07\n\x03MAP\x10\x03\x12\x0b\n\x07SCATTER\x10\x04\x12\r\n\tBIVARIATE\x10\x05\x12\x0b\n\x07RANKING\x10\x06\x12\r\n\tHIGHLIGHT\x10\x07\x12\x0f\n\x0b\x44\x45SCRIPTION\x10\x08\"\xb3\x01\n\x05\x42lock\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12%\n\nleft_tiles\x18\x03 \x03(\x0b\x32\x11.datacommons.Tile\x12&\n\x0bright_tiles\x18\x04 \x03(\x0b\x32\x11.datacommons.Tile\x12\x37\n\x11stat_var_metadata\x18\x05 \x03(\x0b\x32\x1c.datacommons.StatVarMetadata\"b\n\x0fTopicPageConfig\x12+\n\x08metadata\x18\x01 \x01(\x0b\x32\x19.datacommons.PageMetadata\x12\"\n\x06\x62locks\x18\x02 \x03(\x0b\x32\x12.datacommons.Blockb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10topic_page.proto\x12\x0b\x64\x61tacommons\"\xd7\x01\n\x0cPageMetadata\x12\x10\n\x08topic_id\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x01(\t\x12\x12\n\nplace_dcid\x18\x03 \x03(\t\x12Q\n\x15\x63ontained_place_types\x18\x04 \x03(\x0b\x32\x32.datacommons.PageMetadata.ContainedPlaceTypesEntry\x1a:\n\x18\x43ontainedPlaceTypesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"l\n\x0fStatVarMetadata\x12\x10\n\x08stat_var\x18\x01 \x01(\t\x12\r\n\x05\x64\x65nom\x18\x02 \x01(\t\x12\x0c\n\x04unit\x18\x03 \x01(\t\x12\x0f\n\x07scaling\x18\x04 \x01(\x01\x12\x0b\n\x03log\x18\x05 \x01(\x08\x12\x0c\n\x04name\x18\x06 \x01(\t\"\xdf\x01\n\x0fRankingMetadata\x12\x14\n\x0cshow_highest\x18\x01 \x01(\x08\x12\x13\n\x0bshow_lowest\x18\x02 \x01(\x08\x12\x15\n\rshow_increase\x18\x03 \x01(\x08\x12\x15\n\rshow_decrease\x18\x04 \x01(\x08\x12\x16\n\x0e\x64iff_base_date\x18\x05 \x01(\t\x12\x15\n\rhighest_title\x18\x06 \x01(\t\x12\x14\n\x0clowest_title\x18\x07 \x01(\t\x12\x16\n\x0eincrease_title\x18\x08 \x01(\t\x12\x16\n\x0e\x64\x65\x63rease_title\x18\t \x01(\t\"(\n\x11HighlightMetadata\x12\x13\n\x0b\x64\x65scription\x18\x01 \x01(\t\"\x88\x04\n\x04Tile\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12(\n\x04type\x18\x03 \x01(\x0e\x32\x1a.datacommons.Tile.TileType\x12\x37\n\x11stat_var_override\x18\x04 \x03(\x0b\x32\x1c.datacommons.StatVarMetadata\x12\x36\n\x10ranking_metadata\x18\x05 \x01(\x0b\x32\x1c.datacommons.RankingMetadata\x12:\n\x12highlight_metadata\x18\x06 \x01(\x0b\x32\x1e.datacommons.HighlightMetadata\x12I\n\x15\x63ontained_place_types\x18\x07 \x03(\x0b\x32*.datacommons.Tile.ContainedPlaceTypesEntry\x1a:\n\x18\x43ontainedPlaceTypesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"~\n\x08TileType\x12\r\n\tTYPE_NONE\x10\x00\x12\x08\n\x04LINE\x10\x01\x12\x07\n\x03\x42\x41R\x10\x02\x12\x07\n\x03MAP\x10\x03\x12\x0b\n\x07SCATTER\x10\x04\x12\r\n\tBIVARIATE\x10\x05\x12\x0b\n\x07RANKING\x10\x06\x12\r\n\tHIGHLIGHT\x10\x07\x12\x0f\n\x0b\x44\x45SCRIPTION\x10\x08\"\xb3\x01\n\x05\x42lock\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12%\n\nleft_tiles\x18\x03 \x03(\x0b\x32\x11.datacommons.Tile\x12&\n\x0bright_tiles\x18\x04 \x03(\x0b\x32\x11.datacommons.Tile\x12\x37\n\x11stat_var_metadata\x18\x05 \x03(\x0b\x32\x1c.datacommons.StatVarMetadata\"b\n\x0fTopicPageConfig\x12+\n\x08metadata\x18\x01 \x01(\x0b\x32\x19.datacommons.PageMetadata\x12\"\n\x06\x62locks\x18\x02 \x03(\x0b\x32\x12.datacommons.Blockb\x06proto3')
 
 
 
@@ -24,6 +24,7 @@ _STATVARMETADATA = DESCRIPTOR.message_types_by_name['StatVarMetadata']
 _RANKINGMETADATA = DESCRIPTOR.message_types_by_name['RankingMetadata']
 _HIGHLIGHTMETADATA = DESCRIPTOR.message_types_by_name['HighlightMetadata']
 _TILE = DESCRIPTOR.message_types_by_name['Tile']
+_TILE_CONTAINEDPLACETYPESENTRY = _TILE.nested_types_by_name['ContainedPlaceTypesEntry']
 _BLOCK = DESCRIPTOR.message_types_by_name['Block']
 _TOPICPAGECONFIG = DESCRIPTOR.message_types_by_name['TopicPageConfig']
 _TILE_TILETYPE = _TILE.enum_types_by_name['TileType']
@@ -64,11 +65,19 @@ HighlightMetadata = _reflection.GeneratedProtocolMessageType('HighlightMetadata'
 _sym_db.RegisterMessage(HighlightMetadata)
 
 Tile = _reflection.GeneratedProtocolMessageType('Tile', (_message.Message,), {
+
+  'ContainedPlaceTypesEntry' : _reflection.GeneratedProtocolMessageType('ContainedPlaceTypesEntry', (_message.Message,), {
+    'DESCRIPTOR' : _TILE_CONTAINEDPLACETYPESENTRY,
+    '__module__' : 'topic_page_pb2'
+    # @@protoc_insertion_point(class_scope:datacommons.Tile.ContainedPlaceTypesEntry)
+    })
+  ,
   'DESCRIPTOR' : _TILE,
   '__module__' : 'topic_page_pb2'
   # @@protoc_insertion_point(class_scope:datacommons.Tile)
   })
 _sym_db.RegisterMessage(Tile)
+_sym_db.RegisterMessage(Tile.ContainedPlaceTypesEntry)
 
 Block = _reflection.GeneratedProtocolMessageType('Block', (_message.Message,), {
   'DESCRIPTOR' : _BLOCK,
@@ -89,6 +98,8 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   _PAGEMETADATA_CONTAINEDPLACETYPESENTRY._options = None
   _PAGEMETADATA_CONTAINEDPLACETYPESENTRY._serialized_options = b'8\001'
+  _TILE_CONTAINEDPLACETYPESENTRY._options = None
+  _TILE_CONTAINEDPLACETYPESENTRY._serialized_options = b'8\001'
   _PAGEMETADATA._serialized_start=34
   _PAGEMETADATA._serialized_end=249
   _PAGEMETADATA_CONTAINEDPLACETYPESENTRY._serialized_start=191
@@ -100,11 +111,13 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _HIGHLIGHTMETADATA._serialized_start=587
   _HIGHLIGHTMETADATA._serialized_end=627
   _TILE._serialized_start=630
-  _TILE._serialized_end=1015
-  _TILE_TILETYPE._serialized_start=889
-  _TILE_TILETYPE._serialized_end=1015
-  _BLOCK._serialized_start=1018
-  _BLOCK._serialized_end=1197
-  _TOPICPAGECONFIG._serialized_start=1199
-  _TOPICPAGECONFIG._serialized_end=1297
+  _TILE._serialized_end=1150
+  _TILE_CONTAINEDPLACETYPESENTRY._serialized_start=191
+  _TILE_CONTAINEDPLACETYPESENTRY._serialized_end=249
+  _TILE_TILETYPE._serialized_start=1024
+  _TILE_TILETYPE._serialized_end=1150
+  _BLOCK._serialized_start=1153
+  _BLOCK._serialized_end=1332
+  _TOPICPAGECONFIG._serialized_start=1334
+  _TOPICPAGECONFIG._serialized_end=1432
 # @@protoc_insertion_point(module_scope)

--- a/static/js/chart/draw_scatter.ts
+++ b/static/js/chart/draw_scatter.ts
@@ -45,7 +45,7 @@ const MARGINS = {
   bottom: 30,
   left: 60,
   right: 30,
-  top: 30,
+  top: 10,
 };
 const Y_AXIS_WIDTH = 30;
 const STROKE_WIDTH = 1.5;

--- a/static/js/topic_page/block.tsx
+++ b/static/js/topic_page/block.tsx
@@ -148,6 +148,7 @@ function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
             id={id}
             title={tile.title}
             place={props.place}
+            // enclosedPlaceType="County"
             enclosedPlaceType={props.enclosedPlaceType}
             statVarMetadata={
               tile.statVarOverride

--- a/static/js/topic_page/block.tsx
+++ b/static/js/topic_page/block.tsx
@@ -25,6 +25,7 @@ import { randDomId } from "../shared/util";
 import { StatVarMetadata } from "../types/stat_var";
 import { BarTile } from "./bar_tile";
 import { BivariateTile } from "./bivariate_tile";
+import { DEFAULT_PAGE_PLACE_TYPE } from "./constants";
 import { HighlightTile } from "./highlight_tile";
 import { LineTile } from "./line_tile";
 import { MapTile } from "./map_tile";
@@ -67,9 +68,13 @@ export function Block(props: BlockPropType): JSX.Element {
 function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
   const tilesJsx = tiles.map((tile) => {
     const id = randDomId();
+    const placeType =
+      props.place && props.place.types
+        ? props.place.types[0]
+        : DEFAULT_PAGE_PLACE_TYPE;
     const enclosedPlaceType =
-      tile.containedPlaceTypes && tile.containedPlaceTypes[props.place.types[0]]
-        ? tile.containedPlaceTypes[props.place.types[0]]
+      tile.containedPlaceTypes && tile.containedPlaceTypes[placeType]
+        ? tile.containedPlaceTypes[placeType]
         : props.enclosedPlaceType;
     switch (tile.type) {
       case "HIGHLIGHT":

--- a/static/js/topic_page/block.tsx
+++ b/static/js/topic_page/block.tsx
@@ -148,7 +148,6 @@ function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
             id={id}
             title={tile.title}
             place={props.place}
-            // enclosedPlaceType="County"
             enclosedPlaceType={props.enclosedPlaceType}
             statVarMetadata={
               tile.statVarOverride

--- a/static/js/topic_page/block.tsx
+++ b/static/js/topic_page/block.tsx
@@ -67,8 +67,10 @@ export function Block(props: BlockPropType): JSX.Element {
 function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
   const tilesJsx = tiles.map((tile) => {
     const id = randDomId();
-    const enclosedPlaceType = tile.containedPlaceTypes && tile.containedPlaceTypes[props.place.types[0]] ?
-    tile.containedPlaceTypes[props.place.types[0]] : props.enclosedPlaceType;
+    const enclosedPlaceType =
+      tile.containedPlaceTypes && tile.containedPlaceTypes[props.place.types[0]]
+        ? tile.containedPlaceTypes[props.place.types[0]]
+        : props.enclosedPlaceType;
     switch (tile.type) {
       case "HIGHLIGHT":
         return (

--- a/static/js/topic_page/block.tsx
+++ b/static/js/topic_page/block.tsx
@@ -67,6 +67,8 @@ export function Block(props: BlockPropType): JSX.Element {
 function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
   const tilesJsx = tiles.map((tile) => {
     const id = randDomId();
+    const enclosedPlaceType = tile.containedPlaceTypes && tile.containedPlaceTypes[props.place.types[0]] ?
+    tile.containedPlaceTypes[props.place.types[0]] : props.enclosedPlaceType;
     switch (tile.type) {
       case "HIGHLIGHT":
         return (
@@ -88,7 +90,7 @@ function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
             id={id}
             title={tile.title}
             place={props.place}
-            enclosedPlaceType={props.enclosedPlaceType}
+            enclosedPlaceType={enclosedPlaceType}
             statVarMetadata={
               tile.statVarOverride
                 ? tile.statVarOverride
@@ -117,7 +119,7 @@ function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
             id={id}
             title={tile.title}
             place={props.place}
-            enclosedPlaceType={props.enclosedPlaceType}
+            enclosedPlaceType={enclosedPlaceType}
             statVarMetadata={
               tile.statVarOverride
                 ? tile.statVarOverride
@@ -133,7 +135,7 @@ function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
             id={id}
             title={tile.title}
             place={props.place}
-            enclosedPlaceType={props.enclosedPlaceType}
+            enclosedPlaceType={enclosedPlaceType}
             statVarMetadata={
               tile.statVarOverride
                 ? tile.statVarOverride
@@ -148,7 +150,7 @@ function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
             id={id}
             title={tile.title}
             place={props.place}
-            enclosedPlaceType={props.enclosedPlaceType}
+            enclosedPlaceType={enclosedPlaceType}
             statVarMetadata={
               tile.statVarOverride
                 ? tile.statVarOverride
@@ -163,7 +165,7 @@ function renderTiles(tiles: Tile[], props: BlockPropType): JSX.Element {
             id={id}
             title={tile.title}
             place={props.place}
-            enclosedPlaceType={props.enclosedPlaceType}
+            enclosedPlaceType={enclosedPlaceType}
             statVarMetadata={
               tile.statVarOverride
                 ? tile.statVarOverride

--- a/static/js/topic_page/constants.tsx
+++ b/static/js/topic_page/constants.tsx
@@ -15,3 +15,6 @@
  */
 
 export const CHART_HEIGHT = 200;
+
+// Default place type to use for the featured place of the page.
+export const DEFAULT_PAGE_PLACE_TYPE = "Place";

--- a/static/js/topic_page/main_pane.tsx
+++ b/static/js/topic_page/main_pane.tsx
@@ -15,7 +15,6 @@
  */
 import _ from "lodash";
 import React from "react";
-import { ErrorBoundary } from "../shared/error_boundary";
 
 import { ErrorBoundary } from "../shared/error_boundary";
 import { NamedTypedPlace } from "../shared/types";

--- a/static/js/topic_page/main_pane.tsx
+++ b/static/js/topic_page/main_pane.tsx
@@ -57,7 +57,8 @@ interface MainPanePropType {
 
 export function MainPane(props: MainPanePropType): JSX.Element {
   const placeType = props.place.types[0];
-  const enclosedPlaceType = props.pageConfig.metadata.containedPlaceTypes[placeType];
+  const enclosedPlaceType =
+    props.pageConfig.metadata.containedPlaceTypes[placeType];
   return (
     <>
       <PageSelector

--- a/static/js/topic_page/main_pane.tsx
+++ b/static/js/topic_page/main_pane.tsx
@@ -20,6 +20,7 @@ import { ErrorBoundary } from "../shared/error_boundary";
 import { NamedTypedPlace } from "../shared/types";
 import { randDomId } from "../shared/util";
 import { Block, BlockPropType } from "./block";
+import { DEFAULT_PAGE_PLACE_TYPE } from "./constants";
 import { PageSelector } from "./page_selector";
 import { TopicsSummary } from "./topic_page";
 
@@ -56,7 +57,9 @@ interface MainPanePropType {
 }
 
 export function MainPane(props: MainPanePropType): JSX.Element {
-  const placeType = props.place.types[0];
+  const placeType = props.place.types
+    ? props.place.types[0]
+    : DEFAULT_PAGE_PLACE_TYPE;
   const enclosedPlaceType =
     props.pageConfig.metadata.containedPlaceTypes[placeType];
   return (

--- a/static/js/topic_page/main_pane.tsx
+++ b/static/js/topic_page/main_pane.tsx
@@ -23,7 +23,15 @@ import { Block, BlockPropType } from "./block";
 import { PageSelector } from "./page_selector";
 import { TopicsSummary } from "./topic_page";
 
+export interface PageMetadata {
+  topicId: string;
+  topicName: string;
+  // Map of parent type to child place type.
+  containedPlaceTypes: Record<string, string>;
+}
+
 export interface PageConfig {
+  metadata: PageMetadata;
   overviewBlock: BlockPropType;
   blocks: BlockPropType[];
 }
@@ -48,6 +56,8 @@ interface MainPanePropType {
 }
 
 export function MainPane(props: MainPanePropType): JSX.Element {
+  const placeType = props.place.types[0];
+  const enclosedPlaceType = props.pageConfig.metadata.containedPlaceTypes[placeType];
   return (
     <>
       <PageSelector
@@ -63,7 +73,7 @@ export function MainPane(props: MainPanePropType): JSX.Element {
               <Block
                 id={id}
                 place={props.place}
-                enclosedPlaceType={"State"}
+                enclosedPlaceType={enclosedPlaceType}
                 title={block.title}
                 description={block.description}
                 leftTiles={block.leftTiles}

--- a/static/js/topic_page/main_pane.tsx
+++ b/static/js/topic_page/main_pane.tsx
@@ -15,6 +15,7 @@
  */
 import _ from "lodash";
 import React from "react";
+import { ErrorBoundary } from "../shared/error_boundary";
 
 import { ErrorBoundary } from "../shared/error_boundary";
 import { NamedTypedPlace } from "../shared/types";

--- a/static/js/topic_page/scatter_tile.tsx
+++ b/static/js/topic_page/scatter_tile.tsx
@@ -202,7 +202,9 @@ function processData(
       yStatVar.scaling
     );
     if (!placeChartData) {
-      console.log(`SCATTER: no data ${xStatVar} / ${yStatVar} for ${place}. skipping.`);
+      console.log(
+        `SCATTER: no data ${xStatVar} / ${yStatVar} for ${place}. skipping.`
+      );
       continue;
     }
     placeChartData.sources.forEach((source) => {
@@ -250,9 +252,15 @@ function draw(
     showRegression: false,
   };
   const yLabel = getStatVarName(
-    chartData.yStatVar.statVar, [chartData.yStatVar], !_.isEmpty(chartData.yStatVar.denom));
+    chartData.yStatVar.statVar,
+    [chartData.yStatVar],
+    !_.isEmpty(chartData.yStatVar.denom)
+  );
   const xLabel = getStatVarName(
-    chartData.xStatVar.statVar, [chartData.xStatVar], !_.isEmpty(chartData.xStatVar.denom));
+    chartData.xStatVar.statVar,
+    [chartData.xStatVar],
+    !_.isEmpty(chartData.xStatVar.denom)
+  );
   const plotProperties: ScatterPlotProperties = {
     width,
     height: CHART_HEIGHT,

--- a/static/js/topic_page/scatter_tile.tsx
+++ b/static/js/topic_page/scatter_tile.tsx
@@ -175,10 +175,10 @@ function processData(
   statVarMetadata: StatVarMetadata[],
   setChartdata: (data: ScatterChartData) => void
 ): void {
-  const xStatVar = statVarMetadata[0];
-  const yStatVar = statVarMetadata[1];
-  const xPlacePointStat = rawData.placeStats.data[xStatVar.statVar];
+  const yStatVar = statVarMetadata[0];
+  const xStatVar = statVarMetadata[1];
   const yPlacePointStat = rawData.placeStats.data[yStatVar.statVar];
+  const xPlacePointStat = rawData.placeStats.data[xStatVar.statVar];
   if (!xPlacePointStat || !yPlacePointStat) {
     return;
   }

--- a/static/js/topic_page/scatter_tile.tsx
+++ b/static/js/topic_page/scatter_tile.tsx
@@ -29,7 +29,6 @@ import {
   ScatterPlotProperties,
 } from "../chart/draw_scatter";
 import { StatApiResponse } from "../shared/stat_types";
-import { getStatsVarLabel } from "../shared/stats_var_labels";
 import { NamedTypedPlace } from "../shared/types";
 import { getStatsWithinPlace } from "../tools/scatter/util";
 import { GetStatSetResponse } from "../tools/shared_util";
@@ -38,7 +37,7 @@ import { getStringOrNA } from "../utils/number_utils";
 import { getPlaceScatterData } from "../utils/scatter_data_utils";
 import { ChartTileContainer } from "./chart_tile";
 import { CHART_HEIGHT } from "./constants";
-import { ReplacementStrings } from "./string_utils";
+import { getStatVarName, ReplacementStrings } from "./string_utils";
 
 interface ScatterTilePropType {
   id: string;
@@ -202,6 +201,10 @@ function processData(
       xStatVar.scaling,
       yStatVar.scaling
     );
+    if (!placeChartData) {
+      console.log(`SCATTER: no data ${xStatVar} / ${yStatVar} for ${place}. skipping.`);
+      continue;
+    }
     placeChartData.sources.forEach((source) => {
       if (!_.isEmpty(source)) {
         sources.add(source);
@@ -246,18 +249,10 @@ function draw(
     showLabels: false,
     showRegression: false,
   };
-  const yLabelSuffix = !_.isEmpty(chartData.yStatVar.denom)
-    ? " Per Capita"
-    : "";
-  const yLabel = `${getStatsVarLabel(
-    chartData.yStatVar.statVar
-  )}${yLabelSuffix}`;
-  const xLabelSuffix = !_.isEmpty(chartData.xStatVar.denom)
-    ? " Per Capita"
-    : "";
-  const xLabel = `${getStatsVarLabel(
-    chartData.xStatVar.statVar
-  )}${xLabelSuffix}`;
+  const yLabel = getStatVarName(
+    chartData.yStatVar.statVar, [chartData.yStatVar], !_.isEmpty(chartData.yStatVar.denom));
+  const xLabel = getStatVarName(
+    chartData.xStatVar.statVar, [chartData.xStatVar], !_.isEmpty(chartData.xStatVar.denom));
   const plotProperties: ScatterPlotProperties = {
     width,
     height: CHART_HEIGHT,

--- a/static/js/topic_page/string_utils.ts
+++ b/static/js/topic_page/string_utils.ts
@@ -35,12 +35,20 @@ export function formatString(s: string, rs: ReplacementStrings): string {
 
 export function getStatVarName(
   statVarDcid: string,
-  statVars: StatVarMetadata[]
+  statVars: StatVarMetadata[],
+  isPerCapita?: boolean
 ): string {
   for (const svm of statVars) {
     if (svm.statVar === statVarDcid) {
-      return svm.name ? svm.name : getStatsVarLabel(statVarDcid);
+      if (svm.name) {
+        return svm.name;
+      }
+      break;
     }
   }
-  return getStatsVarLabel(statVarDcid);
+  const label = getStatsVarLabel(statVarDcid);
+  if (isPerCapita) {
+    return `${label} Per Capita`;
+  }
+  return label;
 }

--- a/static/js/topic_page/tile.tsx
+++ b/static/js/topic_page/tile.tsx
@@ -41,4 +41,6 @@ export interface Tile {
   statVarOverride?: StatVarMetadata[];
   rankingMetadata?: RankingMetadata;
   highlightMetadata?: HighlightMetadata;
+  // Map of parent type to child place type - overrides the page-level setting.
+  containedPlaceTypes: Record<string, string>;
 }

--- a/static/js/topic_page/topic_page.ts
+++ b/static/js/topic_page/topic_page.ts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import React from "react";
 import ReactDOM from "react-dom";
 
 import { loadLocaleData } from "../i18n/i18n";
 import { NamedTypedPlace } from "../shared/types";
+import { DEFAULT_PAGE_PLACE_TYPE } from "./constants";
 import { MainPane } from "./main_pane";
 
 export interface TopicsSummary {
@@ -36,7 +36,8 @@ function renderPage(): void {
   // TODO(beets): remove these if they remain unused.
   const dcid = document.getElementById("title").dataset.placeDcid;
   const placeName = document.getElementById("place-name").dataset.pn;
-  const placeType = document.getElementById("place-type").dataset.pt;
+  const placeType =
+    document.getElementById("place-type").dataset.pt || DEFAULT_PAGE_PLACE_TYPE;
   const pageConfig = JSON.parse(
     document.getElementById("topic-config").dataset.config
   );
@@ -60,8 +61,8 @@ function renderPage(): void {
 
   ReactDOM.render(
     React.createElement(MainPane, {
-      topic,
       place,
+      topic,
       pageConfig,
       topicsSummary,
     }),


### PR DESCRIPTION
Config updates
- Flip ordering of scatter stat vars (y first, then x)
- Add support for contained_place_types (and added a tile-level override)

Scatter updates
- Removed extra top-margin (and it looks fine on scatter tool)
- Add support for configured stat var names

Equity updates
- Added health scatters