### PR TITLE
Ranking chart API: Restrict parent place type and add population filter 

### DIFF
--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -801,9 +801,9 @@ def api_ranking_chart(dcid):
         place_type = "Country"
     else:
         parent_place_list = get_parent_place(dcid).get(dcid, [])
-        # Get the last parent place returned.
+        # Get the first parent place returned.
         if parent_place_list:
-            parent_place_dcid = parent_place_list[-1]["dcid"]
+            parent_place_dcid = parent_place_list[0]["dcid"]
             place_type = get_place_type(dcid)
         else:
             return Response(json.dumps(result),

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -107,6 +107,7 @@ US_ISO_CODE_PREFIX = 'US'
 ENGLISH_LANG = 'en'
 EARTH_DCID = "Earth"
 PERSON_COUNT_LIMIT = 1000
+POPULATION_DCID = "Count_Person"
 
 # Define blueprint
 bp = Blueprint("api.place", __name__, url_prefix='/api/place')
@@ -822,9 +823,9 @@ def api_ranking_chart(dcid):
     configs = get_ranking_chart_configs()
     # Get the first stat var of each config.
     stat_vars, _ = shared_api.get_stat_vars(configs)
-    # Make sure the ranking chart configs include stat var "Count_Person".
-    if "Count_Person" not in stat_vars:
-        stat_vars.add("Count_Person")
+    # Make sure POPULATION_DCID is included in stat vars.
+    if POPULATION_DCID not in stat_vars:
+        stat_vars.add(POPULATION_DCID)
     sv_data = dc.get_stat_set_within_place(parent_place_dcid, place_type,
                                            list(stat_vars), "")
     sv_data_values = sv_data.get("data", {})
@@ -838,13 +839,12 @@ def api_ranking_chart(dcid):
         place_dcids = place_dcids.union(sv_place_dcids)
     place_names = get_i18n_name(list(place_dcids))
     sv_metadata = sv_data.get("metadata", {})
-    # "Count_Person" is used to filter out the places with the population less than PERSON_COUNT_LIMIT
+    # POPULATION_DCID is used to filter out the places with the population less than PERSON_COUNT_LIMIT
     places_to_rank = set()
-    count_person_data = sv_data_values.get("Count_Person", {})
-    if count_person_data:
-        for place_dcid, place_data in count_person_data.get("stat", {}).items():
-            if place_data.get("value", 0) > PERSON_COUNT_LIMIT:
-                places_to_rank.add(place_dcid)
+    count_person_data = sv_data_values.get(POPULATION_DCID, {})
+    for place_dcid, place_data in count_person_data.get("stat", {}).items():
+        if place_data.get("value", 0) > PERSON_COUNT_LIMIT:
+            places_to_rank.add(place_dcid)
     # Consider the configs with single sv but ignore denominators.
     for config in configs:
         sv = config["statsVars"][0]

--- a/server/tests/api_place_test.py
+++ b/server/tests/api_place_test.py
@@ -670,7 +670,7 @@ class TestApiRankingChart(unittest.TestCase):
         sv1_date2 = "2022"
         sv2_date1 = "2020"
         sv2_date2 = "2022"
-        sv1_value1 = 99
+        sv1_value1 = 98
         sv1_value2 = 100
         sv1_value3 = 12
         sv2_value1 = 100

--- a/server/tests/api_place_test.py
+++ b/server/tests/api_place_test.py
@@ -638,10 +638,10 @@ class TestApiRankingChartHelper(unittest.TestCase):
 
 class TestApiRankingChart(unittest.TestCase):
 
-    @patch('routes.api.place.get_name')
+    @patch('routes.api.place.get_i18n_name')
     @patch('routes.api.place.get_ranking_chart_configs')
     @patch('routes.api.place.get_place_type')
-    @patch('routes.api.place.get_parent_place')
+    @patch('routes.api.place.parent_places')
     @patch('routes.api.place.dc.get_stat_set_within_place')
     def test_api_ranking_chart_not_earth(
         self,
@@ -652,23 +652,32 @@ class TestApiRankingChart(unittest.TestCase):
         mock_name,
     ):
         test_dcid = 'test_dcid'
-        parent_dcid = "parent_dcid"
+        parent_dcid1 = "parent_dcid1"
+        parent_dcid2 = "parent_dcid2"
         place_type = "place_type"
         geo1 = test_dcid
         geo2 = "dcid2"
+        geo3 = "dcid3"
         place_name1 = "place_name1"
         place_name2 = "place_name2"
+        place_name3 = "place_name3"
+        parent_place_type1 = "County"
+        parent_place_type2 = "Continent"
         sv1 = "sv1"
         sv2 = "sv2"
         sv3 = "sv3"
         sv1_date1 = "2020"
         sv1_date2 = "2022"
-        sv2_date1 = "2022"
+        sv2_date1 = "2020"
         sv2_date2 = "2022"
         sv1_value1 = 99
-        sv1_value2 = 50
-        sv2_value1 = 10
+        sv1_value2 = 100
+        sv1_value3 = 12
+        sv2_value1 = 100
         sv2_value2 = 20
+        sv2_value3 = 230
+        count_person_value1 = 1001
+        count_person_value2 = 500
         source1 = "source1"
         source2 = "source2"
         config1 = {
@@ -693,7 +702,15 @@ class TestApiRankingChart(unittest.TestCase):
 
         def parent_place_side_effect(*args):
             if args[0] == test_dcid:
-                return {test_dcid: [{"dcid": parent_dcid}]}
+                return {
+                    test_dcid: [{
+                        "types": [parent_place_type1],
+                        "dcid": parent_dcid1
+                    }, {
+                        "types": [parent_place_type2],
+                        "dcid": parent_dcid2
+                    }]
+                }
             else:
                 return {}
 
@@ -708,8 +725,12 @@ class TestApiRankingChart(unittest.TestCase):
         mock_place_type.side_effect = place_type_side_effect
 
         def name_side_effect(*args):
-            if sorted(args[0]) == sorted([geo1, geo2]):
-                return {geo1: place_name1, geo2: place_name2}
+            if sorted(args[0]) == sorted([geo1, geo2, geo3]):
+                return {
+                    geo1: place_name1,
+                    geo2: place_name2,
+                    geo3: place_name3,
+                }
             else:
                 return {}
 
@@ -728,6 +749,11 @@ class TestApiRankingChart(unittest.TestCase):
                             'date': sv1_date2,
                             'value': sv1_value2,
                             'metaHash': 1
+                        },
+                        geo3: {
+                            'date': sv1_date2,
+                            'value': sv1_value3,
+                            'metaHash': 1
                         }
                     },
                 },
@@ -741,6 +767,30 @@ class TestApiRankingChart(unittest.TestCase):
                         geo2: {
                             'date': sv2_date2,
                             'value': sv2_value2,
+                            'metaHash': 2
+                        },
+                        geo3: {
+                            'date': sv2_date2,
+                            'value': sv2_value3,
+                            'metaHash': 2
+                        }
+                    }
+                },
+                "Count_Person": {
+                    'stat': {
+                        geo1: {
+                            'date': sv2_date1,
+                            'value': count_person_value1,
+                            'metaHash': 2
+                        },
+                        geo2: {
+                            'date': sv2_date2,
+                            'value': count_person_value2,
+                            'metaHash': 2
+                        },
+                        geo3: {
+                            'date': sv2_date1,
+                            'value': count_person_value1,
                             'metaHash': 2
                         }
                     }
@@ -759,8 +809,8 @@ class TestApiRankingChart(unittest.TestCase):
         }
 
         def stats_within_place_side_effect(*args):
-            if args[0] == parent_dcid and args[1] == place_type and sorted(
-                    args[2]) == sorted([sv1, sv2]):
+            if args[0] == parent_dcid1 and args[1] == place_type and sorted(
+                    args[2]) == sorted([sv1, sv2, "Count_Person"]):
                 return stats_within_place
             else:
                 return {}
@@ -773,7 +823,8 @@ class TestApiRankingChart(unittest.TestCase):
         response_data = json.loads(response.data)
         expected_data = {
             sv1: {
-                'date': f'{sv1_date1} – {sv1_date2}',
+                'date':
+                    f'{sv1_date1} – {sv1_date2}',
                 'data': [{
                     "rank": 1,
                     "value": sv1_value1,
@@ -781,22 +832,24 @@ class TestApiRankingChart(unittest.TestCase):
                     "placeName": place_name1
                 }, {
                     "rank": 2,
-                    "value": sv1_value2,
-                    "placeDcid": geo2,
-                    "placeName": place_name2
+                    "value": sv1_value3,
+                    "placeDcid": geo3,
+                    "placeName": place_name3
                 }],
-                'numDataPoints': 2,
-                'exploreUrl': "/ranking/sv1/place_type/parent_dcid?h=test_dcid",
+                'numDataPoints':
+                    2,
+                'exploreUrl':
+                    "/ranking/sv1/place_type/parent_dcid1?h=test_dcid",
                 'sources': [source1]
             },
             sv2: {
                 'date':
-                    sv2_date1,
+                    f'{sv1_date1} – {sv1_date2}',
                 'data': [{
                     "rank": 1,
-                    "value": sv2_value2,
-                    "placeDcid": geo2,
-                    "placeName": place_name2
+                    "value": sv2_value3,
+                    "placeDcid": geo3,
+                    "placeName": place_name3
                 }, {
                     "rank": 2,
                     "value": sv2_value1,
@@ -806,13 +859,13 @@ class TestApiRankingChart(unittest.TestCase):
                 'numDataPoints':
                     2,
                 'exploreUrl':
-                    "/ranking/sv2/place_type/parent_dcid?h=test_dcid&scaling=100&unit=%",
+                    "/ranking/sv2/place_type/parent_dcid1?h=test_dcid&scaling=100&unit=%",
                 'sources': [source2]
             }
         }
         assert response_data == expected_data
 
-    @patch('routes.api.place.get_name')
+    @patch('routes.api.place.get_i18n_name')
     @patch('routes.api.place.get_ranking_chart_configs')
     @patch('routes.api.place.dc.get_stat_set_within_place')
     def test_api_ranking_chart_earth(
@@ -826,8 +879,10 @@ class TestApiRankingChart(unittest.TestCase):
         place_type = "Country"
         geo1 = "dcid1"
         geo2 = "dcid2"
+        geo3 = "dcid3"
         place_name1 = "place_name1"
         place_name2 = "place_name2"
+        place_name3 = "place_name3"
         sv1 = "sv1"
         sv2 = "sv2"
         sv3 = "sv3"
@@ -837,8 +892,12 @@ class TestApiRankingChart(unittest.TestCase):
         sv2_date2 = "2022"
         sv1_value1 = 99
         sv1_value2 = 50
+        sv1_value3 = 30
         sv2_value1 = 10
         sv2_value2 = 20
+        sv2_value3 = 15
+        count_person_value1 = 1001
+        count_person_value2 = 500
         source1 = "source1"
         source2 = "source2"
         config1 = {
@@ -862,8 +921,8 @@ class TestApiRankingChart(unittest.TestCase):
         mock_configs.return_value = [config1, config2]
 
         def name_side_effect(*args):
-            if sorted(args[0]) == sorted([geo1, geo2]):
-                return {geo1: place_name1, geo2: place_name2}
+            if sorted(args[0]) == sorted([geo1, geo2, geo3]):
+                return {geo1: place_name1, geo2: place_name2, geo3: place_name3}
             else:
                 return {}
 
@@ -898,6 +957,25 @@ class TestApiRankingChart(unittest.TestCase):
                             'metaHash': 2
                         }
                     }
+                },
+                "Count_Person": {
+                    'stat': {
+                        geo1: {
+                            'date': sv2_date1,
+                            'value': count_person_value1,
+                            'metaHash': 2
+                        },
+                        geo2: {
+                            'date': sv2_date2,
+                            'value': count_person_value1,
+                            'metaHash': 2
+                        },
+                        geo3: {
+                            'date': sv2_date1,
+                            'value': count_person_value2,
+                            'metaHash': 2
+                        }
+                    }
                 }
             },
             'metadata': {
@@ -914,7 +992,7 @@ class TestApiRankingChart(unittest.TestCase):
 
         def stats_within_place_side_effect(*args):
             if args[0] == parent_dcid and args[1] == place_type and sorted(
-                    args[2]) == sorted([sv1, sv2]):
+                    args[2]) == sorted([sv1, sv2, "Count_Person"]):
                 return stats_within_place
             else:
                 return {}

--- a/server/tests/api_place_test.py
+++ b/server/tests/api_place_test.py
@@ -941,8 +941,13 @@ class TestApiRankingChart(unittest.TestCase):
                             'date': sv1_date2,
                             'value': sv1_value2,
                             'metaHash': 1
-                        }
-                    },
+                        },
+                        geo3: {
+                            'date': sv1_date1,
+                            'value': sv1_value3,
+                            'metaHash': 1
+                        },
+                    }
                 },
                 sv2: {
                     'stat': {
@@ -955,7 +960,12 @@ class TestApiRankingChart(unittest.TestCase):
                             'date': sv2_date2,
                             'value': sv2_value2,
                             'metaHash': 2
-                        }
+                        },
+                        geo3: {
+                            'date': sv2_date1,
+                            'value': sv2_value3,
+                            'metaHash': 2
+                        },
                     }
                 },
                 "Count_Person": {


### PR DESCRIPTION
1. Restrict the parent place type and keep consistent with the rule of place filtering in [getParentPlaces](https://github.com/datacommonsorg/mixer/blob/master/internal/server/placepage/place_page.go) in mixer.

2. Add a population filter so that API won't return data points of places with populations less than 1000. Keep consistent with the rules of the population filtering of the [ranking page](https://source.corp.google.com/piper///depot/google3/datacommons/prophet/related_places/calculator_svobs.cc;l=309-321).
