### PR TITLE
Separate geojson data fetch into a separate module

### DIFF
--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -70,11 +70,9 @@ function App(): JSX.Element {
               <Info />
             </Row>
           )}
-          {showChart && (
-            <Row id="chart-row">
-              <ChartLoader />
-            </Row>
-          )}
+          <Row id="chart-row">
+            <ChartLoader />
+          </Row>
           <div
             id="screen"
             style={{ display: showLoadingSpinner ? "block" : "none" }}

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -332,17 +332,21 @@ export function ChartLoader(): JSX.Element {
         onPlay={onPlay}
         updateDate={updateDate}
       />
-      <PlaceDetails
-        breadcrumbDataValues={chartData.breadcrumbValues}
-        mapDataValues={chartData.mapValues}
-        placeInfo={placeInfo.value}
-        metadata={chartData.metadata}
-        unit={chartData.unit}
-        statVar={statVar.value}
-        geoJsonFeatures={geoJson ? geoJson.features : []}
-        displayOptions={display.value}
-        europeanCountries={chartData.europeanCountries}
-      />
+      {placeInfo.value.parentPlaces && (
+        // Should separate out placeInfo into individual state.
+        // The parentPlaces is only used for breadcumb section.
+        <PlaceDetails
+          breadcrumbDataValues={chartData.breadcrumbValues}
+          mapDataValues={chartData.mapValues}
+          placeInfo={placeInfo.value}
+          metadata={chartData.metadata}
+          unit={chartData.unit}
+          statVar={statVar.value}
+          geoJsonFeatures={geoJson ? geoJson.features : []}
+          displayOptions={display.value}
+          europeanCountries={chartData.europeanCountries}
+        />
+      )}
       <BqModal getSqlQuery={getSqlQuery} showButton={true} />
     </div>
   );

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -131,10 +131,17 @@ export function ChartLoader(): JSX.Element {
 
   // Fetch geojson data when page option is updated.
   useEffect(() => {
-    if (_.isEmpty(geoJson)) {
-      fetchGeoJson(placeInfo.value, setGeoJson);
+    if (
+      placeInfo.value.enclosingPlace.dcid &&
+      placeInfo.value.enclosedPlaceType
+    ) {
+      fetchGeoJson(
+        placeInfo.value.enclosingPlace.dcid,
+        placeInfo.value.enclosedPlaceType,
+        setGeoJson
+      );
     }
-  }, [placeInfo.value]);
+  }, [placeInfo.value.enclosingPlace.dcid, placeInfo.value.enclosedPlaceType]);
 
   // For IPCC grid data, geoJson features is calculated based on the grid
   // DCID.
@@ -220,7 +227,7 @@ export function ChartLoader(): JSX.Element {
     }
   }, [sampleDatesChartData]);
 
-  if (chartData === undefined) {
+  if (!rawData || !statVar.value.info || chartData === undefined) {
     return null;
   } else if (_.isEmpty(geoJson)) {
     <div className="p-5">

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -111,7 +111,7 @@ export function ChartLoader(): JSX.Element {
   const { placeInfo, statVar, isLoading, display } = useContext(Context);
   const [rawData, setRawData] = useState<ChartRawData | undefined>(undefined);
   const [chartData, setChartData] = useState<ChartData | undefined>(undefined);
-  const [geoJson, setGeoJson] = useState<GeoJsonData | undefined>(undefined);
+  const [geoJson, setGeoJson] = useState<GeoJsonData>();
 
   // Map of metahash -> date -> ChartRawData
   const [sampleDatesChartData, setSampleDatesChartData] = useState<
@@ -734,7 +734,7 @@ function loadChartData(
     placeInfo.enclosedPlaceType in MANUAL_GEOJSON_DISTANCES
   ) {
     const geoJsonFeatures = getGeoJsonDataFeatures(
-      Object.keys(rawData.enclosedPlaceStat.stat),
+      Object.keys(rawData.enclosedPlaceStat),
       placeInfo.enclosedPlaceType
     );
     geoJsonData = {

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -95,7 +95,6 @@ interface ChartData {
   breadcrumbValues: { [dcid: string]: number };
   sources: Set<string>;
   dates: Set<string>;
-  geoJsonData: GeoJsonData;
   unit: string;
   mapPointValues: { [dcid: string]: number };
   mapPointsPromise: Promise<Array<MapPoint>>;
@@ -190,7 +189,7 @@ export function ChartLoader(): JSX.Element {
         setLegendBoundsPerCapita(rawData, statVar, display);
       }
     }
-  }, [rawData, statVar.value.metahash, statVar.value.perCapita]);
+  }, [rawData, geoJson, statVar.value.metahash, statVar.value.perCapita]);
 
   useEffect(() => {
     if (onPlayCallback) {
@@ -200,7 +199,7 @@ export function ChartLoader(): JSX.Element {
 
   if (chartData === undefined) {
     return null;
-  } else if (_.isEmpty(chartData.geoJsonData)) {
+  } else if (_.isEmpty(geoJson)) {
     <div className="p-5">
       {`Sorry, maps are not available for ${placeInfo.value.enclosedPlaceType} in ${placeInfo.value.selectedPlace.name}. Try picking another place or type of place.`}
     </div>;
@@ -283,7 +282,7 @@ export function ChartLoader(): JSX.Element {
   return (
     <div className="chart-region">
       <Chart
-        geoJsonData={chartData.geoJsonData}
+        geoJsonData={geoJson}
         mapDataValues={chartData.mapValues}
         metadata={chartData.metadata}
         breadcrumbDataValues={chartData.breadcrumbValues}
@@ -310,9 +309,7 @@ export function ChartLoader(): JSX.Element {
         metadata={chartData.metadata}
         unit={chartData.unit}
         statVar={statVar.value}
-        geoJsonFeatures={
-          chartData.geoJsonData ? chartData.geoJsonData.features : []
-        }
+        geoJsonFeatures={geoJson ? geoJson.features : []}
         displayOptions={display.value}
         europeanCountries={chartData.europeanCountries}
       />
@@ -848,7 +845,6 @@ function loadChartData(
   setChartData({
     breadcrumbValues,
     dates: statVarDates,
-    geoJsonData: geoJsonData,
     mapPointsPromise: rawData.mapPointsPromise,
     mapPointValues,
     mapValues,

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -129,14 +129,15 @@ export function ChartLoader(): JSX.Element {
   //   };
   // }, []);
 
-  // Fetch geojson data.
+  // Fetch geojson data when page option is updated.
   useEffect(() => {
-    if (!geoJson) {
+    if (_.isEmpty(geoJson)) {
       fetchGeoJson(placeInfo.value, setGeoJson);
     }
-  }, [geoJson, placeInfo.value]);
+  }, [placeInfo.value]);
 
-  // Update geojson data if needed.
+  // For IPCC grid data, geoJson features is calculated based on the grid
+  // DCID.
   useEffect(() => {
     if (_.isEmpty(rawData) || _.isEmpty(geoJson)) {
       return;

--- a/static/js/tools/map/geojson.ts
+++ b/static/js/tools/map/geojson.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/static/js/tools/map/geojson.ts
+++ b/static/js/tools/map/geojson.ts
@@ -32,6 +32,7 @@ export function fetchGeoJson(
   placeInfo: PlaceInfo,
   setGeoJson: (data: GeoJsonData) => void
 ): void {
+  console.log("fetch geo json data");
   axios
     .get(
       `/api/choropleth/geojson?placeDcid=${placeInfo.enclosingPlace.dcid}&placeType=${placeInfo.enclosedPlaceType}`

--- a/static/js/tools/map/geojson.ts
+++ b/static/js/tools/map/geojson.ts
@@ -22,20 +22,20 @@ import axios from "axios";
 
 import { GeoJsonData, GeoJsonFeature } from "../../chart/types";
 import { IPCC_PLACE_50_TYPE_DCID } from "../../shared/constants";
-import { PlaceInfo } from "./context";
 
 export const MANUAL_GEOJSON_DISTANCES = {
   [IPCC_PLACE_50_TYPE_DCID]: 0.5,
 };
 
 export function fetchGeoJson(
-  placeInfo: PlaceInfo,
+  parentPlace: string,
+  childType: string,
   setGeoJson: (data: GeoJsonData) => void
 ): void {
   console.log("fetch geo json data");
   axios
     .get(
-      `/api/choropleth/geojson?placeDcid=${placeInfo.enclosingPlace.dcid}&placeType=${placeInfo.enclosedPlaceType}`
+      `/api/choropleth/geojson?placeDcid=${parentPlace}&placeType=${childType}`
     )
     .then((resp) => {
       setGeoJson(resp.data);

--- a/static/js/tools/map/geojson.ts
+++ b/static/js/tools/map/geojson.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Geo Json data.
+ */
+
+import axios from "axios";
+
+import { GeoJsonData, GeoJsonFeature } from "../../chart/types";
+import { IPCC_PLACE_50_TYPE_DCID } from "../../shared/constants";
+import { PlaceInfo } from "./context";
+
+export const MANUAL_GEOJSON_DISTANCES = {
+  [IPCC_PLACE_50_TYPE_DCID]: 0.5,
+};
+
+export function fetchGeoJson(
+  placeInfo: PlaceInfo,
+  setGeoJson: (data: GeoJsonData) => void
+): void {
+  axios
+    .get(
+      `/api/choropleth/geojson?placeDcid=${placeInfo.enclosingPlace.dcid}&placeType=${placeInfo.enclosedPlaceType}`
+    )
+    .then((resp) => {
+      setGeoJson(resp.data);
+    });
+}
+
+export function getGeoJsonDataFeatures(
+  placeDcids: string[],
+  enclosedPlaceType: string
+): GeoJsonFeature[] {
+  const distance = MANUAL_GEOJSON_DISTANCES[enclosedPlaceType];
+  if (!distance) {
+    return [];
+  }
+  const geoJsonFeatures = [];
+  for (const placeDcid of placeDcids) {
+    const dcidPrefixSuffix = placeDcid.split("/");
+    if (dcidPrefixSuffix.length < 2) {
+      continue;
+    }
+    const latlon = dcidPrefixSuffix[1].split("_");
+    if (latlon.length < 2) {
+      continue;
+    }
+    const neLat = Number(latlon[0]) + distance / 2;
+    const neLon = Number(latlon[1]) + distance / 2;
+    const placeName = `${latlon[0]}, ${latlon[1]} (${distance} arc degree)`;
+    // TODO: handle cases of overflowing 180 near the international date line
+    // becasuse not sure if drawing libraries can handle this
+    geoJsonFeatures.push({
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [neLon, neLat],
+              [neLon, neLat - distance],
+              [neLon - distance, neLat - distance],
+              [neLon - distance, neLat],
+              [neLon, neLat],
+            ],
+          ],
+        ],
+      },
+      id: placeDcid,
+      properties: { geoDcid: placeDcid, name: placeName },
+      type: "Feature",
+    });
+  }
+  return geoJsonFeatures;
+}


### PR DESCRIPTION
This is a start of efforts to simplify and speed up map tool by having multiple data fetch components. 

The rendering will be based on needed data instead of all data ready.

Also removed "showChart" check for <ChartLoader> in app.js. This turns out reducing the network request from around 60 to 30 for the first chart load (duplicated data request). The checking is moved into chart_loader.tsx. This also reduces extra geojson fetch when geo types do not change.