### PR TITLE
Fix and refactor browser page provenance issue

### DIFF
--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -31,8 +31,8 @@ NO_OBSPERIOD_KEY = 'no_obsPeriod'
 @bp.route('/triples/<path:direction>/<path:dcid>')
 def triples(direction, dcid):
     """Returns all the triples given a node dcid."""
-    if direction != "in" or direction != "out":
-        return 400, "Invalid direction, use 'in' or 'out'"
+    if direction != "in" and direction != "out":
+        return f"Invalid direction {direction}, use 'in' or 'out'", 400
     return dc.triples(dcid, direction).get("triples")
 
 

--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -40,7 +40,7 @@ def triples(direction, dcid):
 def provenance():
     """Returns all the provenance information."""
     resp = dc.triples("Provenance", "in")
-    prov_list = resp.get("triples").get("typeOf").get("nodes")
+    prov_list = resp.get("triples", {}).get("typeOf", {}).get("nodes", [])
     dcids = map(lambda item: item["dcid"], prov_list)
     resp = dc.property_values(dcids, "url", "out")
     result = {}

--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -32,7 +32,7 @@ NO_OBSPERIOD_KEY = 'no_obsPeriod'
 def triples(direction, dcid):
     """Returns all the triples given a node dcid."""
     if direction != "in" and direction != "out":
-        return f"Invalid direction {direction}, use 'in' or 'out'", 400
+        return "Invalid direction provided, please use 'in' or 'out'", 400
     return dc.triples(dcid, direction).get("triples")
 
 

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -38,7 +38,6 @@ API_ENDPOINTS = {
     'search': '/search',
     'get_property_labels': '/node/property-labels',
     'get_property_values': '/node/property-values',
-    'get_triples': '/node/triples',
     'get_places_in': '/node/places-in',
     'get_place_ranking': '/node/ranking-locations',
     'get_stat_set_series': '/v1/stat/set/series',
@@ -161,12 +160,21 @@ def series_within(parent_place, child_type, stat_vars, all):
         })
 
 
+def triples(node, direction):
+    """Retrieves the triples for a node.
+    Args:
+        node: Node DCID.
+        direction: Predicate direction, either be 'in' or 'out'.
+    """
+    return get(f'/v1/triples/{direction}/{node}')
+
+
 def property_values(nodes, prop, direction):
     """Retrieves the property values for a list of nodes.
     Args:
         nodes: A list of node DCIDs.
         prop: The property label toquery for.
-        dir: Direction of the property, either be 'in' or 'out'.
+        direction: Direction of the property, either be 'in' or 'out'.
     """
     resp = post(f'/v1/bulk/property/values/{direction}', {
         'nodes': sorted(nodes),
@@ -393,17 +401,6 @@ def get_property_values(dcids,
     # Make sure each dcid is in the results dict, and convert sets to lists.
     results = {dcid: sorted(list(unique_results[dcid])) for dcid in dcids}
     return results
-
-
-def get_triples(dcids, limit=0):
-    """
-    Get the triples in the raw format as the REST response.
-
-    This is used by the flask server to retrieve node triples.
-    Limit of 0 does not apply a limit and use all available triples from cache.
-    """
-    url = API_ROOT + API_ENDPOINTS['get_triples']
-    return send_request(url, req_json={'dcids': dcids, 'limit': limit})
 
 
 def get_places_in(dcids, place_type):

--- a/static/js/browser/browser_page.tsx
+++ b/static/js/browser/browser_page.tsx
@@ -176,17 +176,9 @@ export class BrowserPage extends React.Component<
       : this.props.dcid;
   }
 
-  private isProvenanceEntity(prov): boolean {
-    return (
-      prov["subjectTypes"] &&
-      prov["subjectTypes"][0] === "Provenance" &&
-      !!prov["subjectName"]
-    );
-  }
-
   private fetchData(): void {
     const provenancePromise = axios
-      .get("/api/browser/triples/Provenance")
+      .get("/api/browser/provenance")
       .then((resp) => resp.data);
     const labelsPromise = axios
       .get("/api/browser/proplabels/" + this.getArcDcid())
@@ -194,13 +186,11 @@ export class BrowserPage extends React.Component<
     Promise.all([labelsPromise, provenancePromise])
       .then(([labelsData, ProvenanceData]) => {
         const provDomain = {};
-        for (const prov of ProvenanceData) {
-          if (this.isProvenanceEntity(prov)) {
-            try {
-              provDomain[prov["subjectId"]] = new URL(prov["subjectName"]).host;
-            } catch (err) {
-              console.log("Invalid url in prov: " + prov["subjectName"]);
-            }
+        for (const prov in ProvenanceData) {
+          try {
+            provDomain[prov] = new URL(ProvenanceData[prov]).host;
+          } catch (err) {
+            console.log("Invalid url in prov: " + ProvenanceData[prov]);
           }
         }
         this.setState({

--- a/static/js/browser/browser_page.tsx
+++ b/static/js/browser/browser_page.tsx
@@ -184,13 +184,14 @@ export class BrowserPage extends React.Component<
       .get("/api/browser/proplabels/" + this.getArcDcid())
       .then((resp) => resp.data);
     Promise.all([labelsPromise, provenancePromise])
-      .then(([labelsData, ProvenanceData]) => {
+      .then(([labelsData, provenanceData]) => {
         const provDomain = {};
-        for (const prov in ProvenanceData) {
+        for (const provId in provenanceData) {
+          const url = provenanceData[provId];
           try {
-            provDomain[prov] = new URL(ProvenanceData[prov]).host;
+            provDomain[provId] = new URL(url).host;
           } catch (err) {
-            console.log("Invalid url in prov: " + ProvenanceData[prov]);
+            console.log("Invalid url in prov: " + url);
           }
         }
         this.setState({

--- a/static/js/browser/out_arc_section.tsx
+++ b/static/js/browser/out_arc_section.tsx
@@ -220,7 +220,7 @@ export class OutArcSection extends React.Component<
   private fetchDataFromTriples(): void {
     loadSpinner(LOADING_CONTAINER_ID);
     axios
-      .get("/api/browser/out/triples/" + this.props.dcid)
+      .get("/api/browser/triples/out/" + this.props.dcid)
       .then((resp) => {
         const triplesData = resp.data;
         const outArcsByPredProv: OutArcData = {};
@@ -247,6 +247,7 @@ export class OutArcSection extends React.Component<
               text: valueText,
             });
           }
+          outArcsByPredProv[pred] = predData;
         }
         removeSpinner(LOADING_CONTAINER_ID);
         this.setState({


### PR DESCRIPTION
The name of a provenance triple is changed from url to the import name. Browser fetches all provenance and url, so the logic needs to be updated to fetch the url.

This PR also updates to use V1 API for triples fetch. This is only used in browser page.