### PR TITLE
fix broken webdriver test

### DIFF
--- a/server/webdriver_tests/tests/timeline_test.py
+++ b/server/webdriver_tests/tests/timeline_test.py
@@ -144,8 +144,9 @@ class TestCharts(WebdriverBaseTest):
         element_present = EC.presence_of_element_located(
             (By.CLASS_NAME, "svg-node-child"))
         WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
-        self.driver.find_element_by_id("Count_Persondc/g/Demographics-Count_Person").click()
-        
+        self.driver.find_element_by_id(
+            "Count_Persondc/g/Demographics-Count_Person").click()
+
         # Wait until there is a card present.
         shared.wait_for_loading(self.driver)
         element_present = EC.presence_of_element_located(
@@ -158,14 +159,14 @@ class TestCharts(WebdriverBaseTest):
         self.assertEqual(len(charts), 1)
 
         # Uncheck the checked stat var.
-        self.driver.find_element_by_id("Count_Persondc/g/Demographics-Count_Person").click()
+        self.driver.find_element_by_id(
+            "Count_Persondc/g/Demographics-Count_Person").click()
 
         # Assert there are no charts.
         shared.wait_for_loading(self.driver)
         charts = self.driver.find_elements_by_xpath(
             '//*[@id="chart-region"]/div[@class="chart-container"]')
         self.assertEqual(len(charts), 0)
-
 
     def test_place_search_box_and_remove_place(self):
         """Test the timeline tool place search can work correctly."""

--- a/server/webdriver_tests/tests/timeline_test.py
+++ b/server/webdriver_tests/tests/timeline_test.py
@@ -131,7 +131,7 @@ class TestCharts(WebdriverBaseTest):
         WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
 
         charts = self.driver.find_elements_by_xpath(
-            '//*[@id="chart-region"]/div[@class="chart"]')
+            '//*[@id="chart-region"]/div[@class="chart-container"]')
 
         # Assert there is no chart.
         self.assertEqual(len(charts), 0)
@@ -139,28 +139,33 @@ class TestCharts(WebdriverBaseTest):
         # Expand the Demographics section of the stat var hierarchy.
         shared.click_sv_group(self.driver, "Demographics")
 
-        # Wait until population checkbox is present and click on it.
-        element_present = EC.text_to_be_present_in_element(
-            (By.ID, 'hierarchy-section'), "Population")
+        # Wait until stat vars are present and click on Population.
+        shared.wait_for_loading(self.driver)
+        element_present = EC.presence_of_element_located(
+            (By.CLASS_NAME, "svg-node-child"))
         WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
-
-        # Uncheck median age statvar, and the number of charts will become two.
-        population_checkbox = self.driver.find_element_by_xpath(
-            '//*[text()="Population"]')
-        population_checkbox.click()
-        # Check if there is a way to find the chart region refreshed.
-
-        # Wait until there is one card present.
+        self.driver.find_element_by_id("Count_Persondc/g/Demographics-Count_Person").click()
+        
+        # Wait until there is a card present.
+        shared.wait_for_loading(self.driver)
         element_present = EC.presence_of_element_located(
             (By.XPATH, '//*[@id="chart-region"]/div'))
         WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
 
-        # Re-store a list of all the charts.
-        charts = self.driver.find_elements_by_xpath(
-            '//*[@id="chart-region"]/div')
-
         # Assert there is one chart.
+        charts = self.driver.find_elements_by_xpath(
+            '//*[@id="chart-region"]/div[@class="chart-container"]')
         self.assertEqual(len(charts), 1)
+
+        # Uncheck the checked stat var.
+        self.driver.find_element_by_id("Count_Persondc/g/Demographics-Count_Person").click()
+
+        # Assert there are no charts.
+        shared.wait_for_loading(self.driver)
+        charts = self.driver.find_elements_by_xpath(
+            '//*[@id="chart-region"]/div[@class="chart-container"]')
+        self.assertEqual(len(charts), 0)
+
 
     def test_place_search_box_and_remove_place(self):
         """Test the timeline tool place search can work correctly."""


### PR DESCRIPTION
- Webdriver test failure was caused by change in stat var name. Make webdriver test more reliable by finding element based on ID.
- Also realized the test is named "check statvar and uncheck" but the test only tested for checking statvar and not unchecking statvar, so added that part