### PR TITLE
Use mixer API key for local development

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -182,6 +182,14 @@ def create_app():
     if app.config['LOCAL']:
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 
+    if app.config['API_PROJECT']:
+        secret_client = secretmanager.SecretManagerServiceClient()
+        secret_name = secret_client.secret_version_path(cfg.API_PROJECT,
+                                                        'mixer-api-key',
+                                                        'latest')
+        secret_response = secret_client.access_secret_version(name=secret_name)
+        app.config['API_KEY'] = secret_response.payload.data.decode('UTF-8')
+
     # Initialize translations
     babel = Babel(app, default_domain='all')
     app.config['BABEL_DEFAULT_LOCALE'] = i18n.DEFAULT_LOCALE

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -33,6 +33,10 @@ class Config:
     BASE_HTML_PATH = 'base.html'
     # Whether to have account management page
     ADMIN = False
+    # The GCP project of the mixer which Flask talks to. This only needs to
+    # be set for local development. Website deployed to GKE bundles the mixer
+    # as a private service accessible via localhost.
+    API_PROJECT = ''
 
 
 class ProductionConfig(Config):

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -101,6 +101,7 @@ class LocalBaseConfig(Config):
     LOCAL = True
     API_ROOT = 'https://autopush.api.datacommons.org'
     RECON_API_ROOT = 'https://autopush.recon.datacommons.org'
+    API_PROJECT = 'datcom-mixer-autopush'
     AI_CONFIG_PATH = os.path.abspath(
         os.path.join(os.path.curdir, '..', 'deploy/overlays/local/ai.yaml'))
     SCHEME = 'http'
@@ -124,6 +125,7 @@ class LocalPrivateConfig(LocalBaseConfig, PrivateConfig):
     # This needs to talk to local mixer that is setup as a private mixer, which
     # loads csv + tmcf files from GCS
     API_ROOT = 'https://mixer.endpoints.datcom-mixer-statvar.cloud.goog'
+    API_PROJECT = 'datcom-mixer-statvar'
     SECRET_PROJECT = 'datcom-website-private'
 
 
@@ -131,6 +133,7 @@ class LocalFeedingamericaConfig(LocalBaseConfig, PrivateConfig):
     # This needs to talk to local mixer that is setup as a private mixer, which
     # loads csv + tmcf files from GCS
     API_ROOT = 'https://mixer.endpoints.datcom-mixer-statvar.cloud.goog'
+    API_PROJECT = 'datcom-mixer-statvar'
     SECRET_PROJECT = 'datcom-feedingamerica'
     NAME = "Feeding America"
     ENV_NAME = 'FEEDINGAMERICA'
@@ -141,6 +144,7 @@ class LocalStanfordConfig(LocalBaseConfig, PrivateConfig):
     # This needs to talk to local mixer that is setup as a private mixer, which
     # loads csv + tmcf files from GCS
     API_ROOT = 'https://mixer.endpoints.datcom-mixer-statvar.cloud.goog'
+    API_PROJECT = 'datcom-mixer-statvar'
     SECRET_PROJECT = 'datcom-stanford'
     NAME = "Stanford"
     ENV_NAME = 'STANFORD'
@@ -152,6 +156,7 @@ class WebdriverConfig(Config):
     SECRET_PROJECT = 'datcom-website-dev'
     API_ROOT = 'https://autopush.api.datacommons.org'
     RECON_API_ROOT = 'https://autopush.recon.datacommons.org'
+    API_PROJECT = 'datcom-mixer-autopush'
     AI_CONFIG_PATH = None  # No models in this configuration.
     SCHEME = 'http'
 

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -19,8 +19,8 @@ import json
 import logging
 import urllib.parse
 import zlib
-from typing import Mapping
 from cache import cache
+from flask import current_app
 
 import lib.config as libconfig
 import requests
@@ -73,6 +73,8 @@ _MAX_LIMIT = 100
 def get(path):
     url = API_ROOT + path
     headers = {'Content-Type': 'application/json'}
+    if current_app.config['API_KEY']:
+        headers['x-api-key'] = current_app.config['API_KEY']
     # Send the request and verify the request succeeded
     response = requests.get(url, headers=headers)
     if response.status_code != 200:
@@ -98,6 +100,8 @@ def post_wrapper(path, req_str):
     req = json.loads(req_str)
     url = API_ROOT + path
     headers = {'Content-Type': 'application/json'}
+    if current_app.config['API_KEY']:
+        headers['x-api-key'] = current_app.config['API_KEY']
     # Send the request and verify the request succeeded
     response = requests.post(url, json=req, headers=headers)
     if response.status_code != 200:

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -32,15 +32,16 @@
         "geo-albers-usa-territories": "0.1.0",
         "html-webpack-plugin": "^4.4.1",
         "js-cookie": "^2.2.1",
+        "jszip": "^3.10.0",
         "lodash": "^4.17.21",
         "moment": "^2.29.2",
         "pako": "^1.0.11",
+        "papaparse": "^5.3.2",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-collapsible": "2.8.3",
         "react-dom": "^16.13.1",
         "react-intl": "^6.0.4",
-        "react-papaparse": "^4.0.2",
         "reactstrap": "^8.6.0",
         "resize-observer-polyfill": "^1.5.1",
         "sass": "^1.3.0",
@@ -5339,14 +5340,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/@types/papaparse": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.2.tgz",
-      "integrity": "sha512-BNbCHJkTE4RwmAFkCxEalET4mDvGr/1ld7ZtQ4i/laWI/iiVt+GL07stdvufle4KfywyvloqqpIiJscXNCrKxA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
@@ -7551,6 +7544,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/create-react-context": {
       "version": "0.3.0",
@@ -10394,6 +10392,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -10523,8 +10526,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -11014,10 +11016,7 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -14865,6 +14864,17 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.0.tgz",
+      "integrity": "sha512-LDfVtOLtOxb9RXkYOwPyNBTQDL4eUbqahtoY6x07GiDJHwSYvn8sHHIw8wINImV3MqbMNve2gSuM1DDqEKk09Q==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -14912,6 +14922,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -16180,6 +16198,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -16383,19 +16406,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
-    "node_modules/react-papaparse": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/react-papaparse/-/react-papaparse-4.0.2.tgz",
-      "integrity": "sha512-epMdLfJgDcD7tpau897HiRY8vU2Zr6+MCnxo1di1lA+xpri8L/hQAy7ehSBTCVMvUt/O9LgB5Wx3VT9R6Bg2lg==",
-      "dependencies": {
-        "@types/papaparse": "^5.3.1",
-        "papaparse": "^5.3.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
     "node_modules/react-popper": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
@@ -16569,6 +16579,20 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -17330,6 +17354,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -17819,6 +17848,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-length": {
@@ -18986,6 +19023,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/util.promisify": {
       "version": "1.0.0",
@@ -23789,14 +23831,6 @@
       "optional": true,
       "peer": true
     },
-    "@types/papaparse": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.2.tgz",
-      "integrity": "sha512-BNbCHJkTE4RwmAFkCxEalET4mDvGr/1ld7ZtQ4i/laWI/iiVt+GL07stdvufle4KfywyvloqqpIiJscXNCrKxA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/parse5": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
@@ -25485,6 +25519,11 @@
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
       "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
       "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "create-react-context": {
       "version": "0.3.0",
@@ -27703,6 +27742,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -27800,8 +27844,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
@@ -28173,10 +28216,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -31191,6 +31231,17 @@
         "object.assign": "^4.1.0"
       }
     },
+    "jszip": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.0.tgz",
+      "integrity": "sha512-LDfVtOLtOxb9RXkYOwPyNBTQDL4eUbqahtoY6x07GiDJHwSYvn8sHHIw8wINImV3MqbMNve2gSuM1DDqEKk09Q==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -31223,6 +31274,14 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "lines-and-columns": {
@@ -32210,6 +32269,11 @@
         }
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -32385,15 +32449,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
-    "react-papaparse": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/react-papaparse/-/react-papaparse-4.0.2.tgz",
-      "integrity": "sha512-epMdLfJgDcD7tpau897HiRY8vU2Zr6+MCnxo1di1lA+xpri8L/hQAy7ehSBTCVMvUt/O9LgB5Wx3VT9R6Bg2lg==",
-      "requires": {
-        "@types/papaparse": "^5.3.1",
-        "papaparse": "^5.3.1"
-      }
-    },
     "react-popper": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
@@ -32530,6 +32585,20 @@
           "optional": true,
           "peer": true
         }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -33102,6 +33171,11 @@
         }
       }
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "shallow-clone": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -33504,6 +33578,14 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "string-length": {
@@ -34334,6 +34416,11 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "util.promisify": {
       "version": "1.0.0",


### PR DESCRIPTION
We plan to enforce API key for the V1 mixer API. 

This won't affect website deployment in GKE as the the mixer is an internal service within pod, so it does not need API key restriction. However, local website development requires talking to an instance of mixer. For example, regular local dev talks to the autopush mixer instance.

This PR allows a local website instance to fetch the API key from the corresponding mixer project and use it when sending requests.

A prerequisite of this is to creating the API key and store it in the secret manager. I have done this manually for the two mixer projects involved in this PR.