### PR TITLE
Use context directly in map sub components

### DIFF
--- a/static/js/shared/ga_events.test.tsx
+++ b/static/js/shared/ga_events.test.tsx
@@ -47,17 +47,20 @@ import { StatVarHierarchy } from "../stat_var_hierarchy/stat_var_hierarchy";
 import { StatVarHierarchySearch } from "../stat_var_hierarchy/stat_var_search";
 import { Chart as MapToolChart, MAP_TYPE } from "../tools/map/chart";
 import {
+  Context as MapContext,
   DisplayOptionsWrapper as MapDisplayOptionsWrapper,
+  IsLoadingWrapper as MapIsLoadingWrapper,
+  PlaceInfoWrapper as MapPlaceInfoWrapper,
   StatVarWrapper,
 } from "../tools/map/context";
 import { DataPointMetadata } from "../tools/map/util";
 import { Chart as ScatterToolChart } from "../tools/scatter/chart";
 import {
   AxisWrapper,
-  Context,
+  Context as ScatterContext,
   DisplayOptionsWrapper as ScatterDisplayOptionsWrapper,
-  IsLoadingWrapper,
-  PlaceInfoWrapper,
+  IsLoadingWrapper as ScatterIsLoadingWrapper,
+  PlaceInfoWrapper as ScatterPlaceInfoWrapper,
 } from "../tools/scatter/context";
 import { ScatterChartType } from "../tools/scatter/util";
 import { Chart as TimelineToolChart } from "../tools/timeline/chart";
@@ -137,15 +140,6 @@ const MAP_POINTS: MapPoint[] = [
 const MAP_PROPS = {
   breadcrumbDataValues: { PLACE_DCID: NUMBER },
   dates: new Set<string>([""]),
-  display: {
-    value: {
-      color: "",
-      domain: [NUMBER, NUMBER, NUMBER] as [number, number, number],
-      showMapPoints: false,
-      showTimeSlider: false,
-      allowLeaflet: false,
-    },
-  } as MapDisplayOptionsWrapper,
   geoJsonData: {
     features: [],
     properties: {
@@ -155,32 +149,6 @@ const MAP_PROPS = {
   } as GeoJsonData,
   mapDataValues: { [PLACE_DCID]: NUMBER },
   metadata: { [PLACE_DCID]: {} as DataPointMetadata },
-  placeInfo: {
-    enclosedPlaceType: "",
-    enclosingPlace: { dcid: PLACE_DCID, name: PLACE_NAME },
-    mapPointPlaceType: "",
-    parentPlaces: [],
-    selectedPlace: { dcid: PLACE_DCID, name: PLACE_NAME, types: [] },
-  },
-  statVar: {
-    value: {
-      date: "",
-      dcid: STAT_VAR_1,
-      denom: "",
-      info: {},
-      mapPointSv: "",
-      metahash: "",
-      perCapita: false,
-    },
-    set: () => null,
-    setInfo: () => null,
-    setDcid: () => null,
-    setPerCapita: () => null,
-    setDate: () => null,
-    setDenom: () => null,
-    setMapPointSv: () => null,
-    setMetahash: () => null,
-  } as StatVarWrapper,
   sources: new Set<string>([""]),
   unit: "",
   mapPointValues: { [PLACE_DCID]: NUMBER },
@@ -263,6 +231,54 @@ const SCATTER_PROPS = {
   ],
   onSvFacetIdUpdated: () => null,
 };
+
+const MAP_CONTEXT = {
+  isLoading: {} as MapIsLoadingWrapper,
+  display: {
+    value: {
+      color: "",
+      domain: [NUMBER, NUMBER, NUMBER] as [number, number, number],
+      showMapPoints: false,
+      showTimeSlider: false,
+      allowLeaflet: false,
+    },
+  } as MapDisplayOptionsWrapper,
+  placeInfo: {
+    value: {
+      enclosedPlaceType: "",
+      enclosingPlace: { dcid: PLACE_DCID, name: PLACE_NAME },
+      mapPointPlaceType: "",
+      parentPlaces: [],
+      selectedPlace: { dcid: PLACE_DCID, name: PLACE_NAME, types: [] },
+    },
+    set: () => null,
+    setSelectedPlace: () => null,
+    setParentPlaces: () => null,
+    setEnclosingPlace: () => null,
+    setEnclosedPlaceType: () => null,
+    setMapPointPlaceType: () => null,
+  } as MapPlaceInfoWrapper,
+  statVar: {
+    value: {
+      date: "",
+      dcid: STAT_VAR_1,
+      denom: "",
+      info: {},
+      mapPointSv: "",
+      metahash: "",
+      perCapita: false,
+    },
+    set: () => null,
+    setInfo: () => null,
+    setDcid: () => null,
+    setPerCapita: () => null,
+    setDate: () => null,
+    setDenom: () => null,
+    setMapPointSv: () => null,
+    setMetahash: () => null,
+  } as StatVarWrapper,
+};
+
 const SCATTER_CONTEXT = {
   x: {
     value: {
@@ -313,7 +329,7 @@ const SCATTER_CONTEXT = {
       lowerBound: NUMBER,
       upperBound: NUMBER,
     },
-  } as PlaceInfoWrapper,
+  } as ScatterPlaceInfoWrapper,
   display: {
     showQuadrants: false,
     showLabels: false,
@@ -326,7 +342,7 @@ const SCATTER_CONTEXT = {
     setDensity: () => null,
     setRegression: () => null,
   } as ScatterDisplayOptionsWrapper,
-  isLoading: {} as IsLoadingWrapper,
+  isLoading: {} as ScatterIsLoadingWrapper,
 };
 
 // Props for stat var hierarchy.
@@ -585,7 +601,11 @@ describe("test ga event tool chart plot", () => {
     window.gtag = mockgtag;
 
     // When the component is mounted.
-    const { rerender } = render(<MapToolChart {...MAP_PROPS} />);
+    const { rerender } = render(
+      <MapContext.Provider value={MAP_CONTEXT}>
+        <MapToolChart {...MAP_PROPS} />
+      </MapContext.Provider>
+    );
     await waitFor(() => {
       // Check the parameters passed to gtag.
       expect(mockgtag.mock.lastCall).toEqual([
@@ -601,15 +621,23 @@ describe("test ga event tool chart plot", () => {
     });
 
     // When the component is rerendered with the same props.
-    rerender(<MapToolChart {...MAP_PROPS} />);
+    rerender(
+      <MapContext.Provider value={MAP_CONTEXT}>
+        <MapToolChart {...MAP_PROPS} />
+      </MapContext.Provider>
+    );
     await waitFor(() =>
       // Check gtag is not called.
       expect(mockgtag.mock.calls.length).toEqual(1)
     );
 
     // When stat var changes.
-    MAP_PROPS.statVar.value.dcid = STAT_VAR_2;
-    rerender(<MapToolChart {...MAP_PROPS} />);
+    MAP_CONTEXT.statVar.value.dcid = STAT_VAR_2;
+    rerender(
+      <MapContext.Provider value={MAP_CONTEXT}>
+        <MapToolChart {...MAP_PROPS} />
+      </MapContext.Provider>
+    );
     await waitFor(() => {
       // Check gtag is called once, two time in total.
       expect(mockgtag.mock.calls.length).toEqual(2);
@@ -680,9 +708,9 @@ describe("test ga event tool chart plot", () => {
 
     // When the component is mounted.
     const { rerender } = render(
-      <Context.Provider value={SCATTER_CONTEXT}>
+      <ScatterContext.Provider value={SCATTER_CONTEXT}>
         <ScatterToolChart {...SCATTER_PROPS} />
-      </Context.Provider>
+      </ScatterContext.Provider>
     );
     await waitFor(() => {
       // Check the parameters passed to the gtag.
@@ -700,9 +728,9 @@ describe("test ga event tool chart plot", () => {
 
     // When the component is rerendered with the same props.
     rerender(
-      <Context.Provider value={SCATTER_CONTEXT}>
+      <ScatterContext.Provider value={SCATTER_CONTEXT}>
         <ScatterToolChart {...SCATTER_PROPS} />
-      </Context.Provider>
+      </ScatterContext.Provider>
     );
     await waitFor(() =>
       // Check gtag is not called.
@@ -723,9 +751,9 @@ describe("test ga event tool chart plot", () => {
       },
     ];
     rerender(
-      <Context.Provider value={SCATTER_CONTEXT}>
+      <ScatterContext.Provider value={SCATTER_CONTEXT}>
         <ScatterToolChart {...SCATTER_PROPS} />
-      </Context.Provider>
+      </ScatterContext.Provider>
     );
     await waitFor(() => {
       // Check gtag is called once, two times in total.
@@ -796,7 +824,7 @@ describe("test ga event tool stat var click", () => {
 });
 
 describe("test ga event tool place add", () => {
-  test("call gtag when a place is added in the place seaerch bar", async () => {
+  test("call gtag when a place is added in the place search bar", async () => {
     const props = {
       selectedPlace: {
         types: null,
@@ -963,9 +991,9 @@ describe("test ga event tool chart plot option", () => {
 
     // Render the component.
     const scatterToolChart = render(
-      <Context.Provider value={SCATTER_CONTEXT}>
+      <ScatterContext.Provider value={SCATTER_CONTEXT}>
         <ScatterToolChart {...SCATTER_PROPS} />
-      </Context.Provider>
+      </ScatterContext.Provider>
     );
     // Wait for gtag event tool chart plot to be called.
     await waitFor(() => expect(mockgtag.mock.calls.length).toEqual(1));
@@ -1115,7 +1143,11 @@ describe("test ga event tool chart plot option", () => {
     window.gtag = mockgtag;
 
     // Render the component.
-    const mapToolChart = render(<MapToolChart {...MAP_PROPS} />);
+    const mapToolChart = render(
+      <MapContext.Provider value={MAP_CONTEXT}>
+        <MapToolChart {...MAP_PROPS} />
+      </MapContext.Provider>
+    );
     await waitFor(() => expect(mockgtag.mock.calls.length).toEqual(1));
 
     // Click the checkbox of per capita.

--- a/static/js/tools/map/chart_loader.tsx
+++ b/static/js/tools/map/chart_loader.tsx
@@ -26,7 +26,6 @@ import _ from "lodash";
 import React, { useContext, useEffect, useReducer, useState } from "react";
 
 import { GeoJsonData, MapPoint } from "../../chart/types";
-import { EUROPE_NAMED_TYPED_PLACE } from "../../shared/constants";
 import { FacetSelectorFacetInfo } from "../../shared/facet_selector";
 import {
   EntityObservation,
@@ -38,13 +37,10 @@ import {
   SeriesApiResponse,
   StatMetadata,
 } from "../../shared/stat_types";
-import { NamedPlace, StatVarSummary } from "../../shared/types";
+import { StatVarSummary } from "../../shared/types";
 import { getCappedStatVarDate } from "../../shared/util";
 import { stringifyFn } from "../../utils/axios";
-import {
-  ENCLOSED_PLACE_TYPE_NAMES,
-  getEnclosedPlacesPromise,
-} from "../../utils/place_utils";
+import { ENCLOSED_PLACE_TYPE_NAMES } from "../../utils/place_utils";
 import { BqModal } from "../shared/bq_modal";
 import { setUpBqButton } from "../shared/bq_utils";
 import { getMatchingObservation, getUnit } from "../shared_util";
@@ -69,16 +65,6 @@ import { useFetchGeoJson } from "./fetcher/geojson";
 import { useFetchMapPointCoordinate } from "./fetcher/map_point_coordinate";
 import { useFetchMapPointStat } from "./fetcher/map_point_stat";
 import { PlaceDetails } from "./place_details";
-import {
-  useAllStatReady,
-  useBreadcrumbDenomStatReady,
-  useBreadcrumbStatReady,
-  useDefaultStatReady,
-  useDenomStatReady,
-  useGeoJsonReady,
-  useMapPointCoordinateReady,
-  useMapPointStatReady,
-} from "./ready_hooks";
 import {
   BEST_AVAILABLE_METAHASH,
   DataPointMetadata,
@@ -124,6 +110,7 @@ interface ChartData {
 
 export function ChartLoader(): JSX.Element {
   const { placeInfo, statVar, isLoading, display } = useContext(Context);
+
   const [rawData, setRawData] = useState<ChartRawData | undefined>(undefined);
   const [chartData, setChartData] = useState<ChartData | undefined>(undefined);
   const [geoRaster, setGeoRaster] = useState(null);
@@ -149,18 +136,6 @@ export function ChartLoader(): JSX.Element {
   const [chartStore, dispatch] = useReducer(chartStoreReducer, emptyChartStore);
   // -------------------------------------------------------------------------
 
-  // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-  const geoJsonReady = useGeoJsonReady(chartStore);
-  const defaultStatReady = useDefaultStatReady(chartStore);
-  const allStatReady = useAllStatReady(chartStore);
-  const denomStatReady = useDenomStatReady(chartStore);
-  const breadcrumbStatReady = useBreadcrumbStatReady(chartStore);
-  const breadcrumbDenomStatReady = useBreadcrumbDenomStatReady(chartStore);
-  const mapPointStatReady = useMapPointStatReady(chartStore);
-  const mapPointCoordinateReady = useMapPointCoordinateReady(chartStore);
-  // -------------------------------------------------------------------------
-
-  // Fetch european countries.
   const europeanCountries = useFetchEuropeanCountries();
   useFetchGeoJson(dispatch);
   useFetchMapPointCoordinate(dispatch);
@@ -359,13 +334,10 @@ export function ChartLoader(): JSX.Element {
         mapDataValues={chartData.mapValues}
         metadata={chartData.metadata}
         breadcrumbDataValues={chartData.breadcrumbValues}
-        placeInfo={placeInfo.value}
-        statVar={statVar}
         dates={chartData.dates}
         sources={chartData.sources}
         unit={chartData.unit}
         mapPointValues={chartData.mapPointValues}
-        display={display}
         mapPoints={chartStore.mapPointCoordinate.data}
         europeanCountries={europeanCountries}
         rankingLink={chartData.rankingLink}
@@ -383,14 +355,11 @@ export function ChartLoader(): JSX.Element {
         <PlaceDetails
           breadcrumbDataValues={chartData.breadcrumbValues}
           mapDataValues={chartData.mapValues}
-          placeInfo={placeInfo.value}
           metadata={chartData.metadata}
           unit={chartData.unit}
-          statVar={statVar.value}
           geoJsonFeatures={
             chartStore.geoJson.data ? chartStore.geoJson.data.features : []
           }
-          displayOptions={display.value}
           europeanCountries={europeanCountries}
         />
       )}

--- a/static/js/tools/map/leaflet_map.tsx
+++ b/static/js/tools/map/leaflet_map.tsx
@@ -22,7 +22,13 @@ import geoblaze from "geoblaze";
 import { GeoRaster } from "georaster-layer-for-leaflet";
 import L from "leaflet";
 import _ from "lodash";
-import React, { useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import {
   addGeoJsonLayer,
@@ -32,17 +38,14 @@ import {
 import { generateLegendSvg, getColorScale } from "../../chart/draw_map_utils";
 import { GeoJsonData } from "../../chart/types";
 import { MAP_CONTAINER_ID } from "./chart";
-import { DisplayOptionsWrapper, PlaceInfo, StatVarWrapper } from "./context";
+import { Context } from "./context";
 import { DataPointMetadata } from "./util";
 
 interface LeafletMapProps {
   geoJsonData: GeoJsonData;
   geoRaster: GeoRaster;
   metadata: { [dcid: string]: DataPointMetadata };
-  placeInfo: PlaceInfo;
-  statVar: StatVarWrapper;
   unit: string;
-  display: DisplayOptionsWrapper;
 }
 
 const LEGEND_CONTAINER_ID = "choropleth-legend";
@@ -51,6 +54,8 @@ const LEGEND_MARGIN_LEFT = 30;
 const LEGEND_HEIGHT_SCALING = 0.6;
 
 export function LeafletMap(props: LeafletMapProps): JSX.Element {
+  const { placeInfo, statVar, display } = useContext(Context);
+
   const [errorMessage, setErrorMessage] = useState("");
   const chartContainerRef = useRef<HTMLDivElement>();
   const leafletMap = useRef(null);
@@ -64,46 +69,25 @@ export function LeafletMap(props: LeafletMapProps): JSX.Element {
     });
   }, []);
 
-  // Replot when data changes.
-  // TODO: handle resizing of chart area
-  useEffect(() => {
-    if (props.geoRaster) {
-      plot();
-    }
-  }, [props]);
-
-  if (errorMessage) {
-    return <div className="error-message">{errorMessage}</div>;
-  } else {
-    return (
-      <div className="map-section-container leaflet-map-container">
-        <div id={CHART_CONTAINER_ID} ref={chartContainerRef}>
-          <div id={MAP_CONTAINER_ID}></div>
-          <div id={LEGEND_CONTAINER_ID}></div>
-        </div>
-      </div>
-    );
-  }
-
   // Draw a GeoTIFF layer as the background and add a GeoJSON layer to show the
   // boundaries if there is GeoJSON data available.
-  function plot(): void {
+  const plot = useCallback(() => {
     document.getElementById(
       LEGEND_CONTAINER_ID
     ).innerHTML = `<div id="legend-unit">${props.unit || ""}</div>`;
     const width = document.getElementById(CHART_CONTAINER_ID).offsetWidth;
     const height = (width * 2) / 5;
     const svTitle =
-      props.statVar.value.dcid in props.statVar.value.info
-        ? props.statVar.value.info[props.statVar.value.dcid].title
+      statVar.value.dcid in statVar.value.info
+        ? statVar.value.info[statVar.value.dcid].title
         : "";
     const colorScale = getColorScale(
-      svTitle || props.statVar.value.dcid,
+      svTitle || statVar.value.dcid,
       geoblaze.min(props.geoRaster),
       geoblaze.mean(props.geoRaster),
       geoblaze.max(props.geoRaster),
-      props.display.value.color,
-      props.display.value.domain
+      display.value.color,
+      display.value.domain
     );
     const legendHeight = height * LEGEND_HEIGHT_SCALING;
     generateLegendSvg(
@@ -132,6 +116,36 @@ export function LeafletMap(props: LeafletMapProps): JSX.Element {
         props.geoRaster
       );
     }
-    setOptimalMapView(leafletMap.current, props.placeInfo.enclosingPlace.dcid);
+    setOptimalMapView(leafletMap.current, placeInfo.value.enclosingPlace.dcid);
+  }, [
+    props.geoJsonData,
+    props.geoRaster,
+    props.unit,
+    statVar.value.dcid,
+    statVar.value.info,
+    display.value.color,
+    display.value.domain,
+    placeInfo.value.enclosingPlace.dcid,
+  ]);
+
+  // Replot when data changes.
+  // TODO: handle resizing of chart area
+  useEffect(() => {
+    if (props.geoRaster) {
+      plot();
+    }
+  }, [props.geoRaster, plot]);
+
+  if (errorMessage) {
+    return <div className="error-message">{errorMessage}</div>;
+  } else {
+    return (
+      <div className="map-section-container leaflet-map-container">
+        <div id={CHART_CONTAINER_ID} ref={chartContainerRef}>
+          <div id={MAP_CONTAINER_ID}></div>
+          <div id={LEGEND_CONTAINER_ID}></div>
+        </div>
+      </div>
+    );
   }
 }


### PR DESCRIPTION
All the map children components can directly access the context instead of getting them through the props.