### PR TITLE
Use new property values API to fetch names

### DIFF
--- a/server/routes/api/csv.py
+++ b/server/routes/api/csv.py
@@ -18,8 +18,7 @@ import csv
 import io
 
 from flask import Blueprint, request, make_response
-from routes.api.shared import cached_name
-from routes.api.shared import is_valid_date, date_greater_equal_min, date_lesser_equal_max
+from routes.api.shared import names, is_valid_date, date_greater_equal_min, date_lesser_equal_max
 import services.datacommons as dc
 
 # Define blueprint
@@ -101,7 +100,7 @@ def get_point_within_csv_rows(parent_place,
                     break
     facet_info = points_response_all.get("facets", {})
     place_list = sorted(list(data_by_place.keys()))
-    place_names = cached_name("^".join(place_list))
+    place_names = names(place_list)
     result = []
     for place, place_name in place_names.items():
         if row_limit and len(result) >= row_limit:
@@ -166,7 +165,7 @@ def get_series_csv_rows(series_response,
                     data_by_place[place][sv] = series
                     break
     place_list = sorted(list(data_by_place.keys()))
-    place_names = cached_name("^".join(place_list))
+    place_names = names(place_list)
     result = []
     for place, place_name in place_names.items():
         # dict of sv to sorted list of data points available for the sv and is within

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -23,7 +23,7 @@ from cache import cache
 import routes.api.shared as shared_api
 import services.datacommons as dc
 from services.datacommons import fetch_data
-from routes.api.shared import cached_name
+from routes.api.shared import names
 import lib.i18n as i18n
 
 CHILD_PLACE_LIMIT = 50
@@ -125,23 +125,11 @@ def get_place_type(place_dcid):
     return chosen_type
 
 
-def get_name(dcids):
-    """Returns display names for set of dcids.
-
-    Args:
-        dcids: A list of place dcids.
-
-    Returns:
-        A dictionary of display place names, keyed by dcid.
-    """
-    return cached_name('^'.join((sorted(dcids))))
-
-
 @bp.route('/name')
 def api_name():
     """Get place names."""
     dcids = request.args.getlist('dcid')
-    result = get_name(dcids)
+    result = names(dcids)
     return Response(json.dumps(result), 200, mimetype='application/json')
 
 
@@ -187,7 +175,7 @@ def cached_i18n_name(dcids, locale, should_resolve_all):
                 break
     if dcids_default_name:
         if should_resolve_all:
-            default_names = cached_name('^'.join(sorted(dcids_default_name)))
+            default_names = names(dcids_default_name)
         else:
             default_names = {}
         for dcid in dcids_default_name:

--- a/server/routes/api/shared.py
+++ b/server/routes/api/shared.py
@@ -15,34 +15,25 @@
 
 import re
 
-from services.datacommons import fetch_data
-from cache import cache
+import services.datacommons as dc
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def cached_name(dcids):
+def names(dcids):
     """Returns display names for set of dcids.
 
     Args:
-        dcids: ^ separated string of dcids. It must be a single string for the cache.
+        dcids: A list of DCIDs.
 
     Returns:
         A dictionary of display place names, keyed by dcid.
     """
-    dcids = dcids.split('^')
-    response = fetch_data('/node/property-values', {
-        'dcids': dcids,
-        'property': 'name',
-        'direction': 'out'
-    },
-                          compress=False,
-                          post=True)
+    response = dc.property_values(dcids, 'name')
     result = {}
     for dcid in dcids:
         if not dcid:
             continue
-        values = response[dcid].get('out')
-        result[dcid] = values[0]['value'] if values else ''
+        values = response.get(dcid, [])
+        result[dcid] = values[0] if values else ''
     return result
 
 

--- a/server/routes/browser.py
+++ b/server/routes/browser.py
@@ -27,7 +27,7 @@ def browser_main():
 
 @bp.route('/<path:dcid>')
 def browser_node(dcid):
-    node_name = shared_api.cached_name(dcid).get(dcid)
+    node_name = shared_api.names([dcid]).get(dcid)
     if not node_name:
         node_name = dcid
     return render_template('/browser/node.html', dcid=dcid, node_name=node_name)

--- a/server/routes/disease.py
+++ b/server/routes/disease.py
@@ -34,7 +34,7 @@ def main():
 def node(dcid):
     if os.environ.get('FLASK_ENV') == 'production':
         flask.abort(404)
-    node_name = shared_api.cached_name(dcid).get(dcid)
+    node_name = shared_api.names([dcid]).get(dcid)
     if not node_name:
         node_name = dcid
     return render_template('/disease/node.html', dcid=dcid, node_name=node_name)

--- a/server/routes/protein.py
+++ b/server/routes/protein.py
@@ -34,7 +34,7 @@ def main():
 def node(dcid):
     if os.environ.get('FLASK_ENV') == 'production':
         flask.abort(404)
-    node_name = shared_api.cached_name(dcid).get(dcid)
+    node_name = shared_api.names([dcid]).get(dcid)
     if not node_name:
         node_name = dcid
     return render_template('/protein/node.html', dcid=dcid, node_name=node_name)

--- a/server/tests/api/api_csv_test.py
+++ b/server/tests/api/api_csv_test.py
@@ -46,7 +46,7 @@ class TestGetStatsWithinPlaceCsv(unittest.TestCase):
         assert no_stat_vars.status_code == 400
 
     @mock.patch('routes.api.csv.dc.point_within')
-    @mock.patch('routes.api.csv.cached_name')
+    @mock.patch('routes.api.csv.names')
     def test_single_date(self, mock_place_names, mock_point_within):
         expected_parent_place = "country/USA"
         expected_child_type = "State"
@@ -55,7 +55,7 @@ class TestGetStatsWithinPlaceCsv(unittest.TestCase):
         expected_date = "2015"
 
         def place_side_effect(places):
-            if places == "^".join(children_places):
+            if places == children_places:
                 return {
                     "geoId/01": "Alabama",
                     "geoId/02": "",
@@ -159,7 +159,7 @@ class TestGetStatsWithinPlaceCsv(unittest.TestCase):
         )
 
     @mock.patch('routes.api.csv.dc.series_within')
-    @mock.patch('routes.api.csv.cached_name')
+    @mock.patch('routes.api.csv.names')
     def test_date_range(self, mock_place_names, mock_series_within):
         expected_parent_place = "country/USA"
         expected_child_type = "State"
@@ -171,7 +171,7 @@ class TestGetStatsWithinPlaceCsv(unittest.TestCase):
         expected_max_date_month = "2018-01"
 
         def place_side_effect(places):
-            if places == "^".join(children_places):
+            if places == children_places:
                 return {"geoId/01": "", "geoId/06": "California"}
             else:
                 return {}

--- a/server/tests/api/api_place_test.py
+++ b/server/tests/api/api_place_test.py
@@ -128,9 +128,9 @@ class TestApiParentPlaces(unittest.TestCase):
 
 class TestApiPlaceName(unittest.TestCase):
 
-    @patch('routes.api.place.cached_name')
-    def test_parent_places(self, mock_cached_name):
-        mock_cached_name.return_value = {
+    @patch('routes.api.place.names')
+    def test_parent_places(self, mock_names):
+        mock_names.return_value = {
             'geoId/06': 'California',
             'geoId/07': '',
             'geoId/08': 'Colorado'
@@ -150,10 +150,10 @@ class TestApiPlaceI18nName(unittest.TestCase):
 
     @patch('lib.i18n.AVAILABLE_LANGUAGES',
            ['en', 'io', 'la', 'la-ru', 'it', 'ru'])
-    @patch('routes.api.place.cached_name')
+    @patch('routes.api.place.names')
     @patch('routes.api.place.fetch_data')
-    def test_parent_places(self, mock_fetch_data, mock_cached_name):
-        mock_cached_name.return_value = {'geoId/08': 'Colorado'}
+    def test_parent_places(self, mock_fetch_data, mock_names):
+        mock_names.return_value = {'geoId/08': 'Colorado'}
         mock_response = {
             'geoId/05': {
                 'out': [{

--- a/server/tests/api/api_shared_test.py
+++ b/server/tests/api/api_shared_test.py
@@ -18,34 +18,17 @@ import routes.api.shared as shared
 from unittest.mock import patch
 
 
-class TestCachedName(unittest.TestCase):
+class TestNames(unittest.TestCase):
 
-    @patch('routes.api.shared.fetch_data')
-    def test_cached_name(self, mock_data_fetcher):
+    @patch('routes.api.shared.dc.property_values')
+    def test_names(self, mock_property_values_func):
         dcid1 = 'geoId/06'
         dcid2 = 'geoId/07'
         dcid3 = 'geoId/08'
-        mock_response = {
-            dcid1: {
-                'out': [{
-                    'value': 'California',
-                    'provenance': 'prov1'
-                }]
-            },
-            dcid2: {
-                'out': []
-            },
-            dcid3: {
-                'out': [{
-                    'value': 'Colorado',
-                    'provenance': 'prov2'
-                }]
-            }
-        }
-        mock_data_fetcher.side_effect = (
-            lambda url, req, compress, post: mock_response)
-
-        result = shared.cached_name('^'.join([dcid1, dcid2, dcid3]))
+        mock_response = {dcid1: ['California'], dcid2: [], dcid3: ['Colorado']}
+        mock_property_values_func.side_effect = (
+            lambda dcids, name: mock_response)
+        result = shared.names([dcid1, dcid2, dcid3])
         assert result == {dcid1: 'California', dcid2: '', dcid3: 'Colorado'}
 
 

--- a/server/tests/browser_test.py
+++ b/server/tests/browser_test.py
@@ -25,10 +25,10 @@ class TestStaticPage(unittest.TestCase):
         assert response.status_code == 200
         assert b"The Data Commons Graph is constructed by" in response.data
 
-    @patch('routes.api.shared.cached_name')
-    def test_browser_node(self, mock_cached_name):
+    @patch('routes.api.shared.names')
+    def test_browser_node(self, mock_names):
         dcid = 'geoId/06'
-        mock_cached_name.return_value = {dcid: 'California'}
+        mock_names.return_value = {dcid: 'California'}
         response = app.test_client().get('/browser/' + dcid)
         assert response.status_code == 200
         assert b"geoId/06" in response.data


### PR DESCRIPTION
Since dc.property_values() supports cache already, there is no need for a wrapper function to cache names. This is to gradually migrate to use V1 API and simplify existing code.