### PR TITLE
Add choropleth map to the earth page

### DIFF
--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -72,6 +72,8 @@ def get_choropleth_display_level(geoDcid):
     # Territories of the US, e.g. country/USA are also AA1. Restrict this view to only States.
     if geoDcid == 'country/USA':
         return geoDcid, 'State'
+    if geoDcid == 'Earth':
+        return geoDcid, 'Country'
     place_type = place_api.get_place_type(geoDcid)
     display_level = None
     if place_type in CHOROPLETH_DISPLAY_LEVEL_MAP:

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -195,6 +195,7 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
     // Prepare parameters for related charts.
     let unit = this.props.data.unit;
     let scaling = this.props.data.scaling;
+    const isEarth = this.props.dcid == "Earth";
     if (relatedChart && relatedChart.scale) {
       unit = relatedChart.unit;
       scaling = relatedChart.scaling ? relatedChart.scaling : 1;
@@ -254,8 +255,9 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
       let gotChart = false;
       if (
         !!this.props.data.isChoropleth &&
-        this.props.isUsaPlace &&
-        (this.props.placeType === "Country" ||
+        (this.props.isUsaPlace || isEarth) &&
+        (this.props.placeType === "Place" ||
+          this.props.placeType === "Country" ||
           this.props.placeType === "State" ||
           this.props.placeType === "County")
       ) {
@@ -422,7 +424,10 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
           );
         }
       }
-      if (!!this.props.data.isChoropleth && this.props.isUsaPlace) {
+      if (
+        !!this.props.data.isChoropleth &&
+        (this.props.isUsaPlace || isEarth)
+      ) {
         const id = randDomId();
         chartElements.push(
           <Chart

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -195,7 +195,7 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
     // Prepare parameters for related charts.
     let unit = this.props.data.unit;
     let scaling = this.props.data.scaling;
-    const isEarth = this.props.dcid == "Earth";
+    const isEarth = this.props.dcid === "Earth";
     if (relatedChart && relatedChart.scale) {
       unit = relatedChart.unit;
       scaling = relatedChart.scaling ? relatedChart.scaling : 1;
@@ -255,11 +255,11 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
       let gotChart = false;
       if (
         !!this.props.data.isChoropleth &&
-        (this.props.isUsaPlace || isEarth) &&
-        (this.props.placeType === "Place" ||
-          this.props.placeType === "Country" ||
-          this.props.placeType === "State" ||
-          this.props.placeType === "County")
+        (isEarth ||
+          (this.props.isUsaPlace &&
+            (this.props.placeType === "Country" ||
+              this.props.placeType === "State" ||
+              this.props.placeType === "County")))
       ) {
         const id = randDomId();
         chartElements.push(

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -39,7 +39,12 @@ let sidebarTopMax = 0;
 const Y_SCROLL_WINDOW_BREAKPOINT = 992;
 // Margin to apply to the fixed sidebar top.
 const Y_SCROLL_MARGIN = 100;
-const placeTypesWithChoropleth = new Set(["Country", "State", "County"]);
+const placeTypesWithChoropleth = new Set([
+  "Place",
+  "Country",
+  "State",
+  "County",
+]);
 
 window.onload = () => {
   renderPage();
@@ -154,9 +159,10 @@ async function getLandingPageData(
 }
 
 function shouldMakeChoroplethCalls(dcid: string, placeType: string): boolean {
+  const isEarth = dcid == "Earth";
   const isInUSA: boolean =
     dcid.startsWith("geoId") || dcid.startsWith(USA_PLACE_DCID);
-  return isInUSA && placeTypesWithChoropleth.has(placeType);
+  return (isEarth || isInUSA) && placeTypesWithChoropleth.has(placeType);
 }
 
 function renderPage(): void {

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -39,12 +39,7 @@ let sidebarTopMax = 0;
 const Y_SCROLL_WINDOW_BREAKPOINT = 992;
 // Margin to apply to the fixed sidebar top.
 const Y_SCROLL_MARGIN = 100;
-const placeTypesWithChoropleth = new Set([
-  "Place",
-  "Country",
-  "State",
-  "County",
-]);
+const placeTypesWithChoropleth = new Set(["Country", "State", "County"]);
 
 window.onload = () => {
   renderPage();
@@ -159,10 +154,10 @@ async function getLandingPageData(
 }
 
 function shouldMakeChoroplethCalls(dcid: string, placeType: string): boolean {
-  const isEarth = dcid == "Earth";
+  const isEarth = dcid === "Earth";
   const isInUSA: boolean =
     dcid.startsWith("geoId") || dcid.startsWith(USA_PLACE_DCID);
-  return (isEarth || isInUSA) && placeTypesWithChoropleth.has(placeType);
+  return isEarth || (isInUSA && placeTypesWithChoropleth.has(placeType));
 }
 
 function renderPage(): void {


### PR DESCRIPTION
For the visualization part, it turns out that only the chart fig that has complete data can be rendered. So I was only able to render the choropleth map for the population under demographics. 
And there are many sources listed under the chart as well.

![image](https://user-images.githubusercontent.com/98435133/168712120-5d43951c-8ba3-406f-9e18-4175f439dc2f.png)
