### PR TITLE
Pin markupsafe version

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -22,3 +22,4 @@ Werkzeug==1.0.1
 wheel==0.36.2
 yapf==0.31.0
 geojson_rewind==1.0.1
+markupsafe==2.0.1


### PR DESCRIPTION
- flask depends on jinja2 which depends on markupsafe and the latest markupsafe version has a [breaking change](https://github.com/pallets/markupsafe/issues/286) causing an error to be thrown when trying to run flask locally because [Jinja2 depends on the latest version of markupsafe](https://github.com/pallets/jinja/issues/1585)
