### PR TITLE
Handle the case no places returned by the API

### DIFF
--- a/static/css/rich_search.scss
+++ b/static/css/rich_search.scss
@@ -91,6 +91,20 @@
   border-radius: 0 0.5rem 0.5rem 0;
 }
 
+.debug-view .btn {
+  font-size: 0.8rem;
+  color: var(--link-color);
+  width: fit-content;
+  margin-bottom: 0.5rem;
+}
+
+.debug-view .card-body {
+  font-family: monospace;
+  font-size: 0.8rem;
+  font-weight: normal;
+  padding: 0;
+}
+
 #main-pane #plot-container {
   direction: initial;
   padding: 2rem;

--- a/static/js/rich_search/app.tsx
+++ b/static/js/rich_search/app.tsx
@@ -55,9 +55,6 @@ function App({
       <div id="plot-container">
         <Container fluid={true}>
           <Row>
-            <h1 className="mb-4">Rich Search</h1>
-          </Row>
-          <Row>
             <Card className="place-options-card">
               <Container className="place-options" fluid={true}>
                 <div className="place-options-section">
@@ -100,6 +97,7 @@ async function fetchChartsData(query: string): Promise<StatVarResultsPropType> {
         .map((v) => v.dcid)
         .filter((dcid) => !!dcid)
         .slice(0, 6);
+      const debug = resp.data.debug || [];
       const placeName = getPlaceIdsFromNames(
         resp.data.places.map((p) => p.name)
       )
@@ -108,12 +106,18 @@ async function fetchChartsData(query: string): Promise<StatVarResultsPropType> {
         .then(Object.values)
         .then(getPlaceNames);
       const statVarInfo = getStatVarInfo(vars);
-      return Promise.all([Promise.resolve(vars), statVarInfo, placeName]);
+      return Promise.all([
+        Promise.resolve(vars),
+        Promise.resolve(debug),
+        statVarInfo,
+        placeName,
+      ]);
     })
-    .then(([statVarOrder, statVarInfo, placeName]) => ({
+    .then(([statVarOrder, debug, statVarInfo, placeName]) => ({
       statVarOrder,
       statVarInfo,
       placeName,
+      debug,
     }));
 }
 

--- a/static/js/rich_search/stat_vars.tsx
+++ b/static/js/rich_search/stat_vars.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, { useState } from "react";
+import { Button, Card, CardBody, Collapse } from "reactstrap";
 
 import { StatVarInfo } from "../shared/stat_var";
 import { ChartRegion } from "../tools/timeline/chart_region";
@@ -26,6 +27,8 @@ export interface StatVarResultsPropType {
   statVarInfo: { [key: string]: StatVarInfo };
   // Order in which stat vars were selected.
   statVarOrder: string[];
+  // Extra debug information from the search results.
+  debug: string[];
 }
 
 function getURL(places: string[], statsVar: string): string {
@@ -43,11 +46,19 @@ export function StatVarResults({
   placeName,
   statVarInfo,
   statVarOrder,
+  debug,
 }: StatVarResultsPropType): JSX.Element {
+  const [debugOpen, setDebugOpen] = useState(false);
+  const places = Object.keys(placeName);
+  if (!places.length) {
+    return (
+      <section className="block col-12">No places found in the query.</section>
+    );
+  }
   if (!statVarOrder.length) {
     return <section className="block col-12">No results found.</section>;
   }
-  const places = Object.keys(placeName);
+
   return (
     <section className="block col-12">
       <div id="chart-region">
@@ -64,6 +75,26 @@ export function StatVarResults({
           </li>
         ))}
       </ul>
+      {!!debug.length && (
+        <div className="debug-view">
+          <Button
+            className="btn-light"
+            onClick={() => setDebugOpen(!debugOpen)}
+            size="sm"
+          >
+            {debugOpen ? "Hide Debug" : "Show Debug"}
+          </Button>
+          <Collapse isOpen={debugOpen}>
+            <Card>
+              <CardBody>
+                {debug.map((line, key) => (
+                  <div key={key}>{line}</div>
+                ))}
+              </CardBody>
+            </Card>
+          </Collapse>
+        </div>
+      )}
     </section>
   );
 }

--- a/static/js/utils/place_utils.ts
+++ b/static/js/utils/place_utils.ts
@@ -162,6 +162,9 @@ export function getNamedTypedPlace(
 export function getPlaceNames(
   dcids: string[]
 ): Promise<{ [key: string]: string }> {
+  if (!dcids.length) {
+    return Promise.resolve({});
+  }
   let url = "/api/place/name?";
   const urls = [];
   for (const place of dcids) {
@@ -180,6 +183,9 @@ export function getPlaceNames(
 export function getPlaceDcids(
   placeIds: string[]
 ): Promise<Record<string, string>> {
+  if (!placeIds.length) {
+    return Promise.resolve({});
+  }
   const param = placeIds.map((placeId) => "placeIds=" + placeId).join("&");
   return axios
     .get(`/api/place/placeid2dcid?${param}`)


### PR DESCRIPTION
This change properly handles and shows errors when no places were specified in the query. We also add support for displaying generic debug messages.