### PR TITLE
Always add Overview to the category hash map to display it as a subtitle

### DIFF
--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -564,6 +564,9 @@ def data(dcid):
         list(spec_and_stat.keys()) + list(spec_and_stat[OVERVIEW]) +
         raw_page_data["validCategories"][dcid]['category'])
 
+    ordered_category_dict[OVERVIEW] = gettext(
+        f'CHART_TITLE-CHART_CATEGORY-{OVERVIEW}')
+
     for conf in current_app.config['CHART_CONFIG']:
         category = conf['category']
         if category in all_categories:


### PR DESCRIPTION
Always add Overview to the category hash map. This ensures that is displayed as a subtitle and translated to other languages.

Fixes the bug introduced by https://github.com/datacommonsorg/website/pull/1754

Bug: b/206032102

![image](https://user-images.githubusercontent.com/109985835/195956766-01f5cea3-f2a9-46b2-9c80-02525d2794d5.png)
