### PR TITLE
datacommons.py property-values function

### DIFF
--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -328,6 +328,22 @@ def get_property_labels(dcids):
     return results
 
 
+def property_values(entities, prop, dir):
+    resp = post(f'/v1/bulk/property/values/{dir}', {
+        'entities': sorted(entities),
+        'property': prop,
+    })
+    result = {}
+    for item in resp['data']:
+        result[item['entity']] = []
+        for v in item['values']:
+            if 'dcid' in v:
+                result[item['entity']].append(v['dcid'])
+            else:
+                result[item['entity']].append(v['value'])
+    return result
+
+
 def get_property_values(dcids,
                         prop,
                         out=True,

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -335,12 +335,13 @@ def property_values(entities, prop, dir):
     })
     result = {}
     for item in resp['data']:
-        result[item['entity']] = []
-        for v in item['values']:
+        entity, values = item['entity'], item['values']
+        result[entity] = []
+        for v in values:
             if 'dcid' in v:
-                result[item['entity']].append(v['dcid'])
+                result[entity].append(v['dcid'])
             else:
-                result[item['entity']].append(v['value'])
+                result[entity].append(v['value'])
     return result
 
 


### PR DESCRIPTION
Include `property-values` function from [this commit](https://github.com/shifucun/website/blob/79046d4923e7fd1b027cfcf0c24ea92b5249cdc6/server/services/datacommons.py#L156) by @shifucun, updated to use the new V1 endpoint format.