### PR TITLE
[place] handle empty dcids when getting i18n name

### DIFF
--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -113,7 +113,7 @@ def cached_i18n_name(dcids, locale, should_resolve_all):
     Returns:
         A dictionary of place names, keyed by dcid (potentially sparse if should_resolve_all=False)
     """
-    if not dcids: 
+    if not dcids:
         return {}
     dcids = dcids.split('^')
     response = fetch_data('/node/property-values', {

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -113,6 +113,8 @@ def cached_i18n_name(dcids, locale, should_resolve_all):
     Returns:
         A dictionary of place names, keyed by dcid (potentially sparse if should_resolve_all=False)
     """
+    if not dcids: 
+        return {}
     dcids = dcids.split('^')
     response = fetch_data('/node/property-values', {
         'dcids': dcids,


### PR DESCRIPTION
- some non english place pages were erroring out (caught by webdriver) because of trying to get cached_i18n_name for an empty list of dcids