### PR TITLE
[Devops] Terraform config for the website part1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,12 @@ deploy/git/website_hash.txt
 
 # Helm
 build/helm/**/*.tgz
+
+# Terraform
+# Instance variables.
+*.tfvars
+# Local .terraform directories
+**/.terraform/*
+# .tfstate files
+*.tfstate
+*.tfstate.*

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ build/helm/**/*.tgz
 *.tfvars
 # Local .terraform directories
 **/.terraform/*
+**/.terraform.lock.*
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/deploy/terraform-datacommons-website/README.md
+++ b/deploy/terraform-datacommons-website/README.md
@@ -16,9 +16,17 @@ Before this module can be used on a project, you must ensure that the following 
 
 2. Run `gcloud auth application-default login` to configure GCP credentials.
 
-Note: Alternatively, [create a Service Account](https://cloud.google.com/docs/authentication/production#create_service_account) and export a Service Account key.
+    Note: Alternatively, [create a Service Account](https://cloud.google.com/docs/authentication/production#create_service_account) and export a Service Account key.
 
-3. Terraform stores the state of installation in a file. The examples in these modules use GCS to store the state file. If a 
+3. Terraform stores the state of installation in a file. The examples in these modules use GCS to store the state file.
+
+    Note: Examples in these modules assume that the backend bucket already exists. The backend bucket does not have to be in the same GCP project as the resources being installed. You can use the [mb](https://cloud.google.com/storage/docs/gsutil/commands/mb) command to create a new bucket. 
+
+    ```
+    export PROJECT=<Terraform state project id>
+    export BUCKET=<Terraform state bucket name>
+    gsutil mb -p $PROJECT gs://$BUCKET
+    ```
 
 ## Software Dependencies
 
@@ -27,6 +35,8 @@ Note: Alternatively, [create a Service Account](https://cloud.google.com/docs/au
 - [Terraform](https://www.terraform.io/downloads.html) 1.2.5
 - [Terraform Provider for GCP](https://github.com/hashicorp/terraform-provider-google) v4.28
 - [Terraform Provider for GCP Beta](https://github.com/hashicorp/terraform-provider-google-beta) v4.28
+
+    Note: Terraform providers are implicit dependencies installed through `terraform init` call. They do not need to be installed explicitly.
 
 ### gcloud and gsutil
 

--- a/deploy/terraform-datacommons-website/README.md
+++ b/deploy/terraform-datacommons-website/README.md
@@ -1,0 +1,33 @@
+# Terraform Data Commons module
+
+This module handles the creation of Data Commons applications on Google Cloud Platform.
+
+For more on Data Commons, visit https://datacommons.org/about.
+
+# Compatibility
+
+This module is tested on Terraform 1.2.5
+
+# Requirements
+
+Before this module can be used on a project, you must ensure that the following pre-requisites are fulfilled:
+
+1. All [software dependencies](#software-dependencies) are installed on the machine where Terraform is executed.
+
+2. Run `gcloud auth application-default login` to configure GCP credentials.
+
+Note: Alternatively, [create a Service Account](https://cloud.google.com/docs/authentication/production#create_service_account) and export a Service Account key.
+
+3. Terraform stores the state of installation in a file. The examples in these modules use GCS to store the state file. If a 
+
+## Software Dependencies
+
+### Terraform and Plugins
+
+- [Terraform](https://www.terraform.io/downloads.html) 1.2.5
+- [Terraform Provider for GCP](https://github.com/hashicorp/terraform-provider-google) v4.28
+- [Terraform Provider for GCP Beta](https://github.com/hashicorp/terraform-provider-google-beta) v4.28
+
+### gcloud and gsutil
+
+Please follow the [gcloud install doc](https://cloud.google.com/sdk/docs/install) and the [gsutil install doc](https://cloud.google.com/storage/docs/gsutil_install) to install both cli tools in the machine that is calling Terraform. Some modules may need to call gcloud/gsutil in the background. 

--- a/deploy/terraform-datacommons-website/examples/website_v1/.terraform.lock.hcl
+++ b/deploy/terraform-datacommons-website/examples/website_v1/.terraform.lock.hcl
@@ -1,0 +1,79 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.0.0"
+  constraints = "~> 2.0.0"
+  hashes = [
+    "h1:6S7hqjmUnoAZ5D/0F1VlJZKSJsUIBh7Ro0tLjGpKO0g=",
+    "zh:07949780dd6a1d43e7b46950f6e6976581d9724102cb5388d3411a1b6f476bde",
+    "zh:0a4f4636ff93f0644affa8474465dd8c9252946437ad025b28fc9f6603534a24",
+    "zh:0dd7e05a974c649950d1a21d7015d3753324ae52ebdd1744b144bc409ca4b3e8",
+    "zh:2b881032b9aa9d227ac712f614056d050bcdcc67df0dc79e2b2cb76a197059ad",
+    "zh:38feb4787b4570335459ca75a55389df1a7570bdca8cdf5df4c2876afe3c14b4",
+    "zh:40f7e0aaef3b1f4c2ca2bb1189e3fe9af8c296da129423986d1d99ccc8cfb86c",
+    "zh:56b361f64f0f0df5c4f958ae2f0e6f8ba192f35b720b9d3ae1be068fabcf73d9",
+    "zh:5fadb5880cd31c2105f635ded92b9b16f918c1dd989627a4ce62c04939223909",
+    "zh:61fa0be9c14c8c4109cfb7be8d54a80c56d35dbae49d3231cddb59831e7e5a4d",
+    "zh:853774bf97fbc4a784d5af5a4ca0090848430781ae6cfc586adeb48f7c44af79",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.28.0"
+  constraints = ">= 3.43.0, ~> 4.28.0, < 5.0.0"
+  hashes = [
+    "h1:GWIsjFFxrWk2kY+xrzfczjCCBL2m2WuI5/Kw3AF5y2Q=",
+    "zh:17664192fbeb733d6d6cfa17fbd1c54e6f1614f635f48adfae17557e121b63eb",
+    "zh:2993a3ba417c576ca9c6adccb6a6e914b4dedd3f91a735fd14ab8910936d8c11",
+    "zh:452323359fd64dc0fbf96da8c1df1df57cacef72cf2615631662bdec1d73d94e",
+    "zh:492c1d1bfbd9bef2a30fab0096ae642ceeeee81499cf5aa9f4505a884b0855a3",
+    "zh:611875b0246bdbd8815f8e81e744e31466559fec3b4566c9d2f3d1fd54c20292",
+    "zh:63c5084e1ac50165da1feebf2f51af3c8a7b61f817861418850b2b59b010b604",
+    "zh:6efb784223405839aa22fc6e40e37e08dd7ba37310e327dea1731299e5c67104",
+    "zh:ac51b5555bfdee282885475831bdc336f42294687e887f91cd339f15a4f69bc1",
+    "zh:c98e971f99f43aea9e0363cdd478e3b19f79b4553357a089bb10ba7ab897a932",
+    "zh:e9c29205674657f7b31f352a680a17262a797150bcbe76b26939d5cb39d19199",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f968998e7690cd508c1f7847d7fa3ba2ae448d70e94414ada85c1cee81b3bcd9",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "4.28.0"
+  constraints = ">= 3.43.0, ~> 4.28.0, < 5.0.0"
+  hashes = [
+    "h1:OCnAHwByjG7Ck54UXweixWOKuQfheAgIbLvs3Rhttws=",
+    "zh:02049634b3dd7928628145c1993e9a6772b8229e94c0466943dd8a192c7dcf43",
+    "zh:113664260f56d0559c9f4c5b912dd80ee966d09ff3723fe6ae1a71fa4915fdc9",
+    "zh:28de139a2db9ccf280a92fa18ed41f36ea5ef4269fda4124288751eec45b6907",
+    "zh:303dec5be87bd935351bf991da4edff71bab9909ce410a819b3dd0849a27df8b",
+    "zh:579b6cf837488a0e6335c1ca0b81ce0936d2ea29c24b4fb8ba54018e81a0cabb",
+    "zh:77cdb315e9144739241f9ea3e55502104dece33ce0acd9694469a3a5df4e3906",
+    "zh:837c37d168dc557b474b5dac3b850e134779a27ee9df3f49a4427c569d0eae44",
+    "zh:9359bf058b95fa6b9337a3b55168517fd380e6752c383c964fb776513621aca4",
+    "zh:cf3cdef5ed5d4a321ffd2cac070a00ff0f8cee7bfd6a2697c494a1d06937bb67",
+    "zh:e4f647bd336260fc477f7ab77e48e825d49f3d4ed1391bf232b5039cfc411760",
+    "zh:ec3a02205594beeeedd090dd6c831a988fc0ff58fb353cc78dc6395eedf19979",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/deploy/terraform-datacommons-website/examples/website_v1/README.md
+++ b/deploy/terraform-datacommons-website/examples/website_v1/README.md
@@ -1,0 +1,26 @@
+# Data Commons Website v1
+
+This end to end example aims to show how to install a simple and opinionated setup of the [Data Commons website](https://www.datacommons.org/).
+
+This setup has the following key features:
+
+- A regional GKE instance using workload identity.
+- An ingress to the website using global static ip.
+- Optional [IAP](https://cloud.google.com/iap) control to limit website access.
+- User specified GCP storge project.
+
+# Setup
+
+To deploy this example:
+
+1. Copy and paste `variables.tfvars.tpl` into a new file `variables.tf`.
+
+2. Follow the comments and fill out all values of `variables.tf`.
+
+3. Run `BACKEND_BUCKET=your-backend-bucket && terraform init -backend-config="bucket=$BACKEND_BUCKET"`
+
+Replace your-backend-bucket with the name of the GCS bucket where the Terraform state should be stored in. Do not add the "gs://" prefix.
+
+4.  Run `terraform apply -var-file="variables.tfvars"`
+
+This should return a prompt with a list of resources to be created/modified/deleted, enter "yes" to continue.

--- a/deploy/terraform-datacommons-website/examples/website_v1/main.tf
+++ b/deploy/terraform-datacommons-website/examples/website_v1/main.tf
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  backend "gcs" {
+    prefix = "dc_website_v1"
+  }
+}
+
+module "enabled_google_apis" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+  version = "~> 13.0.0"
+  project_id                  = var.project_id
+  disable_services_on_destroy = false
+  activate_apis = [
+    "apikeys.googleapis.com",
+    "binaryauthorization.googleapis.com",
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "containerregistry.googleapis.com",
+    "dns.googleapis.com",
+    "iam.googleapis.com",
+    "iap.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "secretmanager.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "stackdriver.googleapis.com"
+  ]
+}
+
+module "iam" {
+  source                   =  "../../modules/iam"
+  project_id               = var.project_id
+  storage_project_id       = var.storage_project_id
+}
+
+module "iap" {
+  source                   =  "../../modules/iap"
+  project_id               = var.project_id
+  brand_support_email      = var.brand_support_email
+  web_user_members         = var.web_user_members
+}

--- a/deploy/terraform-datacommons-website/examples/website_v1/variables.tf
+++ b/deploy/terraform-datacommons-website/examples/website_v1/variables.tf
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "Project id of the GCP project where the website is to be set up."
+}
+
+variable "storage_project_id" {
+  type        = string
+  description = "Project id of the GCP project id of an existing data storage project."
+}
+
+variable "brand_support_email" {
+  type        = string
+  description = "Branch support email."
+  default     = null
+}
+
+variable "web_user_members" {
+  type        =  list(string)
+  description = "List of users that are allowed to be authenticated in IAP."
+}

--- a/deploy/terraform-datacommons-website/examples/website_v1/variables.tfvars.tpl
+++ b/deploy/terraform-datacommons-website/examples/website_v1/variables.tfvars.tpl
@@ -1,0 +1,19 @@
+# GCP project where the website should be installed.
+# Type: string
+project_id = 
+
+# GCP project where the data is.
+# To use the storge project owned by dc-core team, contact the dc-core team to be allowlisted
+# and then specify "datcom-store",
+# Type: string
+storage_project_id = 
+
+# Who to contact for issues related to installed applications.
+# Type: string
+brand_support_email = 
+
+# A list of users to allow access to the DC website.
+# Type: List[string]
+# Format: Comma separated list of quoted strings, enclosed by []
+web_user_members =
+

--- a/deploy/terraform-datacommons-website/examples/website_v1/variables.tfvars.tpl
+++ b/deploy/terraform-datacommons-website/examples/website_v1/variables.tfvars.tpl
@@ -3,8 +3,11 @@
 project_id = 
 
 # GCP project where the data is.
-# To use the storge project owned by dc-core team, contact the dc-core team to be allowlisted
-# and then specify "datcom-store",
+# To use the storage project owned by dc-core team, 
+# please send an email to support@datacommons.org including
+# the GCP project id specified in the tfvars file created 
+# from this template.
+# After the dc-core team approves access, specify "datcom-store".
 # Type: string
 storage_project_id = 
 

--- a/deploy/terraform-datacommons-website/examples/website_v1/versions.tf
+++ b/deploy/terraform-datacommons-website/examples/website_v1/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">=1.2.5"
+  required_providers {
+    external    = "~> 2.0.0"
+    google      = "~> 4.28.0"
+    google-beta = "~> 4.28.0"
+  }
+}

--- a/deploy/terraform-datacommons-website/modules/iam/README.md
+++ b/deploy/terraform-datacommons-website/modules/iam/README.md
@@ -1,0 +1,32 @@
+# IAM module.
+
+This module provides the GCP resources related to IAM with regards to the Data Commons application suite.
+
+- Creation of GCP workload identity service account.
+- Binding of the above SA to the GCP roles required by the DC website application.
+- Binding of the above SA to the GCP roles required to interact with the storage project.
+
+This module assumes that the GKE cluster will have [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) enabled.
+
+Note: The installer needs Storage Admin(roles/iam.securityAdmin) role be able to modify IAM permissions on the storage project. Please contact the storage project owner to get the required permissions.
+
+## Usage
+
+```tf
+module "dc_iam" {
+  source                   =  "../../modules/iam"
+
+  project_id               = "my-project-id"
+}
+```
+
+Note: Change the source path if the caller module is not from a particular example in the examples folder.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| website\_robot\_account\_id | The prefix of the GCP service account to be created. | `string` | `website-robot` | no |
+| project\_id | GCP project id of the Service Account to be created. | `string` | n/a | yes |
+| storage\_project\_id | GCP project id of the data storage project. For dc-core team owned instances, | `string` | n/a | yes |
+

--- a/deploy/terraform-datacommons-website/modules/iam/README.md
+++ b/deploy/terraform-datacommons-website/modules/iam/README.md
@@ -6,7 +6,7 @@ This module provides the GCP resources related to IAM with regards to the Data C
 - Binding of the above SA to the GCP roles required by the DC website application.
 - Binding of the above SA to the GCP roles required to interact with the storage project.
 
-This module assumes that the GKE cluster will have [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) enabled.
+This module assumes that the GKE cluster, which is installed separately and will depend on this module, will have [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) enabled.
 
 Note: The installer needs Storage Admin(roles/iam.securityAdmin) role be able to modify IAM permissions on the storage project. Please contact the storage project owner to get the required permissions.
 

--- a/deploy/terraform-datacommons-website/modules/iam/main.tf
+++ b/deploy/terraform-datacommons-website/modules/iam/main.tf
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_service_account" "web_robot" {
+  account_id   = var.website_robot_account_id
+  display_name = "The workload identity of DC applications."
+  project      = var.project_id
+}
+
+# Creation of service account is eventually consistent.
+# Sleeping minimizes the chance that iam binding fails right after the SA is created.
+resource "null_resource" "sleep_after_web_robot_creation" {
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
+}
+
+# Instance project permissions
+resource "google_project_iam_member" "web_robot_roles" {
+  for_each = toset([
+    "roles/endpoints.serviceAgent", # service control report for endpoints.
+    "roles/logging.logWriter", # Logging and monitoring
+    "roles/monitoring.metricWriter",
+    "roles/stackdriver.resourceMetadata.writer",
+    "roles/compute.networkViewer",
+    "roles/cloudtrace.agent",
+    "roles/bigquery.jobUser",   # Query BigQuery
+    "roles/pubsub.editor", # TMCF + CSV GCS data change subscription
+    "roles/secretmanager.secretAccessor"
+  ])
+  role = each.key
+  member = "serviceAccount:${google_service_account.web_robot.email}"
+  project = var.project_id
+
+  depends_on = [
+    null_resource.sleep_after_web_robot_creation
+  ]
+}
+
+# Storage project permissions
+resource "google_project_iam_member" "web_robot_storage_roles" {
+  for_each = toset([
+    "roles/bigquery.admin",   # BigQuery
+    "roles/bigtable.reader",  # Bigtable
+    "roles/storage.objectViewer",  # Branch Cache Read
+    "roles/pubsub.editor" # Branch Cache Subscription
+  ])
+  role = each.key
+  member = "serviceAccount:${google_service_account.web_robot.email}"
+  project = var.storage_project_id
+
+  depends_on = [
+    null_resource.sleep_after_web_robot_creation
+  ]
+}

--- a/deploy/terraform-datacommons-website/modules/iam/outputs.tf
+++ b/deploy/terraform-datacommons-website/modules/iam/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "web_robot_email" {
+  description = "Robot service account that was created."
+  value       = google_service_account.web_robot.email
+}

--- a/deploy/terraform-datacommons-website/modules/iam/variables.tf
+++ b/deploy/terraform-datacommons-website/modules/iam/variables.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "GCP project id where the GCP service account for the workload is defined."
+}
+
+variable "storage_project_id" {
+  type        = string
+  description = "GCP project id where the BQ and BT data stores will be located in."
+}
+
+variable "website_robot_account_id" {
+  type        = string
+  description = "The prefix of the GCP service account to be created."
+  default     = "website-robot"
+}

--- a/deploy/terraform-datacommons-website/modules/iap/README.md
+++ b/deploy/terraform-datacommons-website/modules/iap/README.md
@@ -1,0 +1,28 @@
+# IAP module.
+
+This module provides the GCP resources related to setting up [IAP](https://cloud.google.com/iap). IAP restrict access to applications. IAP can be used to protect both internal facing and internal facing applications.
+
+This module sets the IAP allowlist at the project level. This means that applications protected using the OAuth client created from this module will have the same allowlist, specified by the input web_user_members.
+
+## Usage
+
+```tf
+module "dc_iap" {
+  source                   =  "../../modules/iap"
+
+  project_id               = "my-project-id"
+  brand_support_email      = "my-brand-support-email"
+  web_user_members         = [ "user1@domain", "user2@domain" ... ]
+}
+```
+
+Note: Change the source path if the caller module is not from a particular example in the examples folder.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| brand\_support\_email | Who to contact for issues related to installed applications. | `string` | n/a | yes |
+| web\_user\_members | A list of users allowlisted for applications controlled using IAP. | `List[string]` | `website-ksa` | no |
+| project\_id | GCP project id where the DC applications will be running in.| `string` | n/a | yes |
+

--- a/deploy/terraform-datacommons-website/modules/iap/main.tf
+++ b/deploy/terraform-datacommons-website/modules/iap/main.tf
@@ -1,7 +1,23 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # This resource sets up the OAuth consent screen (This is required for IAP).
-# As of google provider version 3.48.0: Only "Organization Internal" brands
-#    can be created programatically via API. To convert it into an external
-#    brands please use the GCP Console.
+# As of google provider version 4.28.0, only "Organization Internal" brands
+# can be created programatically via API. To convert it into an external
+# brands please use the GCP Console.
 # Source: https://registry.terraform.io/providers/hashicorp/google/3.48.0/docs/resources/iap_brand
 resource "google_iap_brand" "project_brand" {
   project           = var.project_id

--- a/deploy/terraform-datacommons-website/modules/iap/main.tf
+++ b/deploy/terraform-datacommons-website/modules/iap/main.tf
@@ -1,0 +1,23 @@
+# This resource sets up the OAuth consent screen (This is required for IAP).
+# As of google provider version 3.48.0: Only "Organization Internal" brands
+#    can be created programatically via API. To convert it into an external
+#    brands please use the GCP Console.
+# Source: https://registry.terraform.io/providers/hashicorp/google/3.48.0/docs/resources/iap_brand
+resource "google_iap_brand" "project_brand" {
+  project           = var.project_id
+  support_email     = var.brand_support_email
+  application_title = "Data Commons website"
+}
+
+resource "google_iap_client" "project_client" {
+  display_name =  "Data Commons OAuth client"
+  brand        =  google_iap_brand.project_brand.name
+}
+
+resource "google_project_iam_member" "web_users" {
+  project = var.project_id
+  role    = "roles/iap.httpsResourceAccessor"
+
+  for_each = toset(var.web_user_members)
+  member   = format("user:%s", each.key)
+}

--- a/deploy/terraform-datacommons-website/modules/iap/outputs.tf
+++ b/deploy/terraform-datacommons-website/modules/iap/outputs.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "oauth_client_id" {
+  description = "OAuth client id used for IAP protected applications."
+  value       = google_iap_client.project_client.client_id
+}
+
+output "oauth_secret" {
+  description = "OAuth client secret used for IAP protected applications."
+  value       = google_iap_client.project_client.secret
+}

--- a/deploy/terraform-datacommons-website/modules/iap/variables.tf
+++ b/deploy/terraform-datacommons-website/modules/iap/variables.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "GCP project id where the DC applications will be running in."
+}
+
+variable "brand_support_email" {
+  type        = string
+  description = "Who to contact for issues related to installed applications."
+  default     = null
+}
+
+variable "web_user_members" {
+  type        =  list(string)
+  description = "A list of users allowlisted for applications controlled using IAP."
+}


### PR DESCRIPTION
This is part 1 of converting one time set up to terraform.

This PR handles 
1) Enabling services
2) IAM binding
3) IAP setups.

Tested: tested using the following variables.tfvars file.

```
# GCP project where the website will be installed.
# Type: string
project_id = "datacom-alexyfchen-tf-test2"

# GCP project where the data is.
storage_project_id = "datcom-store"

# POC for issues related to installed applications.
# Type: string
brand_support_email = "alexyfchen@google.com"

# A list of users to allow access to the DC website.
# Type: List[string]
web_user_members = [ "alexyfchen@google.com"]


```