### PR TITLE
Add missing library for AI model service

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -24,4 +24,6 @@ yapf==0.31.0
 geojson_rewind==1.0.1
 markupsafe==2.0.1
 grpcio==1.44.0
+tensorflow==2.8.0
 tensorflow-serving-api==2.8.0
+numpy==1.21.5

--- a/server/services/ai.py
+++ b/server/services/ai.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Vertex AI inference client and utilities."""
 
+# TODO(shifucun): should remove "numpy", "tensorflow" and use lower level
+# operations since they add big dependency but are only used in a few instances,
+# which can be replaced with basic Python operations.
 import json
 import logging
 import re


### PR DESCRIPTION
I will discuss later with @nopper and see if can remove "numpy" deps as it is only used for one function.

This will fix the deployment error for now.