### PR TITLE
[tree widget] fix invalid regex problem

### DIFF
--- a/static/js/stat_var_hierarchy/stat_var_search.test.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.test.tsx
@@ -69,6 +69,12 @@ test("getHighlightedJSX", () => {
       wantElementContent: ["test ", "match1", " matchABC test"],
       wantHighlightedElements: new Set([1]),
     },
+    {
+      s: "test match1) matchABC test",
+      matches: ["match1)", "match2"],
+      wantElementContent: ["test ", "match1)", " matchABC test"],
+      wantHighlightedElements: new Set([1]),
+    },
   ];
   for (const c of cases) {
     const highlightedResult = wrapper

--- a/static/js/stat_var_hierarchy/stat_var_search.test.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.test.tsx
@@ -34,44 +34,44 @@ test("getHighlightedJSX", () => {
     wantHighlightedElements: Set<number>;
   }[] = [
     {
-      s: "test",
       matches: ["match"],
+      s: "test",
       wantElementContent: ["test"],
       wantHighlightedElements: new Set(),
     },
     {
-      s: "test match test",
       matches: ["match"],
+      s: "test match test",
       wantElementContent: ["test ", "match", " test"],
       wantHighlightedElements: new Set([1]),
     },
     {
-      s: "test match match test",
       matches: ["match"],
+      s: "test match match test",
       wantElementContent: ["test ", "match", " ", "match", " test"],
       wantHighlightedElements: new Set([1, 3]),
     },
     {
-      s: "test match1match2 test test",
       matches: ["match1", "match2"],
+      s: "test match1match2 test test",
       wantElementContent: ["test ", "match1", "", "match2", " test test"],
       wantHighlightedElements: new Set([1, 3]),
     },
     {
-      s: "test match123 test",
       matches: ["match"],
+      s: "test match123 test",
       wantElementContent: ["test ", "match", "123 test"],
       wantHighlightedElements: new Set([1]),
     },
     {
-      s: "test match1 matchABC test",
       matches: ["match1", "match2"],
+      s: "test match1 matchABC test",
       wantElementContent: ["test ", "match1", " matchABC test"],
       wantHighlightedElements: new Set([1]),
     },
     {
-      s: "test match1) matchABC test",
       matches: ["match1)", "match2"],
+      s: "test match1) matchABC test",
       wantElementContent: ["test ", "match1)", " matchABC test"],
       wantHighlightedElements: new Set([1]),
     },

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -185,16 +185,22 @@ export class StatVarHierarchySearch extends React.Component<
     let currResult = [];
     matches.sort((a, b) => b.length - a.length);
     // Escape any invalid symbols in the returned matches
-    matches = matches.map((match) =>
+    const processedMatches = matches.map((match) =>
       match.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1")
     );
-    for (const match of matches) {
-      const re = new RegExp(`(${match})`, "gi");
-      prevResult.forEach((stringPart) =>
-        currResult.push(...stringPart.split(re))
-      );
-      prevResult = currResult;
-      currResult = [];
+    for (const match of processedMatches) {
+      try {
+        const re = new RegExp(`(${match})`, "gi");
+        prevResult.forEach((stringPart) =>
+          currResult.push(...stringPart.split(re))
+        );
+        prevResult = currResult;
+        currResult = [];
+      } catch (e) {
+        // If trying to split the string on one of the returned matches fails,
+        // should just continue through the rest of the matches
+        continue;
+      }
     }
     return (
       <>

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -184,6 +184,7 @@ export class StatVarHierarchySearch extends React.Component<
     let prevResult = [s];
     let currResult = [];
     matches.sort((a, b) => b.length - a.length);
+    // Escape any invalid symbols in the returned matches
     matches = matches.map((match) =>
       match.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1")
     );

--- a/static/js/stat_var_hierarchy/stat_var_search.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_search.tsx
@@ -184,6 +184,9 @@ export class StatVarHierarchySearch extends React.Component<
     let prevResult = [s];
     let currResult = [];
     matches.sort((a, b) => b.length - a.length);
+    matches = matches.map((match) =>
+      match.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1")
+    );
     for (const match of matches) {
       const re = new RegExp(`(${match})`, "gi");
       prevResult.forEach((stringPart) =>
@@ -195,7 +198,7 @@ export class StatVarHierarchySearch extends React.Component<
     return (
       <>
         {prevResult.map((stringPart, i) => {
-          if (matches.indexOf(stringPart) > -1) {
+          if (matches.indexOf(stringPart.toLowerCase()) > -1) {
             return <b key={`${id}-${i}`}>{stringPart}</b>;
           } else {
             return stringPart;


### PR DESCRIPTION
- there was a bug where searching for mortality in the tree widget threw an error. This was because one of the matching tokens returned for this query was "mortality)" and the ")" at the end was causing an invalid regex error. 