### PR TITLE
Adding template style memdb file for Stanford private DC instance

### DIFF
--- a/deploy/overlays/memdb.json.tpl
+++ b/deploy/overlays/memdb.json.tpl
@@ -1,5 +1,5 @@
 {
-  "importName": "Private_DC_Template",
+  "importName": "DC_Template",
   "provenanceUrl": "https://www.datacommons.org/",
   "dataDownloadUrl": "https://www.datacommons.org/",
   "rootSvg": "g/Template",

--- a/deploy/overlays/sample_data.csv.tpl
+++ b/deploy/overlays/sample_data.csv.tpl
@@ -1,0 +1,2 @@
+dcid,observationDate,Value_SV1
+country/USA,2022,100

--- a/deploy/overlays/sample_tmcf.tmcf.tpl
+++ b/deploy/overlays/sample_tmcf.tmcf.tpl
@@ -1,0 +1,7 @@
+Node: E:DC_Template->E0
+typeOf: dcs:StatVarObservation
+variableMeasured: dcs:Template_SV_Level_1
+value: C:DC_Template->Value_SV1
+observationAbout: C:DC_Template->dcid
+observationDate: C:DC_Template->observationDate
+measurementMethod: dcs:DC_Template_Estimate

--- a/deploy/overlays/stanford/memdb.json
+++ b/deploy/overlays/stanford/memdb.json
@@ -1,0 +1,38 @@
+{
+  "importName": "Private_DC_Template",
+  "provenanceUrl": "https://www.datacommons.org/",
+  "dataDownloadUrl": "https://www.datacommons.org/",
+  "rootSvg": "g/Template",
+  "statVarGroups": {
+    "g/Template": {
+      "childStatVarGroups": [
+        {
+          "id": "g/Template_SVG_Level_1",
+          "specializedEntity": "Template SVG Level 1"
+        },
+      ],
+      "childStatVars": [
+        {
+          "id": "Template_SV_Level_1",
+          "searchNames": ["Template SV L1"],
+          "displayName": "Template SV Level 1"
+        },
+      ]
+    },
+    "g/Template_Temp_Level_1": {
+      "childStatVarGroups": [
+        {
+          "id": "g/Template_Temp_Level_2",
+          "specializedEntity": "Template SVG Level 2"
+        }
+      ],
+      "childStatVars": [
+        {
+          "id": "Template_SV_Level_2",
+          "searchNames": ["Template SV L2"],
+          "displayName": "Template SV Level 2"
+        }
+      ]
+    },
+  }
+}

--- a/docs/new_deployment.md
+++ b/docs/new_deployment.md
@@ -94,9 +94,17 @@ Follow the [IAP setup](./iap.md) to use Cloud IAP to restrict access to the new 
 
 ## [Private Instance] Adding Data
 
-Each data import should be contained within a top-level folder in the GCS bucket associated with the instance. Within each folder, there should be exactly one `manifest.json`, exactly one TMCF file, and one or more CSV files.
+Each data import should be contained within a top-level folder in the GCS bucket associated with the instance. Within each folder, there should be exactly one TMCF file, and one or more CSV files.
 
-Each `manifest.json` should be structured as follows:
+Each TMCF file should have one node entry for each Statistical Variable in the import.
+
+CSV files should be structured so that each Statistical Variable has its own column. The first few columns should be reserved for other StatVarObservation properties, such as `observationAbout`, `observationDate`, `observationPeriod`, `unit`, etc.
+
+See the template CSV and TMCF files provided under the deploy/ path. They are called: `sample_data.csv.tp` and `sample_tmcf.tmcf.tpl`.
+
+Additionally, each private instance should also contain a `memdb.json` file. A template file is provided under the `deploy/` path with the name `memdb.json.tpl`. It contains important data import metadata and information about the hierarchical organization of the Statistical Variables (SVs) and Statistical Variable Groups (SVGs). Copy the `memdb.json.tpl` file to the private instance folder and rename to `memdb.json`. Then make appropriate edits to the file.
+
+The `memdb.json` file must have the following fields:
 
 ```json
 {
@@ -108,9 +116,6 @@ Each `manifest.json` should be structured as follows:
 
 `<IMPORT_NAME>` will be used to group the Statistical Variables from the import in the website tree hierarchy navigation.
 
-Each TMCF file should have one node entry for each Statistical Variable in the import.
-
-CSV files should be structured so that each Statistical Variable has its own column. The first few columns should be reserved for other StatVarObservation properties, such as `observationAbout`, `observationDate`, `observationPeriod`, `unit`, etc.
 
 ## Merging Configs
 


### PR DESCRIPTION
Note: the corresponding "template" style csv, tmcf and manifest.json file is here: https://console.cloud.google.com/storage/browser/datcom-stanford-resources/stanford?project=datcom-stanford&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false