### PR TITLE
[download] Add stat var selection alerts

### DIFF
--- a/static/css/tools/download.scss
+++ b/static/css/tools/download.scss
@@ -123,3 +123,16 @@
   display: flex;
   flex-wrap: wrap;
 }
+
+.radio-selection-label,
+.radio-selection-section {
+  padding-top: 0.5rem;
+}
+
+.radio-selection-section {
+  margin-left: 2rem;
+}
+
+.radio-selection-section .form-group {
+  margin-bottom: 0;
+}

--- a/static/js/shared/types.ts
+++ b/static/js/shared/types.ts
@@ -51,7 +51,10 @@ export const StatVarHierarchyType = {
 /**
  * The set of StatVarHierarchyTypes where selection is a radio button.
  */
-export const RADIO_BUTTON_TYPES = new Set([StatVarHierarchyType.MAP, StatVarHierarchyType.STAT_VAR])
+export const RADIO_BUTTON_TYPES = new Set([
+  StatVarHierarchyType.MAP,
+  StatVarHierarchyType.STAT_VAR,
+]);
 
 export interface StatVarInfo {
   id: string;

--- a/static/js/shared/types.ts
+++ b/static/js/shared/types.ts
@@ -45,7 +45,13 @@ export const StatVarHierarchyType = {
   SCATTER: "SCATTER",
   MAP: "MAP",
   STAT_VAR: "STAT_VAR",
+  DOWNLOAD: "DOWNLOAD",
 };
+
+/**
+ * The set of StatVarHierarchyTypes where selection is a radio button.
+ */
+export const RADIO_BUTTON_TYPES = new Set([StatVarHierarchyType.MAP, StatVarHierarchyType.STAT_VAR])
 
 export interface StatVarInfo {
   id: string;

--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -25,6 +25,7 @@ import Collapsible from "react-collapsible";
 
 import { Context, ContextType } from "../shared/context";
 import {
+  RADIO_BUTTON_TYPES,
   StatVarGroupInfo,
   StatVarHierarchyNodeType,
   StatVarHierarchyType,
@@ -39,8 +40,8 @@ const SCROLL_DELAY = 400;
 // Stat var hierarchy types where nodes containing selected SV should be
 // expanded on initial render of the page.
 const INITIAL_EXPANSION_TYPES = [
+  ...Array.from(RADIO_BUTTON_TYPES),
   StatVarHierarchyType.BROWSER,
-  StatVarHierarchyType.MAP,
 ];
 
 interface StatVarGroupNodePropType {

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -297,10 +297,9 @@ export class StatVarHierarchy extends React.Component<
       if (this.props.selectSV) {
         this.props.selectSV(sv);
       }
-      const svPath =
-        RADIO_BUTTON_TYPES.has(this.props.type)
-          ? { [sv]: path }
-          : Object.assign({ [sv]: path }, this.state.svPath);
+      const svPath = RADIO_BUTTON_TYPES.has(this.props.type)
+        ? { [sv]: path }
+        : Object.assign({ [sv]: path }, this.state.svPath);
       this.setState({
         svPath,
       });

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -27,6 +27,7 @@ import React from "react";
 import { Context } from "../shared/context";
 import {
   NamedPlace,
+  RADIO_BUTTON_TYPES,
   StatVarGroupInfo,
   StatVarHierarchyType,
 } from "../shared/types";
@@ -297,7 +298,7 @@ export class StatVarHierarchy extends React.Component<
         this.props.selectSV(sv);
       }
       const svPath =
-        this.props.type === StatVarHierarchyType.MAP
+        RADIO_BUTTON_TYPES.has(this.props.type)
           ? { [sv]: path }
           : Object.assign({ [sv]: path }, this.state.svPath);
       this.setState({

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -25,6 +25,7 @@ import React from "react";
 
 import { Context, ContextType } from "../shared/context";
 import {
+  RADIO_BUTTON_TYPES,
   StatVarHierarchyType,
   StatVarInfo,
   StatVarSummary,
@@ -128,11 +129,7 @@ export class StatVarSectionInput extends React.Component<
   }
 
   render(): JSX.Element {
-    const inputType =
-      this.context.statVarHierarchyType === StatVarHierarchyType.MAP ||
-      this.context.statVarHierarchyType === StatVarHierarchyType.STAT_VAR
-        ? "radio"
-        : "checkbox";
+    const inputType = RADIO_BUTTON_TYPES.has(this.context.statVarHierarchyType) ? "radio" : "checkbox";
     const sectionId = this.props.statVar.id + this.props.path.join("-");
     let className = "node-title";
     if (!this.props.statVar.hasData) {

--- a/static/js/stat_var_hierarchy/stat_var_section_input.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_section_input.tsx
@@ -129,7 +129,9 @@ export class StatVarSectionInput extends React.Component<
   }
 
   render(): JSX.Element {
-    const inputType = RADIO_BUTTON_TYPES.has(this.context.statVarHierarchyType) ? "radio" : "checkbox";
+    const inputType = RADIO_BUTTON_TYPES.has(this.context.statVarHierarchyType)
+      ? "radio"
+      : "checkbox";
     const sectionId = this.props.statVar.id + this.props.path.join("-");
     let className = "node-title";
     if (!this.props.statVar.hasData) {

--- a/static/js/tools/download/page.tsx
+++ b/static/js/tools/download/page.tsx
@@ -93,7 +93,7 @@ export function Page(): JSX.Element {
     // TODO: Try to move the options into a separate component.
     <>
       <StatVarChooser
-        statVars={Object.keys(selectedOptions.selectedStatVars)}
+        statVars={selectedOptions.selectedStatVars}
         placeDcid={selectedOptions.selectedPlace.dcid}
         enclosedPlaceType={selectedOptions.enclosedPlaceType}
         onStatVarSelected={selectSV}

--- a/static/js/tools/download/stat_var_chooser.tsx
+++ b/static/js/tools/download/stat_var_chooser.tsx
@@ -19,8 +19,18 @@
  */
 
 import _ from "lodash";
-import React, { useEffect, useState, useRef } from "react";
-import { Button, Container, FormGroup, Input, Label, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Button,
+  Container,
+  FormGroup,
+  Input,
+  Label,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from "reactstrap";
 
 import { getStatVarInfo } from "../../shared/stat_var";
 import { StatVarHierarchyType } from "../../shared/types";
@@ -41,12 +51,15 @@ interface StatVarChooserProps {
   openSvHierarchyModal: boolean;
 }
 
-const EMPTY_SV_AND_INFO: { dcid: string, info: StatVarInfo } = { dcid: "", info: {} }
+const EMPTY_SV_AND_INFO: { dcid: string; info: StatVarInfo } = {
+  dcid: "",
+  info: {},
+};
 const MAX_SV = 5;
 
 export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
   const [samplePlaces, setSamplePlaces] = useState([]);
-  // extraStatVar holds a stat var that is selected after the max number of 
+  // extraStatVar holds a stat var that is selected after the max number of
   // selected stat vars has been reached. This stat var will either be removed
   // or used to replace another selected stat var.
   const [extraStatVar, setExtraStatVar] = useState(EMPTY_SV_AND_INFO);
@@ -76,7 +89,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
       });
   }, [props.placeDcid, props.enclosedPlaceType]);
 
-  const selectedSVs = { ...props.statVars};
+  const selectedSVs = { ...props.statVars };
   // although we don't propagate the extra stat var selection to the rest of the
   // tool, we do need to pass it to the widget because the StatVarHierarchy has
   // it showing as selected.
@@ -86,18 +99,20 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
 
   return (
     <>
-    <StatVarWidget
-      openSvHierarchyModal={props.openSvHierarchyModal}
-      openSvHierarchyModalCallback={props.openSvHierarchyModalCallback}
-      collapsible={false}
-      svHierarchyType={StatVarHierarchyType.DOWNLOAD}
-      samplePlaces={samplePlaces}
-      deselectSVs={(svList: string[]) => svList.forEach((sv) => {
-        props.onStatVarRemoved(sv)
-      })}
-      selectedSVs={selectedSVs}
-      selectSV={(sv) => selectSV(sv)}
-    />
+      <StatVarWidget
+        openSvHierarchyModal={props.openSvHierarchyModal}
+        openSvHierarchyModalCallback={props.openSvHierarchyModalCallback}
+        collapsible={false}
+        svHierarchyType={StatVarHierarchyType.DOWNLOAD}
+        samplePlaces={samplePlaces}
+        deselectSVs={(svList: string[]) =>
+          svList.forEach((sv) => {
+            props.onStatVarRemoved(sv);
+          })
+        }
+        selectedSVs={selectedSVs}
+        selectSV={(sv) => selectSV(sv)}
+      />
       {/* Modal for selecting stat var to replace when too many are selected */}
       <Modal isOpen={modalOpen} backdrop="static" id="statvar-modal">
         <ModalHeader toggle={closeModal}>
@@ -114,30 +129,35 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
             </div>
             <div className="radio-selection-section">
               {modalSvOrder.current.map((sv, idx) => {
-                return <FormGroup key={sv} radio="true" row>
-                <Label radio="true">
-                  <Input
-                    type="radio"
-                    name="statvar"
-                    defaultChecked={(_.isEmpty(modalSelection) && idx === 0) || modalSelection === sv}
-                    onClick={() => setModalSelection(sv)}
-                  />
-                  {sv in props.statVars ? props.statVars[sv].title || sv : sv}
-                </Label>
-              </FormGroup>
+                return (
+                  <FormGroup key={sv} radio="true" row>
+                    <Label radio="true">
+                      <Input
+                        type="radio"
+                        name="statvar"
+                        defaultChecked={
+                          (_.isEmpty(modalSelection) && idx === 0) ||
+                          modalSelection === sv
+                        }
+                        onClick={() => setModalSelection(sv)}
+                      />
+                      {sv in props.statVars
+                        ? props.statVars[sv].title || sv
+                        : sv}
+                    </Label>
+                  </FormGroup>
+                );
               })}
             </div>
           </Container>
         </ModalBody>
         <ModalFooter>
-          <Button
-            color="primary"
-            onClick={() => confirmStatVars()}
-          >
+          <Button color="primary" onClick={() => confirmStatVars()}>
             Confirm
           </Button>
         </ModalFooter>
-      </Modal></>
+      </Modal>
+    </>
   );
 
   /**
@@ -153,9 +173,11 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
    * Confirms the variable to replace in the modal.
    */
   function confirmStatVars(): void {
-    const svToRemove = _.isEmpty(modalSelection) ? modalSvOrder.current[0] : modalSelection;
+    const svToRemove = _.isEmpty(modalSelection)
+      ? modalSvOrder.current[0]
+      : modalSelection;
     props.onStatVarRemoved(svToRemove);
-    props.onStatVarSelected(extraStatVar.dcid, extraStatVar.info)
+    props.onStatVarSelected(extraStatVar.dcid, extraStatVar.info);
     closeModal();
   }
 
@@ -167,7 +189,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
       .then((svInfo) => {
         const selectedSVInfo = svInfo[sv] || {};
         if (Object.keys(props.statVars).length >= MAX_SV) {
-          setExtraStatVar({ dcid: sv, info: selectedSVInfo})
+          setExtraStatVar({ dcid: sv, info: selectedSVInfo });
           setModalOpen(true);
         } else {
           props.onStatVarSelected(sv, selectedSVInfo);
@@ -175,12 +197,11 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
       })
       .catch(() => {
         if (Object.keys(props.statVars).length >= MAX_SV) {
-          setExtraStatVar({ dcid: sv, info: {}})
+          setExtraStatVar({ dcid: sv, info: {} });
           setModalOpen(true);
         } else {
           props.onStatVarSelected(sv, {});
         }
       });
   }
-
 }

--- a/static/js/tools/download/stat_var_chooser.tsx
+++ b/static/js/tools/download/stat_var_chooser.tsx
@@ -15,7 +15,7 @@
  */
 
 /**
- * Component to pick statvar for map.
+ * Component to pick statvar for download tool.
  */
 
 import React, { useEffect, useState } from "react";
@@ -30,7 +30,7 @@ import { StatVarWidget } from "../shared/stat_var_widget";
 import { StatVarInfo } from "../timeline/chart_region";
 
 interface StatVarChooserProps {
-  statVars: string[];
+  statVars: Record<string, StatVarInfo>;
   placeDcid: string;
   enclosedPlaceType: string;
   onStatVarSelected: (sv: string, svInfo: StatVarInfo) => void;
@@ -60,20 +60,18 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
       });
   }, [props.placeDcid, props.enclosedPlaceType]);
 
-  const svHierarchyProps = {
-    deselectSV: (sv) => props.onStatVarRemoved(sv),
-    places: samplePlaces,
-    selectSV: (sv) => selectSV(sv, props.onStatVarSelected),
-    selectedSVs: props.statVars,
-    type: StatVarHierarchyType.TIMELINE,
-  };
-
   return (
     <StatVarWidget
       openSvHierarchyModal={props.openSvHierarchyModal}
       openSvHierarchyModalCallback={props.openSvHierarchyModalCallback}
-      svHierarchyProps={svHierarchyProps}
       collapsible={false}
+      svHierarchyType={StatVarHierarchyType.DOWNLOAD}
+      samplePlaces={samplePlaces}
+      deselectSVs={(svList: string[]) => svList.forEach((sv) => {
+        props.onStatVarRemoved(sv)
+      })}
+      selectedSVs={props.statVars}
+      selectSV={(sv) => selectSV(sv, props.onStatVarSelected)}
     />
   );
 }

--- a/static/js/tools/download/stat_var_chooser.tsx
+++ b/static/js/tools/download/stat_var_chooser.tsx
@@ -73,7 +73,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
 
   useEffect(() => {
     if (!props.placeDcid || !props.enclosedPlaceType) {
-      return;
+      setSamplePlaces([]);
     }
     getEnclosedPlacesPromise(props.placeDcid, props.enclosedPlaceType)
       .then((enclosedPlaces) => {

--- a/static/js/tools/download/stat_var_chooser.tsx
+++ b/static/js/tools/download/stat_var_chooser.tsx
@@ -74,6 +74,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
   useEffect(() => {
     if (!props.placeDcid || !props.enclosedPlaceType) {
       setSamplePlaces([]);
+      return;
     }
     getEnclosedPlacesPromise(props.placeDcid, props.enclosedPlaceType)
       .then((enclosedPlaces) => {

--- a/static/js/tools/map/stat_var_chooser.tsx
+++ b/static/js/tools/map/stat_var_chooser.tsx
@@ -88,20 +88,23 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
     }
   }, [statVar.value]);
 
-  const svHierarchyProps = {
-    places: samplePlaces,
-    selectSV: (svDcid) => {
-      selectStatVar(statVar, display, placeInfo, svDcid);
-    },
-    selectedSVs: [statVar.value.dcid],
-    type: StatVarHierarchyType.MAP,
-  };
+  const deselectSVs = (svList: string[]) => {
+    if (!_.isEmpty(svList)) {
+      // map tool can only have one stat var selected at a time so if a stat var
+      // is deselected, just set the selected stat var to empty.
+      selectStatVar(statVar, display, placeInfo, "");
+    }
+  }
   return (
     <StatVarWidget
       openSvHierarchyModal={props.openSvHierarchyModal}
       openSvHierarchyModalCallback={props.openSvHierarchyModalCallback}
-      svHierarchyProps={svHierarchyProps}
       collapsible={true}
+      svHierarchyType={StatVarHierarchyType.MAP}
+      samplePlaces={samplePlaces}
+      deselectSVs={deselectSVs}
+      selectedSVs={{ [statVar.value.dcid] : statVar.value.info }}
+      selectSV={(svDcid) => selectStatVar(statVar, display, placeInfo, svDcid)}
     />
   );
 }

--- a/static/js/tools/map/stat_var_chooser.tsx
+++ b/static/js/tools/map/stat_var_chooser.tsx
@@ -94,7 +94,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
       // is deselected, just set the selected stat var to empty.
       selectStatVar(statVar, display, placeInfo, "");
     }
-  }
+  };
   return (
     <StatVarWidget
       openSvHierarchyModal={props.openSvHierarchyModal}
@@ -103,7 +103,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
       svHierarchyType={StatVarHierarchyType.MAP}
       samplePlaces={samplePlaces}
       deselectSVs={deselectSVs}
-      selectedSVs={{ [statVar.value.dcid] : statVar.value.info }}
+      selectedSVs={{ [statVar.value.dcid]: statVar.value.info }}
       selectSV={(svDcid) => selectStatVar(statVar, display, placeInfo, svDcid)}
     />
   );

--- a/static/js/tools/map/stat_var_chooser.tsx
+++ b/static/js/tools/map/stat_var_chooser.tsx
@@ -50,6 +50,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
     const enclosingPlaceDcid = placeInfo.value.enclosingPlace.dcid;
     const enclosedPlaceType = placeInfo.value.enclosedPlaceType;
     if (_.isEmpty(enclosingPlaceDcid) || _.isEmpty(enclosedPlaceType)) {
+      setSamplePlaces([]);
       return;
     }
     getEnclosedPlacesPromise(enclosingPlaceDcid, enclosedPlaceType).then(
@@ -95,6 +96,9 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
       selectStatVar(statVar, display, placeInfo, "");
     }
   };
+  const selectedSVs = !_.isEmpty(statVar.value.dcid)
+    ? { [statVar.value.dcid]: statVar.value.info }
+    : {};
   return (
     <StatVarWidget
       openSvHierarchyModal={props.openSvHierarchyModal}
@@ -103,7 +107,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
       svHierarchyType={StatVarHierarchyType.MAP}
       samplePlaces={samplePlaces}
       deselectSVs={deselectSVs}
-      selectedSVs={{ [statVar.value.dcid]: statVar.value.info }}
+      selectedSVs={selectedSVs}
       selectSV={(svDcid) => selectStatVar(statVar, display, placeInfo, svDcid)}
     />
   );

--- a/static/js/tools/mock_functions.tsx
+++ b/static/js/tools/mock_functions.tsx
@@ -97,9 +97,42 @@ export function axios_mock(): void {
 
   // get place stats vars, geoId/05
   when(axios.post)
-    .calledWith("/api/place/stat-vars/union", { dcids: ["geoId/05"] })
+    .calledWith("/api/place/stat-vars/union", {
+      dcids: ["geoId/05"],
+      statVars: ["Median_Age_Person"],
+    })
     .mockResolvedValue({
-      data: ["Count_Person", "Median_Age_Person", "NotInTheTree"],
+      data: ["Median_Age_Person"],
+    });
+
+  // get place stats vars, geoId/05
+  when(axios.post)
+    .calledWith("/api/place/stat-vars/union", {
+      dcids: ["geoId/05"],
+      statVars: ["Median_Age_Person", "Count_Person"],
+    })
+    .mockResolvedValue({
+      data: ["Count_Person", "Median_Age_Person"],
+    });
+
+  // get place stats vars, geoId/05
+  when(axios.post)
+    .calledWith("/api/place/stat-vars/union", {
+      dcids: ["geoId/05"],
+      statVars: ["NotInTheTree"],
+    })
+    .mockResolvedValue({
+      data: ["NotInTheTree"],
+    });
+
+  // get place stats vars, geoId/05
+  when(axios.post)
+    .calledWith("/api/place/stat-vars/union", {
+      dcids: ["geoId/05"],
+      statVars: ["Count_Person"],
+    })
+    .mockResolvedValue({
+      data: ["Count_Person"],
     });
 
   // get place names, geoId/05

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -155,9 +155,11 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
         collapsible={true}
         svHierarchyType={StatVarHierarchyType.SCATTER}
         samplePlaces={samplePlaces}
-        deselectSVs={(svList: string[]) => svList.forEach((sv) => {
-          removeStatVar(x, y, sv);
-        })}
+        deselectSVs={(svList: string[]) =>
+          svList.forEach((sv) => {
+            removeStatVar(x, y, sv);
+          })
+        }
         selectedSVs={selectedSvs}
         selectSV={(sv) => addStatVar(x, y, sv, setThirdStatVar, setModalOpen)}
       />

--- a/static/js/tools/shared/stat_var_widget.tsx
+++ b/static/js/tools/shared/stat_var_widget.tsx
@@ -18,20 +18,37 @@
  * Component for the stat var widget to be used by the website tools
  */
 
-import React, { createRef } from "react";
+import axios from "axios";
+import _ from "lodash";
+import React, { createRef, useEffect } from "react";
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import { NamedPlace } from "../../shared/types";
 
 import { DrawerToggle } from "../../stat_var_hierarchy/drawer_toggle";
 import {
   StatVarHierarchy,
-  StatVarHierarchyPropType,
 } from "../../stat_var_hierarchy/stat_var_hierarchy";
+import { StatVarInfo } from "../timeline/chart_region";
 
 interface StatVarWidgetPropsType {
+  // Whether or not modal version of sv hierarchy is opened
   openSvHierarchyModal: boolean;
+  // callback function when modal version of sv hierarchy is opened
   openSvHierarchyModalCallback: () => void;
-  svHierarchyProps: StatVarHierarchyPropType;
+  // Whether or not the stat var widget should be able to be collapsed
   collapsible: boolean;
+  // The type of svHierarchy to render
+  svHierarchyType: string;
+  // List of sample places to use to figure out what stat vars are available
+  samplePlaces: NamedPlace[];
+  // Callback function when a list of stat vars are deselected
+  deselectSVs: (svList: string[]) => void;
+  // (Optional) A map of stat var dcid to their StatVarInfo for stat vars 
+  // selected from parent componenet.
+  // For example, in timeline tool, these are stat vars parsed from URL.
+  selectedSVs?: Record<string, StatVarInfo>;
+  // Callback function when a stat var is selected
+  selectSV?: (sv: string) => void;
 }
 
 export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
@@ -52,6 +69,33 @@ export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
       .appendChild(svHierarchyContainerRef.current);
   }
 
+  useEffect(() => {
+    if (!_.isEmpty(props.samplePlaces) && !_.isEmpty(props.selectedSVs)) {
+      axios
+      .post("/api/place/stat-vars/union", {
+        dcids: props.samplePlaces.map((place) => place.dcid),
+        statVars: Object.keys(props.selectedSVs),
+      })
+      .then((resp) => {
+        const availableSVs = resp.data;
+        const unavailableSVs = [];
+        for (const sv in props.selectedSVs) {
+          if (availableSVs.indexOf(sv) === -1) {
+            unavailableSVs.push(sv);
+          }
+        }
+        if (!_.isEmpty(unavailableSVs)) {
+          props.deselectSVs(unavailableSVs);
+          alert(
+            `Sorry, the selected variable${unavailableSVs.length > 1 ? "s" : ""} [${unavailableSVs.map(sv => props.selectedSVs[sv].title || sv).join(
+              ", "
+            )}] ` + `${unavailableSVs.length > 1 ? "are" : "is"} not available for the chosen place${props.samplePlaces.length > 1 ? "s" : ""}.`
+          );
+        }
+      });
+    }
+  }, [props.samplePlaces])
+
   return (
     <>
       <div className="d-none d-lg-flex explore-menu-container" id="explore">
@@ -63,12 +107,12 @@ export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
         )}
         <div ref={svHierarchyContainerRef} className="full-size">
           <StatVarHierarchy
-            type={props.svHierarchyProps.type}
-            places={props.svHierarchyProps.places}
-            selectedSVs={props.svHierarchyProps.selectedSVs}
-            selectSV={props.svHierarchyProps.selectSV}
+            type={props.svHierarchyType}
+            places={props.samplePlaces}
+            selectedSVs={Object.keys(props.selectedSVs)}
+            selectSV={props.selectSV}
             searchLabel={"Statistical Variables"}
-            deselectSV={props.svHierarchyProps.deselectSV}
+            deselectSV={(sv) => props.deselectSVs([sv])}
           />
         </div>
       </div>

--- a/static/js/tools/shared/stat_var_widget.tsx
+++ b/static/js/tools/shared/stat_var_widget.tsx
@@ -22,12 +22,10 @@ import axios from "axios";
 import _ from "lodash";
 import React, { createRef, useEffect } from "react";
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
-import { NamedPlace } from "../../shared/types";
 
+import { NamedPlace } from "../../shared/types";
 import { DrawerToggle } from "../../stat_var_hierarchy/drawer_toggle";
-import {
-  StatVarHierarchy,
-} from "../../stat_var_hierarchy/stat_var_hierarchy";
+import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
 import { StatVarInfo } from "../timeline/chart_region";
 
 interface StatVarWidgetPropsType {
@@ -43,7 +41,7 @@ interface StatVarWidgetPropsType {
   samplePlaces: NamedPlace[];
   // Callback function when a list of stat vars are deselected
   deselectSVs: (svList: string[]) => void;
-  // (Optional) A map of stat var dcid to their StatVarInfo for stat vars 
+  // (Optional) A map of stat var dcid to their StatVarInfo for stat vars
   // selected from parent componenet.
   // For example, in timeline tool, these are stat vars parsed from URL.
   selectedSVs?: Record<string, StatVarInfo>;
@@ -72,29 +70,36 @@ export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
   useEffect(() => {
     if (!_.isEmpty(props.samplePlaces) && !_.isEmpty(props.selectedSVs)) {
       axios
-      .post("/api/place/stat-vars/union", {
-        dcids: props.samplePlaces.map((place) => place.dcid),
-        statVars: Object.keys(props.selectedSVs),
-      })
-      .then((resp) => {
-        const availableSVs = resp.data;
-        const unavailableSVs = [];
-        for (const sv in props.selectedSVs) {
-          if (availableSVs.indexOf(sv) === -1) {
-            unavailableSVs.push(sv);
+        .post("/api/place/stat-vars/union", {
+          dcids: props.samplePlaces.map((place) => place.dcid),
+          statVars: Object.keys(props.selectedSVs),
+        })
+        .then((resp) => {
+          const availableSVs = resp.data;
+          const unavailableSVs = [];
+          for (const sv in props.selectedSVs) {
+            if (availableSVs.indexOf(sv) === -1) {
+              unavailableSVs.push(sv);
+            }
           }
-        }
-        if (!_.isEmpty(unavailableSVs)) {
-          props.deselectSVs(unavailableSVs);
-          alert(
-            `Sorry, the selected variable${unavailableSVs.length > 1 ? "s" : ""} [${unavailableSVs.map(sv => props.selectedSVs[sv].title || sv).join(
-              ", "
-            )}] ` + `${unavailableSVs.length > 1 ? "are" : "is"} not available for the chosen place${props.samplePlaces.length > 1 ? "s" : ""}.`
-          );
-        }
-      });
+          if (!_.isEmpty(unavailableSVs)) {
+            props.deselectSVs(unavailableSVs);
+            alert(
+              `Sorry, the selected variable${
+                unavailableSVs.length > 1 ? "s" : ""
+              } [${unavailableSVs
+                .map((sv) => props.selectedSVs[sv].title || sv)
+                .join(", ")}] ` +
+                `${
+                  unavailableSVs.length > 1 ? "are" : "is"
+                } not available for the chosen place${
+                  props.samplePlaces.length > 1 ? "s" : ""
+                }.`
+            );
+          }
+        });
     }
-  }, [props.samplePlaces])
+  }, [props.samplePlaces]);
 
   return (
     <>

--- a/static/js/tools/stat_var/page.tsx
+++ b/static/js/tools/stat_var/page.tsx
@@ -19,7 +19,6 @@
  */
 
 import axios from "axios";
-import _ from "lodash";
 import React, { Component } from "react";
 import { Button } from "reactstrap";
 

--- a/static/js/tools/stat_var/page.tsx
+++ b/static/js/tools/stat_var/page.tsx
@@ -19,6 +19,7 @@
  */
 
 import axios from "axios";
+import _ from "lodash";
 import React, { Component } from "react";
 import { Button } from "reactstrap";
 
@@ -67,19 +68,17 @@ class Page extends Component<unknown, PageStateType> {
   }
 
   render(): JSX.Element {
-    const svHierarchyProps = {
-      places: [],
-      selectSV: (sv) => this.updateHash(sv),
-      selectedSVs: [this.state.statVar],
-      type: StatVarHierarchyType.STAT_VAR,
-    };
     return (
       <>
         <StatVarWidget
           openSvHierarchyModal={this.state.showSvHierarchyModal}
           openSvHierarchyModalCallback={this.toggleSvHierarchyModal}
-          svHierarchyProps={svHierarchyProps}
           collapsible={false}
+          svHierarchyType={StatVarHierarchyType.STAT_VAR}
+          samplePlaces={[]}
+          deselectSVs={() => this.updateHash("")}
+          selectedSVs={{ [this.state.statVar]: {} }}
+          selectSV={(sv) => this.updateHash(sv)}
         />
         <div id="plot-container">
           <div className="container">

--- a/static/js/tools/timeline/__snapshots__/page.test.tsx.snap
+++ b/static/js/tools/timeline/__snapshots__/page.test.tsx.snap
@@ -21,6 +21,20 @@ exports[`Single place and single stat var 2`] = `
 "<div class=\\"chart-container\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
+      <div class=\\"mdl-chip mdl-chip--deletable\\"><span class=\\"mdl-chip__text mdl-chip__text_clickable\\">Population</span><button class=\\"mdl-chip__action\\"><i class=\\"material-icons\\">cancel</i></button></div>
+    </div>
+    <div class=\\"chart-svg\\"></div>
+  </div>
+  <div class=\\"chart-footer-container no-bottom-border\\">
+    <div class=\\"chart-footer-metadata-section\\"></div>
+    <div class=\\"chart-footer-options-button\\"><span>Chart Options</span><i class=\\"material-icons\\">expand_less</i></div>
+  </div>
+  <div class=\\"chart-footer-options-section\\"><span class=\\"chart-option\\"><div class=\\"form-check\\"><label class=\\"form-check-label\\"><input id=\\"count-ratio\\" type=\\"checkbox\\" class=\\"form-check-input\\">Per Capita</label></div></span><span class=\\"chart-option\\"><div class=\\"form-check\\"><label class=\\"form-check-label\\"><input id=\\"delta-cb-count\\" type=\\"checkbox\\" class=\\"is-delta-input form-check-input\\">Delta</label></div></span><button type=\\"button\\" class=\\"source-selector-open-modal-button btn btn-light btn-sm\\">Select Source</button></div>
+  <div class=\\"feedback-link\\"><a href=\\"/feedback\\">Feedback</a></div>
+</div>
+<div class=\\"chart-container\\">
+  <div class=\\"card\\">
+    <div class=\\"statVarChipRegion\\">
       <div class=\\"mdl-chip mdl-chip--deletable\\"><span class=\\"mdl-chip__text mdl-chip__text_clickable\\">Age</span><button class=\\"mdl-chip__action\\"><i class=\\"material-icons\\">cancel</i></button></div>
     </div>
     <div class=\\"chart-svg\\"></div>
@@ -43,7 +57,7 @@ exports[`Single place and single stat var 3`] = `
         <form class=\\"node-title\\"><input id=\\"Count_Persondc/g/Demographics-Count_Person\\" name=\\"stat-var-hierarchy\\" type=\\"checkbox\\"><label class=\\"selected-node-title\\" for=\\"Count_Persondc/g/Demographics-Count_Person\\">Count Of Person</label></form>
       </div>
       <div>
-        <form class=\\"node-title\\"><input id=\\"Median_Age_Persondc/g/Demographics-Median_Age_Person\\" name=\\"stat-var-hierarchy\\" type=\\"checkbox\\"><label class=\\"\\" for=\\"Median_Age_Persondc/g/Demographics-Median_Age_Person\\">Median age of person</label></form>
+        <form class=\\"node-title\\"><input id=\\"Median_Age_Persondc/g/Demographics-Median_Age_Person\\" name=\\"stat-var-hierarchy\\" type=\\"checkbox\\"><label class=\\"selected-node-title\\" for=\\"Median_Age_Persondc/g/Demographics-Median_Age_Person\\">Median age of person</label></form>
       </div>
     </div>
     <div class=\\"svg-node-child\\">

--- a/static/js/tools/timeline/page.test.tsx
+++ b/static/js/tools/timeline/page.test.tsx
@@ -37,7 +37,7 @@ test("Single place and single stat var", () => {
   Object.defineProperty(window, "location", {
     writable: true,
     value: {
-      hash: "#&place=geoId/05&statsVar=Median_Age_Person",
+      hash: "#place=geoId/05&statsVar=Median_Age_Person",
     },
   });
   // Mock drawGroupLineChart() as getComputedTextLength can has issue with jest
@@ -78,31 +78,56 @@ test("Single place and single stat var", () => {
           expect(window.location.hash).toEqual(
             "#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person"
           );
-
           expect(
             pretty(wrapper.find("#chart-region").getDOMNode().innerHTML)
           ).toMatchSnapshot();
-
-          // delete one statVar from the statVar chips
-          wrapper
-            .find("#hierarchy-section input")
-            .at(1)
-            .simulate("change", { target: { checked: false } });
-          Promise.resolve(wrapper).then(() => {
-            wrapper.update();
-            // Hack to mimic the browser behavior as there is no native
-            // browser environment in jest.
-            window.location.hash = "#" + window.location.hash;
-            expect(window.location.hash).toEqual(
-              "#place=geoId%2F05&statsVar=Count_Person"
-            );
-            expect(
-              pretty(wrapper.find("#chart-region").getDOMNode().innerHTML)
-            ).toMatchSnapshot();
-            expect(
-              pretty(wrapper.find("#hierarchy-section").getDOMNode().innerHTML)
-            ).toMatchSnapshot();
-          });
+          // Hack to trigger hashchange event to fire
+          window.dispatchEvent(
+            new HashChangeEvent("hashchange", {
+              oldURL: `#place=geoId/05&statsVar=Median_Age_Person`,
+              newURL: `#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person`,
+            })
+          );
+          Promise.resolve(wrapper)
+            .then(() => wrapper.update())
+            .then(() => wrapper.update())
+            .then(() => {
+              // delete one statVar from the statVar chips
+              wrapper
+                .find("#hierarchy-section input")
+                .at(1)
+                .simulate("change", { target: { checked: false } });
+              Promise.resolve(wrapper)
+                .then(() => wrapper.update())
+                .then(() => {
+                  // Hack to mimic the browser behavior as there is no native
+                  // browser environment in jest.
+                  window.location.hash = "#" + window.location.hash;
+                  expect(window.location.hash).toEqual(
+                    "#place=geoId%2F05&statsVar=Count_Person"
+                  );
+                  // Hack to trigger hashchange event to fire
+                  window.dispatchEvent(
+                    new HashChangeEvent("hashchange", {
+                      oldURL: `#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person`,
+                      newURL: `#place=geoId%2F05&statsVar=Count_Person`,
+                    })
+                  );
+                  Promise.resolve(wrapper).then(() => {
+                    expect(
+                      pretty(
+                        wrapper.find("#chart-region").getDOMNode().innerHTML
+                      )
+                    ).toMatchSnapshot();
+                    expect(
+                      pretty(
+                        wrapper.find("#hierarchy-section").getDOMNode()
+                          .innerHTML
+                      )
+                    ).toMatchSnapshot();
+                  });
+                });
+            });
         });
       });
     });

--- a/static/js/tools/timeline/page.test.tsx
+++ b/static/js/tools/timeline/page.test.tsx
@@ -84,7 +84,8 @@ test("Single place and single stat var", () => {
           // Hack to trigger hashchange event to fire
           window.dispatchEvent(
             new HashChangeEvent("hashchange", {
-              newURL: "#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person",
+              newURL:
+                "#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person",
               oldURL: "#place=geoId/05&statsVar=Median_Age_Person",
             })
           );
@@ -110,7 +111,8 @@ test("Single place and single stat var", () => {
                   window.dispatchEvent(
                     new HashChangeEvent("hashchange", {
                       newURL: "#place=geoId%2F05&statsVar=Count_Person",
-                      oldURL: "#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person",
+                      oldURL:
+                        "#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person",
                     })
                   );
                   Promise.resolve(wrapper).then(() => {

--- a/static/js/tools/timeline/page.test.tsx
+++ b/static/js/tools/timeline/page.test.tsx
@@ -84,8 +84,8 @@ test("Single place and single stat var", () => {
           // Hack to trigger hashchange event to fire
           window.dispatchEvent(
             new HashChangeEvent("hashchange", {
-              oldURL: `#place=geoId/05&statsVar=Median_Age_Person`,
-              newURL: `#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person`,
+              newURL: "#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person",
+              oldURL: "#place=geoId/05&statsVar=Median_Age_Person",
             })
           );
           Promise.resolve(wrapper)
@@ -109,8 +109,8 @@ test("Single place and single stat var", () => {
                   // Hack to trigger hashchange event to fire
                   window.dispatchEvent(
                     new HashChangeEvent("hashchange", {
-                      oldURL: `#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person`,
-                      newURL: `#place=geoId%2F05&statsVar=Count_Person`,
+                      newURL: "#place=geoId%2F05&statsVar=Count_Person",
+                      oldURL: "#place=geoId%2F05&statsVar=Median_Age_Person__Count_Person",
                     })
                   );
                   Promise.resolve(wrapper).then(() => {

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -147,13 +147,14 @@ class Page extends Component<unknown, PageStateType> {
         tokens: new Set(availableSVs),
       };
       setTokensToUrl([statVarTokenInfo]);
-    }
+    };
 
     const svToSvInfo = {};
     for (const sv of statVars) {
-      svToSvInfo[sv] = sv in this.state.statVarInfo ? this.state.statVarInfo[sv] : {};
+      svToSvInfo[sv] =
+        sv in this.state.statVarInfo ? this.state.statVarInfo[sv] : {};
     }
-    
+
     return (
       <>
         <StatVarWidget
@@ -164,7 +165,9 @@ class Page extends Component<unknown, PageStateType> {
           samplePlaces={namedPlaces}
           deselectSVs={deselectSVs}
           selectedSVs={svToSvInfo}
-          selectSV={(sv) => addToken(TIMELINE_URL_PARAM_KEYS.STAT_VAR, statVarSep, sv)}
+          selectSV={(sv) =>
+            addToken(TIMELINE_URL_PARAM_KEYS.STAT_VAR, statVarSep, sv)
+          }
         />
         <div id="plot-container">
           <Container fluid={true}>
@@ -177,7 +180,9 @@ class Page extends Component<unknown, PageStateType> {
                 <Col sm={12}>
                   <SearchBar
                     places={this.state.placeName}
-                    addPlace={(place) => addToken(TIMELINE_URL_PARAM_KEYS.PLACE, placeSep, place)}
+                    addPlace={(place) =>
+                      addToken(TIMELINE_URL_PARAM_KEYS.PLACE, placeSep, place)
+                    }
                     removePlace={(place) => {
                       removeToken(
                         TIMELINE_URL_PARAM_KEYS.PLACE,

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -50,7 +50,6 @@ class Page extends Component<unknown, PageStateType> {
   constructor(props: unknown) {
     super(props);
     this.fetchDataAndRender = this.fetchDataAndRender.bind(this);
-    this.addPlaceAction = this.addPlaceAction.bind(this);
     this.state = {
       placeName: {},
       statVarInfo: {},
@@ -140,23 +139,32 @@ class Page extends Component<unknown, PageStateType> {
       sv.includes("|") ? sv.split("|")[0] : sv
     );
 
-    const svHierarchyProps = {
-      deselectSV: (sv) =>
-        removeToken(TIMELINE_URL_PARAM_KEYS.STAT_VAR, statVarSep, sv),
-      places: namedPlaces,
-      selectSV: (sv) =>
-        addToken(TIMELINE_URL_PARAM_KEYS.STAT_VAR, statVarSep, sv),
-      selectedSVs: statVars,
-      type: StatVarHierarchyType.TIMELINE,
-    };
-    // TODO(beets): Factor out stat var widget related elements into a separate component.
+    const deselectSVs = (svList: string[]) => {
+      const availableSVs = statVars.filter((sv) => svList.indexOf(sv) === -1);
+      const statVarTokenInfo = {
+        name: TIMELINE_URL_PARAM_KEYS.STAT_VAR,
+        sep: statVarSep,
+        tokens: new Set(availableSVs),
+      };
+      setTokensToUrl([statVarTokenInfo]);
+    }
+
+    const svToSvInfo = {};
+    for (const sv of statVars) {
+      svToSvInfo[sv] = sv in this.state.statVarInfo ? this.state.statVarInfo[sv] : {};
+    }
+    
     return (
       <>
         <StatVarWidget
           openSvHierarchyModal={this.state.showSvHierarchyModal}
           openSvHierarchyModalCallback={this.toggleSvHierarchyModal}
-          svHierarchyProps={svHierarchyProps}
           collapsible={true}
+          svHierarchyType={StatVarHierarchyType.SCATTER}
+          samplePlaces={namedPlaces}
+          deselectSVs={deselectSVs}
+          selectedSVs={svToSvInfo}
+          selectSV={(sv) => addToken(TIMELINE_URL_PARAM_KEYS.STAT_VAR, statVarSep, sv)}
         />
         <div id="plot-container">
           <Container fluid={true}>
@@ -169,9 +177,7 @@ class Page extends Component<unknown, PageStateType> {
                 <Col sm={12}>
                   <SearchBar
                     places={this.state.placeName}
-                    addPlace={(place) => {
-                      this.addPlaceAction(place);
-                    }}
+                    addPlace={(place) => addToken(TIMELINE_URL_PARAM_KEYS.PLACE, placeSep, place)}
                     removePlace={(place) => {
                       removeToken(
                         TIMELINE_URL_PARAM_KEYS.PLACE,
@@ -204,48 +210,6 @@ class Page extends Component<unknown, PageStateType> {
         </div>
       </>
     );
-  }
-
-  private addPlaceAction(place: string): void {
-    // We only need to check the availability of selected stat vars when adding
-    // the first place (ie. when the current list of places is empty) because
-    // we take the union of the eligible stat vars for all places.
-    if (!_.isEmpty(this.state.statVarInfo) && _.isEmpty(this.state.placeName)) {
-      axios
-        .post("/api/place/stat-vars/union", {
-          dcids: [place],
-          statVars: Object.keys(this.state.statVarInfo),
-        })
-        .then((resp) => {
-          const availableSVs: string[] = resp.data;
-          const unavailableSV = [];
-          for (const sv in this.state.statVarInfo) {
-            if (availableSVs.indexOf(sv) === -1) {
-              unavailableSV.push(this.state.statVarInfo[sv].title || sv);
-            }
-          }
-          const placeTokenInfo = {
-            name: TIMELINE_URL_PARAM_KEYS.PLACE,
-            sep: placeSep,
-            tokens: new Set([place]),
-          };
-          const statVarTokenInfo = {
-            name: TIMELINE_URL_PARAM_KEYS.STAT_VAR,
-            sep: statVarSep,
-            tokens: new Set(availableSVs),
-          };
-          setTokensToUrl([placeTokenInfo, statVarTokenInfo]);
-          if (!_.isEmpty(unavailableSV)) {
-            alert(
-              `Sorry, the selected variable(s) [${unavailableSV.join(", ")}] ` +
-                "are not available for the chosen place."
-            );
-          }
-        })
-        .catch(() => addToken(TIMELINE_URL_PARAM_KEYS.PLACE, placeSep, place));
-    } else {
-      addToken(TIMELINE_URL_PARAM_KEYS.PLACE, placeSep, place);
-    }
   }
 }
 

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import _ from "lodash";
 import React, { Component, createRef, RefObject } from "react";
 import { Button, Card, Col, Container, Row } from "reactstrap";
 

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import axios from "axios";
 import _ from "lodash";
 import React, { Component, createRef, RefObject } from "react";
 import { Button, Card, Col, Container, Row } from "reactstrap";


### PR DESCRIPTION
- Add alert when place changes and chosen stat vars are unavailable
    - Refactored stat var widget to do this so that all tools are consistent in behavior
    - This also fixes: [issue #1522 ](https://github.com/datacommonsorg/website/issues/1522)
    
![screen-recording-_42_](https://user-images.githubusercontent.com/69875368/170073298-25161746-f35e-4c69-9089-d7cf02549e8e.gif)

- Add modal that pops up when more than 5 stat vars are chosen for download tool

![screen-recording-_41_](https://user-images.githubusercontent.com/69875368/170073211-19bfbbdc-8aaf-4fe9-bf48-a6ce187fa077.gif)