### PR TITLE
Fix data sparsity issue in place page

### DIFF
--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -22,15 +22,7 @@ class Config:
     SCHEME = 'https'
     # Additional stat vars that need to be fetched for place page data.
     # This is only needed for local development when cache is not up to date.
-    NEW_STAT_VARS = [
-        "Count_CriminalIncidents_IsHateCrime",
-        "Count_CriminalIncidents_BiasMotivationGender_IsHateCrime",
-        "Count_CriminalIncidents_BiasMotivationRace_IsHateCrime",
-        "Count_CriminalIncidents_BiasMotivationReligion_IsHateCrime",
-        "Count_CriminalIncidents_BiasMotivationEthnicity_IsHateCrime",
-        "Count_CriminalIncidents_BiasMotivationSexualOrientation_IsHateCrime",
-        "Count_CriminalIncidents_BiasMotivationDisabilityStatus_IsHateCrime"
-    ]
+    NEW_STAT_VARS = []
     ENABLE_BLOCKLIST = False
     # If the deployment is a private instance.
     PRIVATE = False

--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -396,15 +396,13 @@ def get_i18n_all_child_places(raw_page_data):
 
 def has_data(data):
     for item in data:
-        if (item.get('trend', {}) or
-            item.get('similar', {}) or
-            item.get('nearyby', {}) or
-                item.get('child', {})):
+        if (item.get('trend', {}) or item.get('similar', {}) or
+                item.get('nearyby', {}) or item.get('child', {})):
             return True
     return False
 
 
-@ bp.route('/data/<path:dcid>')
+@bp.route('/data/<path:dcid>')
 @cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
 def data(dcid):
     """
@@ -529,8 +527,7 @@ def data(dcid):
     # Get chart category name translations
     categories = {}
     for category in list(spec_and_stat.keys()) + list(spec_and_stat[OVERVIEW]):
-        categories[category] = gettext(
-            f'CHART_TITLE-CHART_CATEGORY-{category}')
+        categories[category] = gettext(f'CHART_TITLE-CHART_CATEGORY-{category}')
 
     # Get display name for all places
     all_places = [dcid]

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -169,8 +169,8 @@ def cached_i18n_name(dcids, locale, should_resolve_all):
         'property': 'nameWithLanguage',
         'direction': 'out'
     },
-        compress=False,
-        post=True)
+                          compress=False,
+                          post=True)
     result = {}
     dcids_default_name = []
     locales = i18n.locale_choices(locale)
@@ -255,9 +255,9 @@ def stat_vars(dcid):
     response = fetch_data('/place/stat-vars', {
         'dcids': [dcid],
     },
-        compress=False,
-        post=False,
-        has_payload=False)
+                          compress=False,
+                          post=False,
+                          has_payload=False)
     return response['places'][dcid].get('statVars', [])
 
 
@@ -278,9 +278,9 @@ def get_stat_vars_union(places, stat_vars):
         'dcids': places,
         'statVars': stat_vars,
     },
-        compress=False,
-        post=True,
-        has_payload=False).get('statVars', [])
+                      compress=False,
+                      post=True,
+                      has_payload=False).get('statVars', [])
 
 
 @bp.route('/stat-vars/union', methods=['POST'])
@@ -319,8 +319,8 @@ def child_fetch(dcid):
         'property': 'containedInPlace',
         'direction': 'in'
     },
-        compress=False,
-        post=True)
+                                    compress=False,
+                                    post=True)
     places = contained_response[dcid].get('in', [])
 
     overlaps_response = fetch_data('/node/property-values', {
@@ -328,8 +328,8 @@ def child_fetch(dcid):
         'property': 'geoOverlaps',
         'direction': 'in'
     },
-        compress=False,
-        post=True)
+                                   compress=False,
+                                   post=True)
     places = places + overlaps_response[dcid].get('in', [])
 
     dcid_str = '^'.join(sorted(map(lambda x: x['dcid'], places)))
@@ -438,8 +438,8 @@ def get_parent_place(dcids):
         'property': 'containedInPlace',
         'direction': 'out'
     },
-        compress=False,
-        post=True)
+                          compress=False,
+                          post=True)
     result = {}
     for dcid in dcids:
         parents = response[dcid].get('out', [])
@@ -642,7 +642,7 @@ def get_state_code(dcids):
         if iso_code:
             split_iso_code = iso_code[0].split("-")
             if len(split_iso_code
-                   ) > 1 and split_iso_code[0] == US_ISO_CODE_PREFIX:
+                  ) > 1 and split_iso_code[0] == US_ISO_CODE_PREFIX:
                 state_code = split_iso_code[1]
         result[dcid] = state_code
 
@@ -747,8 +747,8 @@ def placeid2dcid():
                              "in_prop": "placeId",
                              "out_prop": "dcid",
                              "ids": place_ids
-    },
-        headers={'Content-Type': 'application/json'})
+                         },
+                         headers={'Content-Type': 'application/json'})
     if resp.status_code == 200:
         entities = resp.json().get('entities', [])
         result = {}

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import collections
-from ctypes.wintypes import PLCID
 import json
 import requests
 

--- a/static/js/place/main_pane.tsx
+++ b/static/js/place/main_pane.tsx
@@ -24,9 +24,11 @@ import {
   PageChart,
 } from "../chart/types";
 import { intl } from "../i18n/i18n";
+import { randDomId } from "../shared/util";
 import { ChartBlock } from "./chart_block";
 import { ChartHeader } from "./chart_header";
 import { Overview } from "./overview";
+
 
 interface MainPanePropType {
   /**
@@ -101,7 +103,7 @@ class MainPane extends React.Component<MainPanePropType> {
   renderChartBlock(data: ChartBlockData, category: string): JSX.Element {
     return (
       <ChartBlock
-        key={data.title}
+        key={data.title + randDomId()}
         dcid={this.props.dcid}
         placeName={this.props.placeName}
         placeType={this.props.placeType}
@@ -127,10 +129,10 @@ class MainPane extends React.Component<MainPanePropType> {
         {this.showOverview() && (
           <Overview dcid={this.props.dcid} locale={this.props.locale} />
         )}
-        {topics.map((topic: string) => {
+        {topics.map((topic: string, index: number) => {
           if (isOverview) {
             return (
-              <section className="block col-12" key={topic}>
+              <section className="block col-12" key={topic + index}>
                 <ChartHeader
                   text={topic}
                   place={this.props.dcid}
@@ -150,8 +152,11 @@ class MainPane extends React.Component<MainPanePropType> {
             // UI.
             return [
               topic && (
-                <section className="block topic-header col-12" key={topic}>
-                  <h2 key={topic} id={topic} className="topic">
+                <section
+                  className="block topic-header col-12"
+                  key={topic + index}
+                >
+                  <h2 id={topic} className="topic">
                     {topic}
                   </h2>
                 </section>

--- a/static/js/place/main_pane.tsx
+++ b/static/js/place/main_pane.tsx
@@ -29,7 +29,6 @@ import { ChartBlock } from "./chart_block";
 import { ChartHeader } from "./chart_header";
 import { Overview } from "./overview";
 
-
 interface MainPanePropType {
   /**
    * The place dcid.

--- a/static/js/place/place_autocomplete.ts
+++ b/static/js/place/place_autocomplete.ts
@@ -19,6 +19,53 @@ import { getPlaceDcids } from "../utils/place_utils";
 let ac: google.maps.places.Autocomplete;
 let acs: google.maps.places.AutocompleteService;
 
+// Some India cities have limited data, override to show the corresponding district page.
+const PLACE_OVERRIDE = {
+  "wikidataId/Q1156": "wikidataId/Q2341660",
+  "wikidataId/Q987": "wikidataId/Q1353",
+  "wikidataId/Q1355": "wikidataId/Q806463",
+  "wikidataId/Q1361": "wikidataId/Q15340",
+  "wikidataId/Q1070": "wikidataId/Q401686",
+  "wikidataId/Q1352": "wikidataId/Q15116",
+  "wikidataId/Q1348": "wikidataId/Q2088496",
+  "wikidataId/Q4629": "wikidataId/Q1797317",
+  "wikidataId/Q1538": "wikidataId/Q1797336",
+  "wikidataId/Q66485": "wikidataId/Q1134781",
+  "wikidataId/Q47916": "wikidataId/Q1773416",
+  "wikidataId/Q66568": "wikidataId/Q2089152",
+  "wikidataId/Q1513": "wikidataId/Q1797367",
+  "wikidataId/Q66616": "wikidataId/Q742938",
+  "wikidataId/Q207749": "wikidataId/Q943099",
+  "wikidataId/Q80989": "wikidataId/Q1797245",
+  "wikidataId/Q200016": "wikidataId/Q15394",
+  "wikidataId/Q80484": "wikidataId/Q100077",
+  "wikidataId/Q11909": "wikidataId/Q578285",
+  "wikidataId/Q207098": "wikidataId/Q1773444",
+  "wikidataId/Q200123": "wikidataId/Q172482",
+  "wikidataId/Q42941": "wikidataId/Q606343",
+  "wikidataId/Q200235": "wikidataId/Q1797269",
+  "wikidataId/Q174461": "wikidataId/Q1947380",
+  "wikidataId/Q200663": "wikidataId/Q2086173",
+  "wikidataId/Q200237": "wikidataId/Q1764627",
+  "wikidataId/Q11854": "wikidataId/Q1815245",
+  "wikidataId/Q79980": "wikidataId/Q1321140",
+  "wikidataId/Q170115": "wikidataId/Q1506029",
+  "wikidataId/Q200713": "wikidataId/Q592942",
+  "wikidataId/Q244159": "wikidataId/Q2240791",
+  "wikidataId/Q48403": "wikidataId/Q202822",
+  "wikidataId/Q162442": "wikidataId/Q1773426",
+  "wikidataId/Q205697": "wikidataId/Q1478937",
+  "wikidataId/Q158467": "wikidataId/Q2085310",
+  "wikidataId/Q200878": "wikidataId/Q632093",
+  "wikidataId/Q9885": "wikidataId/Q15136",
+  "wikidataId/Q200019": "wikidataId/Q1434965",
+  "wikidataId/Q228405": "wikidataId/Q15184",
+  "wikidataId/Q372773": "wikidataId/Q2295914",
+  "wikidataId/Q207754": "wikidataId/Q15201",
+  "wikidataId/Q41496": "wikidataId/Q15194",
+  "wikidataId/Q281796": "wikidataId/Q2981389",
+};
+
 /**
  * Setup search input autocomplete
  *
@@ -76,7 +123,11 @@ const queryAutocompleteCallback = (place_name) => (predictions, status) => {
 function getPlaceAndRender(placeId: string, placeName: string): void {
   getPlaceDcids([placeId])
     .then((data) => {
-      window.location.href = localizeLink(`/place/${data[placeId]}`);
+      let dcid = data[placeId];
+      if (dcid in PLACE_OVERRIDE) {
+        dcid = PLACE_OVERRIDE[dcid];
+      }
+      window.location.href = localizeLink(`/place/${dcid}`);
     })
     .catch(() => {
       placeNotFoundAlert(placeName);

--- a/static/js/place/place_autocomplete.ts
+++ b/static/js/place/place_autocomplete.ts
@@ -19,53 +19,6 @@ import { getPlaceDcids } from "../utils/place_utils";
 let ac: google.maps.places.Autocomplete;
 let acs: google.maps.places.AutocompleteService;
 
-// Some India cities have limited data, override to show the corresponding district page.
-const PLACE_OVERRIDE = {
-  "wikidataId/Q1156": "wikidataId/Q2341660",
-  "wikidataId/Q987": "wikidataId/Q1353",
-  "wikidataId/Q1355": "wikidataId/Q806463",
-  "wikidataId/Q1361": "wikidataId/Q15340",
-  "wikidataId/Q1070": "wikidataId/Q401686",
-  "wikidataId/Q1352": "wikidataId/Q15116",
-  "wikidataId/Q1348": "wikidataId/Q2088496",
-  "wikidataId/Q4629": "wikidataId/Q1797317",
-  "wikidataId/Q1538": "wikidataId/Q1797336",
-  "wikidataId/Q66485": "wikidataId/Q1134781",
-  "wikidataId/Q47916": "wikidataId/Q1773416",
-  "wikidataId/Q66568": "wikidataId/Q2089152",
-  "wikidataId/Q1513": "wikidataId/Q1797367",
-  "wikidataId/Q66616": "wikidataId/Q742938",
-  "wikidataId/Q207749": "wikidataId/Q943099",
-  "wikidataId/Q80989": "wikidataId/Q1797245",
-  "wikidataId/Q200016": "wikidataId/Q15394",
-  "wikidataId/Q80484": "wikidataId/Q100077",
-  "wikidataId/Q11909": "wikidataId/Q578285",
-  "wikidataId/Q207098": "wikidataId/Q1773444",
-  "wikidataId/Q200123": "wikidataId/Q172482",
-  "wikidataId/Q42941": "wikidataId/Q606343",
-  "wikidataId/Q200235": "wikidataId/Q1797269",
-  "wikidataId/Q174461": "wikidataId/Q1947380",
-  "wikidataId/Q200663": "wikidataId/Q2086173",
-  "wikidataId/Q200237": "wikidataId/Q1764627",
-  "wikidataId/Q11854": "wikidataId/Q1815245",
-  "wikidataId/Q79980": "wikidataId/Q1321140",
-  "wikidataId/Q170115": "wikidataId/Q1506029",
-  "wikidataId/Q200713": "wikidataId/Q592942",
-  "wikidataId/Q244159": "wikidataId/Q2240791",
-  "wikidataId/Q48403": "wikidataId/Q202822",
-  "wikidataId/Q162442": "wikidataId/Q1773426",
-  "wikidataId/Q205697": "wikidataId/Q1478937",
-  "wikidataId/Q158467": "wikidataId/Q2085310",
-  "wikidataId/Q200878": "wikidataId/Q632093",
-  "wikidataId/Q9885": "wikidataId/Q15136",
-  "wikidataId/Q200019": "wikidataId/Q1434965",
-  "wikidataId/Q228405": "wikidataId/Q15184",
-  "wikidataId/Q372773": "wikidataId/Q2295914",
-  "wikidataId/Q207754": "wikidataId/Q15201",
-  "wikidataId/Q41496": "wikidataId/Q15194",
-  "wikidataId/Q281796": "wikidataId/Q2981389",
-};
-
 /**
  * Setup search input autocomplete
  *
@@ -123,11 +76,7 @@ const queryAutocompleteCallback = (place_name) => (predictions, status) => {
 function getPlaceAndRender(placeId: string, placeName: string): void {
   getPlaceDcids([placeId])
     .then((data) => {
-      let dcid = data[placeId];
-      if (dcid in PLACE_OVERRIDE) {
-        dcid = PLACE_OVERRIDE[dcid];
-      }
-      window.location.href = localizeLink(`/place/${dcid}`);
+      window.location.href = localizeLink(`/place/${data[placeId]}`);
     })
     .catch(() => {
       placeNotFoundAlert(placeName);


### PR DESCRIPTION
- Borrow category data from all categories into Overview page.
- For a set of India cities, use the District place as search result.
- [Bonus]: remove additional stat vars for place page data fetch.