### PR TITLE
Only allow places with MIDs from NLP API

### DIFF
--- a/server/services/ai.py
+++ b/server/services/ai.py
@@ -181,7 +181,7 @@ def _get_places(language_client: language_v1.LanguageServiceClient,
     })
     locations = [
         e for e in response.entities
-        if e.type == language_v1.Entity.Type.LOCATION
+        if e.type == language_v1.Entity.Type.LOCATION and "mid" in e.metadata
     ]
     return locations
 

--- a/static/js/rich_search/app.tsx
+++ b/static/js/rich_search/app.tsx
@@ -105,7 +105,8 @@ async function fetchChartsData(query: string): Promise<StatVarResultsPropType> {
         .then(getPlaceDcids)
         .then(Object.values)
         .then(getPlaceNames);
-      const statVarInfo = getStatVarInfo(vars);
+      const statVarInfo = vars.length
+        ? getStatVarInfo(vars) : Promise.resolve({});
       return Promise.all([
         Promise.resolve(vars),
         Promise.resolve(debug),

--- a/static/js/rich_search/app.tsx
+++ b/static/js/rich_search/app.tsx
@@ -106,7 +106,8 @@ async function fetchChartsData(query: string): Promise<StatVarResultsPropType> {
         .then(Object.values)
         .then(getPlaceNames);
       const statVarInfo = vars.length
-        ? getStatVarInfo(vars) : Promise.resolve({});
+        ? getStatVarInfo(vars)
+        : Promise.resolve({});
       return Promise.all([
         Promise.resolve(vars),
         Promise.resolve(debug),


### PR DESCRIPTION
The NLP API that we use in the search UI can return non-places like the word houses or cities, we can filter those examples by using the MID attribute.