### PR TITLE
[tree widget] various search result ui updates

### DIFF
--- a/static/css/stat_var_hierarchy.scss
+++ b/static/css/stat_var_hierarchy.scss
@@ -16,14 +16,18 @@
 
 $vertical-spacing: 15px;
 $horizontal-spacing: 15px;
+$large-font-size: 0.9rem;
+$medium-font-size: 0.85rem;
+$small-font-size: 0.75rem;
 
 .stat-var-hierarchy-container {
   min-height: 20rem;
-  font-size: 0.95rem;
+  font-size: $medium-font-size;
   line-height: 1.8rem;
 }
 
 .statvar-hierarchy-search-section {
+  font-size: $medium-font-size;
   margin-bottom: $vertical-spacing;
 }
 
@@ -31,8 +35,12 @@ $horizontal-spacing: 15px;
   position: relative;
 }
 
+.statvar-hierarchy-search-section .statvar-search-input {
+  font-size: $medium-font-size;
+}
+
 .stat-var-hierarchy-container .material-icons {
-  font-size: 18px;
+  font-size: 15px;
   vertical-align: middle;
 }
 
@@ -50,11 +58,11 @@ $horizontal-spacing: 15px;
 }
 
 .node-title .bullet + .title {
-  font-size: .9rem;
+  font-size: $medium-font-size;
 }
 
 .node-title .material-icons + .title {
-  font-size: 0.9rem;
+  font-size: $medium-font-size;
   font-weight: 600;
   line-height: 2rem;
 }
@@ -97,7 +105,7 @@ $horizontal-spacing: 15px;
 
 .search-results-heading {
   background-color: #f0f0f0;
-  font-size: 1rem;
+  font-size: $medium-font-size;
   margin-bottom: 0;
   line-height: 1.8;
 }
@@ -123,7 +131,7 @@ $horizontal-spacing: 15px;
 .node-title .sv-count {
   margin-left: 1ch;
   font-weight: 300;
-  font-size: 85%;
+  font-size: $medium-font-size;
 }
 
 .node-title:hover {
@@ -141,4 +149,39 @@ $horizontal-spacing: 15px;
 
 .node-no-data {
   opacity: 30%;
+}
+
+.svg-search-result-subtitle {
+  font-size: $small-font-size;
+  padding-left: 0.5rem;
+  font-weight: 300;
+}
+
+.svg-search-result-title {
+  font-weight: 500;
+}
+
+.sv-search-loading {
+  padding: 0.4rem 15px;
+  display: flex;
+  align-items: center;
+}
+
+.sv-search-loading span {
+  padding: 0 0.5rem;
+}
+
+#sv-search-spinner {
+  content: "";
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid var(--dc-gray-lite);
+  border-top: 2px solid var(--dc-primary);
+  border-radius: 100%;
+  will-change: transform;
+  animation: spin 1s infinite linear;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/static/css/tools/stat_var_widget.scss
+++ b/static/css/tools/stat_var_widget.scss
@@ -87,10 +87,8 @@ $transparent-red: rgba(240, 230, 231, 0.2);
 }
 
 .statvar-hierarchy-search-section {
-  font-size: 0.9rem;
   padding: $container-outer-vert-margin $container-outer-horizontal-margin 0;
 }
-
 #hierarchy-section {
   padding: 0 $container-outer-horizontal-margin $container-outer-vert-margin;
   width: fit-content;
@@ -98,19 +96,15 @@ $transparent-red: rgba(240, 230, 231, 0.2);
 
 .stat-var-hierarchy-container .title {
   margin-bottom: 3px;
-  font-size: 1rem;
+  font-size: $large-font-size;
   letter-spacing: 0;
   line-height: 26px;
   padding-bottom: 8px;
 }
 
-.statvar-hierarchy-search-section .statvar-search-input {
-  font-size: 1rem;
-}
-
 .statvar-hierarchy-search-results {
   max-height: max(90%, 50vh) !important;
-  width: $widget-min-width - 2 * $container-outer-horizontal-margin !important;
+  width: 60% !important;
 }
 
 #explore-menu-toggle,
@@ -138,11 +132,11 @@ form.node-title {
 
 
 #stat-var-hierarchy-section .node-title label {
-  font-size: .85rem;
+  font-size: $medium-font-size;
 }
 
 #stat-var-hierarchy-section .node-title .material-icons + .title {
-  font-size: .9rem;
+  font-size: $medium-font-size;
   line-height: 2em;
 }
 
@@ -151,7 +145,7 @@ form.node-title {
   position: absolute;
   background-color: #fff;
   color: #3b3b3b;
-  font-size: 0.8rem;
+  font-size: $small-font-size;
   border-radius: 3px;
   border: 0.5px solid #dee2e6;
   padding: 0.3rem;
@@ -174,7 +168,7 @@ form.node-title {
 
 .show-sv-toggle {
   color: white;
-  font-size: 0.9rem;
+  font-size: $medium-font-size;
   display: flex;
   align-items: center;
 }

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -230,9 +230,9 @@ export class StatVarHierarchySearch extends React.Component<
     }
     this.setState({
       query: displayName,
+      showResults: false,
       svResults: [],
       svgResults: [],
-      showResults: false,
     });
   };
 

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -77,19 +77,24 @@ export class StatVarHierarchySearch extends React.Component<
       _.isEmpty(this.state.svResults) &&
       _.isEmpty(this.state.svgResults);
     return (
-      <div className="statvar-hierarchy-search-section">
+      <div
+        className="statvar-hierarchy-search-section"
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+            this.setState({ showResults: false });
+          }
+        }}
+      >
         {this.props.searchLabel && (
           <div className="title">{this.props.searchLabel}</div>
         )}
-        <div className="search-input-container">
+        <div className="search-input-container" tabIndex={-1}>
           <input
             className="statvar-search-input form-control"
             type="text"
             value={this.state.query}
             onChange={this.onInputChanged}
             placeholder="Search or explore below"
-            onBlur={() => this.setState({ showResults: false })}
-            onFocus={() => this.setState({ showResults: true })}
           />
           {!_.isEmpty(this.state.query) && (
             <span
@@ -101,7 +106,7 @@ export class StatVarHierarchySearch extends React.Component<
           )}
         </div>
         {renderResults && (
-          <div className="statvar-hierarchy-search-results">
+          <div className="statvar-hierarchy-search-results" tabIndex={-1}>
             {!_.isEmpty(this.state.svgResults) && (
               <div className="svg-search-results">
                 <h5 className="search-results-heading">
@@ -144,6 +149,7 @@ export class StatVarHierarchySearch extends React.Component<
   }
 
   private onInputChanged = (event) => {
+    this.setState({ showResults: true });
     const query = event.target.value;
     // When the seach text is fully removed, should call onSelectChange to
     // show the clean hierarchy.
@@ -226,6 +232,7 @@ export class StatVarHierarchySearch extends React.Component<
       query: displayName,
       svResults: [],
       svgResults: [],
+      showResults: false,
     });
   };
 

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -236,7 +236,7 @@ export class StatVarHierarchySearch extends React.Component<
         subtitle +=
           svg.statVars.length > 1
             ? "includes statistical variables:"
-            : "includes statistical variables:";
+            : "includes statistical variable:";
         for (const sv of svg.statVars.slice(0, NUM_EXAMPLE_SV_RESULTS)) {
           subtitle += ` ${sv.name} |`;
         }


### PR DESCRIPTION
- add additional information in stat var group results about what stat vars are contained in that stat var group
- widen search results section
- make font smaller
- show loading as soon as user starts typing
- close results dropdown when user clicks outside the search area

![screen-recording-_1_](https://user-images.githubusercontent.com/69875368/152448313-9eada1af-5cb5-4737-97ce-4a9a762b043a.gif)

