### PR TITLE
Add choropleth map to the earth page

### DIFF
--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -72,6 +72,8 @@ def get_choropleth_display_level(geoDcid):
     # Territories of the US, e.g. country/USA are also AA1. Restrict this view to only States.
     if geoDcid == 'country/USA':
         return geoDcid, 'State'
+    if geoDcid == 'Earth':
+        return geoDcid, 'Country'
     place_type = place_api.get_place_type(geoDcid)
     display_level = None
     if place_type in CHOROPLETH_DISPLAY_LEVEL_MAP:

--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -41,9 +41,9 @@ CHOROPLETH_DISPLAY_LEVEL_MAP = {
 }
 
 # Place type to get choropleth for, keyed by geoDcid
-# This works for special geoDcid.
-# 1. country/USA are also AA1. Restrict this view to only States.
-# 2. display the chorpleth for earth in the country level.
+# These are the special cases.
+# 1. Territories of the US, e.g. country/USA, are also AA1. Restrict this view to only States.
+# 2. For Earth, display the countries.
 SPECIAL_CHOROPLETH_DISPLAY_LEVEL_MAP = {
     "country/USA": "State",
     "Earth": "Country"

--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -39,6 +39,16 @@ CHOROPLETH_DISPLAY_LEVEL_MAP = {
     "AdministrativeArea2": "AdministrativeArea2",
     "AdministrativeArea3": "AdministrativeArea3"
 }
+
+# Place type to get choropleth for, keyed by geoDcid
+# This works for special geoDcid.
+# 1. country/USA are also AA1. Restrict this view to only States.
+# 2. display the chorpleth for earth in the country level.
+SPECIAL_CHOROPLETH_DISPLAY_LEVEL_MAP = {
+    "country/USA": "State",
+    "Earth": "Country"
+}
+
 # GeoJSON property to use, keyed by display level.
 CHOROPLETH_GEOJSON_PROPERTY_MAP = {
     "Country": "geoJsonCoordinatesDP3",
@@ -69,11 +79,10 @@ def get_choropleth_display_level(geoDcid):
                 parent place dcid)
             display level (AdministrativeArea1 or AdministrativeArea2)
     """
-    # Territories of the US, e.g. country/USA are also AA1. Restrict this view to only States.
-    if geoDcid == 'country/USA':
-        return geoDcid, 'State'
-    if geoDcid == 'Earth':
-        return geoDcid, 'Country'
+    if geoDcid in SPECIAL_CHOROPLETH_DISPLAY_LEVEL_MAP:
+        display_level = SPECIAL_CHOROPLETH_DISPLAY_LEVEL_MAP[geoDcid]
+        return geoDcid, display_level
+
     place_type = place_api.get_place_type(geoDcid)
     display_level = None
     if place_type in CHOROPLETH_DISPLAY_LEVEL_MAP:

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -28,7 +28,10 @@ import { intl, localizeSearchParams } from "../i18n/i18n";
 import { EARTH_NAMED_TYPED_PLACE } from "../shared/constants";
 import { randDomId } from "../shared/util";
 import { Chart } from "./chart";
-import { displayNameForPlaceType } from "./util";
+import {
+  displayNameForPlaceType,
+  USA_PLACE_TYPES_WITH_CHOROPLETH,
+} from "./util";
 
 interface ChartBlockPropType {
   /**
@@ -258,9 +261,7 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
         !!this.props.data.isChoropleth &&
         (isEarth ||
           (this.props.isUsaPlace &&
-            (this.props.placeType === "Country" ||
-              this.props.placeType === "State" ||
-              this.props.placeType === "County")))
+            USA_PLACE_TYPES_WITH_CHOROPLETH.has(this.props.placeType)))
       ) {
         const id = randDomId();
         chartElements.push(

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -195,6 +195,7 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
     // Prepare parameters for related charts.
     let unit = this.props.data.unit;
     let scaling = this.props.data.scaling;
+    const isEarth = this.props.dcid === "Earth";
     if (relatedChart && relatedChart.scale) {
       unit = relatedChart.unit;
       scaling = relatedChart.scaling ? relatedChart.scaling : 1;
@@ -254,10 +255,11 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
       let gotChart = false;
       if (
         !!this.props.data.isChoropleth &&
-        this.props.isUsaPlace &&
-        (this.props.placeType === "Country" ||
-          this.props.placeType === "State" ||
-          this.props.placeType === "County")
+        (isEarth ||
+          (this.props.isUsaPlace &&
+            (this.props.placeType === "Country" ||
+              this.props.placeType === "State" ||
+              this.props.placeType === "County")))
       ) {
         const id = randDomId();
         chartElements.push(
@@ -422,7 +424,10 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
           );
         }
       }
-      if (!!this.props.data.isChoropleth && this.props.isUsaPlace) {
+      if (
+        !!this.props.data.isChoropleth &&
+        (this.props.isUsaPlace || isEarth)
+      ) {
         const id = randDomId();
         chartElements.push(
           <Chart

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -25,6 +25,7 @@ import {
   GeoJsonData,
 } from "../chart/types";
 import { intl, localizeSearchParams } from "../i18n/i18n";
+import { EARTH_NAMED_TYPED_PLACE } from "../shared/constants";
 import { randDomId } from "../shared/util";
 import { Chart } from "./chart";
 import { displayNameForPlaceType } from "./util";
@@ -99,7 +100,7 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
         break;
       }
     }
-    const isEarth = this.props.dcid == "Earth";
+    const isEarth = this.props.dcid == EARTH_NAMED_TYPED_PLACE.dcid;
     // We will localize Earth to a translation of "the World".
     // However, we will not localize other Place names, as we will later
     // pull the localized names from the KG.
@@ -195,7 +196,7 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
     // Prepare parameters for related charts.
     let unit = this.props.data.unit;
     let scaling = this.props.data.scaling;
-    const isEarth = this.props.dcid === "Earth";
+    const isEarth = this.props.dcid === EARTH_NAMED_TYPED_PLACE.dcid;
     if (relatedChart && relatedChart.scale) {
       unit = relatedChart.unit;
       scaling = relatedChart.scaling ? relatedChart.scaling : 1;

--- a/static/js/place/chart_block.tsx
+++ b/static/js/place/chart_block.tsx
@@ -100,7 +100,7 @@ class ChartBlock extends React.Component<ChartBlockPropType> {
         break;
       }
     }
-    const isEarth = this.props.dcid == EARTH_NAMED_TYPED_PLACE.dcid;
+    const isEarth = this.props.dcid === EARTH_NAMED_TYPED_PLACE.dcid;
     // We will localize Earth to a translation of "the World".
     // However, we will not localize other Place names, as we will later
     // pull the localized names from the KG.

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -21,7 +21,7 @@ import ReactDOM from "react-dom";
 
 import { CachedChoroplethData, GeoJsonData, PageData } from "../chart/types";
 import { loadLocaleData } from "../i18n/i18n";
-import { USA_PLACE_DCID } from "../shared/constants";
+import { EARTH_NAMED_TYPED_PLACE, USA_PLACE_DCID } from "../shared/constants";
 import { ChildPlace } from "./child_places_menu";
 import { MainPane } from "./main_pane";
 import { Menu } from "./menu";
@@ -29,7 +29,7 @@ import { PageSubtitle } from "./page_subtitle";
 import { ParentPlace } from "./parent_breadcrumbs";
 import { initSearchAutocomplete } from "./place_autocomplete";
 import { PlaceHighlight } from "./place_highlight";
-import { isPlaceInUsa } from "./util";
+import { isPlaceInUsa, USA_PLACE_TYPES_WITH_CHOROPLETH } from "./util";
 
 // Window scroll position to start fixing the sidebar.
 let yScrollLimit = 0;
@@ -39,7 +39,6 @@ let sidebarTopMax = 0;
 const Y_SCROLL_WINDOW_BREAKPOINT = 992;
 // Margin to apply to the fixed sidebar top.
 const Y_SCROLL_MARGIN = 100;
-const placeTypesWithChoropleth = new Set(["Country", "State", "County"]);
 
 window.onload = () => {
   renderPage();
@@ -154,10 +153,10 @@ async function getLandingPageData(
 }
 
 function shouldMakeChoroplethCalls(dcid: string, placeType: string): boolean {
-  const isEarth = dcid === "Earth";
+  const isEarth = dcid === EARTH_NAMED_TYPED_PLACE.dcid;
   const isInUSA: boolean =
     dcid.startsWith("geoId") || dcid.startsWith(USA_PLACE_DCID);
-  return isEarth || (isInUSA && placeTypesWithChoropleth.has(placeType));
+  return isEarth || (isInUSA && USA_PLACE_TYPES_WITH_CHOROPLETH.has(placeType));
 }
 
 function renderPage(): void {

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -154,9 +154,10 @@ async function getLandingPageData(
 }
 
 function shouldMakeChoroplethCalls(dcid: string, placeType: string): boolean {
+  const isEarth = dcid === "Earth";
   const isInUSA: boolean =
     dcid.startsWith("geoId") || dcid.startsWith(USA_PLACE_DCID);
-  return isInUSA && placeTypesWithChoropleth.has(placeType);
+  return isEarth || (isInUSA && placeTypesWithChoropleth.has(placeType));
 }
 
 function renderPage(): void {

--- a/static/js/place/util.ts
+++ b/static/js/place/util.ts
@@ -32,6 +32,14 @@ export function isPlaceInUsa(dcid: string, parentPlaces: string[]): boolean {
   }
   return false;
 }
+/**
+ * A set of place types to render a choropleth for.
+ */
+export const USA_PLACE_TYPES_WITH_CHOROPLETH = new Set([
+  "Country",
+  "State",
+  "County",
+]);
 
 const singularPlaceTypeMessages = defineMessages({
   Country: {


### PR DESCRIPTION
For the visualization part, it turns out that only the chart fig that has complete data can be rendered. So I was only able to render the choropleth for the population under demographics. And there are many sources listed under the chart as well.

![image](https://user-images.githubusercontent.com/98435133/168906201-582dde19-f48b-4553-bca7-3cab55f267dd.png)
