### PR TITLE
Use BigQuery query API for /translator page

### DIFF
--- a/static/js/translator/constants.ts
+++ b/static/js/translator/constants.ts
@@ -254,7 +254,7 @@ WHERE {
   ?obs1 typeOf StatVarObservation .
   ?obs1 observationAbout ?node .
   ?obs1 variableMeasured LifeExpectancy_Person .
-  ?obs1 observationDate "2018" .
+  ?obs1 observationDate "2010" .
   ?obs1 value ?life_expectancy .
 
   ?obs2 typeOf StatVarObservation .

--- a/static/js/translator/constants.ts
+++ b/static/js/translator/constants.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-export const input = {
-  observation: {
-    mapping: `
+export const mapping = `
 Node: E:StatisticalVariable->E1
 typeOf: StatisticalVariable
 dcid: C:StatisticalVariable->id
@@ -245,8 +243,10 @@ Node: E:Triple->E2
 typeOf: Provenance
 dcid: C:Triple->prov_id
 functionalDeps: dcid
-`,
-    sparql: `
+`;
+
+export const sparql = {
+  observation: `
 SELECT ?node ?life_expectancy ?median_age
 WHERE {
   ?node typeOf State .
@@ -262,29 +262,13 @@ WHERE {
   ?obs2 variableMeasured Median_Age_Person .
   ?obs2 observationDate "2018" .
   ?obs2 value ?median_age .
-}
-`,
-  },
-  sv: {
-    mapping: `
-Node: E:Triple->E1
-dcid: C:Triple->subject_id
-provenance: E:Triple->E2
-C:Triple->predicate: C:Triple->object_value
-functionalDeps: dcid
-
-Node: E:Triple->E2
-typeOf: Provenance
-dcid: C:Triple->prov_id
-functionalDeps: dcid
-    `,
-    sparql: `
+}`,
+  sv: `
 SELECT ?sv
 WHERE {
   ?sv typeOf StatisticalVariable .
   ?sv measuredProperty count .
   ?sv populationType Person .
 }
-    `,
-  },
+`,
 };

--- a/static/js/translator/page.tsx
+++ b/static/js/translator/page.tsx
@@ -17,7 +17,7 @@
 import axios from "axios";
 import React from "react";
 
-import { input } from "./constants";
+import { mapping, sparql } from "./constants";
 import { Binding, Constraint, Translation } from "./translation";
 
 interface PagePropType {
@@ -70,10 +70,10 @@ export class Page extends React.Component<PagePropType, PageStateType> {
   }
 
   onModeChange(event: React.ChangeEvent<HTMLInputElement>): void {
-    this.mappingInputElem.current.value = input[event.target.value].mapping;
-    this.sparqlInputElem.current.value = input[event.target.value].sparql;
-    this.mapping = input[event.target.value].mapping;
-    this.sparql = input[event.target.value].sparql;
+    this.mappingInputElem.current.value = mapping;
+    this.sparqlInputElem.current.value = sparql[event.target.value];
+    this.mapping = mapping;
+    this.sparql = sparql[event.target.value];
     this.updateTranslation();
   }
 
@@ -132,7 +132,10 @@ export class Page extends React.Component<PagePropType, PageStateType> {
           bindings={this.state.bindings}
           constraints={this.state.constraints}
         ></Translation>
-        <a href={this.createBqUrl()}> BigQuery Link</a>
+        <a href={this.createBqUrl()} target="_blank" rel="noreferrer">
+          {" "}
+          BigQuery Link
+        </a>
       </div>
     );
   }

--- a/static/js/translator/page.tsx
+++ b/static/js/translator/page.tsx
@@ -140,7 +140,7 @@ export class Page extends React.Component<PagePropType, PageStateType> {
     );
   }
 
-  private createBqUrl() {
+  private createBqUrl(): string {
     const query = encodeURIComponent(this.state.sql);
     return `https://pantheon.corp.google.com/bigquery;create-new-query-tab=${query}`;
   }

--- a/static/js/translator/page.tsx
+++ b/static/js/translator/page.tsx
@@ -132,8 +132,14 @@ export class Page extends React.Component<PagePropType, PageStateType> {
           bindings={this.state.bindings}
           constraints={this.state.constraints}
         ></Translation>
+        <a href={this.createBqUrl()}> BigQuery Link</a>
       </div>
     );
+  }
+
+  private createBqUrl() {
+    const query = encodeURIComponent(this.state.sql);
+    return `https://pantheon.corp.google.com/bigquery;create-new-query-tab=${query}`;
   }
 
   private updateTranslation() {

--- a/static/js/translator/translator.ts
+++ b/static/js/translator/translator.ts
@@ -21,7 +21,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
-import { input } from "./constants";
+import { mapping, sparql } from "./constants";
 import { Page } from "./page";
 
 /**
@@ -30,8 +30,8 @@ import { Page } from "./page";
 window.onload = function () {
   ReactDOM.render(
     React.createElement(Page, {
-      mapping: input.observation.mapping,
-      sparql: input.observation.sparql,
+      mapping: mapping,
+      sparql: sparql.observation,
     }),
     document.getElementById("translator")
   );

--- a/static/js/translator/translator.ts
+++ b/static/js/translator/translator.ts
@@ -30,7 +30,7 @@ import { Page } from "./page";
 window.onload = function () {
   ReactDOM.render(
     React.createElement(Page, {
-      mapping: mapping,
+      mapping,
       sparql: sparql.observation,
     }),
     document.getElementById("translator")


### PR DESCRIPTION
This is also to verify that we can build BigQuery links from raw query string.

Tested and works ([link](https://pantheon.corp.google.com/bigquery;create-new-query-tab=SELECT%20_datcom_store_dc_kg_latest_Place_0.id%20AS%20node%2C%20_datcom_store_dc_kg_latest_StatVarObservation_1.value%20AS%20life_expectancy%2C%20_datcom_store_dc_kg_latest_StatVarObservation_2.value%20AS%20median_age%20FROM%20%60datcom-store.dc_kg_latest.StatVarObservation%60%20AS%20_datcom_store_dc_kg_latest_StatVarObservation_1%20JOIN%20%60datcom-store.dc_kg_latest.Place%60%20AS%20_datcom_store_dc_kg_latest_Place_0%20ON%20_datcom_store_dc_kg_latest_StatVarObservation_1.observation_about%20%3D%20_datcom_store_dc_kg_latest_Place_0.id%20JOIN%20%60datcom-store.dc_kg_latest.StatVarObservation%60%20AS%20_datcom_store_dc_kg_latest_StatVarObservation_2%20ON%20_datcom_store_dc_kg_latest_Place_0.id%20%3D%20_datcom_store_dc_kg_latest_StatVarObservation_2.observation_about%20WHERE%20_datcom_store_dc_kg_latest_Place_0.type%20%3D%20%22State%22%20AND%20_datcom_store_dc_kg_latest_StatVarObservation_1.observation_date%20%3D%20%222010%22%20AND%20_datcom_store_dc_kg_latest_StatVarObservation_1.variable_measured%20%3D%20%22LifeExpectancy_Person%22%20AND%20_datcom_store_dc_kg_latest_StatVarObservation_2.observation_date%20%3D%20%222018%22%20AND%20_datcom_store_dc_kg_latest_StatVarObservation_2.variable_measured%20%3D%20%22Median_Age_Person%22))

