### PR TITLE
[Disease Browser] Add disease chart descriptions, common name and integrate interfaces in one file 

### DIFF
--- a/static/js/biomedical/bio_charts_utils.ts
+++ b/static/js/biomedical/bio_charts_utils.ts
@@ -15,7 +15,7 @@
  */
 import * as d3 from "d3";
 
-import { DiseaseGeneAssociationData } from "./disease/chart";
+import { DiseaseGeneAssociationData } from "./disease/types";
 import { ProteinNumData } from "./protein/chart";
 import { DiseaseAssociationType } from "./protein/page";
 import { InteractionLink, ProteinNode } from "./protein/types";

--- a/static/js/biomedical/disease/chart.ts
+++ b/static/js/biomedical/disease/chart.ts
@@ -24,6 +24,10 @@ import {
   MARGIN,
   NUM_DATA_POINTS,
 } from "../bio_charts_utils";
+import {
+  DiseaseGeneAssociationData,
+  DiseaseSymptomAssociationData,
+} from "./types";
 // graph specific dimensions
 const GRAPH_HEIGHT = 400;
 const GRAPH_WIDTH = 760;
@@ -35,60 +39,6 @@ const LEGEND_CIRCLE_RADIUS = 4;
 const ERROR_BAR_CAP_LENGTH = 10;
 
 //TODO: Create a type.ts file and move all interfaces there
-export interface DiseaseGeneAssociationData {
-  // name of the associated gene
-  name: string;
-  // confidence score
-  score: number;
-  // lower confidence value = score - (interval/2)
-  lowerInterval: number;
-  // upper confidence value = score + (interval/2)
-  upperInterval: number;
-}
-
-export interface DiseaseSymptomAssociationData {
-  // name of the symptom
-  name: string;
-  // odds Ratio for association
-  oddsRatio: number;
-}
-
-export interface CompoundDiseaseTreatmentData {
-  // node name and link
-  node: string;
-  // chemical compound id
-  id: string;
-  // chemical compound name
-  name: string;
-  // FDA clinical phase for which the compound has been studied
-  clinicalPhaseNumber: number;
-}
-
-export interface CompoundDiseaseContraindicationData {
-  // node name
-  node: string;
-  // chemical compound id
-  id: string;
-  // chemical compound name
-  name: string;
-  // drug central source name
-  drugSource: string;
-}
-
-export interface ChemicalCompoundDataType {
-  // node name
-  node: string;
-  // chemical compound id
-  id: string;
-  // chemical compound name
-  name: string;
-  // drug central source name
-  drugSource: string;
-  // FDA clinical phase for which the compound has been studied
-  clinicalPhaseNumber: number;
-  // chemical compound association type
-  type: string;
-}
 
 /**
  * Draws the disease-gene association charts for the disease of interest

--- a/static/js/biomedical/disease/data_processing_utils.ts
+++ b/static/js/biomedical/disease/data_processing_utils.ts
@@ -285,3 +285,31 @@ export function getCompoundDiseaseContraindication(
   processedData.sort((a, b) => (a.drugSource > b.drugSource ? 1 : -1));
   return processedData;
 }
+
+/**
+ * Fetches the common name of the disease of interest
+ * @param data
+ * @returns - string with disease common name 
+ */
+ export function getDiseaseCommonName(data: GraphNodes): string {
+  let commonName = null;
+  if (!data) {
+    return;
+  }
+  // check for null values
+  if (_.isEmpty(data.nodes) || _.isEmpty(data.nodes[0].neighbors)) {
+    return;
+  }
+  for (const neighbour of data.nodes[0].neighbors) {
+    if (neighbour.property !== "commonName") {
+      continue;
+    }
+    // check for null or non-existent property values
+    if (_.isEmpty(neighbour.nodes)) {
+      continue;
+    }
+    commonName = neighbour.nodes[0].value;
+    return commonName;
+  }
+}
+

--- a/static/js/biomedical/disease/data_processing_utils.ts
+++ b/static/js/biomedical/disease/data_processing_utils.ts
@@ -22,7 +22,7 @@ import {
   CompoundDiseaseTreatmentData,
   DiseaseGeneAssociationData,
   DiseaseSymptomAssociationData,
-} from "./chart";
+} from "./types";
 /**
  * Fetches the disease-gene association data
  * @param data - the data pertaining to the disease of interest
@@ -89,6 +89,7 @@ export function getDiseaseGeneAssociation(
   }
   return rawData;
 }
+
 /**
  * Fetches the disease-symptom association data
  * @param data

--- a/static/js/biomedical/disease/data_processing_utils.ts
+++ b/static/js/biomedical/disease/data_processing_utils.ts
@@ -289,9 +289,9 @@ export function getCompoundDiseaseContraindication(
 /**
  * Fetches the common name of the disease of interest
  * @param data
- * @returns - string with disease common name 
+ * @returns - string with disease common name
  */
- export function getDiseaseCommonName(data: GraphNodes): string {
+export function getDiseaseCommonName(data: GraphNodes): string {
   let commonName = null;
   if (!data) {
     return;
@@ -309,7 +309,10 @@ export function getCompoundDiseaseContraindication(
       continue;
     }
     commonName = neighbour.nodes[0].value;
-    return commonName;
+    // capitalize the first letter of the disease name
+    const formattedDiseaseName =
+      commonName[1].toUpperCase() + commonName.slice(2);
+    // return formatted disease name with double quotes removed
+    return formattedDiseaseName.replaceAll('"', "");
   }
 }
-

--- a/static/js/biomedical/disease/disease_chart.test.tsx
+++ b/static/js/biomedical/disease/disease_chart.test.tsx
@@ -4,12 +4,6 @@ import Adapter from "enzyme-adapter-react-16";
 Enzyme.configure({ adapter: new Adapter() });
 
 import { GraphNodes } from "../../shared/types";
-import {
-  CompoundDiseaseContraindicationData,
-  CompoundDiseaseTreatmentData,
-  DiseaseGeneAssociationData,
-  DiseaseSymptomAssociationData,
-} from "./chart";
 import dataDOID2403 from "./data_DOID_2403.json";
 import {
   getCompoundDiseaseContraindication,
@@ -17,6 +11,12 @@ import {
   getDiseaseGeneAssociation,
   getDiseaseSymptomAssociation,
 } from "./data_processing_utils";
+import {
+  CompoundDiseaseContraindicationData,
+  CompoundDiseaseTreatmentData,
+  DiseaseGeneAssociationData,
+  DiseaseSymptomAssociationData,
+} from "./types";
 
 test("getDiseaseGeneAssociation", () => {
   const cases: {

--- a/static/js/biomedical/disease/drug_table.tsx
+++ b/static/js/biomedical/disease/drug_table.tsx
@@ -1,24 +1,8 @@
 import React from "react";
 
 import { GRAPH_BROWSER_REDIRECT } from "../bio_charts_utils";
-import {
-  CompoundDiseaseContraindicationData,
-  CompoundDiseaseTreatmentData,
-} from "./chart";
+import { DrugTreatmentTableProps } from "./types";
 
-export interface DrugTreatmentTableColumn {
-  // the column id
-  id: string;
-  // the column display name or header
-  name: string;
-}
-export interface DrugTreatmentTableProps {
-  // stores the column id and column name
-  // retains the order of the columns and column ids should match the keys of the objects in the data array
-  columns: DrugTreatmentTableColumn[];
-  // the data is either of type CompoundDiseaseContraindicationData or CompoundDiseaseTreatmentData
-  data: CompoundDiseaseContraindicationData[] | CompoundDiseaseTreatmentData[];
-}
 export function DrugTreatmentTable(
   props: DrugTreatmentTableProps
 ): JSX.Element {

--- a/static/js/biomedical/disease/page.tsx
+++ b/static/js/biomedical/disease/page.tsx
@@ -35,6 +35,7 @@ import {
   getDiseaseSymptomAssociation,
 } from "./data_processing_utils";
 import { DrugTreatmentTable } from "./drug_table";
+
 export interface PagePropType {
   dcid: string;
   nodeName: string;

--- a/static/js/biomedical/disease/page.tsx
+++ b/static/js/biomedical/disease/page.tsx
@@ -127,6 +127,10 @@ export class Page extends React.Component<PagePropType, PageStateType> {
         </div>
         <br></br>
         <h5>Chemical Compound Disease Contraindication</h5>
+        <p>
+          The chemical compounds contraindicated with {diseaseName} as reported
+          by the ChEMBL database.
+        </p>
         <br></br>
         <div>
           <div id="table"></div>

--- a/static/js/biomedical/disease/page.tsx
+++ b/static/js/biomedical/disease/page.tsx
@@ -22,6 +22,7 @@ import axios from "axios";
 import React from "react";
 
 import { GraphNodes } from "../../shared/types";
+import { GRAPH_BROWSER_REDIRECT } from "../bio_charts_utils";
 import {
   drawDiseaseGeneAssocChart,
   drawDiseaseSymptomAssociationChart,
@@ -29,6 +30,7 @@ import {
 import {
   getCompoundDiseaseContraindication,
   getCompoundDiseaseTreatment,
+  getDiseaseCommonName,
   getDiseaseGeneAssociation,
   getDiseaseSymptomAssociation,
 } from "./data_processing_utils";
@@ -65,6 +67,8 @@ export class Page extends React.Component<PagePropType, PageStateType> {
     );
   }
   render(): JSX.Element {
+    const diseaseName = getDiseaseCommonName(this.state.data);
+    const diseaseLink = `${GRAPH_BROWSER_REDIRECT}${this.props.dcid}`;
     const chemicalCompoundDiseaseTreatment = getCompoundDiseaseTreatment(
       this.state.data
     );
@@ -85,13 +89,33 @@ export class Page extends React.Component<PagePropType, PageStateType> {
 
     return (
       <>
-        <h2>Disease Browser</h2>
+        <h2>{diseaseName}</h2>
+        <h6>
+          <a href={diseaseLink}>Graph Browser View</a>
+        </h6>
         <h5>Disease-Gene Association</h5>
+        <p>
+          The association score of {diseaseName} with genes as reported by
+          DISEASES by Jensen Lab. Associations were determined by text mining of
+          the literature. 10 associations for the disease of interest are
+          displayed.
+        </p>
         <div id="disease-gene-association-chart"></div>
         <h5>Disease-Symptom Association</h5>
+        <p>
+          The association score of {diseaseName} with symptoms as reported by
+          SPOKE by UCSF. Associations were determined by interactions of
+          biomedical entities in a graph-theoretic database. The top 10 symptom
+          associations are displayed for the disease of interest.
+        </p>
         <div id="disease-symptom-association-chart"></div>
         <br></br>
         <h5>Chemical Compound Disease Treatment</h5>
+        <p>
+          The chemical compounds associated with the treatment of {diseaseName}{" "}
+          as reported by the ChEMBL database. The compounds are arranged in
+          decreasing order of the FDA clinical phase number.
+        </p>
         <br></br>
         <div>
           <div id="table"></div>

--- a/static/js/biomedical/disease/types.ts
+++ b/static/js/biomedical/disease/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// types file containing different disease-specific interfaces
+
+export interface DiseaseGeneAssociationData {
+  // name of the associated gene
+  name: string;
+  // confidence score
+  score: number;
+  // lower confidence value = score - (interval/2)
+  lowerInterval: number;
+  // upper confidence value = score + (interval/2)
+  upperInterval: number;
+}
+
+export interface DiseaseSymptomAssociationData {
+  // name of the symptom
+  name: string;
+  // odds Ratio for association
+  oddsRatio: number;
+}
+
+export interface CompoundDiseaseTreatmentData {
+  // node name and link
+  node: string;
+  // chemical compound id
+  id: string;
+  // chemical compound name
+  name: string;
+  // FDA clinical phase for which the compound has been studied
+  clinicalPhaseNumber: number;
+}
+
+export interface CompoundDiseaseContraindicationData {
+  // node name
+  node: string;
+  // chemical compound id
+  id: string;
+  // chemical compound name
+  name: string;
+  // drug central source name
+  drugSource: string;
+}
+
+export interface ChemicalCompoundDataType {
+  // node name
+  node: string;
+  // chemical compound id
+  id: string;
+  // chemical compound name
+  name: string;
+  // drug central source name
+  drugSource: string;
+  // FDA clinical phase for which the compound has been studied
+  clinicalPhaseNumber: number;
+  // chemical compound association type
+  type: string;
+}
+
+export interface DrugTreatmentTableColumn {
+  // the column id
+  id: string;
+  // the column display name or header
+  name: string;
+}
+
+export interface DrugTreatmentTableProps {
+  // stores the column id and column name
+  // retains the order of the columns and column ids should match the keys of the objects in the data array
+  columns: DrugTreatmentTableColumn[];
+  // the data is either of type CompoundDiseaseContraindicationData or CompoundDiseaseTreatmentData
+  data: CompoundDiseaseContraindicationData[] | CompoundDiseaseTreatmentData[];
+}


### PR DESCRIPTION
In this PR, I've added the description for each chart and table. In addition, I've linked it to the graph browser view and added the disease common name as the first header (instead of the disease ontology ID, with the former being more intuitive and easy to understand). I've also added a types file with all disease browser interfaces added to it, for the sake of better organization of the code. 
<img width="1051" alt="Screen Shot 2022-08-22 at 5 05 51 PM" src="https://user-images.githubusercontent.com/57412795/186033657-ef74b7ee-ba73-43c5-8f0a-b8a3b06be0cd.png">