### PR TITLE
[wizard 2] Add dropdown selectors for mapping section

### DIFF
--- a/static/css/import_wizard2.scss
+++ b/static/css/import_wizard2.scss
@@ -202,4 +202,19 @@ tr th:last-child {
 
 #mapping-section td {
   text-align: left;
+  word-break: break-all;
+}
+
+#mapping-section td:first-child {
+  max-width: 12%;
+}
+
+.place-type-property-option {
+  display: flex;
+  align-items: center;
+  padding: 0.7rem 0 0 0.5rem;
+}
+
+.place-type-property-option span {
+  width: 4rem;
 }

--- a/static/js/import_wizard2/components/mapping_page.tsx
+++ b/static/js/import_wizard2/components/mapping_page.tsx
@@ -61,7 +61,8 @@ export function MappingPage(props: MappingPageProps): JSX.Element {
     // TODO: Use actual prediction from server-side detection API.
     const predictedMapping = new Map();
     setPredictedMapping(predictedMapping);
-    const userMappingFn = TEMPLATE_PREDICTION_VALIDATION[props.selectedTemplate];
+    const userMappingFn =
+      TEMPLATE_PREDICTION_VALIDATION[props.selectedTemplate];
     setUserMapping(userMappingFn(predictedMapping));
   }, [props.csvData, props.selectedTemplate]);
 

--- a/static/js/import_wizard2/components/mapping_page.tsx
+++ b/static/js/import_wizard2/components/mapping_page.tsx
@@ -26,7 +26,7 @@ import { Button } from "reactstrap";
 import {
   TEMPLATE_MAPPING_COMPONENTS,
   TEMPLATE_OPTIONS,
-  TEMPLATE_USER_MAPPING_FN,
+  TEMPLATE_PREDICTION_VALIDATION,
 } from "../templates";
 import { CsvData, Mapping, ValueMap } from "../types";
 import { shouldGenerateCsv } from "../utils/file_generation";
@@ -58,10 +58,10 @@ export function MappingPage(props: MappingPageProps): JSX.Element {
   }
 
   useEffect(() => {
-    // TODO(beets): Use server-side detection API.
+    // TODO: Use actual prediction from server-side detection API.
     const predictedMapping = new Map();
     setPredictedMapping(predictedMapping);
-    const userMappingFn = TEMPLATE_USER_MAPPING_FN[props.selectedTemplate];
+    const userMappingFn = TEMPLATE_PREDICTION_VALIDATION[props.selectedTemplate];
     setUserMapping(userMappingFn(predictedMapping));
   }, [props.csvData, props.selectedTemplate]);
 

--- a/static/js/import_wizard2/components/mapping_preview_section.tsx
+++ b/static/js/import_wizard2/components/mapping_preview_section.tsx
@@ -19,7 +19,7 @@
  * import package
  */
 import JSZip from "jszip";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "reactstrap";
 
 import { ValueMap } from "../../import_wizard/types";
@@ -48,12 +48,24 @@ export function MappingPreviewSection(
   props: MappingPreviewSectionProps
 ): JSX.Element {
   const [isGeneratingFiles, setIsGeneratingFiles] = useState(false);
-  const zipFolder = new JSZip().folder("importPackage");
-  const sampleObs = generateRowObservations(
-    props.correctedMapping,
-    props.csvData,
-    props.valueMap
+  const [sampleObs, setSampleObs] = useState(
+    generateRowObservations(
+      props.correctedMapping,
+      props.csvData,
+      props.valueMap
+    )
   );
+  const zipFolder = new JSZip().folder("importPackage");
+
+  useEffect(() => {
+    setSampleObs(
+      generateRowObservations(
+        props.correctedMapping,
+        props.csvData,
+        props.valueMap
+      )
+    );
+  }, [props.correctedMapping, props.csvData, props.valueMap]);
 
   return (
     <>
@@ -78,9 +90,9 @@ export function MappingPreviewSection(
           })}
         </div>
       </div>
-      <div className="nav-btn">
-        <Button onClick={onDownloadClicked}>Download Package</Button>
-      </div>
+      <Button className="nav-btn" onClick={onDownloadClicked}>
+        Download Package
+      </Button>
       <div
         id="screen"
         style={{ display: isGeneratingFiles ? "block" : "none" }}

--- a/static/js/import_wizard2/components/shared/mapping_column_input.tsx
+++ b/static/js/import_wizard2/components/shared/mapping_column_input.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Component for selecting a column mapping
+ */
+
+import _ from "lodash";
+import React from "react";
+import { Input } from "reactstrap";
+
+import { Column, MappingType, MappingVal } from "../../types";
+
+interface MappingColumnInputProps {
+  mappingVal: MappingVal;
+  onMappingValUpdate: (mappingVal: MappingVal) => void;
+  orderedColumns: Array<Column>;
+}
+
+export function MappingColumnInput(
+  props: MappingColumnInputProps
+): JSX.Element {
+  function onSelectionChange(selection: string): void {
+    if (selection === "") {
+      props.onMappingValUpdate(null);
+    } else {
+      const column = props.orderedColumns[Number(selection)];
+      props.onMappingValUpdate({
+        type: MappingType.COLUMN,
+        column,
+      });
+    }
+  }
+
+  return (
+    <Input
+      className="column-option-dropdown"
+      type="select"
+      value={
+        !_.isEmpty(props.mappingVal) && !_.isEmpty(props.mappingVal.column)
+          ? props.mappingVal.column.columnIdx
+          : ""
+      }
+      onChange={(e) => onSelectionChange(e.target.value)}
+    >
+      <option value="" key="">
+        Select a column
+      </option>
+      {props.orderedColumns.map((column, i) => (
+        <option value={i} key={column.id}>
+          {column.header}
+        </option>
+      ))}
+    </Input>
+  );
+}

--- a/static/js/import_wizard2/components/shared/mapping_place_input.tsx
+++ b/static/js/import_wizard2/components/shared/mapping_place_input.tsx
@@ -49,6 +49,8 @@ export function MappingPlaceInput(props: MappingPlaceInputProps): JSX.Element {
   const validPlaceProperties = getValidPlaceProperties();
 
   useEffect(() => {
+    // TODO: Instead of fetching, pass the data with the html and set as ref on
+    // component load.
     fetchPlaceTypeProperties();
   }, []);
 

--- a/static/js/import_wizard2/components/shared/mapping_place_input.tsx
+++ b/static/js/import_wizard2/components/shared/mapping_place_input.tsx
@@ -182,7 +182,7 @@ export function MappingPlaceInput(props: MappingPlaceInputProps): JSX.Element {
       placeProperty = props.mappingVal.placeProperty || placeProperty;
     }
     newMappingVal.placeType = placeType;
-    newMappingVal.placeProperty = placeType;
+    newMappingVal.placeProperty = placeProperty;
     props.onMappingValUpdate(newMappingVal);
   }
 
@@ -207,8 +207,8 @@ export function MappingPlaceInput(props: MappingPlaceInputProps): JSX.Element {
     }
     const updatedMappingVal = {
       ...props.mappingVal,
-      placeType,
       placeProperty: updatedPlaceProperty,
+      placeType,
     };
     props.onMappingValUpdate(updatedMappingVal);
   }

--- a/static/js/import_wizard2/components/shared/mapping_place_input.tsx
+++ b/static/js/import_wizard2/components/shared/mapping_place_input.tsx
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Component for selecting place mapping
+ */
+
+import axios from "axios";
+import _ from "lodash";
+import React, { useEffect, useState } from "react";
+import { Input } from "reactstrap";
+
+import {
+  Column,
+  DCProperty,
+  DCType,
+  MappingType,
+  MappingVal,
+  TypeProperty,
+} from "../../types";
+import { parseSupportedTypePropertiesResponse } from "../../utils/detection";
+import { MappingColumnInput } from "./mapping_column_input";
+
+interface MappingPlaceInputProps {
+  mappingType: MappingType;
+  mappingVal: MappingVal;
+  onMappingValUpdate: (mappingVal: MappingVal) => void;
+  orderedColumns: Array<Column>;
+}
+
+export function MappingPlaceInput(props: MappingPlaceInputProps): JSX.Element {
+  const [placeTypes, setPlaceTypes] = useState<DCType[]>(null);
+  // key is place type dcid and value is list of corresponding place properties
+  const [placeTypeToProperties, setPlaceTypeToProperties] =
+    useState<Record<string, DCProperty[]>>(null);
+  const validPlaceProperties = getValidPlaceProperties();
+
+  useEffect(() => {
+    fetchPlaceTypeProperties();
+  }, []);
+
+  if (_.isNull(placeTypeToProperties)) {
+    return null;
+  }
+
+  return (
+    <>
+      <MappingColumnInput
+        mappingVal={props.mappingVal}
+        onMappingValUpdate={onPlaceUpdate}
+        orderedColumns={props.orderedColumns}
+      />
+      {!_.isEmpty(props.mappingVal) && (
+        <div className="place-type-property-section">
+          <div className="place-type-property-option">
+            <span>Type:</span>
+            <Input
+              className="column-option-dropdown"
+              type="select"
+              value={
+                props.mappingVal.placeType
+                  ? props.mappingVal.placeType.dcid
+                  : ""
+              }
+              onChange={(e) => {
+                const placeType = placeTypes.find(
+                  (type) => type.dcid === e.target.value
+                );
+                onPlaceTypePropertyUpdate(
+                  placeType,
+                  props.mappingVal.placeProperty
+                );
+              }}
+            >
+              {placeTypes.map((placeType) => (
+                <option value={placeType.dcid} key={placeType.dcid}>
+                  {placeType.displayName}
+                </option>
+              ))}
+            </Input>
+          </div>
+          <div className="place-type-property-option">
+            <span>Format:</span>
+            <Input
+              className="column-option-dropdown"
+              type="select"
+              value={
+                props.mappingVal.placeProperty
+                  ? props.mappingVal.placeProperty.dcid
+                  : ""
+              }
+              onChange={(e) => {
+                const placeProperty = validPlaceProperties.find(
+                  (prop) => prop.dcid === e.target.value
+                );
+                onPlaceTypePropertyUpdate(
+                  props.mappingVal.placeType,
+                  placeProperty
+                );
+              }}
+            >
+              {validPlaceProperties.map((property) => (
+                <option value={property.dcid} key={property.dcid}>
+                  {property.displayName}
+                </option>
+              ))}
+            </Input>
+          </div>
+        </div>
+      )}
+    </>
+  );
+
+  function fetchPlaceTypeProperties(): void {
+    axios
+      .get("/api/detection/supported_place_properties")
+      .then((resp) => {
+        const placeTypeProperties = parseSupportedTypePropertiesResponse(
+          resp.data
+        );
+        const placeTypes = [];
+        const placeTypeToProperties = {};
+        placeTypeProperties.forEach((tp: TypeProperty) => {
+          if (!(tp.dcType.dcid in placeTypeToProperties)) {
+            placeTypes.push(tp.dcType);
+            placeTypeToProperties[tp.dcType.dcid] = [];
+          }
+          if (tp.dcProperty) {
+            placeTypeToProperties[tp.dcType.dcid].push(tp.dcProperty);
+          }
+        });
+        setPlaceTypes(placeTypes);
+        setPlaceTypeToProperties(placeTypeToProperties);
+      })
+      .catch(() => {
+        setPlaceTypes([]);
+        setPlaceTypeToProperties({});
+      });
+  }
+
+  function getValidPlaceProperties(): DCProperty[] {
+    if (!placeTypeToProperties) {
+      return [];
+    }
+    let validPlaceProperties = [];
+    if (props.mappingVal && props.mappingVal.placeType) {
+      validPlaceProperties = Object.values(
+        placeTypeToProperties[props.mappingVal.placeType.dcid] || {}
+      );
+    } else if (!_.isEmpty(placeTypes)) {
+      validPlaceProperties = Object.values(
+        placeTypeToProperties[placeTypes[0].dcid] || {}
+      );
+    }
+    return validPlaceProperties;
+  }
+
+  function onPlaceUpdate(newMappingVal: MappingVal): void {
+    if (_.isEmpty(newMappingVal)) {
+      props.onMappingValUpdate(newMappingVal);
+    }
+    // get place type and place property for the mapping val
+    let placeType = !_.isEmpty(placeTypes) ? placeTypes[0] : null;
+    let placeProperty = !_.isEmpty(validPlaceProperties)
+      ? validPlaceProperties[0]
+      : null;
+    if (props.mappingVal) {
+      placeType = props.mappingVal.placeType || placeType;
+      placeProperty = props.mappingVal.placeProperty || placeProperty;
+    }
+    newMappingVal.placeType = placeType;
+    newMappingVal.placeProperty = placeType;
+    props.onMappingValUpdate(newMappingVal);
+  }
+
+  function onPlaceTypePropertyUpdate(
+    placeType: DCType,
+    placeProperty?: DCProperty
+  ): void {
+    const possibleProperties = placeTypeToProperties[placeType.dcid] || [];
+    const possiblePropertyDcids = new Set(
+      possibleProperties.map((prop) => prop.dcid)
+    );
+    let updatedPlaceProperty = placeProperty;
+    // If no place property selected or selected place property is not valid for
+    // the selected place type, update place property to a valid one
+    if (
+      _.isEmpty(placeProperty) ||
+      !possiblePropertyDcids.has(placeProperty.dcid)
+    ) {
+      updatedPlaceProperty = !_.isEmpty(possibleProperties)
+        ? possibleProperties[0]
+        : null;
+    }
+    const updatedMappingVal = {
+      ...props.mappingVal,
+      placeType,
+      placeProperty: updatedPlaceProperty,
+    };
+    props.onMappingValUpdate(updatedMappingVal);
+  }
+}

--- a/static/js/import_wizard2/templates.tsx
+++ b/static/js/import_wizard2/templates.tsx
@@ -228,6 +228,7 @@ function getConstantVarUserMapping(predictedMapping: Mapping): Mapping {
       const invalidNonStatVarVal =
         mappedThing !== MappedThing.STAT_VAR && _.isEmpty(mappingVal.column);
       if (invalidStatVarVal || invalidNonStatVarVal) {
+        console.log(`Invalid mappingVal for ${mappedThing}. Entry deleted from mapping.`);
         userMapping.delete(mappedThing);
       }
     });
@@ -239,7 +240,7 @@ function getConstantVarUserMapping(predictedMapping: Mapping): Mapping {
 // the user mapping to use for that template.
 // TODO: add test that checks every template has a user mapping function once
 //       user mapping functions are added for the rest of the existing templates
-export const TEMPLATE_USER_MAPPING_FN: {
+export const TEMPLATE_PREDICTION_VALIDATION: {
   [templateId: string]: (predictedMapping: Mapping) => Mapping;
 } = {
   constantVar: getConstantVarUserMapping,

--- a/static/js/import_wizard2/templates.tsx
+++ b/static/js/import_wizard2/templates.tsx
@@ -228,7 +228,9 @@ function getConstantVarUserMapping(predictedMapping: Mapping): Mapping {
       const invalidNonStatVarVal =
         mappedThing !== MappedThing.STAT_VAR && _.isEmpty(mappingVal.column);
       if (invalidStatVarVal || invalidNonStatVarVal) {
-        console.log(`Invalid mappingVal for ${mappedThing}. Entry deleted from mapping.`);
+        console.log(
+          `Invalid mappingVal for ${mappedThing}. Entry deleted from mapping.`
+        );
         userMapping.delete(mappedThing);
       }
     });

--- a/static/js/import_wizard2/templates.tsx
+++ b/static/js/import_wizard2/templates.tsx
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import _ from "lodash";
 import React from "react";
 
-import { CsvData, Mapping } from "../import_wizard/types";
 import { ConstantVar } from "./components/mapping_templates/constant_var";
 import { MulitVarCol } from "./components/mapping_templates/multi_var_col";
 import { MultiVarMultiDateCol } from "./components/mapping_templates/multi_var_mulit_date_col";
 import { SingleVarMultiDateCol } from "./components/mapping_templates/single_var_multi_date_col";
+import { CsvData, MappedThing, Mapping } from "./types";
 
 // information about a template
 export interface TemplateInfo {
@@ -197,7 +198,7 @@ export const TEMPLATE_OPTIONS: { [templateId: string]: TemplateInfo } = {
 
 export interface MappingTemplateProps {
   csvData: CsvData;
-  predictedMapping: Mapping;
+  userMapping: Mapping;
   onChangeUserMapping: (mapping: Mapping) => void;
 }
 
@@ -212,4 +213,34 @@ export const TEMPLATE_MAPPING_COMPONENTS: {
   multiVarCol: MulitVarCol,
   multiVarMultiDateCol: MultiVarMultiDateCol,
   singleVarMultiDateCol: SingleVarMultiDateCol,
+};
+
+function getConstantVarUserMapping(predictedMapping: Mapping): Mapping {
+  let userMapping = new Map();
+  if (!_.isEmpty(predictedMapping)) {
+    userMapping = _.clone(predictedMapping);
+    predictedMapping.forEach((mappingVal, mappedThing) => {
+      // mappingVal for stat var must have fileConstant
+      const invalidStatVarVal =
+        mappedThing === MappedThing.STAT_VAR &&
+        _.isEmpty(mappingVal.fileConstant);
+      // mappingVal for non stat var things must have a column
+      const invalidNonStatVarVal =
+        mappedThing !== MappedThing.STAT_VAR && _.isEmpty(mappingVal.column);
+      if (invalidStatVarVal || invalidNonStatVarVal) {
+        userMapping.delete(mappedThing);
+      }
+    });
+  }
+  return userMapping;
+}
+
+// Map of templateId to a function that takes the predicted mapping and returns
+// the user mapping to use for that template.
+// TODO: add test that checks every template has a user mapping function once
+//       user mapping functions are added for the rest of the existing templates
+export const TEMPLATE_USER_MAPPING_FN: {
+  [templateId: string]: (predictedMapping: Mapping) => Mapping;
+} = {
+  constantVar: getConstantVarUserMapping,
 };

--- a/static/js/import_wizard2/types.ts
+++ b/static/js/import_wizard2/types.ts
@@ -93,12 +93,10 @@ export interface MappingVal {
   // Column that holds the mapping values. Should be set if type is
   // MappingType.COLUMN
   column?: Column;
-  // Record of column idx to the place property (in KG) associated with that
-  // column or column header. Should be set if MappedThing is PLACE.
-  placeProperty?: { [columnIdx: number]: DCProperty };
-  // Record of column idx to the place type (in KG) associated with that
-  // column or column header. Should be set if MappedThing is PLACE.
-  placeType?: { [columnIdx: number]: DCType };
+  // When MappedThing is PLACE, the value corresponds to place property in KG
+  placeProperty?: DCProperty;
+  // When MappedThing is PLACE, the value corresponds to place type in KG
+  placeType?: DCType;
   // List of column headers that act as the mapping values. Should be set if
   // type is MappingType.COLUMN_HEADERS
   headers?: Column[];

--- a/static/js/import_wizard2/utils/detection.test.tsx
+++ b/static/js/import_wizard2/utils/detection.test.tsx
@@ -46,11 +46,11 @@ test("jsonParsingPlaceDateColumns", () => {
 
   expect(got["Place"].type).toEqual("column");
   expect(got["Place"].column).toEqual({ id: "a", header: "b", columnIdx: 0 });
-  expect(got["Place"].placeType[0]).toEqual({
+  expect(got["Place"].placeType).toEqual({
     dcid: "Country",
     displayName: "Country",
   });
-  expect(got["Place"].placeProperty[0]).toEqual({
+  expect(got["Place"].placeProperty).toEqual({
     dcid: "countryAlpha3Code",
     displayName: "Alpha 3 Code",
   });
@@ -93,11 +93,11 @@ test("jsonParsingPlaceDateHeaders", () => {
 
   expect(got["Place"].type).toEqual("column");
   expect(got["Place"].column).toEqual({ id: "a", header: "b", columnIdx: 0 });
-  expect(got["Place"].placeType[0]).toEqual({
+  expect(got["Place"].placeType).toEqual({
     dcid: "State",
     displayName: "State",
   });
-  expect(got["Place"].placeProperty[0]).toEqual({
+  expect(got["Place"].placeProperty).toEqual({
     dcid: "name",
     displayName: "Name",
   });
@@ -184,11 +184,11 @@ test("jsonParsingPlaceCorrectDateSkipped", () => {
 
   expect(got["Place"].type).toEqual("column");
   expect(got["Place"].column).toEqual({ id: "a", header: "b", columnIdx: 0 });
-  expect(got["Place"].placeType[0]).toEqual({
+  expect(got["Place"].placeType).toEqual({
     dcid: "Country",
     displayName: "Country",
   });
-  expect(got["Place"].placeProperty[0]).toEqual({
+  expect(got["Place"].placeProperty).toEqual({
     dcid: "countryAlpha3Code",
     displayName: "Alpha 3 Code",
   });

--- a/static/js/import_wizard2/utils/detection.ts
+++ b/static/js/import_wizard2/utils/detection.ts
@@ -112,10 +112,8 @@ export function parseDetectionApiResponse(
         continue;
       }
       mValValidated.placeType = {
-        [col.columnIdx]: {
-          dcid: mVal[PLACETYPE_API_KEY][DCID_API_KEY],
-          displayName: mVal[PLACETYPE_API_KEY][DISP_NAME_API_KEY],
-        },
+        dcid: mVal[PLACETYPE_API_KEY][DCID_API_KEY],
+        displayName: mVal[PLACETYPE_API_KEY][DISP_NAME_API_KEY],
       };
     }
 
@@ -130,10 +128,8 @@ export function parseDetectionApiResponse(
         continue;
       }
       mValValidated.placeProperty = {
-        [col.columnIdx]: {
-          dcid: mVal[PLACEPROP_API_KEY][DCID_API_KEY],
-          displayName: mVal[PLACEPROP_API_KEY][DISP_NAME_API_KEY],
-        },
+        dcid: mVal[PLACEPROP_API_KEY][DCID_API_KEY],
+        displayName: mVal[PLACEPROP_API_KEY][DISP_NAME_API_KEY],
       };
     }
 

--- a/static/js/import_wizard2/utils/file_generation.test.ts
+++ b/static/js/import_wizard2/utils/file_generation.test.ts
@@ -33,13 +33,8 @@ test("generateTranslationMetadataJson", () => {
       {
         type: MappingType.COLUMN,
         column: countryCol,
-        placeProperty: {
-          3: {
-            dcid: "name",
-            displayName: "name",
-          },
-        },
-        placeType: { 3: { dcid: "Country", displayName: "Country" } },
+        placeProperty: { dcid: "name", displayName: "name" },
+        placeType: { dcid: "Country", displayName: "Country" },
       },
     ],
     [
@@ -57,12 +52,10 @@ test("generateTranslationMetadataJson", () => {
         type: MappingType.COLUMN,
         column: countryCol,
         placeProperty: {
-          3: {
-            dcid: "countryAlpha3Code",
-            displayName: "Alpha 3 Code",
-          },
+          dcid: "countryAlpha3Code",
+          displayName: "Alpha 3 Code",
         },
-        placeType: { 3: { dcid: "Country", displayName: "Country" } },
+        placeType: { dcid: "Country", displayName: "Country" },
       },
     ],
     [
@@ -85,14 +78,14 @@ test("generateTranslationMetadataJson", () => {
       prediction: new Map(),
       correctedMapping: correctedMapping,
       expected:
-        '{"predictions":{},"correctedMapping":{"Place":{"type":"column","column":{"id":"d3","header":"d","columnIdx":3},"placeProperty":{"3":{"dcid":"countryAlpha3Code","displayName":"Alpha 3 Code"}},"placeType":{"3":{"dcid":"Country","displayName":"Country"}}},"Date":{"type":"columnHeader","headers":[{"id":"2022-100","header":"2022-10","columnIdx":0},{"id":"20211","header":"2021-10","columnIdx":1}]}}}',
+        '{"predictions":{},"correctedMapping":{"Place":{"type":"column","column":{"id":"d3","header":"d","columnIdx":3},"placeProperty":{"dcid":"countryAlpha3Code","displayName":"Alpha 3 Code"},"placeType":{"dcid":"Country","displayName":"Country"}},"Date":{"type":"columnHeader","headers":[{"id":"2022-100","header":"2022-10","columnIdx":0},{"id":"20211","header":"2021-10","columnIdx":1}]}}}',
     },
     {
       name: "empty correctedMapping",
       prediction: predictedMapping,
       correctedMapping: new Map(),
       expected:
-        '{"predictions":{"Place":{"type":"column","column":{"id":"d3","header":"d","columnIdx":3},"placeProperty":{"3":{"dcid":"name","displayName":"name"}},"placeType":{"3":{"dcid":"Country","displayName":"Country"}}},"Date":{"type":"column","column":{"id":"c2","header":"c","columnIdx":2}}},"correctedMapping":{}}',
+        '{"predictions":{"Place":{"type":"column","column":{"id":"d3","header":"d","columnIdx":3},"placeProperty":{"dcid":"name","displayName":"name"},"placeType":{"dcid":"Country","displayName":"Country"}},"Date":{"type":"column","column":{"id":"c2","header":"c","columnIdx":2}}},"correctedMapping":{}}',
     },
     {
       name: "both empty",
@@ -105,7 +98,7 @@ test("generateTranslationMetadataJson", () => {
       prediction: predictedMapping,
       correctedMapping: correctedMapping,
       expected:
-        '{"predictions":{"Place":{"type":"column","column":{"id":"d3","header":"d","columnIdx":3},"placeProperty":{"3":{"dcid":"name","displayName":"name"}},"placeType":{"3":{"dcid":"Country","displayName":"Country"}}},"Date":{"type":"column","column":{"id":"c2","header":"c","columnIdx":2}}},"correctedMapping":{"Place":{"type":"column","column":{"id":"d3","header":"d","columnIdx":3},"placeProperty":{"3":{"dcid":"countryAlpha3Code","displayName":"Alpha 3 Code"}},"placeType":{"3":{"dcid":"Country","displayName":"Country"}}},"Date":{"type":"columnHeader","headers":[{"id":"2022-100","header":"2022-10","columnIdx":0},{"id":"20211","header":"2021-10","columnIdx":1}]}}}',
+        '{"predictions":{"Place":{"type":"column","column":{"id":"d3","header":"d","columnIdx":3},"placeProperty":{"dcid":"name","displayName":"name"},"placeType":{"dcid":"Country","displayName":"Country"}},"Date":{"type":"column","column":{"id":"c2","header":"c","columnIdx":2}}},"correctedMapping":{"Place":{"type":"column","column":{"id":"d3","header":"d","columnIdx":3},"placeProperty":{"dcid":"countryAlpha3Code","displayName":"Alpha 3 Code"},"placeType":{"dcid":"Country","displayName":"Country"}},"Date":{"type":"columnHeader","headers":[{"id":"2022-100","header":"2022-10","columnIdx":0},{"id":"20211","header":"2021-10","columnIdx":1}]}}}',
     },
   ];
 

--- a/static/js/import_wizard2/utils/tmcf_generation.test.tsx
+++ b/static/js/import_wizard2/utils/tmcf_generation.test.tsx
@@ -24,7 +24,7 @@ test("SingleNodeTMCF", () => {
       {
         type: MappingType.COLUMN,
         column: { id: "iso", header: "iso", columnIdx: 1 },
-        placeProperty: { 1: { dcid: "isoCode", displayName: "isoCode" } },
+        placeProperty: { dcid: "isoCode", displayName: "isoCode" },
       },
     ],
     [
@@ -78,7 +78,7 @@ test("MultiNodeTMCF_DateValueInHeader", () => {
       {
         type: MappingType.COLUMN,
         column: { id: "id", header: "id", columnIdx: 1 },
-        placeProperty: { 1: { dcid: "dcid", displayName: "dcid" } },
+        placeProperty: { dcid: "dcid", displayName: "dcid" },
       },
     ],
     [
@@ -134,14 +134,8 @@ test("MultiNodeTMCF_PlaceValueInHeader", () => {
           { id: "California_1", header: "California", columnIdx: 3 },
           { id: "Nevada_2", header: "Nevada", columnIdx: 4 },
         ],
-        placeProperty: {
-          3: { dcid: "name", displayName: "name" },
-          4: { dcid: "name", displayName: "name" },
-        },
-        placeType: {
-          3: { dcid: "AdministrativeArea1", displayName: "State" },
-          4: { dcid: "AdministrativeArea1", displayName: "State" },
-        },
+        placeProperty: { dcid: "name", displayName: "name" },
+        placeType: { dcid: "AdministrativeArea1", displayName: "State" },
         type: MappingType.COLUMN_HEADER,
       },
     ],
@@ -195,76 +189,6 @@ test("MultiNodeTMCF_PlaceValueInHeader", () => {
   expect(generateTMCF(input)).toEqual(expected);
 });
 
-test("MultiNodeTMCF_PlaceValueInHeader_DiffPlaceTypes", () => {
-  const input: Mapping = new Map([
-    [
-      MappedThing.PLACE,
-      {
-        headers: [
-          { id: "California_1", header: "California", columnIdx: 3 },
-          { id: "USA_1", header: "USA", columnIdx: 4 },
-        ],
-        placeProperty: {
-          3: { dcid: "name", displayName: "name" },
-          4: { dcid: "countryAlpha3Code", displayName: "Alpha 3 Code" },
-        },
-        placeType: {
-          3: { dcid: "AdministrativeArea1", displayName: "State" },
-          4: { dcid: "Country", displayName: "Country" },
-        },
-        type: MappingType.COLUMN_HEADER,
-      },
-    ],
-    [
-      MappedThing.STAT_VAR,
-      {
-        type: MappingType.COLUMN,
-        column: { id: "indicators", header: "indicators", columnIdx: 2 },
-      },
-    ],
-    [
-      MappedThing.DATE,
-      {
-        type: MappingType.COLUMN,
-        column: { id: "year", header: "year", columnIdx: 1 },
-      },
-    ],
-    [
-      MappedThing.UNIT,
-      {
-        type: MappingType.FILE_CONSTANT,
-        fileConstant: "USDollar",
-      },
-    ],
-  ]);
-  const expected =
-    "Node: E:CSVTable->E0\n" +
-    "typeOf: dcs:AdministrativeArea1\n" +
-    'name: "California"\n' +
-    "\n" +
-    "Node: E:CSVTable->E2\n" +
-    "typeOf: dcs:Country\n" +
-    "countryAlpha3Code: dcid:USA\n" +
-    "\n" +
-    "Node: E:CSVTable->E1\n" +
-    "typeOf: dcs:StatVarObservation\n" +
-    "value: C:CSVTable->California_1\n" +
-    "observationAbout: E:CSVTable->E0\n" +
-    "variableMeasured: C:CSVTable->indicators\n" +
-    "observationDate: C:CSVTable->year\n" +
-    "unit: dcid:USDollar\n" +
-    "\n" +
-    "Node: E:CSVTable->E3\n" +
-    "typeOf: dcs:StatVarObservation\n" +
-    "value: C:CSVTable->USA_1\n" +
-    "observationAbout: E:CSVTable->E2\n" +
-    "variableMeasured: C:CSVTable->indicators\n" +
-    "observationDate: C:CSVTable->year\n" +
-    "unit: dcid:USDollar\n";
-
-  expect(generateTMCF(input)).toEqual(expected);
-});
-
 test("SingleNodeTMCFWithUnitColumnConstant", () => {
   const input: Mapping = new Map([
     [
@@ -272,7 +196,7 @@ test("SingleNodeTMCFWithUnitColumnConstant", () => {
       {
         type: MappingType.COLUMN,
         column: { id: "iso", header: "iso", columnIdx: 1 },
-        placeProperty: { 1: { dcid: "isoCode", displayName: "isoCode" } },
+        placeProperty: { dcid: "isoCode", displayName: "isoCode" },
       },
     ],
     [
@@ -326,7 +250,7 @@ test("MultiNodeTMCF_UnitAsSomeColumnConstants", () => {
       {
         type: MappingType.COLUMN,
         column: { id: "id", header: "id", columnIdx: 1 },
-        placeProperty: { 1: { dcid: "dcid", displayName: "dcid" } },
+        placeProperty: { dcid: "dcid", displayName: "dcid" },
       },
     ],
     [

--- a/static/js/import_wizard2/utils/tmcf_generation.ts
+++ b/static/js/import_wizard2/utils/tmcf_generation.ts
@@ -59,10 +59,10 @@ function getConstPV(prop: string, val: string): string {
   }
 }
 
-function getPlaceType(colIdx: number, mval: MappingVal): string {
+function getPlaceType(mval: MappingVal): string {
   let placeType = PLACE_TYPE;
-  if (mval.placeType != null && colIdx in mval.placeType) {
-    placeType = mval.placeType[colIdx].dcid;
+  if (!_.isEmpty(mval.placeType) && !_.isEmpty(mval.placeType.dcid)) {
+    placeType = mval.placeType.dcid;
   }
   return placeType;
 }
@@ -105,17 +105,14 @@ export function generateTMCF(mappings: Mapping): string {
       commonPVs.push(getConstPV(mappedProp, mval.fileConstant));
     } else if (mval.type === MappingType.COLUMN) {
       if (mthing === MappedThing.PLACE) {
-        const placeProperty = mval.placeProperty[mval.column.columnIdx].dcid;
+        const placeProperty = mval.placeProperty.dcid;
         if (placeProperty === DCID_PROP) {
           // Place with DCID property can be a column ref.
           commonPVs.push(getColPV(mappedProp, mval.column.id));
         } else {
           // For place with non-DCID property, we should introduce a place node,
           // and use entity reference.
-          const node = initNode(
-            nodeIdx,
-            getPlaceType(mval.column.columnIdx, mval)
-          );
+          const node = initNode(nodeIdx, getPlaceType(mval));
           node.push(getColPV(placeProperty, mval.column.id));
           placeNodes.push(node);
           nodeIdx++;
@@ -150,13 +147,11 @@ export function generateTMCF(mappings: Mapping): string {
     mval.headers.forEach((hdr) => {
       let hasPlaceRef = false;
       const placeProperty =
-        colHdrThing === MappedThing.PLACE
-          ? mval.placeProperty[hdr.columnIdx].dcid
-          : "";
+        colHdrThing === MappedThing.PLACE ? mval.placeProperty.dcid : "";
       if (colHdrThing === MappedThing.PLACE && placeProperty !== DCID_PROP) {
         hasPlaceRef = true;
         // For place with non-DCID property, we should introduce a place node.
-        const node = initNode(nodeIdx, getPlaceType(hdr.columnIdx, mval));
+        const node = initNode(nodeIdx, getPlaceType(mval));
         node.push(getConstPV(placeProperty, hdr.header));
         placeNodes.push(node);
         nodeIdx++;

--- a/static/js/import_wizard2/utils/validation.test.tsx
+++ b/static/js/import_wizard2/utils/validation.test.tsx
@@ -91,7 +91,7 @@ test("Fail_ValueMissing", () => {
       {
         type: MappingType.COLUMN,
         column: { id: "iso", header: "iso", columnIdx: 1 },
-        placeProperty: { 1: { dcid: "isoCode", displayName: "isoCode" } },
+        placeProperty: { dcid: "isoCode", displayName: "isoCode" },
       },
     ],
     [
@@ -113,45 +113,6 @@ test("Fail_ValueMissing", () => {
   expect(checkMappings(input)).toEqual(expected);
 });
 
-test("Fail_MissingPlaceProperties", () => {
-  const input: Mapping = new Map([
-    [
-      MappedThing.PLACE,
-      {
-        type: MappingType.COLUMN_HEADER,
-        headers: [
-          { id: "California_1", header: "California", columnIdx: 3 },
-          { id: "Nevada_2", header: "Nevada", columnIdx: 4 },
-        ],
-        placeProperty: { 3: { dcid: "name", displayName: "name" } },
-      },
-    ],
-    [
-      MappedThing.STAT_VAR,
-      {
-        type: MappingType.COLUMN,
-        column: { id: "indicators", header: "indicators", columnIdx: 2 },
-      },
-    ],
-    [
-      MappedThing.DATE,
-      {
-        type: MappingType.COLUMN,
-        column: { id: "date", header: "date", columnIdx: 3 },
-      },
-    ],
-    [
-      MappedThing.UNIT,
-      {
-        type: MappingType.FILE_CONSTANT,
-        fileConstant: "USDollar",
-      },
-    ],
-  ]);
-  const expected = ["Nevada: Place mapping is missing placeProperty"];
-  expect(checkMappings(input)).toEqual(expected);
-});
-
 test("Pass_DateInColumnHeader", () => {
   const input: Mapping = new Map([
     [
@@ -159,7 +120,7 @@ test("Pass_DateInColumnHeader", () => {
       {
         type: MappingType.COLUMN,
         column: { id: "iso", header: "iso", columnIdx: 1 },
-        placeProperty: { 1: { dcid: "isoCode", displayName: "isoCode" } },
+        placeProperty: { dcid: "isoCode", displayName: "isoCode" },
       },
     ],
     [
@@ -198,7 +159,7 @@ test("Pass_NoColumnHeader", () => {
       {
         type: MappingType.COLUMN,
         column: { id: "iso", header: "iso", columnIdx: 1 },
-        placeProperty: { 1: { dcid: "isoCode", displayName: "isoCode" } },
+        placeProperty: { dcid: "isoCode", displayName: "isoCode" },
       },
     ],
     [

--- a/static/js/import_wizard2/utils/validation.ts
+++ b/static/js/import_wizard2/utils/validation.ts
@@ -38,7 +38,6 @@ import {
  * (6) PLACE must specify placeProperty
  * (7) VALUE, if it appears, has to be COLUMN
  * (8) PLACE should not be CONSTANT (its atypical and not exposed in UI)
- * (9) PLACE (mapped thing) COLUMN (mapping type) must have one place property
  *
  * TODO: Consider returning enum + string pair for error categories
  *
@@ -69,17 +68,9 @@ export function checkMappings(mappings: Mapping): Array<string> {
         errors.push(mthingName + ": missing value for COLUMN type ");
       }
       if (mthing === MappedThing.PLACE) {
-        if (
-          _.isEmpty(mval.placeProperty) ||
-          _.isEmpty(mval.placeProperty[mval.column.columnIdx])
-        ) {
+        if (_.isEmpty(mval.placeProperty)) {
           // Check #6
           errors.push("Place mapping is missing placeProperty");
-        } else if (Object.keys(mval.placeProperty).length !== 1) {
-          // Check #9
-          errors.push(
-            "Place mapping for a column expected to have one placeProperty"
-          );
         }
       }
       numNonConsts++;
@@ -93,14 +84,6 @@ export function checkMappings(mappings: Mapping): Array<string> {
           // Check #6
           errors.push("Place mapping is missing placeProperty");
         }
-        mval.headers.forEach((header) => {
-          if (_.isEmpty(mval.placeProperty[header.columnIdx])) {
-            // Check #6
-            errors.push(
-              header.header + ": Place mapping is missing placeProperty"
-            );
-          }
-        });
       }
       colHdrThings.push(mthing);
       numNonConsts++;


### PR DESCRIPTION
- add a generic column selector component & use it in constant var mapping section
- add a place selector component that has place type and property selecting
    - while doing this, reverted MappingVal to only having a single placeType and placeProperty. We had made MappingVal take multiple placeType and placeProperties in import wizard v1 because as the user goes through each column, they could potentially assign multiple columns to be place & have a different place type/property for each chosen column. In import wizard 2, users currently can not get to that state of having multiple place types and properties, so I decided to simplify the MappingVal structure for now.
- add another constant mapping in templates.tsx which is a mapping between templateId and function for getting userMapping based off of predictedMapping. This is to ensure the assumptions we make about the mapping for each template are true. 
     - this may not be needed later when we pass the templateId to the detection API and update the detection API
- moved detection api response parsers to import_wizard2 folder

![Screen Shot 2022-09-16 at 9 56 42 AM](https://user-images.githubusercontent.com/69875368/190709936-34e8db9e-9e36-4586-87ca-82fc864e3a02.png)
