### PR TITLE
[bigquery] small fixes to the bq modal style

### DIFF
--- a/static/css/place/place.scss
+++ b/static/css/place/place.scss
@@ -20,6 +20,7 @@
 @import "place_search";
 @import "../shared/story_block.scss";
 @import "../shared/story_chart.scss";
+@import "../shared/modal.scss";
 
 $vertical-section-border: 1px solid var(--dc-gray-lite);
 $vertical-section-margin: 2rem;
@@ -292,12 +293,6 @@ h3 {
   margin-bottom: 15px;
 }
 
-.modal-dialog {
-  @include media-breakpoint-down(md) {
-    max-width: calc(100% - 30px);
-  }
-}
-
 .modal .modal-chart-container {
   display: flex;
   justify-content: center;
@@ -321,14 +316,7 @@ h3 {
 }
 
 .modal textarea {
-  background: #efefef;
-  border-radius: 3px;
-  border: $chart-border;
-  display: flex;
-  font-family: monospace;
   height: 8rem;
-  margin: auto;
-  padding: 0.5rem;
 }
 
 .landing-link {

--- a/static/css/shared/modal.scss
+++ b/static/css/shared/modal.scss
@@ -21,6 +21,7 @@ $border: 0.5px solid #dee2e6;
 .modal-dialog {
   @include media-breakpoint-down(md) {
     max-width: calc(100% - 30px);
+    margin: auto;
   }
 }
 

--- a/static/css/shared/modal.scss
+++ b/static/css/shared/modal.scss
@@ -14,27 +14,22 @@
  * limitations under the License.
  */
 
-/* Styles for <BqModal> */
+/* Shared styles for <Modal> */
 
-@import "shared/modal.scss";
+$border: 0.5px solid #dee2e6;
 
-.big-query-modal .modal-content {
-  height: 90vh;
+.modal-dialog {
+  @include media-breakpoint-down(md) {
+    max-width: calc(100% - 30px);
+  }
 }
 
-.modal-body {
+.modal textarea {
+  background: #efefef;
+  border-radius: 3px;
+  border: $border;
   display: flex;
-  flex-direction: column;
-}
-
-.big-query-modal textarea {
-  width: 100%;
-  height: 100%;
-  flex: 1 1 auto;
-}
-
-.big-query-sql-instructions {
-  word-wrap: break-word;
-  white-space: normal;
-  flex: 0 0 auto;
+  font-family: monospace;
+  margin: auto;
+  padding: 0.5rem;
 }

--- a/static/js/tools/shared/bq_modal.tsx
+++ b/static/js/tools/shared/bq_modal.tsx
@@ -67,29 +67,34 @@ export function BqModal(props: BqModalPropType): JSX.Element {
       </ModalHeader>
       <ModalBody>
         <div className="big-query-sql-instructions mb-3">
-          <div>
-            To run this query, first{" "}
-            <a
-              href={
-                "https://console.cloud.google.com/bigquery/analytics-hub/exchanges(analyticshub:projects/841968438789/locations/us/dataExchanges/data_commons_17d0b72b0b2/listings/data_commons_1803e67fbc9)"
-              }
-            >
-              link Data Commons to Your GCP Project
-            </a>
-            , then copy and paste the query into the{" "}
-            <a
-              href={
-                "https://console.cloud.google.com/bigquery;create-new-query-tab"
-              }
-            >
-              BigQuery Editor
-            </a>
-            .
-          </div>
-          <div>
+          <p>To run this query:</p>
+          <ol>
+            <li>
+              <a
+                href={
+                  "https://console.cloud.google.com/bigquery/analytics-hub/exchanges(analyticshub:projects/841968438789/locations/us/dataExchanges/data_commons_17d0b72b0b2/listings/data_commons_1803e67fbc9)"
+                }
+              >
+                Link Data Commons to your Google Cloud Project
+              </a>
+              .
+            </li>
+            <li>
+              Copy and paste the query into the{" "}
+              <a
+                href={
+                  "https://console.cloud.google.com/bigquery;create-new-query-tab"
+                }
+              >
+                BigQuery Editor
+              </a>
+              .
+            </li>
+          </ol>
+          <p>
             For more information on querying Data Commons, see{" "}
             <a href={"https://docs.datacommons.org/bigquery/"}>this guide</a>.
-          </div>
+          </p>
         </div>
         <textarea
           className="copy-svg"

--- a/static/js/tools/shared/bq_modal.tsx
+++ b/static/js/tools/shared/bq_modal.tsx
@@ -18,8 +18,6 @@ import _ from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 import { Modal, ModalBody, ModalHeader } from "reactstrap";
 
-const MODAL_MAX_WIDTH = "90vw";
-
 interface BqModalPropType {
   showButton: boolean;
   getSqlQuery: () => string;
@@ -62,14 +60,13 @@ export function BqModal(props: BqModalPropType): JSX.Element {
   return (
     <Modal
       isOpen={modalOpen}
-      className="big-query-modal"
-      style={{ maxWidth: MODAL_MAX_WIDTH }}
+      className="big-query-modal modal-dialog-centered modal-lg"
     >
       <ModalHeader toggle={() => setModalOpen(false)}>
         Analyze this data in BigQuery
       </ModalHeader>
       <ModalBody>
-        <div className="big-query-sql-instructions">
+        <div className="big-query-sql-instructions mb-3">
           <div>
             To run this query, first{" "}
             <a
@@ -94,15 +91,13 @@ export function BqModal(props: BqModalPropType): JSX.Element {
             <a href={"https://docs.datacommons.org/bigquery/"}>this guide</a>.
           </div>
         </div>
-        <div className="sql-text-area">
-          <textarea
-            className="copy-svg mt-3"
-            value={query}
-            readOnly
-            ref={textAreaRef}
-            onClick={textAreaOnClick}
-          />
-        </div>
+        <textarea
+          className="copy-svg"
+          value={query}
+          readOnly
+          ref={textAreaRef}
+          onClick={textAreaOnClick}
+        />
       </ModalBody>
     </Modal>
   );


### PR DESCRIPTION
I noticed an overflow at narrow sizes. Factored out some style from the chart export modal to share a consistent look.

Since textareas can't expand to fit content without js, I thought it would be simplest to make the entire modal super tall, since our queries do get really long.

![localhost_8080_tools_timeline (4)](https://user-images.githubusercontent.com/6052978/164390068-45cb5629-4859-4184-9281-94b8ccfcb672.png)
![localhost_8080_tools_timeline (5)](https://user-images.githubusercontent.com/6052978/164390076-b9dd2ac8-c7a0-4d75-bc7a-4de56005dc4d.png)

