### PR TITLE
Add date param for ranking page

### DIFF
--- a/static/js/ranking/ranking.ts
+++ b/static/js/ranking/ranking.ts
@@ -37,7 +37,7 @@ window.onload = () => {
   const unit = urlParams.get("unit");
   let scaling = Number(urlParams.get("scaling"));
   scaling = isNaN(scaling) || scaling == 0 ? 1 : scaling;
-
+  const date = urlParams.get("date");
   loadLocaleData(locale, [
     import(`../i18n/compiled-lang/${locale}/place.json`),
     import(`../i18n/compiled-lang/${locale}/stats_var_titles.json`),
@@ -52,6 +52,7 @@ window.onload = () => {
         isPerCapita,
         unit,
         scaling,
+        date,
       }),
       document.getElementById("main-pane")
     );

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -68,7 +68,7 @@ class RankingHistogram extends React.Component<
 
   drawChart(): void {
     const rankList = this.props.ranking.info;
-    const dataPoints = rankList.map( (d) => {
+    const dataPoints = rankList.map((d) => {
       const value = d.value || 0;
       return new DataPoint(d.placeName, value * this.props.scaling);
     });

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -68,9 +68,10 @@ class RankingHistogram extends React.Component<
 
   drawChart(): void {
     const rankList = this.props.ranking.info;
-    const dataPoints = rankList.map(
-      (d) => new DataPoint(d.placeName, d.value * this.props.scaling)
-    );
+    const dataPoints = rankList.map( (d) => {
+      const value = d.value || 0;
+      return new DataPoint(d.placeName, value * this.props.scaling);
+    });
 
     this.chartElementRef.current.innerHTML = "";
     drawHistogram(

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -124,7 +124,7 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
 
   private renderToggle(): JSX.Element {
     const svData = this.state.data;
-    if (svData.rankAll) return;
+    if (!_.isEmpty(svData.rankAll)) return;
     if (this.isBottom) {
       // show link to top 100
       const params = new URLSearchParams(window.location.search);
@@ -377,6 +377,9 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
             }
           } else if (this.props.isPerCapita) {
             // empty pop series but is per capita
+            console.log(
+              `${place} excluded from ranking because of missing population data.`
+            );
             continue;
           }
           rankInfo.push({

--- a/static/js/ranking/ranking_page.tsx
+++ b/static/js/ranking/ranking_page.tsx
@@ -124,7 +124,9 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
 
   private renderToggle(): JSX.Element {
     const svData = this.state.data;
-    if (!_.isEmpty(svData.rankAll)) return;
+    if (!_.isEmpty(svData.rankAll)) {
+      return;
+    }
     if (this.isBottom) {
       // show link to top 100
       const params = new URLSearchParams(window.location.search);
@@ -361,7 +363,7 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
           if (_.isEmpty(placeStat)) {
             continue;
           }
-          let value = placeStat.value === undefined ? 0 : placeStat.value;
+          let value = _.isUndefined(placeStat.value) ? 0 : placeStat.value;
           const popSeries =
             this.props.withinPlace in population
               ? Object.values(population[this.props.withinPlace].data)[0]
@@ -383,10 +385,10 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
             continue;
           }
           rankInfo.push({
-            rank: null,
-            value: value,
             placeDcid: place,
             placeName: placeNames[place] || place,
+            rank: null,
+            value,
           });
         }
         // Sort the RankInfo by their values and update each RankInfo with their
@@ -397,9 +399,9 @@ class Page extends React.Component<RankingPagePropType, RankingPageStateType> {
         });
         this.setState({
           data: {
-            rankTop1000: { info: rankInfo.slice(0, RANK_SIZE) },
-            rankBottom1000: { info: rankInfo.slice(-RANK_SIZE) },
             rankAll: rankInfo.length < RANK_SIZE ? { info: rankInfo } : null,
+            rankBottom1000: { info: rankInfo.slice(-RANK_SIZE) },
+            rankTop1000: { info: rankInfo.slice(0, RANK_SIZE) },
           },
         });
       }

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -250,10 +250,7 @@ export function Chart(props: ChartProps): JSX.Element {
           <div className="map-footer">
             <div className="sources">Data from {sourcesJsx}</div>
             {mainSvInfo.ranked && (
-              <a
-                className="explore-timeline-link"
-                href={props.rankingLink}
-              >
+              <a className="explore-timeline-link" href={props.rankingLink}>
                 <span className="explore-timeline-text">Explore rankings</span>
                 <i className="material-icons">keyboard_arrow_right</i>
               </a>

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -71,6 +71,7 @@ interface ChartProps {
   mapPointsPromise: Promise<Array<MapPoint>>;
   display: DisplayOptionsWrapper;
   europeanCountries: Array<string>;
+  rankingLink: string;
 }
 
 export const MAP_CONTAINER_ID = "choropleth-map";
@@ -251,7 +252,7 @@ export function Chart(props: ChartProps): JSX.Element {
             {mainSvInfo.ranked && (
               <a
                 className="explore-timeline-link"
-                href={`/ranking/${statVarDcid}/${props.placeInfo.enclosedPlaceType}/${placeDcid}`}
+                href={props.rankingLink}
               >
                 <span className="explore-timeline-text">Explore rankings</span>
                 <i className="material-icons">keyboard_arrow_right</i>

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -108,12 +108,7 @@ export function ChartLoader(): JSX.Element {
 
   useEffect(() => {
     if (!_.isEmpty(rawData)) {
-      loadChartData(
-        rawData,
-        placeInfo.value,
-        statVar.value,
-        setChartData
-      );
+      loadChartData(rawData, placeInfo.value, statVar.value, setChartData);
     }
   }, [rawData, statVar.value.perCapita]);
 
@@ -442,7 +437,7 @@ function fetchData(
           mapPointStat: mapPointData ? mapPointData.data[mapPointSv] : null,
           mapPointsPromise,
           europeanCountries,
-          dataDate
+          dataDate,
         });
       }
     )
@@ -556,14 +551,26 @@ function loadChartData(
     sources: sourceSet,
     unit,
     europeanCountries: rawData.europeanCountries,
-    rankingLink: getRankingLink(statVar, placeInfo.selectedPlace.dcid, placeInfo.enclosedPlaceType, rawData.dataDate, unit)
+    rankingLink: getRankingLink(
+      statVar,
+      placeInfo.selectedPlace.dcid,
+      placeInfo.enclosedPlaceType,
+      rawData.dataDate,
+      unit
+    ),
   });
 }
 
-function getRankingLink(statVar: StatVar, placeDcid: string, placeType: string, date: string, unit: string): string {
+function getRankingLink(
+  statVar: StatVar,
+  placeDcid: string,
+  placeType: string,
+  date: string,
+  unit: string
+): string {
   let params = "";
   params += statVar.perCapita ? "&pc=1" : "";
   params += unit ? `&unit=${unit}` : "";
-  params += date ? `&date=${date}` : ""; 
-  return `/ranking/${statVar.dcid}/${placeType}/${placeDcid}?${params}`
+  params += date ? `&date=${date}` : "";
+  return `/ranking/${statVar.dcid}/${placeType}/${placeDcid}?${params}`;
 }

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -62,6 +62,7 @@ interface ChartRawData {
   mapPointStat: PlacePointStat;
   mapPointsPromise: Promise<Array<MapPoint>>;
   europeanCountries: Array<string>;
+  dataDate: string;
 }
 
 interface ChartData {
@@ -75,6 +76,7 @@ interface ChartData {
   mapPointValues: { [dcid: string]: number };
   mapPointsPromise: Promise<Array<MapPoint>>;
   europeanCountries: Array<string>;
+  rankingLink: string;
 }
 
 export function ChartLoader(): JSX.Element {
@@ -108,8 +110,8 @@ export function ChartLoader(): JSX.Element {
     if (!_.isEmpty(rawData)) {
       loadChartData(
         rawData,
-        statVar.value.perCapita,
         placeInfo.value,
+        statVar.value,
         setChartData
       );
     }
@@ -155,6 +157,7 @@ export function ChartLoader(): JSX.Element {
         display={display}
         mapPointsPromise={chartData.mapPointsPromise}
         europeanCountries={chartData.europeanCountries}
+        rankingLink={chartData.rankingLink}
       />
       <div id="source-picker">
         <span>Pick Source</span>
@@ -165,8 +168,8 @@ export function ChartLoader(): JSX.Element {
           onChange={(e) => {
             loadChartData(
               rawData,
-              statVar.value.perCapita,
               placeInfo.value,
+              statVar.value,
               setChartData,
               e.target.value
             );
@@ -439,6 +442,7 @@ function fetchData(
           mapPointStat: mapPointData ? mapPointData.data[mapPointSv] : null,
           mapPointsPromise,
           europeanCountries,
+          dataDate
         });
       }
     )
@@ -452,8 +456,8 @@ function fetchData(
 // rendering the chart component
 function loadChartData(
   rawData: ChartRawData,
-  isPerCapita: boolean,
   placeInfo: PlaceInfo,
+  statVar: StatVar,
   setChartData: (data: ChartData) => void,
   metaHash?: string
 ): void {
@@ -473,7 +477,7 @@ function loadChartData(
         ? rawData.allPlaceStat[metaHash]
         : rawData.placeStat,
       placeDcid,
-      isPerCapita,
+      statVar.perCapita,
       rawData.population,
       rawData.metadataMap
     );
@@ -499,7 +503,7 @@ function loadChartData(
     const placeChartData = getPlaceChartData(
       rawData.breadcrumbPlaceStat,
       place.dcid,
-      isPerCapita,
+      statVar.perCapita,
       rawData.population,
       rawData.metadataMap
     );
@@ -552,5 +556,14 @@ function loadChartData(
     sources: sourceSet,
     unit,
     europeanCountries: rawData.europeanCountries,
+    rankingLink: getRankingLink(statVar, placeInfo.selectedPlace.dcid, placeInfo.enclosedPlaceType, rawData.dataDate, unit)
   });
+}
+
+function getRankingLink(statVar: StatVar, placeDcid: string, placeType: string, date: string, unit: string): string {
+  let params = "";
+  params += statVar.perCapita ? "&pc=1" : "";
+  params += unit ? `&unit=${unit}` : "";
+  params += date ? `&date=${date}` : ""; 
+  return `/ranking/${statVar.dcid}/${placeType}/${placeDcid}?${params}`
 }

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -447,6 +447,20 @@ function fetchData(
     });
 }
 
+function getRankingLink(
+  statVar: StatVar,
+  placeDcid: string,
+  placeType: string,
+  date: string,
+  unit: string
+): string {
+  let params = "";
+  params += statVar.perCapita ? "&pc=1" : "";
+  params += unit ? `&unit=${unit}` : "";
+  params += date ? `&date=${date}` : "";
+  return `/ranking/${statVar.dcid}/${placeType}/${placeDcid}?${params}`;
+}
+
 // Takes fetched data and processes it to be in a form that can be used for
 // rendering the chart component
 function loadChartData(
@@ -559,18 +573,4 @@ function loadChartData(
       unit
     ),
   });
-}
-
-function getRankingLink(
-  statVar: StatVar,
-  placeDcid: string,
-  placeType: string,
-  date: string,
-  unit: string
-): string {
-  let params = "";
-  params += statVar.perCapita ? "&pc=1" : "";
-  params += unit ? `&unit=${unit}` : "";
-  params += date ? `&date=${date}` : "";
-  return `/ranking/${statVar.dcid}/${placeType}/${placeDcid}?${params}`;
 }


### PR DESCRIPTION
- when there is a date specified for the ranking page, get data using within-places endpoint and do on the fly ranking calculation
- if map tool has a date set, "explore ranking" link will redirect to ranking page with that specified date