### PR TITLE
Fix bugs where GA event parameters are not surrounded by brackets.

### DIFF
--- a/static/js/place/menu.tsx
+++ b/static/js/place/menu.tsx
@@ -20,6 +20,8 @@ import { PageChart } from "../chart/types";
 import { intl, LocalizedLink } from "../i18n/i18n";
 import {
   GA_EVENT_PLACE_CATEGORY_CLICK,
+  GA_PARAM_PLACE_CATEGORY_CLICK,
+  GA_PARAM_PLACE_CATEGORY_CLICK_SOURCE,
   GA_VALUE_PLACE_CATEGORY_CLICK_OVERVIEW,
   GA_VALUE_PLACE_CATEGORY_CLICK_SOURCE_SIDEBAR,
   triggerGAEvent,
@@ -53,8 +55,8 @@ class MenuCategory extends React.Component<MenuCategoryPropsType> {
           text={this.props.categoryDisplayStr}
           handleClick={() =>
             triggerGAEvent(GA_EVENT_PLACE_CATEGORY_CLICK, {
-              GA_PARAM_PLACE_CATEGORY_CLICK: category,
-              GA_PARAM_PLACE_CATEGORY_CLICK_SOURCE:
+              [GA_PARAM_PLACE_CATEGORY_CLICK]: category,
+              [GA_PARAM_PLACE_CATEGORY_CLICK_SOURCE]:
                 GA_VALUE_PLACE_CATEGORY_CLICK_SOURCE_SIDEBAR,
             })
           }
@@ -127,9 +129,9 @@ class Menu extends React.Component<MenuPropsType> {
               })}
               handleClick={() =>
                 triggerGAEvent(GA_EVENT_PLACE_CATEGORY_CLICK, {
-                  GA_PARAM_PLACE_CATEGORY_CLICK:
+                  [GA_PARAM_PLACE_CATEGORY_CLICK]:
                     GA_VALUE_PLACE_CATEGORY_CLICK_OVERVIEW,
-                  GA_PARAM_PLACE_CATEGORY_CLICK_SOURCE:
+                  [GA_PARAM_PLACE_CATEGORY_CLICK_SOURCE]:
                     GA_VALUE_PLACE_CATEGORY_CLICK_SOURCE_SIDEBAR,
                 })
               }

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -27,6 +27,7 @@ import React from "react";
 import { Context } from "../shared/context";
 import {
   GA_EVENT_TOOL_STAT_VAR_CLICK,
+  GA_PARAM_STAT_VAR,
   triggerGAEvent,
 } from "../shared/ga_events";
 import {
@@ -300,7 +301,9 @@ export class StatVarHierarchy extends React.Component<
     } else {
       if (this.props.selectSV) {
         this.props.selectSV(sv);
-        triggerGAEvent(GA_EVENT_TOOL_STAT_VAR_CLICK, { GA_PARAM_STAT_VAR: sv });
+        triggerGAEvent(GA_EVENT_TOOL_STAT_VAR_CLICK, {
+          [GA_PARAM_STAT_VAR]: sv,
+        });
       }
       const svPath = RADIO_BUTTON_TYPES.has(this.props.type)
         ? { [sv]: path }

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -194,8 +194,8 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
     this.resizeObserver.observe(this.svgContainer.current);
     // Triggered when the component is mounted and send data to google analytics.
     triggerGAEvent(GA_EVENT_TOOL_CHART_PLOT, {
-      GA_PARAM_PLACE_DCID: Object.keys(this.props.placeNames),
-      GA_PARAM_STAT_VAR: Object.keys(this.props.statVarInfos),
+      [GA_PARAM_PLACE_DCID]: Object.keys(this.props.placeNames),
+      [GA_PARAM_STAT_VAR]: Object.keys(this.props.statVarInfos),
     });
   }
 


### PR DESCRIPTION
We set the object key by variable. In order to let the key be the value of the variable, we need to use bracket notation. e.g.,
const GA_PARAM_PLACE_DCID = "place_dcid";
triggerGAEvent(GA_EVENT_TOOL_CHART_PLOT, {
      [GA_PARAM_PLACE_DCID]: Object.keys(this.props.placeNames),
    });
Without brackets, the key will be "GA_PARAM_PLACE_DCID" instead of "place_dcid"
The following is the document for this syntax:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names