### PR TITLE
[map] fix non float string error in getting map points data

### DIFF
--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -20,6 +20,7 @@ import services.datacommons as dc_service
 import routes.api.place as place_api
 import routes.api.landing_page as landing_page_api
 
+from routes.api.shared import is_float
 from geojson_rewind import rewind
 from cache import cache
 from flask import Blueprint, current_app, request, Response, g, url_for
@@ -496,6 +497,8 @@ def get_map_points():
     for subject_dcid, latitude in lat_by_subject.items():
         longitude = lon_by_subject.get(subject_dcid, [])
         if len(latitude) == 0 or len(longitude) == 0:
+            continue
+        if not is_float(latitude[0]) or not is_float(longitude[0]):
             continue
         geo_id = geo_by_latlon_subject.get(subject_dcid, "")
         map_point = {

--- a/server/routes/api/shared.py
+++ b/server/routes/api/shared.py
@@ -42,3 +42,12 @@ def cached_name(dcids):
         values = response[dcid].get('out')
         result[dcid] = values[0]['value'] if values else ''
     return result
+
+
+def is_float(query_string):
+    """Checks if a string can be converted to a float"""
+    try:
+        float(query_string)
+        return True
+    except ValueError:
+        return False

--- a/server/tests/api_shared_test.py
+++ b/server/tests/api_shared_test.py
@@ -47,3 +47,22 @@ class TestCachedName(unittest.TestCase):
 
         result = shared_api.cached_name('^'.join([dcid1, dcid2, dcid3]))
         assert result == {dcid1: 'California', dcid2: '', dcid3: 'Colorado'}
+
+
+class TestIsFloat(unittest.TestCase):
+
+    def test_is_float(self):
+        cases = [{
+            'query': 'abc',
+            'expected': False
+        }, {
+            'query': '1.26',
+            'expected': True
+        }, {
+            'query': '-',
+            'expected': False
+        }]
+        for test_case in cases:
+            print(test_case)
+            result = shared_api.is_float(test_case.get("query"))
+            assert result == test_case.get("expected")

--- a/server/tests/api_shared_test.py
+++ b/server/tests/api_shared_test.py
@@ -61,6 +61,12 @@ class TestIsFloat(unittest.TestCase):
         }, {
             'query': '-',
             'expected': False
+        }, {
+            'query': '0.0',
+            'expected': True
+        }, {
+            'query': '3',
+            'expected': True
         }]
         for test_case in cases:
             print(test_case)


### PR DESCRIPTION
- when getting map points, sometimes error thrown because longitude/latitude string was not a float. Should skip those map points