### PR TITLE
Do not auto release feeding america instance

### DIFF
--- a/scripts/autopush.sh
+++ b/scripts/autopush.sh
@@ -40,4 +40,4 @@ for src in $(gsutil ls gs://datcom-control/autopush/*_latest_base_cache_version.
 done
 $ROOT/scripts/deploy_gke.sh autopush us-central1
 $ROOT/scripts/deploy_gke.sh autopush europe-west2
-$ROOT/scripts/deploy_gke.sh feedingamerica us-central1
+# $ROOT/scripts/deploy_gke.sh feedingamerica us-central1


### PR DESCRIPTION
As the instance is used as production use. The deployment should be done manually.