### PR TITLE
Increase mixer memory to accomadate for more data

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -108,9 +108,9 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "6G"
+              memory: "8G"
             requests:
-              memory: "6G"
+              memory: "8G"
           args:
             - --mixer_project=$(MIXER_PROJECT)
             - --store_project=$(STORE_PROJECT)


### PR DESCRIPTION
Seeing OOM during the deployment. This is likely due to the increased data from stat var (group). Before a scalable fix, increase the memory to let deployment work smoothly.