### PR TITLE
[Disease Browser] Add second chart for the disease browser 

### DIFF
--- a/static/js/biomedical/disease/chart.ts
+++ b/static/js/biomedical/disease/chart.ts
@@ -45,6 +45,13 @@ export interface DiseaseGeneAssociationData {
   upperInterval: number;
 }
 
+export interface DiseaseSymptomAssociationData {
+  // name of the symptom
+  name: string;
+  // odds Ratio for association 
+  oddsRatio: number;
+}
+
 /**
  * Draws the disease-gene association charts for the disease of interest
  * @param id - the div id where the chart is rendered on the page
@@ -174,3 +181,74 @@ export function drawDiseaseGeneAssocChart(
       (d) => `Gene Name: ${d.name}<br>Confidence Score: ${d.score}`
     );
 }
+
+export function drawDiseaseSymptomAssociationChart(
+  id: string,
+  data: DiseaseSymptomAssociationData[]
+): void {
+  // checks if the data is empty or not
+  if (_.isEmpty(data)) {
+    return;
+  }
+  const height = GRAPH_HEIGHT - MARGIN.top - MARGIN.bottom;
+  const width = GRAPH_WIDTH - MARGIN.left - MARGIN.right;
+  const svg = d3
+  .select(`#${id}`)
+  .append("svg")
+  .attr("width", width + MARGIN.left + MARGIN.right)
+  .attr("height", height + MARGIN.top + MARGIN.bottom)
+  .append("g")
+  .attr("transform", "translate(" + MARGIN.left + "," + MARGIN.top + ")");
+  // slicing the data to display 10 values only
+  data = data.slice(0, NUM_DATA_POINTS);
+  // sorts the data in descreasing order
+  data.sort((a, b) => {
+    return b.oddsRatio - a.oddsRatio;
+  });
+  // plots the axes
+  const x = d3
+    .scaleBand()
+    .range([0, width])
+    .domain(
+      data.map((d) => {
+        return d.name;
+      })
+    )
+    .padding(1);
+  svg
+    .append("g")
+    .attr("transform", "translate(0," + height + ")")
+    .call(d3.axisBottom(x))
+    .selectAll("text")
+    .attr("transform", "translate(-10,0)rotate(-45)")
+    .style("text-anchor", "end");
+  addXLabel(width, height + 15, "Symptom Names", svg);  
+  const y = d3
+    .scaleLinear()
+    .domain([0, d3.max(data, (d) => d.oddsRatio) + Y_AXIS_LIMIT])
+    .range([height, 0]);
+  svg.append("g").call(d3.axisLeft(y));
+  addYLabel(height, "Odds Ratio Associatiom Score", svg);
+  const circleIDFunc = getElementIDFunc(id, "circle");
+  // the circles
+  svg
+    .selectAll("disease-symptom-circle")
+    .data(data)
+    .enter()
+    .append("circle")
+    .attr("cx", (d) => {
+      return x(d.name);
+    })
+    .attr("cy", (d) => {
+      return y(d.oddsRatio);
+    })
+    .attr("r", LEGEND_CIRCLE_RADIUS)
+    .attr("id", (d, i) => circleIDFunc(i))
+    .style("fill", "maroon")
+    .call(
+      handleMouseEvents,
+      circleIDFunc,
+      (d) => `Symptom: ${d.name}<br>Odds Ratio Association: ${d.oddsRatio}`
+    );
+}
+

--- a/static/js/biomedical/disease/chart.ts
+++ b/static/js/biomedical/disease/chart.ts
@@ -48,7 +48,7 @@ export interface DiseaseGeneAssociationData {
 export interface DiseaseSymptomAssociationData {
   // name of the symptom
   name: string;
-  // odds Ratio for association 
+  // odds Ratio for association
   oddsRatio: number;
 }
 
@@ -193,12 +193,12 @@ export function drawDiseaseSymptomAssociationChart(
   const height = GRAPH_HEIGHT - MARGIN.top - MARGIN.bottom;
   const width = GRAPH_WIDTH - MARGIN.left - MARGIN.right;
   const svg = d3
-  .select(`#${id}`)
-  .append("svg")
-  .attr("width", width + MARGIN.left + MARGIN.right)
-  .attr("height", height + MARGIN.top + MARGIN.bottom)
-  .append("g")
-  .attr("transform", "translate(" + MARGIN.left + "," + MARGIN.top + ")");
+    .select(`#${id}`)
+    .append("svg")
+    .attr("width", width + MARGIN.left + MARGIN.right)
+    .attr("height", height + MARGIN.top + MARGIN.bottom)
+    .append("g")
+    .attr("transform", "translate(" + MARGIN.left + "," + MARGIN.top + ")");
   // slicing the data to display 10 values only
   data = data.slice(0, NUM_DATA_POINTS);
   // sorts the data in descreasing order
@@ -222,7 +222,7 @@ export function drawDiseaseSymptomAssociationChart(
     .selectAll("text")
     .attr("transform", "translate(-10,0)rotate(-45)")
     .style("text-anchor", "end");
-  addXLabel(width, height + 15, "Symptom Names", svg);  
+  addXLabel(width, height + 15, "Symptom Names", svg);
   const y = d3
     .scaleLinear()
     .domain([0, d3.max(data, (d) => d.oddsRatio) + Y_AXIS_LIMIT])
@@ -248,7 +248,6 @@ export function drawDiseaseSymptomAssociationChart(
     .call(
       handleMouseEvents,
       circleIDFunc,
-      (d) => `Symptom: ${d.name}<br>Odds Ratio Association: ${d.oddsRatio}`
+      (d) => "Symptom: ${d.name}<br>Odds Ratio Association: ${d.oddsRatio}"
     );
 }
-

--- a/static/js/biomedical/disease/chart.ts
+++ b/static/js/biomedical/disease/chart.ts
@@ -93,7 +93,9 @@ export function drawDiseaseGeneAssocChart(
     .attr("transform", "translate(0," + height + ")")
     .call(d3.axisBottom(x))
     .selectAll("text")
-    .attr("transform", "translate(-10,0)rotate(-45)")
+    .attr("dx", "-.8em")
+    .attr("dy", ".15em")
+    .attr("transform", "rotate(-35)")
     .style("text-anchor", "end");
   addXLabel(width, height, "Gene Names", svg);
   const y = d3
@@ -220,7 +222,9 @@ export function drawDiseaseSymptomAssociationChart(
     .attr("transform", "translate(0," + height + ")")
     .call(d3.axisBottom(x))
     .selectAll("text")
-    .attr("transform", "translate(-10,0)rotate(-45)")
+    .attr("dx", "-.8em")
+    .attr("dy", ".15em")
+    .attr("transform", "rotate(-30)")
     .style("text-anchor", "end");
   addXLabel(width, height + 15, "Symptom Names", svg);
   const y = d3

--- a/static/js/biomedical/disease/chart.ts
+++ b/static/js/biomedical/disease/chart.ts
@@ -200,9 +200,9 @@ export function drawDiseaseSymptomAssociationChart(
     .append("g")
     .attr("transform", "translate(" + MARGIN.left + "," + MARGIN.top + ")");
   // slicing the data to display 10 values only
-  data = data.slice(0, NUM_DATA_POINTS);
+  let slicedData = data.slice(0, NUM_DATA_POINTS);
   // sorts the data in descreasing order
-  data.sort((a, b) => {
+  slicedData.sort((a, b) => {
     return b.oddsRatio - a.oddsRatio;
   });
   // plots the axes
@@ -210,7 +210,7 @@ export function drawDiseaseSymptomAssociationChart(
     .scaleBand()
     .range([0, width])
     .domain(
-      data.map((d) => {
+      slicedData.map((d) => {
         return d.name;
       })
     )
@@ -225,7 +225,7 @@ export function drawDiseaseSymptomAssociationChart(
   addXLabel(width, height + 15, "Symptom Names", svg);
   const y = d3
     .scaleLinear()
-    .domain([0, d3.max(data, (d) => d.oddsRatio) + Y_AXIS_LIMIT])
+    .domain([0, d3.max(slicedData, (d) => d.oddsRatio) + Y_AXIS_LIMIT])
     .range([height, 0]);
   svg.append("g").call(d3.axisLeft(y));
   addYLabel(height, "Odds Ratio Associatiom Score", svg);
@@ -233,7 +233,7 @@ export function drawDiseaseSymptomAssociationChart(
   // the circles
   svg
     .selectAll("disease-symptom-circle")
-    .data(data)
+    .data(slicedData)
     .enter()
     .append("circle")
     .attr("cx", (d) => {
@@ -248,6 +248,6 @@ export function drawDiseaseSymptomAssociationChart(
     .call(
       handleMouseEvents,
       circleIDFunc,
-      (d) => "Symptom: ${d.name}<br>Odds Ratio Association: ${d.oddsRatio}"
+      (d) => `Symptom: ${d.name}<br>Odds Ratio Association: ${d.oddsRatio}`
     );
 }

--- a/static/js/biomedical/disease/chart.ts
+++ b/static/js/biomedical/disease/chart.ts
@@ -200,7 +200,7 @@ export function drawDiseaseSymptomAssociationChart(
     .append("g")
     .attr("transform", "translate(" + MARGIN.left + "," + MARGIN.top + ")");
   // slicing the data to display 10 values only
-  let slicedData = data.slice(0, NUM_DATA_POINTS);
+  const slicedData = data.slice(0, NUM_DATA_POINTS);
   // sorts the data in descreasing order
   slicedData.sort((a, b) => {
     return b.oddsRatio - a.oddsRatio;

--- a/static/js/biomedical/disease/data_processing_utils.ts
+++ b/static/js/biomedical/disease/data_processing_utils.ts
@@ -29,7 +29,7 @@ export function getDiseaseGeneAssociation(
   data: GraphNodes
 ): DiseaseGeneAssociationData[] {
   // checks if the data is empty
-  if (!data) {
+  if (_.isEmpty(data)) {
     return [];
   }
   const rawData: DiseaseGeneAssociationData[] = [];
@@ -95,7 +95,7 @@ export function getDiseaseSymptomAssociation(
   data: GraphNodes
 ): DiseaseSymptomAssociationData[] {
   // checks if the data is empty
-  if (!data) {
+  if (_.isEmpty(data)) {
     return [];
   }
   const rawData: DiseaseSymptomAssociationData[] = [];

--- a/static/js/biomedical/disease/data_processing_utils.ts
+++ b/static/js/biomedical/disease/data_processing_utils.ts
@@ -123,7 +123,7 @@ export function getDiseaseSymptomAssociation(
           oddsRatioValue = n.nodes[0].value;
         } else if (n.property === "medicalSubjectHeadingID") {
           for (const n1 of n.nodes) {
-            if ( _.isEmpty(n1.neighbors)) {
+            if (_.isEmpty(n1.neighbors)) {
               continue;
             }
             for (const n2 of n1.neighbors) {

--- a/static/js/biomedical/disease/data_processing_utils.ts
+++ b/static/js/biomedical/disease/data_processing_utils.ts
@@ -123,7 +123,7 @@ export function getDiseaseSymptomAssociation(
           oddsRatioValue = n.nodes[0].value;
         } else if (n.property === "medicalSubjectHeadingID") {
           for (const n1 of n.nodes) {
-            if (n1.neighbors === undefined || _.isEmpty(n1.value)) {
+            if (n1.neighbors === undefined || _.isEmpty(n1.neighbors)) {
               continue;
             }
             for (const n2 of n1.neighbors) {

--- a/static/js/biomedical/disease/data_processing_utils.ts
+++ b/static/js/biomedical/disease/data_processing_utils.ts
@@ -123,7 +123,7 @@ export function getDiseaseSymptomAssociation(
           oddsRatioValue = n.nodes[0].value;
         } else if (n.property === "medicalSubjectHeadingID") {
           for (const n1 of n.nodes) {
-            if (n1.neighbors === undefined || _.isEmpty(n1.neighbors)) {
+            if ( _.isEmpty(n1.neighbors)) {
               continue;
             }
             for (const n2 of n1.neighbors) {

--- a/static/js/biomedical/disease/data_processing_utils.ts
+++ b/static/js/biomedical/disease/data_processing_utils.ts
@@ -16,7 +16,10 @@
 import _ from "lodash";
 
 import { GraphNodes } from "../../shared/types";
-import { DiseaseGeneAssociationData, DiseaseSymptomAssociationData } from "./chart";
+import {
+  DiseaseGeneAssociationData,
+  DiseaseSymptomAssociationData,
+} from "./chart";
 /**
  * Fetches the disease-gene association data
  * @param data - the data pertaining to the disease of interest
@@ -85,8 +88,8 @@ export function getDiseaseGeneAssociation(
 }
 /**
  * Fetches the disease-symptom association data
- * @param data 
- * @returns 
+ * @param data
+ * @returns
  */
 export function getDiseaseSymptomAssociation(
   data: GraphNodes
@@ -112,19 +115,19 @@ export function getDiseaseSymptomAssociation(
         continue;
       }
       for (const n of node.neighbors) {
-        if(n.property === "associationOddsRatio") {
+        if (n.property === "associationOddsRatio") {
           // check for empty list and null gene values
           if (_.isEmpty(n.nodes) || _.isEmpty(n.nodes[0].value)) {
             continue;
           }
           oddsRatioValue = n.nodes[0].value;
-        } else if(n.property === "medicalSubjectHeadingID") {
-          for(const n1 of n.nodes) {
+        } else if (n.property === "medicalSubjectHeadingID") {
+          for (const n1 of n.nodes) {
             if (n1.neighbors === undefined || _.isEmpty(n1.value)) {
               continue;
             }
-            for(const n2 of n1.neighbors) {
-              if(n2.property !== "descriptorName") {
+            for (const n2 of n1.neighbors) {
+              if (n2.property !== "descriptorName") {
                 continue;
               }
               // check if the list is empty or not
@@ -136,11 +139,11 @@ export function getDiseaseSymptomAssociation(
           }
         }
       }
-      // skip over null values, and add the rest to the array 
-      if(!!symptom && !!oddsRatioValue) {
+      // skip over null values, and add the rest to the array
+      if (!!symptom && !!oddsRatioValue) {
         rawData.push({
           name: symptom,
-          oddsRatio: Number(oddsRatioValue)
+          oddsRatio: Number(oddsRatioValue),
         });
       }
     }

--- a/static/js/biomedical/disease/page.tsx
+++ b/static/js/biomedical/disease/page.tsx
@@ -22,8 +22,14 @@ import axios from "axios";
 import React from "react";
 
 import { GraphNodes } from "../../shared/types";
-import { drawDiseaseGeneAssocChart, drawDiseaseSymptomAssociationChart } from "./chart";
-import { getDiseaseGeneAssociation, getDiseaseSymptomAssociation } from "./data_processing_utils";
+import {
+  drawDiseaseGeneAssocChart,
+  drawDiseaseSymptomAssociationChart,
+} from "./chart";
+import {
+  getDiseaseGeneAssociation,
+  getDiseaseSymptomAssociation,
+} from "./data_processing_utils";
 export interface PagePropType {
   dcid: string;
   nodeName: string;
@@ -43,7 +49,9 @@ export class Page extends React.Component<PagePropType, PageStateType> {
   }
   componentDidUpdate(): void {
     const diseaseGeneAssociation = getDiseaseGeneAssociation(this.state.data);
-    const diseaseSymptomAssociation = getDiseaseSymptomAssociation(this.state.data);
+    const diseaseSymptomAssociation = getDiseaseSymptomAssociation(
+      this.state.data
+    );
     drawDiseaseGeneAssocChart(
       "disease-gene-association-chart",
       diseaseGeneAssociation

--- a/static/js/biomedical/disease/page.tsx
+++ b/static/js/biomedical/disease/page.tsx
@@ -22,8 +22,8 @@ import axios from "axios";
 import React from "react";
 
 import { GraphNodes } from "../../shared/types";
-import { drawDiseaseGeneAssocChart } from "./chart";
-import { getDiseaseGeneAssociation } from "./data_processing_utils";
+import { drawDiseaseGeneAssocChart, drawDiseaseSymptomAssociationChart } from "./chart";
+import { getDiseaseGeneAssociation, getDiseaseSymptomAssociation } from "./data_processing_utils";
 export interface PagePropType {
   dcid: string;
   nodeName: string;
@@ -43,9 +43,14 @@ export class Page extends React.Component<PagePropType, PageStateType> {
   }
   componentDidUpdate(): void {
     const diseaseGeneAssociation = getDiseaseGeneAssociation(this.state.data);
+    const diseaseSymptomAssociation = getDiseaseSymptomAssociation(this.state.data);
     drawDiseaseGeneAssocChart(
       "disease-gene-association-chart",
       diseaseGeneAssociation
+    );
+    drawDiseaseSymptomAssociationChart(
+      "disease-symptom-association-chart",
+      diseaseSymptomAssociation
     );
   }
   render(): JSX.Element {
@@ -54,6 +59,8 @@ export class Page extends React.Component<PagePropType, PageStateType> {
         <h2>Disease Browser</h2>
         <h5>Disease-Gene Association</h5>
         <div id="disease-gene-association-chart"></div>
+        <h5>Disease-Symptom Association</h5>
+        <div id="disease-symptom-association-chart"></div>
       </>
     );
   }

--- a/static/js/biomedical/protein/data_processing_utils.ts
+++ b/static/js/biomedical/protein/data_processing_utils.ts
@@ -92,8 +92,8 @@ const CHEM_RELATIONS = [
  * @returns - array with tissue name and corresponding expression score
  */
 export function getTissueScore(data: GraphNodes): ProteinStrData[] {
-  // Tissue to score mapping.
-  if (!data) {
+  // checks if the data is empty
+  if (_.isEmpty(data)) {
     return [];
   }
   const returnData: ProteinStrData[] = [];
@@ -144,8 +144,8 @@ export function getProteinInteraction(
   data: GraphNodes,
   nodeName: string
 ): InteractingProteinType[] {
-  // Protein Interaction to confidence score mapping.
-  if (!data) {
+  // Checks if the data is empty
+  if (_.isEmpty(data)) {
     return [];
   }
   const returnData = [] as InteractingProteinType[];
@@ -215,8 +215,8 @@ export function getProteinInteraction(
 export function getDiseaseGeneAssoc(
   data: GraphNodes
 ): DiseaseAssociationType[] {
-  // Disease Gene Associations
-  if (!data) {
+  // Checks if the data is empty
+  if (_.isEmpty(data)) {
     return [];
   }
   const returnData: DiseaseAssociationType[] = [];
@@ -286,8 +286,8 @@ export function getDiseaseGeneAssoc(
  * @returns - array with variant id and log 2 association score
  */
 export function getVarGeneAssoc(data: GraphNodes): ProteinVarType[] {
-  // Variant Gene Associations
-  if (!data) {
+  // Checks if the data is empty
+  if (_.isEmpty(data)) {
     return [];
   }
   const returnData = [] as ProteinVarType[];
@@ -368,8 +368,8 @@ export function getVarGeneAssoc(data: GraphNodes): ProteinVarType[] {
  * @returns - array with variant count and corresponding variant functional category
  */
 export function getVarTypeAssoc(data: GraphNodes): ProteinNumData[] {
-  // Variant Gene Associations
-  if (!data) {
+  // Checks if the data is empty
+  if (_.isEmpty(data)) {
     return [];
   }
   const returnData: ProteinNumData[] = [];
@@ -428,8 +428,8 @@ export function getVarTypeAssoc(data: GraphNodes): ProteinNumData[] {
  * @returns - array with variant count and corresponding variant clinical significance
  */
 export function getVarSigAssoc(data: GraphNodes): ProteinNumData[] {
-  // Variant Gene Associations
-  if (!data) {
+  // Checks if the data is empty
+  if (_.isEmpty(data)) {
     return [];
   }
   const result: ProteinNumData[] = [];
@@ -488,8 +488,8 @@ export function getVarSigAssoc(data: GraphNodes): ProteinNumData[] {
  * @returns - array with count and drug-gene association type
  */
 export function getChemicalGeneAssoc(data: GraphNodes): ProteinNumData[] {
-  // Chem Gene Associations
-  if (!data) {
+  // Checks if the data is empty
+  if (_.isEmpty(data)) {
     return [];
   }
   const result: ProteinNumData[] = [];


### PR DESCRIPTION
<img width="936" alt="Screen Shot 2022-07-25 at 10 22 41 AM" src="https://user-images.githubusercontent.com/57412795/180815300-af81eb4c-ced0-43a7-8485-921b36400bae.png">

I added the disease symptom association chart. For the disease of interest, the x axis has the symptoms and the y axis has the association score.