### PR TITLE
Create default config map for ai-config

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -25,3 +25,8 @@ resources:
   - ../../mixer/deploy/mapping
   - deployment.yaml
   - namespace.yaml
+
+configMapGenerator:
+  - name: ai-config
+    files:
+      - ai.yaml

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -38,6 +38,7 @@ configMapGenerator:
       - mixerProject=datcom-website-autopush
       - serviceName=website-esp.endpoints.datcom-website-autopush.cloud.goog
   - name: ai-config
+    behavior: replace
     files:
       - ai.yaml
 

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -35,6 +35,7 @@ configMapGenerator:
       - mixerProject=datcom-website-dev
       - serviceName=website-esp.endpoints.datcom-website-dev.cloud.goog
   - name: ai-config
+    behavior: replace
     files:
       - ai.yaml
 

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -41,6 +41,7 @@ configMapGenerator:
     files:
       - redis.json
   - name: ai-config
+    behavior: replace
     files:
       - ai.yaml
 


### PR DESCRIPTION
Environment does not need to create empty ai.yaml if NLP is not used.