### PR TITLE
[timeline] fix bulk download formatting

### DIFF
--- a/server/templates/tools/timeline_bulk_download.html
+++ b/server/templates/tools/timeline_bulk_download.html
@@ -27,7 +27,7 @@ limitations under the License.
 {% endblock %}
 
 {% block content %}
-<div id="main-pane" class="container mt-5">
+<div id="timeline-bulk" class="container mt-5">
   <h1 class="mb-3">Bulk Download Data</h1>
   <p>
     Download CSVs of the latest data for these variables:<br />


### PR DESCRIPTION
there is a display-flex on #main-pane which caused the weird column layout