### PR TITLE
[import wizard] Set up the skeleton for V2

### DIFF
--- a/server/routes/import_wizard.py
+++ b/server/routes/import_wizard.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Import Wizard routes"""
 
+import flask
 import os
 from flask import Blueprint, render_template
 

--- a/server/routes/import_wizard.py
+++ b/server/routes/import_wizard.py
@@ -22,3 +22,11 @@ bp = Blueprint('import_wizard', __name__, url_prefix='/import')
 @bp.route('/')
 def main():
     return render_template('/import_wizard.html')
+
+
+@bp.route('/new')
+def main_new():
+    if os.environ.get('FLASK_ENV') == 'production' or os.environ.get(
+            'FLASK_ENV') == 'staging':
+        flask.abort(404)
+    return render_template('/import_wizard2.html')

--- a/server/templates/import_wizard2.html
+++ b/server/templates/import_wizard2.html
@@ -1,0 +1,39 @@
+{#
+  Copyright 2022 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{%- extends BASE_HTML -%}
+
+{% set subpage_title = "Import Wizard" %}
+{% set subpage_url = url_for('import_wizard.main_new') %}
+{% set title = "Import Wizard" %}
+{% set main_id = 'main-import-wizard' %}
+{% set page_id = 'page-import-wizard' %}
+
+{% block head %}
+  <link rel="stylesheet" href={{url_for('static', filename='css/import_wizard2.min.css')}} >
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
+{% endblock %}
+
+{% block content %}
+<div id="main-body">
+  <div id="main-pane" class="container"></div>
+</div>
+{% endblock %}
+
+{% block footer %}
+  <script src={{url_for('static', filename='import_wizard2.js', t=config['VERSION'])}}></script>
+{% endblock %}

--- a/server/templates/import_wizard2.html
+++ b/server/templates/import_wizard2.html
@@ -24,8 +24,6 @@
 
 {% block head %}
   <link rel="stylesheet" href={{url_for('static', filename='css/import_wizard2.min.css')}} >
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
 {% endblock %}
 
 {% block content %}

--- a/server/tests/import_wizard_test.py
+++ b/server/tests/import_wizard_test.py
@@ -24,3 +24,8 @@ class TestStaticPage(unittest.TestCase):
         response = app.test_client().get('/import/')
         assert response.status_code == 200
         assert b"Import Wizard - Data Commons" in response.data
+
+    def test_import_wizard_static_new(self):
+        response = app.test_client().get('/import/new')
+        assert response.status_code == 200
+        assert b"Import Wizard - Data Commons" in response.data

--- a/static/css/import_wizard2.scss
+++ b/static/css/import_wizard2.scss
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
- @import "base";
+@import "base";

--- a/static/css/import_wizard2.scss
+++ b/static/css/import_wizard2.scss
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ @import "base";

--- a/static/js/import_wizard2/components/page.tsx
+++ b/static/js/import_wizard2/components/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Main component for the import wizard.
+ */
+
+import _ from "lodash";
+import React, { useState } from "react";
+
+export function Page(): JSX.Element {
+  const [page, setPage] = useState(0);
+
+  return <div></div>;
+}

--- a/static/js/import_wizard2/components/page.tsx
+++ b/static/js/import_wizard2/components/page.tsx
@@ -18,11 +18,8 @@
  * Main component for the import wizard.
  */
 
-import _ from "lodash";
-import React, { useState } from "react";
+import React from "react";
 
 export function Page(): JSX.Element {
-  const [page, setPage] = useState(0);
-
   return <div></div>;
 }

--- a/static/js/import_wizard2/import_wizard.ts
+++ b/static/js/import_wizard2/import_wizard.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { Page } from "./components/page";
+
+ReactDOM.render(
+  React.createElement(Page),
+  document.getElementById("main-pane")
+);

--- a/static/js/import_wizard2/import_wizard.ts
+++ b/static/js/import_wizard2/import_wizard.ts
@@ -18,7 +18,9 @@ import ReactDOM from "react-dom";
 
 import { Page } from "./components/page";
 
-ReactDOM.render(
-  React.createElement(Page),
-  document.getElementById("main-pane")
-);
+window.onload = () => {
+  ReactDOM.render(
+    React.createElement(Page),
+    document.getElementById("main-pane")
+  );
+}

--- a/static/js/import_wizard2/import_wizard.ts
+++ b/static/js/import_wizard2/import_wizard.ts
@@ -23,4 +23,4 @@ window.onload = () => {
     React.createElement(Page),
     document.getElementById("main-pane")
   );
-}
+};

--- a/static/js/import_wizard2/types.ts
+++ b/static/js/import_wizard2/types.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum MappingType {
+  COLUMN = "column",
+  COLUMN_HEADER = "columnHeader",
+  FILE_CONSTANT = "fileConstant",
+  // COLUMN_CONSTANT MappingType can be used for any MappedThing, but currently
+  // the UI only supports COLUMN_CONSTANT for MappedThing.UNIT
+  COLUMN_CONSTANT = "columnConstant",
+}
+
+export enum MappedThing {
+  DATE = "Date",
+  PLACE = "Place",
+  STAT_VAR = "StatVar",
+  UNIT = "Unit",
+  VALUE = "Value",
+}
+
+export const MAPPED_THING_NAMES = {
+  [MappedThing.VALUE]: "Observation Value",
+  [MappedThing.STAT_VAR]: "Name of Variable",
+};
+
+export interface Column {
+  // Id of the column.
+  // If in the original csv, there are two or more columns with the same header,
+  // id will be <header>_<columnIdx>.
+  // If a header is updated to a name that is a duplicate, id will be
+  // <header>_<columnIdx>.
+  // Otherwise, id will be the same as the header.
+  id: string;
+  // column header name, can either come from the original csv or updated by
+  // user.
+  header: string;
+  // column index (leftmost column will be 0)
+  columnIdx: number;
+}
+
+export interface MappingVal {
+  type: MappingType;
+  // Column that holds the mapping values. Should be set if type is
+  // MappingType.COLUMN
+  column?: Column;
+  // Record of column idx to the place property (in KG) associated with that
+  // column or column header. Should be set if MappedThing is PLACE.
+  placeProperty?: { [columnIdx: number]: DCProperty };
+  // Record of column idx to the place type (in KG) associated with that
+  // column or column header. Should be set if MappedThing is PLACE.
+  placeType?: { [columnIdx: number]: DCType };
+  // List of column headers that act as the mapping values. Should be set if
+  // type is MappingType.COLUMN_HEADERS
+  headers?: Column[];
+  // Constant value for the whole file as the mapping value. Should be set if
+  // type is MappingType.FILE_CONSTANT
+  fileConstant?: string;
+  // Record of column idx to the constant to use for that column.
+  // Should be set if type is MappingType.COLUMN_CONSTANT.
+  columnConstants?: { [columnIdx: number]: string };
+}
+
+export type Mapping = Map<MappedThing, MappingVal>;
+
+// CSV Row number.
+export type RowNumber = number;
+
+// CvsData should contain the minimum sufficient data from the
+// data csv file which will be used for all processing, e.g. column detection,
+// and display/rendering.
+export interface CsvData {
+  // This field should dictate the fixed (internal) order of all csv columns.
+  orderedColumns: Array<Column>;
+
+  // columnValuesSampled is a map from column index to an extract of the
+  // values in the column. The column index is with reference to the order in
+  // orderedColumns.
+  // This extract could be all of the column's values or a sample. This is the
+  // structure that should be used for detection heuristics and other advanced
+  // processing.
+  // It is assumed that all columns present in the original csv data file will
+  // be represented in this structure. All indices in the orderedColumnNames
+  // array should be present as keys of columnValuesSampled.
+  // Note that the length of all column-values need not be the same, e.g. due to
+  // the removal of duplicate values.
+  columnValuesSampled: Map<number, Array<string>>;
+
+  // rowsForDisplay is a mapping from the row index in the original csv file to
+  // the contents of the row. This is a convenience structure to assist with
+  // previews etc. It is not expected to contain the entire csv data, i.e. there
+  // is no expectation that this structure contains all rows.
+  // It is also assumed that order of values in the array will correspond to
+  // the orderedColumnNames.
+  rowsForDisplay: Map<RowNumber, Array<string>>;
+
+  // The raw csv data can be either in the form of a file or a URL. One of the
+  // following fields must be set:
+
+  // if csv input was a user uploaded file, the uploaded csv file.
+  rawCsvFile?: File;
+  // if csv input was a user entered url, the url to get the csv file.
+  rawCsvUrl?: string;
+}
+
+// Types used for Detection.
+
+// An abstraction for a Data Commons entity, e.g. a place type or property.
+interface Entity {
+  dcid: string;
+  displayName: string;
+}
+
+// A Data Commons entity type, e.g. Country (which a type of Place).
+export type DCType = Entity;
+
+// A Data Commons property, e.g. longitude.
+export type DCProperty = Entity;
+
+// Denotes a level of confidence in the detection.
+// It can be associated with any detected type.
+export enum ConfidenceLevel {
+  Uncertain,
+  Low,
+  High,
+}
+
+export interface TypeProperty {
+  // The Data Commons type.
+  dcType: DCType;
+
+  // (Optional) The Data Commons property.
+  dcProperty?: DCProperty;
+}
+
+export interface DetectedDetails {
+  // The detected Type and (optional) Property.
+  detectedTypeProperty: TypeProperty;
+
+  // The level of confidence associated with the detection.
+  confidence: ConfidenceLevel;
+}
+
+// A map from the mapped thing (aka StatVarObs props) to the property value.
+export type Observation = Map<MappedThing, string>;
+
+// Observations keyed by CSV row number. A row has multiple observations when
+// the Mapping is of type COLUMN_HEADER with multiple MappingVal.headers.
+export type RowObservations = Map<RowNumber, Array<Observation>>;
+
+// Map of cell value in the original csv to cell value in the cleaned csv.
+// originalValue is a string converted to all lowercase.
+export type ValueMap = { [originalValue: string]: string };

--- a/static/js/import_wizard2/types.ts
+++ b/static/js/import_wizard2/types.ts
@@ -36,6 +36,43 @@ export const MAPPED_THING_NAMES = {
   [MappedThing.STAT_VAR]: "Name of Variable",
 };
 
+// Types used for Detection.
+
+// An abstraction for a Data Commons entity, e.g. a place type or property.
+interface Entity {
+  dcid: string;
+  displayName: string;
+}
+
+// A Data Commons entity type, e.g. Country (which a type of Place).
+export type DCType = Entity;
+
+// A Data Commons property, e.g. longitude.
+export type DCProperty = Entity;
+
+// Denotes a level of confidence in the detection.
+// It can be associated with any detected type.
+export enum ConfidenceLevel {
+  Uncertain,
+  Low,
+  High,
+}
+
+export interface TypeProperty {
+  // The Data Commons type.
+  dcType: DCType;
+
+  // (Optional) The Data Commons property.
+  dcProperty?: DCProperty;
+}
+
+export interface DetectedDetails {
+  // The detected Type and (optional) Property.
+  detectedTypeProperty: TypeProperty;
+
+  // The level of confidence associated with the detection.
+  confidence: ConfidenceLevel;
+}
 export interface Column {
   // Id of the column.
   // If in the original csv, there are two or more columns with the same header,
@@ -113,44 +150,6 @@ export interface CsvData {
   rawCsvFile?: File;
   // if csv input was a user entered url, the url to get the csv file.
   rawCsvUrl?: string;
-}
-
-// Types used for Detection.
-
-// An abstraction for a Data Commons entity, e.g. a place type or property.
-interface Entity {
-  dcid: string;
-  displayName: string;
-}
-
-// A Data Commons entity type, e.g. Country (which a type of Place).
-export type DCType = Entity;
-
-// A Data Commons property, e.g. longitude.
-export type DCProperty = Entity;
-
-// Denotes a level of confidence in the detection.
-// It can be associated with any detected type.
-export enum ConfidenceLevel {
-  Uncertain,
-  Low,
-  High,
-}
-
-export interface TypeProperty {
-  // The Data Commons type.
-  dcType: DCType;
-
-  // (Optional) The Data Commons property.
-  dcProperty?: DCProperty;
-}
-
-export interface DetectedDetails {
-  // The detected Type and (optional) Property.
-  detectedTypeProperty: TypeProperty;
-
-  // The level of confidence associated with the detection.
-  confidence: ConfidenceLevel;
 }
 
 // A map from the mapped thing (aka StatVarObs props) to the property value.

--- a/static/webpack.config.js
+++ b/static/webpack.config.js
@@ -87,6 +87,10 @@ const config = {
     import_wizard: [
       __dirname + "/js/import_wizard/import_wizard.ts",
       __dirname + "/css/import_wizard.scss"
+    ],
+    import_wizard2: [
+      __dirname + "/js/import_wizard2/import_wizard.ts",
+      __dirname + "/css/import_wizard2.scss"
     ]
   },
   output: {


### PR DESCRIPTION
- added the changes to have V2 appear at /import/new
- types.ts is copied from V1 - static/js/import2 will have all the files needed for V2 (even if they're duplicate files from V1) so that when we do the flip, we can just rename the folder and delete the V1 folder