### PR TITLE
[analytics] disable consent manager (and just disble client storage)

### DIFF
--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -51,6 +51,7 @@ class ProdSustainabilityConfig(ProductionConfig):
 
 
 class StagingConfig(Config):
+    GA_ACCOUNT = 'UA-117119267-2'
     ENABLE_BLOCKLIST = True
     pass
 

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -194,6 +194,7 @@
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
     integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
     crossorigin="anonymous"></script>
+  {# Enable Google Analytics with cookieless tracking. #}
   {% if GA_ACCOUNT %}
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_ACCOUNT }}"></script>
   <script>

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -194,18 +194,15 @@
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
     integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
     crossorigin="anonymous"></script>
-  {%- if GA_ACCOUNT -%}
+  {% if GA_ACCOUNT %}
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_ACCOUNT }}"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
+    function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', '{{ GA_ACCOUNT }}');
-    gtag('consent', 'default', {'ad_storage': 'denied'});
-    gtag('consent', 'default', {'analytics_storage': 'denied'});
-    gtag('set', {'allow_google_signals': false});
+    gtag('config', '{{ GA_ACCOUNT }}', { client_storage: 'none', anonymize_ip: true });
   </script>
-  {%- endif -%}
+  {% endif %}
   {% block footer %}
   {% endblock %}
 </body>


### PR DESCRIPTION
Also made some corresponding changes to tag manager. I'm not sure if that's why the stats dropped, since the diff from the release seems benign except for the new settings.

https://github.com/datacommonsorg/website/compare/v1.13.1...v1.14.0

Disabling client_storage should turn off cookies too. Will test this post release (also added back our existing GA to staging for testing).