### PR TITLE
[map refactor] Add data fetcher modules and a chart store

### DIFF
--- a/static/js/shared/stat_types.ts
+++ b/static/js/shared/stat_types.ts
@@ -37,8 +37,18 @@ export interface EntityObservation {
   [entity: string]: Observation;
 }
 
+export interface EntityObservationWrapper {
+  data: EntityObservation;
+  facets: FacetStore;
+}
+
 export interface EntityObservationList {
   [entity: string]: Observation[];
+}
+
+export interface EntityObservationListWrapper {
+  data: EntityObservationList;
+  facets: FacetStore;
 }
 
 export interface Series {
@@ -51,33 +61,38 @@ export interface EntitySeries {
   [entity: string]: Series;
 }
 
+export interface EntitySeriesWrapper {
+  data: EntitySeries;
+  facets: FacetStore;
+}
+
 export interface EntitySeriesList {
   [entity: string]: Series[];
 }
 
 export interface SeriesApiResponse {
-  facets: Record<string, StatMetadata>;
+  facets: FacetStore;
   data: {
     [variable: string]: EntitySeries;
   };
 }
 
 export interface SeriesAllApiResponse {
-  facets: Record<string, StatMetadata>;
+  facets: FacetStore;
   data: {
     [variable: string]: EntitySeriesList;
   };
 }
 
 export interface PointApiResponse {
-  facets: Record<string, StatMetadata>;
+  facets: FacetStore;
   data: {
     [variable: string]: EntityObservation;
   };
 }
 
 export interface PointAllApiResponse {
-  facets: Record<string, StatMetadata>;
+  facets: FacetStore;
   data: {
     [variable: string]: EntityObservationList;
   };
@@ -97,3 +112,5 @@ export interface PlaceStatDateWithinPlace {
 export interface GetPlaceStatDateWithinPlaceResponse {
   data: Record<string, Record<string, Array<PlaceStatDateWithinPlace>>>;
 }
+
+export type FacetStore = Record<string, StatMetadata>;

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -23,13 +23,7 @@ import axios from "axios";
 import geoblaze from "geoblaze";
 import { GeoRaster } from "georaster-layer-for-leaflet";
 import _ from "lodash";
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useReducer,
-  useState,
-} from "react";
+import React, { useContext, useEffect, useReducer, useState } from "react";
 
 import { GeoJsonData, MapPoint } from "../../chart/types";
 import { EUROPE_NAMED_TYPED_PLACE } from "../../shared/constants";
@@ -67,6 +61,16 @@ import {
 } from "./context";
 import { fetchGeoJson } from "./geojson";
 import { PlaceDetails } from "./place_details";
+import {
+  useAllStatReady,
+  useBreadcrumbDenomStatReady,
+  useBreadcrumbStatReady,
+  useDefaultStatReady,
+  useDenomStatReady,
+  useGeoJsonReady,
+  useMapPointCoordinateReady,
+  useMapPointStatReady,
+} from "./ready_hook";
 import {
   BEST_AVAILABLE_METAHASH,
   DataPointMetadata,
@@ -139,137 +143,18 @@ export function ChartLoader(): JSX.Element {
   // }, []);
 
   // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-  // START useReducer
   const [chartStore, dispatch] = useReducer(chartStoreReducer, emptyChartStore);
-  // END useReducer
   // -------------------------------------------------------------------------
 
   // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-  // The functions below are memoized and only change when the dependant
-  // variables change.
-  const geoJsonReady = useCallback(() => {
-    const c = chartStore.geoJson.context;
-    return (
-      !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType
-    );
-  }, [
-    chartStore.geoJson.context,
-    placeInfo.value.enclosingPlace.dcid,
-    placeInfo.value.enclosedPlaceType,
-  ]);
-
-  const defaultStatReady = useCallback(() => {
-    const c = chartStore.defaultStat.context;
-    return (
-      !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
-      statVar.value.dcid == c.statVar.dcid &&
-      statVar.value.date == c.statVar.date
-    );
-  }, [
-    chartStore.defaultStat.context,
-    placeInfo.value.enclosingPlace.dcid,
-    placeInfo.value.enclosedPlaceType,
-    statVar.value.dcid,
-    statVar.value.date,
-  ]);
-
-  const allStatReady = useCallback(() => {
-    const c = chartStore.allStat.context;
-    return (
-      !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
-      statVar.value.dcid == c.statVar.dcid &&
-      statVar.value.date == c.statVar.date
-    );
-  }, [
-    chartStore.allStat.context,
-    placeInfo.value.enclosingPlace.dcid,
-    placeInfo.value.enclosedPlaceType,
-    statVar.value.dcid,
-    statVar.value.date,
-  ]);
-
-  const denomStatReady = useCallback(() => {
-    const c = chartStore.denomStat.context;
-    console.log("denomStatReady");
-    return (
-      !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
-      statVar.value.denom == c.statVar.denom
-    );
-  }, [
-    chartStore.denomStat.context,
-    placeInfo.value.enclosingPlace.dcid,
-    placeInfo.value.enclosedPlaceType,
-    statVar.value.denom,
-  ]);
-
-  const breadcrumbStatReady = useCallback(() => {
-    const c = chartStore.breadcrumbStat.context;
-    console.log("breadcrumbStatReady");
-    return (
-      !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      statVar.value.dcid == c.statVar.dcid &&
-      statVar.value.date == c.statVar.date
-    );
-  }, [
-    chartStore.breadcrumbStat.context,
-    placeInfo.value.enclosingPlace.dcid,
-    statVar.value.dcid,
-    statVar.value.date,
-  ]);
-
-  const breadcrumbDenomStatReady = useCallback(() => {
-    const c = chartStore.breadcrumbDenomStat.context;
-    return (
-      !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      statVar.value.denom == c.statVar.denom
-    );
-  }, [
-    chartStore.breadcrumbDenomStat.context,
-    placeInfo.value.enclosingPlace.dcid,
-    statVar.value.denom,
-  ]);
-
-  const mapPointStatReady = useCallback(() => {
-    const c = chartStore.mapPointStat.context;
-    return (
-      !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.mapPointPlaceType == c.placeInfo.mapPointPlaceType &&
-      statVar.value.dcid == c.statVar.dcid &&
-      statVar.value.mapPointSv == c.statVar.mapPointSv &&
-      statVar.value.date == c.statVar.date
-    );
-  }, [
-    chartStore.mapPointStat.context,
-    placeInfo.value.enclosingPlace.dcid,
-    placeInfo.value.mapPointPlaceType,
-    statVar.value.dcid,
-    statVar.value.mapPointSv,
-    statVar.value.date,
-  ]);
-
-  const mapPointCoordinateReady = useCallback(() => {
-    const c = chartStore.mapPointCoordinate.context;
-    return (
-      !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.mapPointPlaceType == c.placeInfo.mapPointPlaceType
-    );
-  }, [
-    chartStore.mapPointCoordinate.context,
-    placeInfo.value.enclosingPlace.dcid,
-    placeInfo.value.mapPointPlaceType,
-  ]);
+  const geoJsonReady = useGeoJsonReady(chartStore);
+  const defaultStatReady = useDefaultStatReady(chartStore);
+  const allStatReady = useAllStatReady(chartStore);
+  const denomStatReady = useDenomStatReady(chartStore);
+  const breadcrumbStatReady = useBreadcrumbStatReady(chartStore);
+  const breadcrumbDenomStatReady = useBreadcrumbDenomStatReady(chartStore);
+  const mapPointStatReady = useMapPointStatReady(chartStore);
+  const mpPointCoordinateReady = useMapPointCoordinateReady(chartStore);
   // -------------------------------------------------------------------------
 
   // Fetch geojson data when page option is updated.

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -138,13 +138,13 @@ export function ChartLoader(): JSX.Element {
   //   };
   // }, []);
 
-  // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
   // START useReducer
   const [chartStore, dispatch] = useReducer(chartStoreReducer, emptyChartStore);
   // END useReducer
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
 
-  // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
   // The functions below are memoized and only change when the dependant
   // variables change.
   const geoJsonReady = useCallback(() => {
@@ -270,7 +270,7 @@ export function ChartLoader(): JSX.Element {
     placeInfo.value.enclosingPlace.dcid,
     placeInfo.value.mapPointPlaceType,
   ]);
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
 
   // Fetch geojson data when page option is updated.
   useEffect(() => {

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -154,7 +154,7 @@ export function ChartLoader(): JSX.Element {
   const breadcrumbStatReady = useBreadcrumbStatReady(chartStore);
   const breadcrumbDenomStatReady = useBreadcrumbDenomStatReady(chartStore);
   const mapPointStatReady = useMapPointStatReady(chartStore);
-  const mpPointCoordinateReady = useMapPointCoordinateReady(chartStore);
+  const mapPointCoordinateReady = useMapPointCoordinateReady(chartStore);
   // -------------------------------------------------------------------------
 
   // Fetch geojson data when page option is updated.

--- a/static/js/tools/map/chart_store.ts
+++ b/static/js/tools/map/chart_store.ts
@@ -35,34 +35,42 @@ export enum ChartDataType {
   mapPointCoordinate,
 }
 
-export interface ChartStoreData {
-  geoJson?: GeoJsonData;
-  defaultStat?: EntityObservationWrapper;
-  allStat?: EntityObservationListWrapper;
-  denomStat?: EntitySeriesWrapper;
-  breadcrumbStat?: EntityObservationWrapper;
-  breadcrumbDenomStat?: EntitySeriesWrapper;
-  mapPointStat?: EntityObservationWrapper;
-  mapPointCoordinates?: Array<MapPoint>;
-}
-
-export interface ChartStoreContext {
-  geoJson?: DataContext;
-  defaultStat?: DataContext;
-  allStat?: DataContext;
-  denomStat?: DataContext;
-  breadcrumbStat?: DataContext;
-  breadcrumbDenomStat?: DataContext;
-  mapPointStat?: DataContext;
-  mapPointCoordinate?: DataContext;
-}
-
 // ChartStore holds the raw data and corresponding context.
 // When context changes, the data fetch is async and could take long time. The
 // context here is used to check if the data context matches the actual context.
 export interface ChartStore {
-  data?: ChartStoreData;
-  context?: ChartStoreContext;
+  geoJson?: {
+    data: GeoJsonData;
+    context: DataContext;
+  };
+  defaultStat?: {
+    data: EntityObservationWrapper;
+    context: DataContext;
+  };
+  allStat?: {
+    data: EntityObservationListWrapper;
+    context: DataContext;
+  };
+  denomStat?: {
+    data: EntitySeriesWrapper;
+    context: DataContext;
+  };
+  breadcrumbStat?: {
+    data: EntityObservationWrapper;
+    context: DataContext;
+  };
+  breadcrumbDenomStat?: {
+    data: EntitySeriesWrapper;
+    context: DataContext;
+  };
+  mapPointStat?: {
+    data: EntityObservationWrapper;
+    context: DataContext;
+  };
+  mapPointCoordinates?: {
+    data: Array<MapPoint>;
+    context: DataContext;
+  };
 }
 
 /**
@@ -70,69 +78,69 @@ export interface ChartStore {
  *
  * Data is ready if the context in ChartStore matches the current context.
  *
- * @param c The data context from chart store.
+ * @param ctx The data context from chart store.
  * @param type The type of the data.
  * @param placeInfo The current placeInfo from the context.
  * @param statVar The current statVar from the context.
  * @returns
  */
 export const isDataReady = (
-  c: DataContext,
+  ctx: DataContext,
   type: ChartDataType,
   placeInfo: PlaceInfo,
   statVar: StatVar
 ): boolean => {
-  if (_.isEmpty(c)) {
+  if (_.isEmpty(ctx)) {
     return false;
   }
   switch (type) {
     case ChartDataType.geoJson:
       return (
-        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-        placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType
+        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
+        placeInfo.enclosedPlaceType === ctx.placeInfo.enclosedPlaceType
       );
     case ChartDataType.defaultStat:
       return (
-        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-        placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
-        statVar.dcid === c.statVar.dcid &&
-        statVar.date === c.statVar.date
+        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
+        placeInfo.enclosedPlaceType === ctx.placeInfo.enclosedPlaceType &&
+        statVar.dcid === ctx.statVar.dcid &&
+        statVar.date === ctx.statVar.date
       );
     case ChartDataType.allStat:
       return (
-        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-        placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
-        statVar.dcid === c.statVar.dcid &&
-        statVar.date === c.statVar.date
+        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
+        placeInfo.enclosedPlaceType === ctx.placeInfo.enclosedPlaceType &&
+        statVar.dcid === ctx.statVar.dcid &&
+        statVar.date === ctx.statVar.date
       );
     case ChartDataType.denomStat:
       return (
-        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-        placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
-        statVar.denom === c.statVar.denom
+        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
+        placeInfo.enclosedPlaceType === ctx.placeInfo.enclosedPlaceType &&
+        statVar.denom === ctx.statVar.denom
       );
     case ChartDataType.breadcrumbStat:
       return (
-        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-        statVar.dcid === c.statVar.dcid &&
-        statVar.date === c.statVar.date
+        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
+        statVar.dcid === ctx.statVar.dcid &&
+        statVar.date === ctx.statVar.date
       );
     case ChartDataType.breadcrumbDenomStat:
       return (
-        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-        statVar.denom === c.statVar.denom
+        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
+        statVar.denom === ctx.statVar.denom
       );
     case ChartDataType.mapPointStat:
       return (
-        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-        statVar.dcid === c.statVar.dcid &&
-        statVar.dcid === c.statVar.dcid &&
-        statVar.date === c.statVar.date
+        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
+        statVar.dcid === ctx.statVar.dcid &&
+        statVar.dcid === ctx.statVar.dcid &&
+        statVar.date === ctx.statVar.date
       );
     case ChartDataType.mapPointCoordinate:
       return (
-        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-        placeInfo.mapPointPlaceType === c.placeInfo.mapPointPlaceType
+        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
+        placeInfo.mapPointPlaceType === ctx.placeInfo.mapPointPlaceType
       );
   }
 };
@@ -152,9 +160,9 @@ export function chartStoreReducer(
 ): ChartStore {
   const field = ChartDataType[action.type];
   const newStore = _.cloneDeep(chartStore);
-  newStore.data[field] = action.payload;
+  newStore[field].data = action.payload;
   if (action.context) {
-    newStore.context[field] = action.context;
+    newStore[field].context = action.context;
   }
   return newStore;
 }

--- a/static/js/tools/map/chart_store.ts
+++ b/static/js/tools/map/chart_store.ts
@@ -57,11 +57,25 @@ export interface ChartStoreContext {
   mapPointCoordinate?: DataContext;
 }
 
+// ChartStore holds the raw data and corresponding context.
+// When context changes, the data fetch is async and could take long time. The
+// context here is used to check if the data context matches the actual context.
 export interface ChartStore {
   data?: ChartStoreData;
   context?: ChartStoreContext;
 }
 
+/**
+ * Check whether data is ready to use.
+ *
+ * Data is ready if the context in ChartStore matches the current context.
+ *
+ * @param c The data context from chart store.
+ * @param type The type of the data.
+ * @param placeInfo The current placeInfo from the context.
+ * @param statVar The current statVar from the context.
+ * @returns
+ */
 export const isDataReady = (
   c: DataContext,
   type: ChartDataType,
@@ -130,6 +144,8 @@ export interface ChartStoreAction {
   error?: string;
 }
 
+// A reducer used by a useReducer() hook. It adds a type of data to the
+// ChartStore.
 export function chartStoreReducer(
   chartStore: ChartStore,
   action: ChartStoreAction

--- a/static/js/tools/map/chart_store.ts
+++ b/static/js/tools/map/chart_store.ts
@@ -25,14 +25,14 @@ import {
 import { DataContext } from "./context";
 
 export enum ChartDataType {
-  geoJson,
-  defaultStat,
-  allStat,
-  denomStat,
-  breadcrumbStat,
-  breadcrumbDenomStat,
-  mapPointStat,
-  mapPointCoordinate,
+  GEO_JSON = "geoJson",
+  DEFAULT_STAT = "defaultStat",
+  ALL_STAT = "allStat",
+  DENOM_STAT = "denomStat",
+  BREADCRUMB_STAT = "breadcrumbStat",
+  BREADCRUMB_DENOM_STAT = "breadcrumbDenomStat",
+  MAP_POINT_STAT = "mapPointStat",
+  MAP_POINT_COORDINATE = "mapPointCoordinate",
 }
 
 // ChartStore holds the raw data and corresponding context.

--- a/static/js/tools/map/chart_store.ts
+++ b/static/js/tools/map/chart_store.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import _ from "lodash";
+
+import { GeoJsonData, MapPoint } from "../../chart/types";
+import {
+  EntityObservationListWrapper,
+  EntityObservationWrapper,
+  EntitySeriesWrapper,
+} from "../../shared/stat_types";
+import { DataContext, PlaceInfo, StatVar } from "./context";
+
+export enum ChartDataType {
+  geoJson,
+  defaultStat,
+  allStat,
+  denomStat,
+  breadcrumbStat,
+  breadcrumbDenomStat,
+  mapPointStat,
+  mapPointCoordinates,
+}
+
+export interface ChartStoreData {
+  geoJson?: GeoJsonData;
+  defaultStat?: EntityObservationWrapper;
+  allStat?: EntityObservationListWrapper;
+  denomStat?: EntitySeriesWrapper;
+  breadcrumbStat?: EntityObservationWrapper;
+  breadcrumbDenomStat?: EntitySeriesWrapper;
+  mapPointStat?: EntityObservationWrapper;
+  mapPointCoordinates?: Array<MapPoint>;
+}
+
+export interface ChartStoreContext {
+  geoJson?: DataContext;
+  defaultStat?: DataContext;
+  allStat?: DataContext;
+  denomStat?: DataContext;
+  breadcrumbStat?: DataContext;
+  breadcrumbDenomStat?: DataContext;
+  mapPointStat?: DataContext;
+  mapPointCoordinate?: DataContext;
+}
+
+export interface ChartStore {
+  data?: ChartStoreData;
+  context?: ChartStoreContext;
+}
+
+export const geoJsonReady = (
+  context: ChartStoreContext,
+  placeInfo: PlaceInfo
+) => {
+  const c = context.geoJson;
+  return (
+    !_.isEmpty(c) &&
+    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.enclosedPlaceType == c.placeInfo.enclosedPlaceType
+  );
+};
+
+export const defaultStatReady = (
+  context: ChartStoreContext,
+  placeInfo: PlaceInfo,
+  statVar: StatVar
+) => {
+  const c = context.defaultStat;
+  return (
+    !_.isEmpty(c) &&
+    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
+    statVar.dcid == c.statVar.dcid &&
+    statVar.date == c.statVar.date
+  );
+};
+
+export const allStatReady = (
+  context: ChartStoreContext,
+  placeInfo: PlaceInfo,
+  statVar: StatVar
+) => {
+  const c = context.allStat;
+  return (
+    !_.isEmpty(c) &&
+    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
+    statVar.dcid == c.statVar.dcid &&
+    statVar.date == c.statVar.date
+  );
+};
+
+export const denomStatReady = (
+  context: ChartStoreContext,
+  placeInfo: PlaceInfo,
+  statVar: StatVar
+) => {
+  const c = context.denomStat;
+  return (
+    !_.isEmpty(c) &&
+    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
+    statVar.denom == c.statVar.denom
+  );
+};
+
+export const breadcrumbStatReady = (
+  context: ChartStoreContext,
+  placeInfo: PlaceInfo,
+  statVar: StatVar
+) => {
+  const c = context.breadcrumbStat;
+  return (
+    !_.isEmpty(c) &&
+    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+    statVar.dcid == c.statVar.dcid &&
+    statVar.date == c.statVar.date
+  );
+};
+
+export const breadcrumbDenomStatReady = (
+  context: ChartStoreContext,
+  placeInfo: PlaceInfo,
+  statVar: StatVar
+) => {
+  const c = context.breadcrumbDenomStat;
+  return (
+    !_.isEmpty(c) &&
+    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+    statVar.denom == c.statVar.denom
+  );
+};
+
+export const mapPointStatReady = (
+  context: ChartStoreContext,
+  placeInfo: PlaceInfo,
+  statVar: StatVar
+) => {
+  const c = context.mapPointStat;
+  return (
+    !_.isEmpty(c) &&
+    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+    statVar.dcid == c.statVar.dcid &&
+    statVar.dcid == c.statVar.dcid &&
+    statVar.date == c.statVar.date
+  );
+};
+
+export const mapPointCoordinateReady = (
+  context: ChartStoreContext,
+  placeInfo: PlaceInfo
+) => {
+  const c = context.mapPointCoordinate;
+  return (
+    !_.isEmpty(c) &&
+    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.mapPointPlaceType == c.placeInfo.mapPointPlaceType
+  );
+};
+
+export interface ChartStoreAction {
+  type: ChartDataType;
+  payload: any;
+  context?: DataContext;
+}
+
+export function chartStoreReducer(
+  chartStore: ChartStore,
+  action: ChartStoreAction
+): ChartStore {
+  const field = ChartDataType[action.type];
+  const newStore = _.cloneDeep(chartStore);
+  newStore.data[field] = action.payload;
+  if (action.context) {
+    newStore.context[field] = action.context;
+  }
+  return newStore;
+}

--- a/static/js/tools/map/chart_store.ts
+++ b/static/js/tools/map/chart_store.ts
@@ -32,7 +32,7 @@ export enum ChartDataType {
   breadcrumbStat,
   breadcrumbDenomStat,
   mapPointStat,
-  mapPointCoordinates,
+  mapPointCoordinate,
 }
 
 export interface ChartStoreData {
@@ -62,120 +62,72 @@ export interface ChartStore {
   context?: ChartStoreContext;
 }
 
-export const geoJsonReady = (
-  context: ChartStoreContext,
-  placeInfo: PlaceInfo
-) => {
-  const c = context.geoJson;
-  return (
-    !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType
-  );
-};
-
-export const defaultStatReady = (
-  context: ChartStoreContext,
+export const isDataReady = (
+  c: DataContext,
+  type: ChartDataType,
   placeInfo: PlaceInfo,
   statVar: StatVar
-) => {
-  const c = context.defaultStat;
-  return (
-    !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
-    statVar.dcid === c.statVar.dcid &&
-    statVar.date === c.statVar.date
-  );
-};
-
-export const allStatReady = (
-  context: ChartStoreContext,
-  placeInfo: PlaceInfo,
-  statVar: StatVar
-) => {
-  const c = context.allStat;
-  return (
-    !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
-    statVar.dcid === c.statVar.dcid &&
-    statVar.date === c.statVar.date
-  );
-};
-
-export const denomStatReady = (
-  context: ChartStoreContext,
-  placeInfo: PlaceInfo,
-  statVar: StatVar
-) => {
-  const c = context.denomStat;
-  return (
-    !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
-    statVar.denom === c.statVar.denom
-  );
-};
-
-export const breadcrumbStatReady = (
-  context: ChartStoreContext,
-  placeInfo: PlaceInfo,
-  statVar: StatVar
-) => {
-  const c = context.breadcrumbStat;
-  return (
-    !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-    statVar.dcid === c.statVar.dcid &&
-    statVar.date === c.statVar.date
-  );
-};
-
-export const breadcrumbDenomStatReady = (
-  context: ChartStoreContext,
-  placeInfo: PlaceInfo,
-  statVar: StatVar
-) => {
-  const c = context.breadcrumbDenomStat;
-  return (
-    !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-    statVar.denom === c.statVar.denom
-  );
-};
-
-export const mapPointStatReady = (
-  context: ChartStoreContext,
-  placeInfo: PlaceInfo,
-  statVar: StatVar
-) => {
-  const c = context.mapPointStat;
-  return (
-    !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-    statVar.dcid === c.statVar.dcid &&
-    statVar.dcid === c.statVar.dcid &&
-    statVar.date === c.statVar.date
-  );
-};
-
-export const mapPointCoordinateReady = (
-  context: ChartStoreContext,
-  placeInfo: PlaceInfo
-) => {
-  const c = context.mapPointCoordinate;
-  return (
-    !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.mapPointPlaceType === c.placeInfo.mapPointPlaceType
-  );
+): boolean => {
+  if (_.isEmpty(c)) {
+    return false;
+  }
+  switch (type) {
+    case ChartDataType.geoJson:
+      return (
+        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+        placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType
+      );
+    case ChartDataType.defaultStat:
+      return (
+        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+        placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
+        statVar.dcid === c.statVar.dcid &&
+        statVar.date === c.statVar.date
+      );
+    case ChartDataType.allStat:
+      return (
+        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+        placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
+        statVar.dcid === c.statVar.dcid &&
+        statVar.date === c.statVar.date
+      );
+    case ChartDataType.denomStat:
+      return (
+        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+        placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
+        statVar.denom === c.statVar.denom
+      );
+    case ChartDataType.breadcrumbStat:
+      return (
+        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+        statVar.dcid === c.statVar.dcid &&
+        statVar.date === c.statVar.date
+      );
+    case ChartDataType.breadcrumbDenomStat:
+      return (
+        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+        statVar.denom === c.statVar.denom
+      );
+    case ChartDataType.mapPointStat:
+      return (
+        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+        statVar.dcid === c.statVar.dcid &&
+        statVar.dcid === c.statVar.dcid &&
+        statVar.date === c.statVar.date
+      );
+    case ChartDataType.mapPointCoordinate:
+      return (
+        placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+        placeInfo.mapPointPlaceType === c.placeInfo.mapPointPlaceType
+      );
+  }
 };
 
 export interface ChartStoreAction {
   type: ChartDataType;
-  payload: any;
+  payload?: any;
   context?: DataContext;
+  error?: string;
 }
 
 export function chartStoreReducer(

--- a/static/js/tools/map/chart_store.ts
+++ b/static/js/tools/map/chart_store.ts
@@ -22,7 +22,7 @@ import {
   EntityObservationWrapper,
   EntitySeriesWrapper,
 } from "../../shared/stat_types";
-import { DataContext, PlaceInfo, StatVar } from "./context";
+import { DataContext } from "./context";
 
 export enum ChartDataType {
   geoJson,
@@ -67,7 +67,7 @@ export interface ChartStore {
     data: EntityObservationWrapper;
     context?: DataContext;
   };
-  mapPointCoordinates: {
+  mapPointCoordinate: {
     data: Array<MapPoint>;
     context?: DataContext;
   };
@@ -95,85 +95,9 @@ export const emptyChartStore = {
   mapPointStat: {
     data: null,
   },
-  mapPointCoordinates: {
+  mapPointCoordinate: {
     data: null,
   },
-};
-
-/**
- * Check whether data is ready to use.
- *
- * Data is ready if the context in ChartStore matches the current context.
- *
- * @param ctx The data context from chart store.
- * @param type The type of the data.
- * @param placeInfo The current placeInfo from the context.
- * @param statVar The current statVar from the context.
- * @returns
- */
-export const isDataReady = (
-  dataWrapper: { data: any; context?: DataContext },
-  type: ChartDataType,
-  placeInfo: PlaceInfo,
-  statVar: StatVar
-): boolean => {
-  if (_.isEmpty(dataWrapper)) {
-    return false;
-  }
-  const ctx = dataWrapper.context;
-  if (_.isEmpty(ctx)) {
-    return false;
-  }
-  switch (type) {
-    case ChartDataType.geoJson:
-      return (
-        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
-        placeInfo.enclosedPlaceType === ctx.placeInfo.enclosedPlaceType
-      );
-    case ChartDataType.defaultStat:
-      return (
-        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
-        placeInfo.enclosedPlaceType === ctx.placeInfo.enclosedPlaceType &&
-        statVar.dcid === ctx.statVar.dcid &&
-        statVar.date === ctx.statVar.date
-      );
-    case ChartDataType.allStat:
-      return (
-        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
-        placeInfo.enclosedPlaceType === ctx.placeInfo.enclosedPlaceType &&
-        statVar.dcid === ctx.statVar.dcid &&
-        statVar.date === ctx.statVar.date
-      );
-    case ChartDataType.denomStat:
-      return (
-        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
-        placeInfo.enclosedPlaceType === ctx.placeInfo.enclosedPlaceType &&
-        statVar.denom === ctx.statVar.denom
-      );
-    case ChartDataType.breadcrumbStat:
-      return (
-        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
-        statVar.dcid === ctx.statVar.dcid &&
-        statVar.date === ctx.statVar.date
-      );
-    case ChartDataType.breadcrumbDenomStat:
-      return (
-        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
-        statVar.denom === ctx.statVar.denom
-      );
-    case ChartDataType.mapPointStat:
-      return (
-        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
-        statVar.dcid === ctx.statVar.dcid &&
-        statVar.dcid === ctx.statVar.dcid &&
-        statVar.date === ctx.statVar.date
-      );
-    case ChartDataType.mapPointCoordinate:
-      return (
-        placeInfo.enclosingPlace.dcid === ctx.placeInfo.enclosingPlace.dcid &&
-        placeInfo.mapPointPlaceType === ctx.placeInfo.mapPointPlaceType
-      );
-  }
 };
 
 export interface ChartStoreAction {

--- a/static/js/tools/map/chart_store.ts
+++ b/static/js/tools/map/chart_store.ts
@@ -69,8 +69,8 @@ export const geoJsonReady = (
   const c = context.geoJson;
   return (
     !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.enclosedPlaceType == c.placeInfo.enclosedPlaceType
+    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType
   );
 };
 
@@ -82,10 +82,10 @@ export const defaultStatReady = (
   const c = context.defaultStat;
   return (
     !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
-    statVar.dcid == c.statVar.dcid &&
-    statVar.date == c.statVar.date
+    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
+    statVar.dcid === c.statVar.dcid &&
+    statVar.date === c.statVar.date
   );
 };
 
@@ -97,10 +97,10 @@ export const allStatReady = (
   const c = context.allStat;
   return (
     !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
-    statVar.dcid == c.statVar.dcid &&
-    statVar.date == c.statVar.date
+    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
+    statVar.dcid === c.statVar.dcid &&
+    statVar.date === c.statVar.date
   );
 };
 
@@ -112,9 +112,9 @@ export const denomStatReady = (
   const c = context.denomStat;
   return (
     !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
-    statVar.denom == c.statVar.denom
+    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
+    statVar.denom === c.statVar.denom
   );
 };
 
@@ -126,9 +126,9 @@ export const breadcrumbStatReady = (
   const c = context.breadcrumbStat;
   return (
     !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-    statVar.dcid == c.statVar.dcid &&
-    statVar.date == c.statVar.date
+    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+    statVar.dcid === c.statVar.dcid &&
+    statVar.date === c.statVar.date
   );
 };
 
@@ -140,8 +140,8 @@ export const breadcrumbDenomStatReady = (
   const c = context.breadcrumbDenomStat;
   return (
     !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-    statVar.denom == c.statVar.denom
+    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+    statVar.denom === c.statVar.denom
   );
 };
 
@@ -153,10 +153,10 @@ export const mapPointStatReady = (
   const c = context.mapPointStat;
   return (
     !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-    statVar.dcid == c.statVar.dcid &&
-    statVar.dcid == c.statVar.dcid &&
-    statVar.date == c.statVar.date
+    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+    statVar.dcid === c.statVar.dcid &&
+    statVar.dcid === c.statVar.dcid &&
+    statVar.date === c.statVar.date
   );
 };
 
@@ -167,8 +167,8 @@ export const mapPointCoordinateReady = (
   const c = context.mapPointCoordinate;
   return (
     !_.isEmpty(c) &&
-    placeInfo.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-    placeInfo.mapPointPlaceType == c.placeInfo.mapPointPlaceType
+    placeInfo.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+    placeInfo.mapPointPlaceType === c.placeInfo.mapPointPlaceType
   );
 };
 

--- a/static/js/tools/map/chart_store.ts
+++ b/static/js/tools/map/chart_store.ts
@@ -39,39 +39,66 @@ export enum ChartDataType {
 // When context changes, the data fetch is async and could take long time. The
 // context here is used to check if the data context matches the actual context.
 export interface ChartStore {
-  geoJson?: {
+  geoJson: {
     data: GeoJsonData;
-    context: DataContext;
+    context?: DataContext;
   };
-  defaultStat?: {
+  defaultStat: {
     data: EntityObservationWrapper;
-    context: DataContext;
+    context?: DataContext;
   };
-  allStat?: {
+  allStat: {
     data: EntityObservationListWrapper;
-    context: DataContext;
+    context?: DataContext;
   };
-  denomStat?: {
+  denomStat: {
     data: EntitySeriesWrapper;
-    context: DataContext;
+    context?: DataContext;
   };
-  breadcrumbStat?: {
+  breadcrumbStat: {
     data: EntityObservationWrapper;
-    context: DataContext;
+    context?: DataContext;
   };
-  breadcrumbDenomStat?: {
+  breadcrumbDenomStat: {
     data: EntitySeriesWrapper;
-    context: DataContext;
+    context?: DataContext;
   };
-  mapPointStat?: {
+  mapPointStat: {
     data: EntityObservationWrapper;
-    context: DataContext;
+    context?: DataContext;
   };
-  mapPointCoordinates?: {
+  mapPointCoordinates: {
     data: Array<MapPoint>;
-    context: DataContext;
+    context?: DataContext;
   };
 }
+
+export const emptyChartStore = {
+  geoJson: {
+    data: null,
+  },
+  defaultStat: {
+    data: null,
+  },
+  allStat: {
+    data: null,
+  },
+  denomStat: {
+    data: null,
+  },
+  breadcrumbStat: {
+    data: null,
+  },
+  breadcrumbDenomStat: {
+    data: null,
+  },
+  mapPointStat: {
+    data: null,
+  },
+  mapPointCoordinates: {
+    data: null,
+  },
+};
 
 /**
  * Check whether data is ready to use.
@@ -85,11 +112,15 @@ export interface ChartStore {
  * @returns
  */
 export const isDataReady = (
-  ctx: DataContext,
+  dataWrapper: { data: any; context?: DataContext },
   type: ChartDataType,
   placeInfo: PlaceInfo,
   statVar: StatVar
 ): boolean => {
+  if (_.isEmpty(dataWrapper)) {
+    return false;
+  }
+  const ctx = dataWrapper.context;
   if (_.isEmpty(ctx)) {
     return false;
   }
@@ -160,7 +191,7 @@ export function chartStoreReducer(
 ): ChartStore {
   const field = ChartDataType[action.type];
   const newStore = _.cloneDeep(chartStore);
-  newStore[field].data = action.payload;
+  newStore[field] = { data: action.payload };
   if (action.context) {
     newStore[field].context = action.context;
   }

--- a/static/js/tools/map/context.ts
+++ b/static/js/tools/map/context.ts
@@ -33,19 +33,19 @@ import {
 // Information relating to the stat var to plot
 export interface StatVar {
   // additional information about stat vars. key is stat var dcid.
-  info: Record<string, StatVarInfo>;
+  info?: Record<string, StatVarInfo>;
   // dcid of the chosen stat var
-  dcid: string;
+  dcid?: string;
   // Whether to plot per capita values
-  perCapita: boolean;
+  perCapita?: boolean;
   // dcid of the stat var to use to calculate per capita
-  denom: string;
+  denom?: string;
   // date of the stat var data to get
-  date: string;
+  date?: string;
   // dcid of the stat var to use for map points
-  mapPointSv: string;
+  mapPointSv?: string;
   // metahash of the source to get data from
-  metahash: string;
+  metahash?: string;
 }
 
 // Wraps StatVarInfo with its setters
@@ -65,15 +65,15 @@ export interface StatVarWrapper {
 // Information relating to the places to plot
 export interface PlaceInfo {
   // The current place that has been selected
-  selectedPlace: NamedTypedPlace;
+  selectedPlace?: NamedTypedPlace;
   // The parent places of the selected place
-  parentPlaces: Array<NamedTypedPlace>;
+  parentPlaces?: Array<NamedTypedPlace>;
   // Place that encloses the places to plot
-  enclosingPlace: NamedPlace;
+  enclosingPlace?: NamedPlace;
   // The type of place to plot
-  enclosedPlaceType: string;
+  enclosedPlaceType?: string;
   // The type of place to show points on the map for
-  mapPointPlaceType: string;
+  mapPointPlaceType?: string;
 }
 
 // Wraps PlaceInfo with its setters
@@ -127,6 +127,11 @@ export interface DisplayOptionsWrapper {
   set: Setter<DisplayOptions>;
   setShowMapPoints: Setter<boolean>;
   setShowTimeSlider: Setter<boolean>;
+}
+
+export interface DataContext {
+  statVar?: StatVar;
+  placeInfo?: PlaceInfo;
 }
 
 export interface ContextType {

--- a/static/js/tools/map/fetcher/all_stat.ts
+++ b/static/js/tools/map/fetcher/all_stat.ts
@@ -40,7 +40,7 @@ export function fetchAllStat(
   dispatch: Dispatch<ChartStoreAction>
 ): void {
   const action: ChartStoreAction = {
-    type: ChartDataType.allStat,
+    type: ChartDataType.ALL_STAT,
     context: {
       placeInfo: {
         enclosingPlace: {

--- a/static/js/tools/map/fetcher/all_stat.ts
+++ b/static/js/tools/map/fetcher/all_stat.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch all facets stat data.
+ */
+
+import axios from "axios";
+import { Dispatch } from "react";
+
+import {
+  EntityObservationListWrapper,
+  PointAllApiResponse,
+} from "../../../shared/stat_types";
+import { stringifyFn } from "../../../utils/axios";
+import { ChartDataType, ChartStoreAction } from "../chart_store";
+import { getDate } from "../util";
+
+export function fetchAllStat(
+  parentEntity: string,
+  childType: string,
+  statVar: string,
+  date: string,
+  dispatch: Dispatch<ChartStoreAction>
+): void {
+  axios
+    .get<PointAllApiResponse>("/api/observations/point/within/all", {
+      params: {
+        child_type: childType,
+        date: getDate(statVar, date),
+        parent_entity: parentEntity,
+        variables: [statVar],
+      },
+      paramsSerializer: stringifyFn,
+    })
+    .then((resp) => {
+      dispatch({
+        type: ChartDataType.allStat,
+        payload: {
+          data: resp.data.data[statVar],
+          facets: resp.data.facets,
+        } as EntityObservationListWrapper,
+        context: {
+          placeInfo: {
+            enclosingPlace: {
+              dcid: parentEntity,
+              name: "",
+            },
+            enclosedPlaceType: childType,
+          },
+          statVar: {
+            dcid: statVar,
+            date: date,
+          },
+        },
+      });
+      console.log("all stat dispatched");
+    });
+}

--- a/static/js/tools/map/fetcher/all_stat.ts
+++ b/static/js/tools/map/fetcher/all_stat.ts
@@ -63,7 +63,7 @@ export function fetchAllStat(
           },
           statVar: {
             dcid: statVar,
-            date: date,
+            date,
           },
         },
       });

--- a/static/js/tools/map/fetcher/all_stat.ts
+++ b/static/js/tools/map/fetcher/all_stat.ts
@@ -18,6 +18,8 @@
  * Fetch all facets stat data.
  */
 
+// TODO(shifucun): remove all the console.log() debugging.
+
 import axios from "axios";
 import _ from "lodash";
 import { Dispatch } from "react";

--- a/static/js/tools/map/fetcher/breadcrumb_denom_stat.ts
+++ b/static/js/tools/map/fetcher/breadcrumb_denom_stat.ts
@@ -39,7 +39,8 @@ export function fetchBreadcrumbDenomStat(
     context: {
       placeInfo: {
         enclosingPlace: {
-          // The last place is the selected place.
+          // entities are the parent places + the enclosing place.
+          // so the last element is the enclosing place.
           dcid: entities[entities.length - 1],
           name: "",
         },

--- a/static/js/tools/map/fetcher/breadcrumb_denom_stat.ts
+++ b/static/js/tools/map/fetcher/breadcrumb_denom_stat.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch the breadcrumb (parent places) denominator stat data
+ */
+
+import axios from "axios";
+import { Dispatch } from "react";
+
+import {
+  EntitySeriesWrapper,
+  SeriesApiResponse,
+} from "../../../shared/stat_types";
+import { stringifyFn } from "../../../utils/axios";
+import { ChartDataType, ChartStoreAction } from "../chart_store";
+
+export function fetchBreadcrumbDenomStat(
+  entities: string[],
+  statVar: string,
+  dispatch: Dispatch<ChartStoreAction>
+): void {
+  axios
+    .get<SeriesApiResponse>("/api/observations/series", {
+      params: {
+        entities: entities,
+        variables: [statVar],
+      },
+      paramsSerializer: stringifyFn,
+    })
+    .then((resp) => {
+      dispatch({
+        type: ChartDataType.breadcrumbDenomStat,
+        payload: {
+          data: resp.data.data[statVar],
+          facets: resp.data.facets,
+        } as EntitySeriesWrapper,
+        context: {
+          placeInfo: {
+            enclosingPlace: {
+              // The last place is the selected place.
+              dcid: entities[entities.length - 1],
+              name: "",
+            },
+          },
+          statVar: {
+            denom: statVar,
+          },
+        },
+      });
+      console.log("breadcrumb denom stat dispatched");
+    });
+}

--- a/static/js/tools/map/fetcher/breadcrumb_denom_stat.ts
+++ b/static/js/tools/map/fetcher/breadcrumb_denom_stat.ts
@@ -35,7 +35,7 @@ export function fetchBreadcrumbDenomStat(
   dispatch: Dispatch<ChartStoreAction>
 ): void {
   const action: ChartStoreAction = {
-    type: ChartDataType.breadcrumbDenomStat,
+    type: ChartDataType.BREADCRUMB_DENOM_STAT,
     context: {
       placeInfo: {
         enclosingPlace: {

--- a/static/js/tools/map/fetcher/breadcrumb_stat.ts
+++ b/static/js/tools/map/fetcher/breadcrumb_stat.ts
@@ -37,7 +37,7 @@ export function fetchBreadcrumbStat(
   dispatch: Dispatch<ChartStoreAction>
 ): void {
   const action: ChartStoreAction = {
-    type: ChartDataType.breadcrumbStat,
+    type: ChartDataType.BREADCRUMB_STAT,
     context: {
       placeInfo: {
         enclosingPlace: {

--- a/static/js/tools/map/fetcher/breadcrumb_stat.ts
+++ b/static/js/tools/map/fetcher/breadcrumb_stat.ts
@@ -60,7 +60,7 @@ export function fetchBreadcrumbStat(
           },
           statVar: {
             dcid: statVar,
-            date: date,
+            date,
           },
         },
       });

--- a/static/js/tools/map/fetcher/breadcrumb_stat.ts
+++ b/static/js/tools/map/fetcher/breadcrumb_stat.ts
@@ -41,6 +41,8 @@ export function fetchBreadcrumbStat(
     context: {
       placeInfo: {
         enclosingPlace: {
+          // entities are the parent places + the enclosing place.
+          // so the last element is the enclosing place.
           dcid: entities[entities.length - 1],
           name: "",
         },

--- a/static/js/tools/map/fetcher/breadcrumb_stat.ts
+++ b/static/js/tools/map/fetcher/breadcrumb_stat.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch the breadcrumb (parent places) stat data
+ */
+
+import axios from "axios";
+import { Dispatch } from "react";
+
+import {
+  EntityObservationWrapper,
+  PointApiResponse,
+} from "../../../shared/stat_types";
+import { stringifyFn } from "../../../utils/axios";
+import { ChartDataType, ChartStoreAction } from "../chart_store";
+import { getDate } from "../util";
+
+export function fetchBreadcrumbStat(
+  entities: string[],
+  statVar: string,
+  date: string,
+  dispatch: Dispatch<ChartStoreAction>
+): void {
+  axios
+    .get<PointApiResponse>("/api/observations/point", {
+      params: {
+        date: getDate(statVar, date),
+        entities: entities,
+        variables: [statVar],
+      },
+      paramsSerializer: stringifyFn,
+    })
+    .then((resp) => {
+      dispatch({
+        type: ChartDataType.breadcrumbStat,
+        payload: {
+          data: resp.data.data[statVar],
+          facets: resp.data.facets,
+        } as EntityObservationWrapper,
+        context: {
+          placeInfo: {
+            enclosingPlace: {
+              dcid: entities[entities.length - 1],
+              name: "",
+            },
+          },
+          statVar: {
+            dcid: statVar,
+            date: date,
+          },
+        },
+      });
+      console.log("breadcrumb stat dispatched");
+    });
+}

--- a/static/js/tools/map/fetcher/default_stat.ts
+++ b/static/js/tools/map/fetcher/default_stat.ts
@@ -38,7 +38,7 @@ export function fetchDefaultStat(
   dispatch: Dispatch<ChartStoreAction>
 ): void {
   const action: ChartStoreAction = {
-    type: ChartDataType.defaultStat,
+    type: ChartDataType.DEFAULT_STAT,
     error: null,
     context: {
       placeInfo: {

--- a/static/js/tools/map/fetcher/default_stat.ts
+++ b/static/js/tools/map/fetcher/default_stat.ts
@@ -63,7 +63,7 @@ export function fetchDefaultStat(
           },
           statVar: {
             dcid: statVar,
-            date: date,
+            date,
           },
         },
       });

--- a/static/js/tools/map/fetcher/default_stat.ts
+++ b/static/js/tools/map/fetcher/default_stat.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch the default (best available) stat data
+ */
+
+import axios from "axios";
+import { Dispatch } from "react";
+
+import {
+  EntityObservationWrapper,
+  PointApiResponse,
+} from "../../../shared/stat_types";
+import { stringifyFn } from "../../../utils/axios";
+import { ChartDataType, ChartStoreAction } from "../chart_store";
+import { getDate } from "../util";
+
+export function fetchDefaultStat(
+  parentEntity: string,
+  childType: string,
+  statVar: string,
+  date: string,
+  dispatch: Dispatch<ChartStoreAction>
+): void {
+  axios
+    .get<PointApiResponse>("/api/observations/point/within", {
+      params: {
+        child_type: childType,
+        date: getDate(statVar, date),
+        parent_entity: parentEntity,
+        variables: [statVar],
+      },
+      paramsSerializer: stringifyFn,
+    })
+    .then((resp) => {
+      dispatch({
+        type: ChartDataType.defaultStat,
+        payload: {
+          data: resp.data.data[statVar],
+          facets: resp.data.facets,
+        } as EntityObservationWrapper,
+        context: {
+          placeInfo: {
+            enclosingPlace: {
+              dcid: parentEntity,
+              name: "",
+            },
+            enclosedPlaceType: childType,
+          },
+          statVar: {
+            dcid: statVar,
+            date: date,
+          },
+        },
+      });
+      console.log("default stat dispatched");
+    });
+}

--- a/static/js/tools/map/fetcher/denom_stat.ts
+++ b/static/js/tools/map/fetcher/denom_stat.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch the stat data for denominator stat var
+ */
+
+import axios from "axios";
+import { Dispatch } from "react";
+
+import {
+  EntitySeriesWrapper,
+  SeriesApiResponse,
+} from "../../../shared/stat_types";
+import { stringifyFn } from "../../../utils/axios";
+import { ChartDataType, ChartStoreAction } from "../chart_store";
+
+export function fetchDenomStat(
+  parentEntity: string,
+  childType: string,
+  statVar: string,
+  dispatch: Dispatch<ChartStoreAction>
+): void {
+  axios
+    .get<SeriesApiResponse>("/api/observations/series/within", {
+      params: {
+        child_type: childType,
+        parent_entity: parentEntity,
+        variables: [statVar],
+      },
+      paramsSerializer: stringifyFn,
+    })
+    .then((resp) => {
+      dispatch({
+        type: ChartDataType.denomStat,
+        payload: {
+          data: resp.data.data[statVar],
+          facets: resp.data.facets,
+        } as EntitySeriesWrapper,
+        context: {
+          placeInfo: {
+            enclosingPlace: {
+              // The last place is the selected place.
+              dcid: parentEntity,
+              name: "",
+            },
+            enclosedPlaceType: childType,
+          },
+          statVar: {
+            denom: statVar,
+          },
+        },
+      });
+      console.log("denom stat dispatched");
+    });
+}

--- a/static/js/tools/map/fetcher/denom_stat.ts
+++ b/static/js/tools/map/fetcher/denom_stat.ts
@@ -36,7 +36,7 @@ export function fetchDenomStat(
   dispatch: Dispatch<ChartStoreAction>
 ): void {
   const action: ChartStoreAction = {
-    type: ChartDataType.denomStat,
+    type: ChartDataType.DENOM_STAT,
     error: null,
     context: {
       placeInfo: {

--- a/static/js/tools/map/fetcher/denom_stat.ts
+++ b/static/js/tools/map/fetcher/denom_stat.ts
@@ -41,7 +41,6 @@ export function fetchDenomStat(
     context: {
       placeInfo: {
         enclosingPlace: {
-          // The last place is the selected place.
           dcid: parentEntity,
           name: "",
         },

--- a/static/js/tools/map/fetcher/european_countries.ts
+++ b/static/js/tools/map/fetcher/european_countries.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch european countries.
+ */
+
+import { EUROPE_NAMED_TYPED_PLACE } from "../../../shared/constants";
+import { NamedPlace } from "../../../shared/types";
+import { getEnclosedPlacesPromise } from "../../../utils/place_utils";
+
+export function fetchEuropeanCountries(
+  setEuropeanCountries: (data: Array<NamedPlace>) => void
+): void {
+  getEnclosedPlacesPromise(EUROPE_NAMED_TYPED_PLACE.dcid, "Country").then(
+    (resp: Array<NamedPlace>) => {
+      setEuropeanCountries(resp);
+      console.log("european countries loaded");
+    }
+  );
+}

--- a/static/js/tools/map/fetcher/geojson.ts
+++ b/static/js/tools/map/fetcher/geojson.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch Geo Json data.
+ */
+
+import axios from "axios";
+import { Dispatch } from "react";
+
+import { GeoJsonData, GeoJsonFeature } from "../../../chart/types";
+import { IPCC_PLACE_50_TYPE_DCID } from "../../../shared/constants";
+import { ChartDataType, ChartStoreAction } from "../chart_store";
+
+export const MANUAL_GEOJSON_DISTANCES = {
+  [IPCC_PLACE_50_TYPE_DCID]: 0.5,
+};
+
+export function fetchGeoJson(
+  parentPlace: string,
+  childType: string,
+  dispatch: Dispatch<ChartStoreAction>
+): void {
+  axios
+    .get(
+      `/api/choropleth/geojson?placeDcid=${parentPlace}&placeType=${childType}`
+    )
+    .then((resp) => {
+      dispatch({
+        type: ChartDataType.geoJson,
+        payload: resp.data as GeoJsonData,
+        context: {
+          placeInfo: {
+            enclosingPlace: {
+              dcid: parentPlace,
+              name: "",
+            },
+            enclosedPlaceType: childType,
+          },
+        },
+      });
+      console.log("geojson dispatched");
+    });
+}
+
+export function getGeoJsonDataFeatures(
+  placeDcids: string[],
+  enclosedPlaceType: string
+): GeoJsonFeature[] {
+  const distance = MANUAL_GEOJSON_DISTANCES[enclosedPlaceType];
+  if (!distance) {
+    return [];
+  }
+  const geoJsonFeatures = [];
+  for (const placeDcid of placeDcids) {
+    const dcidPrefixSuffix = placeDcid.split("/");
+    if (dcidPrefixSuffix.length < 2) {
+      continue;
+    }
+    const latlon = dcidPrefixSuffix[1].split("_");
+    if (latlon.length < 2) {
+      continue;
+    }
+    const neLat = Number(latlon[0]) + distance / 2;
+    const neLon = Number(latlon[1]) + distance / 2;
+    const placeName = `${latlon[0]}, ${latlon[1]} (${distance} arc degree)`;
+    // TODO: handle cases of overflowing 180 near the international date line
+    // becasuse not sure if drawing libraries can handle this
+    geoJsonFeatures.push({
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [neLon, neLat],
+              [neLon, neLat - distance],
+              [neLon - distance, neLat - distance],
+              [neLon - distance, neLat],
+              [neLon, neLat],
+            ],
+          ],
+        ],
+      },
+      id: placeDcid,
+      properties: { geoDcid: placeDcid, name: placeName },
+      type: "Feature",
+    });
+  }
+  return geoJsonFeatures;
+}

--- a/static/js/tools/map/fetcher/geojson.ts
+++ b/static/js/tools/map/fetcher/geojson.ts
@@ -31,7 +31,7 @@ export function fetchGeoJson(
   dispatch: Dispatch<ChartStoreAction>
 ): void {
   const action: ChartStoreAction = {
-    type: ChartDataType.geoJson,
+    type: ChartDataType.GEO_JSON,
     error: null,
     context: {
       placeInfo: {

--- a/static/js/tools/map/fetcher/geojson.ts
+++ b/static/js/tools/map/fetcher/geojson.ts
@@ -22,13 +22,8 @@ import axios from "axios";
 import _ from "lodash";
 import { Dispatch } from "react";
 
-import { GeoJsonData, GeoJsonFeature } from "../../../chart/types";
-import { IPCC_PLACE_50_TYPE_DCID } from "../../../shared/constants";
+import { GeoJsonData } from "../../../chart/types";
 import { ChartDataType, ChartStoreAction } from "../chart_store";
-
-export const MANUAL_GEOJSON_DISTANCES = {
-  [IPCC_PLACE_50_TYPE_DCID]: 0.5,
-};
 
 export function fetchGeoJson(
   parentPlace: string,
@@ -65,50 +60,4 @@ export function fetchGeoJson(
       action.error = "error fetching geo json data";
       dispatch(action);
     });
-}
-
-export function getGeoJsonDataFeatures(
-  placeDcids: string[],
-  enclosedPlaceType: string
-): GeoJsonFeature[] {
-  const distance = MANUAL_GEOJSON_DISTANCES[enclosedPlaceType];
-  if (!distance) {
-    return [];
-  }
-  const geoJsonFeatures = [];
-  for (const placeDcid of placeDcids) {
-    const dcidPrefixSuffix = placeDcid.split("/");
-    if (dcidPrefixSuffix.length < 2) {
-      continue;
-    }
-    const latlon = dcidPrefixSuffix[1].split("_");
-    if (latlon.length < 2) {
-      continue;
-    }
-    const neLat = Number(latlon[0]) + distance / 2;
-    const neLon = Number(latlon[1]) + distance / 2;
-    const placeName = `${latlon[0]}, ${latlon[1]} (${distance} arc degree)`;
-    // TODO: handle cases of overflowing 180 near the international date line
-    // becasuse not sure if drawing libraries can handle this
-    geoJsonFeatures.push({
-      geometry: {
-        type: "MultiPolygon",
-        coordinates: [
-          [
-            [
-              [neLon, neLat],
-              [neLon, neLat - distance],
-              [neLon - distance, neLat - distance],
-              [neLon - distance, neLat],
-              [neLon, neLat],
-            ],
-          ],
-        ],
-      },
-      id: placeDcid,
-      properties: { geoDcid: placeDcid, name: placeName },
-      type: "Feature",
-    });
-  }
-  return geoJsonFeatures;
 }

--- a/static/js/tools/map/fetcher/map_point_coordinate.ts
+++ b/static/js/tools/map/fetcher/map_point_coordinate.ts
@@ -32,7 +32,7 @@ export function fetchMapPointCoordinate(
   dispatch: Dispatch<ChartStoreAction>
 ): void {
   const action: ChartStoreAction = {
-    type: ChartDataType.mapPointCoordinate,
+    type: ChartDataType.MAP_POINT_COORDINATE,
     error: null,
     context: {
       placeInfo: {

--- a/static/js/tools/map/fetcher/map_point_coordinate.ts
+++ b/static/js/tools/map/fetcher/map_point_coordinate.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch the map point geo coordinates.
+ */
+
+import axios from "axios";
+import { Dispatch } from "react";
+
+import { MapPoint } from "../../../chart/types";
+import { stringifyFn } from "../../../utils/axios";
+import { ChartDataType, ChartStoreAction } from "../chart_store";
+
+export function fetchMapPointCoordinate(
+  parentEntity: string,
+  placeType: string,
+  dispatch: Dispatch<ChartStoreAction>
+): void {
+  axios
+    .get<Array<MapPoint>>("/api/choropleth/map-points", {
+      params: {
+        parentDcid: parentEntity,
+        placeType: placeType,
+      },
+      paramsSerializer: stringifyFn,
+    })
+    .then((resp) => {
+      dispatch({
+        type: ChartDataType.mapPointCoordinates,
+        payload: resp.data as Array<MapPoint>,
+        context: {
+          placeInfo: {
+            enclosingPlace: {
+              dcid: parentEntity,
+              name: "",
+            },
+            mapPointPlaceType: placeType,
+          },
+        },
+      });
+      console.log("map point coordinate dispatched");
+    });
+}

--- a/static/js/tools/map/fetcher/map_point_coordinate.ts
+++ b/static/js/tools/map/fetcher/map_point_coordinate.ts
@@ -47,7 +47,7 @@ export function fetchMapPointCoordinate(
   axios
     .get<Array<MapPoint>>("/api/choropleth/map-points", {
       params: {
-        parentDcid: parentEntity,
+        placeDcid: parentEntity,
         placeType: placeType,
       },
       paramsSerializer: stringifyFn,

--- a/static/js/tools/map/fetcher/map_point_stat.ts
+++ b/static/js/tools/map/fetcher/map_point_stat.ts
@@ -63,7 +63,7 @@ export function fetchMapPointStat(
           },
           statVar: {
             dcid: statVar,
-            date: date,
+            date,
           },
         },
       });

--- a/static/js/tools/map/fetcher/map_point_stat.ts
+++ b/static/js/tools/map/fetcher/map_point_stat.ts
@@ -34,6 +34,7 @@ export function fetchMapPointStat(
   parentEntity: string,
   childType: string,
   statVar: string,
+  mapPointSv: string,
   date: string,
   dispatch: Dispatch<ChartStoreAction>
 ): void {
@@ -46,30 +47,32 @@ export function fetchMapPointStat(
           dcid: parentEntity,
           name: "",
         },
-        enclosedPlaceType: childType,
+        mapPointPlaceType: childType,
       },
       statVar: {
         dcid: statVar,
         date,
+        mapPointSv,
       },
     },
   };
+  const usedSV = mapPointSv || statVar;
   axios
     .get<PointApiResponse>("/api/observations/point/within", {
       params: {
         child_type: childType,
-        date: getDate(statVar, date),
+        date: getDate(usedSV, date),
         parent_entity: parentEntity,
-        variables: [statVar],
+        variables: [usedSV],
       },
       paramsSerializer: stringifyFn,
     })
     .then((resp) => {
-      if (_.isEmpty(resp.data.data[statVar])) {
+      if (_.isEmpty(resp.data.data[usedSV])) {
         action.error = "error fetching map point stat data";
       } else {
         action.payload = {
-          data: resp.data.data[statVar],
+          data: resp.data.data[usedSV],
           facets: resp.data.facets,
         } as EntityObservationWrapper;
       }

--- a/static/js/tools/map/fetcher/map_point_stat.ts
+++ b/static/js/tools/map/fetcher/map_point_stat.ts
@@ -19,6 +19,7 @@
  */
 
 import axios from "axios";
+import _ from "lodash";
 import { Dispatch } from "react";
 
 import {
@@ -36,6 +37,23 @@ export function fetchMapPointStat(
   date: string,
   dispatch: Dispatch<ChartStoreAction>
 ): void {
+  const action: ChartStoreAction = {
+    type: ChartDataType.mapPointStat,
+    error: null,
+    context: {
+      placeInfo: {
+        enclosingPlace: {
+          dcid: parentEntity,
+          name: "",
+        },
+        enclosedPlaceType: childType,
+      },
+      statVar: {
+        dcid: statVar,
+        date,
+      },
+    },
+  };
   axios
     .get<PointApiResponse>("/api/observations/point/within", {
       params: {
@@ -47,26 +65,19 @@ export function fetchMapPointStat(
       paramsSerializer: stringifyFn,
     })
     .then((resp) => {
-      dispatch({
-        type: ChartDataType.mapPointStat,
-        payload: {
+      if (_.isEmpty(resp.data.data[statVar])) {
+        action.error = "error fetching map point stat data";
+      } else {
+        action.payload = {
           data: resp.data.data[statVar],
           facets: resp.data.facets,
-        } as EntityObservationWrapper,
-        context: {
-          placeInfo: {
-            enclosingPlace: {
-              dcid: parentEntity,
-              name: "",
-            },
-            enclosedPlaceType: childType,
-          },
-          statVar: {
-            dcid: statVar,
-            date,
-          },
-        },
-      });
+        } as EntityObservationWrapper;
+      }
+      dispatch(action);
       console.log("map point stat dispatched");
+    })
+    .catch(() => {
+      action.error = "error fetching map point stat data";
+      dispatch(action);
     });
 }

--- a/static/js/tools/map/fetcher/map_point_stat.ts
+++ b/static/js/tools/map/fetcher/map_point_stat.ts
@@ -39,7 +39,7 @@ export function fetchMapPointStat(
   dispatch: Dispatch<ChartStoreAction>
 ): void {
   const action: ChartStoreAction = {
-    type: ChartDataType.mapPointStat,
+    type: ChartDataType.MAP_POINT_STAT,
     error: null,
     context: {
       placeInfo: {

--- a/static/js/tools/map/fetcher/map_point_stat.ts
+++ b/static/js/tools/map/fetcher/map_point_stat.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fetch the map point stat data.
+ */
+
+import axios from "axios";
+import { Dispatch } from "react";
+
+import {
+  EntityObservationWrapper,
+  PointApiResponse,
+} from "../../../shared/stat_types";
+import { stringifyFn } from "../../../utils/axios";
+import { ChartDataType, ChartStoreAction } from "../chart_store";
+import { getDate } from "../util";
+
+export function fetchMapPointStat(
+  parentEntity: string,
+  childType: string,
+  statVar: string,
+  date: string,
+  dispatch: Dispatch<ChartStoreAction>
+): void {
+  axios
+    .get<PointApiResponse>("/api/observations/point/within", {
+      params: {
+        child_type: childType,
+        date: getDate(statVar, date),
+        parent_entity: parentEntity,
+        variables: [statVar],
+      },
+      paramsSerializer: stringifyFn,
+    })
+    .then((resp) => {
+      dispatch({
+        type: ChartDataType.mapPointStat,
+        payload: {
+          data: resp.data.data[statVar],
+          facets: resp.data.facets,
+        } as EntityObservationWrapper,
+        context: {
+          placeInfo: {
+            enclosingPlace: {
+              dcid: parentEntity,
+              name: "",
+            },
+            enclosedPlaceType: childType,
+          },
+          statVar: {
+            dcid: statVar,
+            date: date,
+          },
+        },
+      });
+      console.log("map point stat dispatched");
+    });
+}

--- a/static/js/tools/map/geojson.ts
+++ b/static/js/tools/map/geojson.ts
@@ -20,7 +20,7 @@
 
 import axios from "axios";
 
-import { GeoJsonData, GeoJsonFeature } from "../../chart/types";
+import { GeoJsonData } from "../../chart/types";
 import { IPCC_PLACE_50_TYPE_DCID } from "../../shared/constants";
 
 export const MANUAL_GEOJSON_DISTANCES = {
@@ -40,50 +40,4 @@ export function fetchGeoJson(
     .then((resp) => {
       setGeoJson(resp.data);
     });
-}
-
-export function getGeoJsonDataFeatures(
-  placeDcids: string[],
-  enclosedPlaceType: string
-): GeoJsonFeature[] {
-  const distance = MANUAL_GEOJSON_DISTANCES[enclosedPlaceType];
-  if (!distance) {
-    return [];
-  }
-  const geoJsonFeatures = [];
-  for (const placeDcid of placeDcids) {
-    const dcidPrefixSuffix = placeDcid.split("/");
-    if (dcidPrefixSuffix.length < 2) {
-      continue;
-    }
-    const latlon = dcidPrefixSuffix[1].split("_");
-    if (latlon.length < 2) {
-      continue;
-    }
-    const neLat = Number(latlon[0]) + distance / 2;
-    const neLon = Number(latlon[1]) + distance / 2;
-    const placeName = `${latlon[0]}, ${latlon[1]} (${distance} arc degree)`;
-    // TODO: handle cases of overflowing 180 near the international date line
-    // becasuse not sure if drawing libraries can handle this
-    geoJsonFeatures.push({
-      geometry: {
-        type: "MultiPolygon",
-        coordinates: [
-          [
-            [
-              [neLon, neLat],
-              [neLon, neLat - distance],
-              [neLon - distance, neLat - distance],
-              [neLon - distance, neLat],
-              [neLon, neLat],
-            ],
-          ],
-        ],
-      },
-      id: placeDcid,
-      properties: { geoDcid: placeDcid, name: placeName },
-      type: "Feature",
-    });
-  }
-  return geoJsonFeatures;
 }

--- a/static/js/tools/map/ready_hook.ts
+++ b/static/js/tools/map/ready_hook.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import _ from "lodash";
+import { useCallback, useContext } from "react";
+
+import { ChartStore } from "./chart_store";
+import { Context } from "./context";
+
+export function useGeoJsonReady(chartStore: ChartStore) {
+  const { placeInfo } = useContext(Context);
+
+  return useCallback(() => {
+    const c = chartStore.geoJson.context;
+    return (
+      !_.isEmpty(c) &&
+      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType
+    );
+  }, [
+    chartStore.geoJson.context,
+    placeInfo.value.enclosingPlace.dcid,
+    placeInfo.value.enclosedPlaceType,
+  ]);
+}
+
+export function useDefaultStatReady(chartStore: ChartStore) {
+  const { placeInfo, statVar } = useContext(Context);
+  return useCallback(() => {
+    const c = chartStore.defaultStat.context;
+    return (
+      !_.isEmpty(c) &&
+      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
+      statVar.value.dcid == c.statVar.dcid &&
+      statVar.value.date == c.statVar.date
+    );
+  }, [
+    chartStore.defaultStat.context,
+    placeInfo.value.enclosingPlace.dcid,
+    placeInfo.value.enclosedPlaceType,
+    statVar.value.dcid,
+    statVar.value.date,
+  ]);
+}
+
+export function useAllStatReady(chartStore: ChartStore) {
+  const { placeInfo, statVar } = useContext(Context);
+  return useCallback(() => {
+    const c = chartStore.allStat.context;
+    return (
+      !_.isEmpty(c) &&
+      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
+      statVar.value.dcid == c.statVar.dcid &&
+      statVar.value.date == c.statVar.date
+    );
+  }, [
+    chartStore.allStat.context,
+    placeInfo.value.enclosingPlace.dcid,
+    placeInfo.value.enclosedPlaceType,
+    statVar.value.dcid,
+    statVar.value.date,
+  ]);
+}
+
+export function useDenomStatReady(chartStore: ChartStore) {
+  const { placeInfo, statVar } = useContext(Context);
+  return useCallback(() => {
+    const c = chartStore.denomStat.context;
+    return (
+      !_.isEmpty(c) &&
+      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
+      statVar.value.denom == c.statVar.denom
+    );
+  }, [
+    chartStore.denomStat.context,
+    placeInfo.value.enclosingPlace.dcid,
+    placeInfo.value.enclosedPlaceType,
+    statVar.value.denom,
+  ]);
+}
+
+export function useBreadcrumbStatReady(chartStore: ChartStore) {
+  const { placeInfo, statVar } = useContext(Context);
+  return useCallback(() => {
+    const c = chartStore.breadcrumbStat.context;
+    return (
+      !_.isEmpty(c) &&
+      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+      statVar.value.dcid == c.statVar.dcid &&
+      statVar.value.date == c.statVar.date
+    );
+  }, [
+    chartStore.breadcrumbStat.context,
+    placeInfo.value.enclosingPlace.dcid,
+    statVar.value.dcid,
+    statVar.value.date,
+  ]);
+}
+
+export function useBreadcrumbDenomStatReady(chartStore: ChartStore) {
+  const { placeInfo, statVar } = useContext(Context);
+  return useCallback(() => {
+    const c = chartStore.breadcrumbDenomStat.context;
+    return (
+      !_.isEmpty(c) &&
+      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+      statVar.value.denom == c.statVar.denom
+    );
+  }, [
+    chartStore.breadcrumbDenomStat.context,
+    placeInfo.value.enclosingPlace.dcid,
+    statVar.value.denom,
+  ]);
+}
+
+export function useMapPointStatReady(chartStore: ChartStore) {
+  const { placeInfo, statVar } = useContext(Context);
+  return useCallback(() => {
+    const c = chartStore.mapPointStat.context;
+    return (
+      !_.isEmpty(c) &&
+      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.mapPointPlaceType == c.placeInfo.mapPointPlaceType &&
+      statVar.value.dcid == c.statVar.dcid &&
+      statVar.value.mapPointSv == c.statVar.mapPointSv &&
+      statVar.value.date == c.statVar.date
+    );
+  }, [
+    chartStore.mapPointStat.context,
+    placeInfo.value.enclosingPlace.dcid,
+    placeInfo.value.mapPointPlaceType,
+    statVar.value.dcid,
+    statVar.value.mapPointSv,
+    statVar.value.date,
+  ]);
+}
+
+export function useMapPointCoordinateReady(chartStore: ChartStore) {
+  const { placeInfo } = useContext(Context);
+  return useCallback(() => {
+    const c = chartStore.mapPointCoordinate.context;
+    return (
+      !_.isEmpty(c) &&
+      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.mapPointPlaceType == c.placeInfo.mapPointPlaceType
+    );
+  }, [
+    chartStore.mapPointCoordinate.context,
+    placeInfo.value.enclosingPlace.dcid,
+    placeInfo.value.mapPointPlaceType,
+  ]);
+}

--- a/static/js/tools/map/ready_hook.ts
+++ b/static/js/tools/map/ready_hook.ts
@@ -27,8 +27,8 @@ export function useGeoJsonReady(chartStore: ChartStore) {
     const c = chartStore.geoJson.context;
     return (
       !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType
+      placeInfo.value.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.enclosedPlaceType === c.placeInfo.enclosedPlaceType
     );
   }, [
     chartStore.geoJson.context,
@@ -43,10 +43,10 @@ export function useDefaultStatReady(chartStore: ChartStore) {
     const c = chartStore.defaultStat.context;
     return (
       !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
-      statVar.value.dcid == c.statVar.dcid &&
-      statVar.value.date == c.statVar.date
+      placeInfo.value.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
+      statVar.value.dcid === c.statVar.dcid &&
+      statVar.value.date === c.statVar.date
     );
   }, [
     chartStore.defaultStat.context,
@@ -63,10 +63,10 @@ export function useAllStatReady(chartStore: ChartStore) {
     const c = chartStore.allStat.context;
     return (
       !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
-      statVar.value.dcid == c.statVar.dcid &&
-      statVar.value.date == c.statVar.date
+      placeInfo.value.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
+      statVar.value.dcid === c.statVar.dcid &&
+      statVar.value.date === c.statVar.date
     );
   }, [
     chartStore.allStat.context,
@@ -83,9 +83,9 @@ export function useDenomStatReady(chartStore: ChartStore) {
     const c = chartStore.denomStat.context;
     return (
       !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.enclosedPlaceType == c.placeInfo.enclosedPlaceType &&
-      statVar.value.denom == c.statVar.denom
+      placeInfo.value.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
+      statVar.value.denom === c.statVar.denom
     );
   }, [
     chartStore.denomStat.context,
@@ -101,9 +101,9 @@ export function useBreadcrumbStatReady(chartStore: ChartStore) {
     const c = chartStore.breadcrumbStat.context;
     return (
       !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      statVar.value.dcid == c.statVar.dcid &&
-      statVar.value.date == c.statVar.date
+      placeInfo.value.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+      statVar.value.dcid === c.statVar.dcid &&
+      statVar.value.date === c.statVar.date
     );
   }, [
     chartStore.breadcrumbStat.context,
@@ -119,8 +119,8 @@ export function useBreadcrumbDenomStatReady(chartStore: ChartStore) {
     const c = chartStore.breadcrumbDenomStat.context;
     return (
       !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      statVar.value.denom == c.statVar.denom
+      placeInfo.value.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+      statVar.value.denom === c.statVar.denom
     );
   }, [
     chartStore.breadcrumbDenomStat.context,
@@ -135,11 +135,11 @@ export function useMapPointStatReady(chartStore: ChartStore) {
     const c = chartStore.mapPointStat.context;
     return (
       !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.mapPointPlaceType == c.placeInfo.mapPointPlaceType &&
-      statVar.value.dcid == c.statVar.dcid &&
-      statVar.value.mapPointSv == c.statVar.mapPointSv &&
-      statVar.value.date == c.statVar.date
+      placeInfo.value.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.mapPointPlaceType === c.placeInfo.mapPointPlaceType &&
+      statVar.value.dcid === c.statVar.dcid &&
+      statVar.value.mapPointSv === c.statVar.mapPointSv &&
+      statVar.value.date === c.statVar.date
     );
   }, [
     chartStore.mapPointStat.context,
@@ -157,8 +157,8 @@ export function useMapPointCoordinateReady(chartStore: ChartStore) {
     const c = chartStore.mapPointCoordinate.context;
     return (
       !_.isEmpty(c) &&
-      placeInfo.value.enclosingPlace.dcid == c.placeInfo.enclosingPlace.dcid &&
-      placeInfo.value.mapPointPlaceType == c.placeInfo.mapPointPlaceType
+      placeInfo.value.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
+      placeInfo.value.mapPointPlaceType === c.placeInfo.mapPointPlaceType
     );
   }, [
     chartStore.mapPointCoordinate.context,

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -655,7 +655,7 @@ export function getLegendBounds(
   return legendBounds;
 }
 
-export function getDate(statVar: string, date: string) {
+export function getDate(statVar: string, date: string): string {
   let res = "";
   const cappedDate = getCappedStatVarDate(statVar);
   // If there is a specified date, get the data for that date. If no specified

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -42,6 +42,7 @@ import {
   NamedTypedPlace,
   ProvenanceSummary,
 } from "../../shared/types";
+import { getCappedStatVarDate } from "../../shared/util";
 import { getDateRange } from "../../utils/string_utils";
 import { getMatchingObservation, isChildPlaceOf } from "../shared_util";
 import { DisplayOptions, PlaceInfo, StatVar } from "./context";
@@ -652,4 +653,17 @@ export function getLegendBounds(
     }
   }
   return legendBounds;
+}
+
+export function getDate(statVar: string, date: string) {
+  let res = "";
+  const cappedDate = getCappedStatVarDate(statVar);
+  // If there is a specified date, get the data for that date. If no specified
+  // date, still need to cut data for prediction data that extends to 2099
+  if (date) {
+    res = date;
+  } else if (cappedDate) {
+    res = cappedDate;
+  }
+  return res;
 }

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -20,6 +20,7 @@
 
 import _ from "lodash";
 
+import { GeoJsonFeature } from "../../chart/types";
 import {
   BANGLADESH_PLACE_DCID,
   CHINA_PLACE_DCID,
@@ -138,6 +139,10 @@ export const CHILD_PLACE_TYPE_MAPPING = {
 
 export const ENCLOSED_PLACE_TYPE_NAMES = {
   [IPCC_PLACE_50_TYPE_DCID]: "0.5 Arc Degree",
+};
+
+export const MANUAL_GEOJSON_DISTANCES = {
+  [IPCC_PLACE_50_TYPE_DCID]: 0.5,
 };
 
 export const BEST_AVAILABLE_METAHASH = "Best Available";
@@ -666,4 +671,50 @@ export function getDate(statVar: string, date: string): string {
     res = cappedDate;
   }
   return res;
+}
+
+export function getGeoJsonDataFeatures(
+  placeDcids: string[],
+  enclosedPlaceType: string
+): GeoJsonFeature[] {
+  const distance = MANUAL_GEOJSON_DISTANCES[enclosedPlaceType];
+  if (!distance) {
+    return [];
+  }
+  const geoJsonFeatures = [];
+  for (const placeDcid of placeDcids) {
+    const dcidPrefixSuffix = placeDcid.split("/");
+    if (dcidPrefixSuffix.length < 2) {
+      continue;
+    }
+    const latlon = dcidPrefixSuffix[1].split("_");
+    if (latlon.length < 2) {
+      continue;
+    }
+    const neLat = Number(latlon[0]) + distance / 2;
+    const neLon = Number(latlon[1]) + distance / 2;
+    const placeName = `${latlon[0]}, ${latlon[1]} (${distance} arc degree)`;
+    // TODO: handle cases of overflowing 180 near the international date line
+    // becasuse not sure if drawing libraries can handle this
+    geoJsonFeatures.push({
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [neLon, neLat],
+              [neLon, neLat - distance],
+              [neLon - distance, neLat - distance],
+              [neLon - distance, neLat],
+              [neLon, neLat],
+            ],
+          ],
+        ],
+      },
+      id: placeDcid,
+      properties: { geoDcid: placeDcid, name: placeName },
+      type: "Feature",
+    });
+  }
+  return geoJsonFeatures;
 }


### PR DESCRIPTION
This is a no-op change to existing code and prepares for future updates of chart_loader.

The goal is to remove the dependency of data fetch and processing. Ideally, the tool only needs to fetch the needed data and will render the map when all necessary data is ready. The other data can be loaded on the background or on-demand, which can be controlled independently without touching the component logic.

Some design thoughts:

- Each data load should be in a separate module, which fetches data and sends the raw data to the desired component. These modules are put in /fetcher folder. New data fetcher should be created in the same pattern.

- All the raw data are used in various ways to construct the chart data, the construction depends on context (user input) and is dependent on data availability. Here I created a ChartStore to hold all the raw data and also the context when they are created. This has the following benefits:
1.  Allow each fetcher to independently "dispatch" the data. The data is merged using "useReducer" hook in the UI component.
2. The UI component can check if the data is ready by comparing the context in ChartStore vs the current context.
3. In future change, the async data processing dependency can be resolved by "useEffect()".  By checking the readiness of the data, each useEffect() can exit early if needed.