### PR TITLE
Better check of browser page provenance triples

### DIFF
--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -85,3 +85,4 @@ gcloud endpoints services deploy mixer-grpc.$MIXER_HASH.pb endpoints.yaml --proj
 git checkout HEAD -- kustomization.yaml
 cd $ROOT
 git checkout HEAD -- deploy/git/mixer_hash.txt
+git checkout HEAD -- deploy/git/website_hash.txt

--- a/static/js/browser/browser_page.tsx
+++ b/static/js/browser/browser_page.tsx
@@ -217,7 +217,11 @@ export class BrowserPage extends React.Component<
       .then(([labelsData, ProvenanceData]) => {
         const provDomain = {};
         for (const prov of ProvenanceData) {
-          if (prov["predicate"] === "typeOf" && !!prov["subjectName"]) {
+          if (
+            prov["subjectTypes"] &&
+            prov["subjectTypes"][0] === "Provenance" &&
+            !!prov["subjectName"]
+          ) {
             provDomain[prov["subjectId"]] = new URL(prov["subjectName"]).host;
           }
         }

--- a/static/js/browser/browser_page.tsx
+++ b/static/js/browser/browser_page.tsx
@@ -206,6 +206,14 @@ export class BrowserPage extends React.Component<
       : this.props.dcid;
   }
 
+  private isProvenanceEntity(prov): boolean {
+    return (
+      prov["subjectTypes"] &&
+      prov["subjectTypes"][0] === "Provenance" &&
+      !!prov["subjectName"]
+    );
+  }
+
   private fetchData(): void {
     const provenancePromise = axios
       .get("/api/browser/triples/Provenance")
@@ -217,11 +225,7 @@ export class BrowserPage extends React.Component<
       .then(([labelsData, ProvenanceData]) => {
         const provDomain = {};
         for (const prov of ProvenanceData) {
-          if (
-            prov["subjectTypes"] &&
-            prov["subjectTypes"][0] === "Provenance" &&
-            !!prov["subjectName"]
-          ) {
+          if (this.isProvenanceEntity(prov)) {
             provDomain[prov["subjectId"]] = new URL(prov["subjectName"]).host;
           }
         }


### PR DESCRIPTION
In import group mode, subject name is added to all triples. In the the "Provenance" triples data, when "Provenance" is subject, its name "Provenance" is used as URL and lead to errors. This makes the check more robust.