### PR TITLE
Chip component cleanup and place selector fixes

### DIFF
--- a/server/webdriver_tests/tests/map_test.py
+++ b/server/webdriver_tests/tests/map_test.py
@@ -144,7 +144,7 @@ class TestMap(WebdriverBaseTest):
             '.pac-item:nth-child(1)')
         first_result.click()
         element_present = EC.presence_of_element_located(
-            (By.CLASS_NAME, 'mdl-chip'))
+            (By.CLASS_NAME, 'chip'))
         WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
 
         # Choose stat var

--- a/server/webdriver_tests/tests/scatter_test.py
+++ b/server/webdriver_tests/tests/scatter_test.py
@@ -106,7 +106,7 @@ class TestScatter(WebdriverBaseTest):
             '.pac-item:nth-child(1)')
         first_result.click()
         element_present = EC.presence_of_element_located(
-            (By.CLASS_NAME, 'mdl-chip'))
+            (By.CLASS_NAME, 'chip'))
         WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
 
         # Choose place type

--- a/static/css/_search_place.scss
+++ b/static/css/_search_place.scss
@@ -56,7 +56,7 @@
     color: rgba(0, 0, 0, 0.25);
   }
 
-  #location-field .mdl-chip {
+  #location-field .chip {
     margin-right: 6px;
     border: 0.5px solid #5384ec;
     background: rgba(66, 133, 244, 0.08);
@@ -99,9 +99,18 @@
     display: none;
   }
 
-  .mdl-chip:focus {
+  .chip:focus {
     outline: 0;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
       0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  }
+
+  .input-area-hidden #place-list {
+    flex-grow: 1;
+  }
+  
+  .input-area-hidden #ac {
+    visibility: hidden;
+    width: 0;
   }
 }

--- a/static/css/_search_place.scss
+++ b/static/css/_search_place.scss
@@ -21,6 +21,10 @@
     display: none;
   }
 
+  .input-area-hidden #place-list {
+    flex-grow: 1;
+  }
+
   #search #location-field #place-list {
     margin-left: 36px;
     padding: 12px 0;
@@ -34,6 +38,11 @@
     background: url("../images/icon-pin.svg") no-repeat;
     background-position: center;
     position: absolute;
+  }
+
+  .input-area-hidden #ac {
+    visibility: hidden;
+    width: 0;
   }
 
   #location-field #ac {
@@ -103,14 +112,5 @@
     outline: 0;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
       0 1px 5px 0 rgba(0, 0, 0, 0.12);
-  }
-
-  .input-area-hidden #place-list {
-    flex-grow: 1;
-  }
-  
-  .input-area-hidden #ac {
-    visibility: hidden;
-    width: 0;
   }
 }

--- a/static/css/_search_place.scss
+++ b/static/css/_search_place.scss
@@ -65,6 +65,12 @@
     color: rgba(0, 0, 0, 0.25);
   }
 
+  .chip:focus {
+    outline: 0;
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
+      0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  }
+
   #location-field .chip {
     margin-right: 6px;
     border: 0.5px solid #5384ec;
@@ -106,11 +112,5 @@
 
   .pac-logo:after {
     display: none;
-  }
-
-  .chip:focus {
-    outline: 0;
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
-      0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
 }

--- a/static/css/place_selector.scss
+++ b/static/css/place_selector.scss
@@ -84,6 +84,7 @@
 .place-selector-main-selectors {
   display: flex;
   flex-grow: 1;
+  flex-wrap: wrap;
 }
 
 #place-selector-place-type:focus {

--- a/static/css/shared/chip.scss
+++ b/static/css/shared/chip.scss
@@ -15,21 +15,22 @@
  */
 
 // Set up wrapping for long stat var names.
-.mdl-chip__text {
+.chip-text {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: calc(100% - 28px); // Account for the chip close button.
   overflow: hidden;
   font-size: 13px;
   vertical-align: middle;
+  display: inline-block;
 }
 
-.mdl-chip__text_clickable:hover {
+.chip-clickable-text:hover {
   cursor: pointer;
   text-decoration: underline;
 }
 
-.mdl-chip {
+.chip {
   height: 32px;
   line-height: 30px;
   padding: 0 8px 0 15px;
@@ -43,7 +44,7 @@
   font-size: 0;
 }
 
-.mdl-chip__action {
+.chip-action {
   height: 24px;
   width: 24px;
   line-height: 33px;
@@ -64,7 +65,7 @@
   overflow: hidden;
 }
 
-.mdl-chip__action .material-icons {
+.chip-action .material-icons {
   color: #3c4043;
   font-size: 18px;
 }

--- a/static/css/tools/map.scss
+++ b/static/css/tools/map.scss
@@ -132,15 +132,6 @@
   font-size: 1.3rem;
 }
 
-.input-area-hidden #place-list {
-  flex-grow: 1;
-}
-
-.input-area-hidden #ac {
-  visibility: hidden;
-  width: 0;
-}
-
 #chart-container {
   width: 100%;
   display: flex;

--- a/static/css/tools/scatter.scss
+++ b/static/css/tools/scatter.scss
@@ -85,15 +85,6 @@
   min-width: 10rem;
 }
 
-.input-area-hidden #place-list {
-  flex-grow: 1;
-}
-
-.input-area-hidden #ac {
-  visibility: hidden;
-  width: 0;
-}
-
 .scatter-dot:hover {
   cursor: pointer;
   fill: var(--dc-primary);

--- a/static/js/shared/chip.tsx
+++ b/static/js/shared/chip.tsx
@@ -34,15 +34,14 @@ interface ChipPropsType {
 }
 
 export function Chip(props: ChipPropsType): JSX.Element {
-  // TODO: clean up class names - don't need to maintain mdl-chip naming
   return (
     <div
-      className="mdl-chip mdl-chip--deletable"
+      className="chip"
       style={props.color ? { backgroundColor: props.color } : {}}
     >
       <span
-        className={`mdl-chip__text ${
-          props.onTextClick && "mdl-chip__text_clickable"
+        className={`chip-text${
+          props.onTextClick ? " chip-clickable-text" : ""
         }`}
         onClick={() => {
           if (props.onTextClick) {
@@ -52,7 +51,7 @@ export function Chip(props: ChipPropsType): JSX.Element {
       >
         {props.title}
       </span>
-      <button className="mdl-chip__action">
+      <button className="chip-action">
         <i
           className="material-icons"
           onClick={() => props.removeChip(props.id)}

--- a/static/js/tools/timeline/__snapshots__/page.test.tsx.snap
+++ b/static/js/tools/timeline/__snapshots__/page.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Single place and single stat var 1`] = `
 "<div class=\\"chart-container\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
-      <div class=\\"mdl-chip mdl-chip--deletable\\"><span class=\\"mdl-chip__text mdl-chip__text_clickable\\">Age</span><button class=\\"mdl-chip__action\\"><i class=\\"material-icons\\">cancel</i></button></div>
+      <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\">Age</span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>
     </div>
     <div class=\\"chart-svg\\"></div>
   </div>
@@ -21,7 +21,7 @@ exports[`Single place and single stat var 2`] = `
 "<div class=\\"chart-container\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
-      <div class=\\"mdl-chip mdl-chip--deletable\\"><span class=\\"mdl-chip__text mdl-chip__text_clickable\\">Age</span><button class=\\"mdl-chip__action\\"><i class=\\"material-icons\\">cancel</i></button></div>
+      <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\">Age</span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>
     </div>
     <div class=\\"chart-svg\\"></div>
   </div>
@@ -76,7 +76,7 @@ exports[`chart options 1`] = `
 "<div class=\\"chart-container\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
-      <div class=\\"mdl-chip mdl-chip--deletable\\"><span class=\\"mdl-chip__text mdl-chip__text_clickable\\">Population</span><button class=\\"mdl-chip__action\\"><i class=\\"material-icons\\">cancel</i></button></div>
+      <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\">Population</span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>
     </div>
     <div class=\\"chart-svg\\"></div>
   </div>
@@ -93,7 +93,7 @@ exports[`statVar not in PV-tree 1`] = `
 "<div class=\\"chart-container\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
-      <div class=\\"mdl-chip mdl-chip--deletable\\"><span class=\\"mdl-chip__text mdl-chip__text_clickable\\"></span><button class=\\"mdl-chip__action\\"><i class=\\"material-icons\\">cancel</i></button></div>
+      <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\"></span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>
     </div>
     <div class=\\"chart-svg\\"></div>
   </div>


### PR DESCRIPTION
- clean up class names for the chip component because no longer need to maintain the "mdl-chip" naming
- fix place selector component overflow by adding flex-wrap and hiding input area once place has been chosen