### PR TITLE
[disaster dashboard] add flask endpoints

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -22,6 +22,7 @@ import urllib.error
 
 from flask import Flask, request, g
 from flask_babel import Babel
+from google.cloud import storage
 
 import firebase_admin
 from firebase_admin import credentials
@@ -36,6 +37,7 @@ from opencensus.trace.samplers import AlwaysOnSampler
 import lib.config as libconfig
 import lib.i18n as i18n
 import lib.util as libutil
+from lib.disaster_dashboard import get_disaster_dashboard_config
 import services.ai as ai
 
 propagator = google_cloud_format.GoogleCloudFormatPropagator()
@@ -97,7 +99,7 @@ def register_routes_common(app):
     from routes.api import (browser as browser_api, choropleth, place as
                             place_api, landing_page, ranking as ranking_api,
                             stats, translator, csv, facets, series, point,
-                            observation_dates)
+                            observation_dates, disaster_dashboard)
     app.register_blueprint(browser_api.bp)
     app.register_blueprint(choropleth.bp)
     app.register_blueprint(factcheck.bp)
@@ -111,6 +113,7 @@ def register_routes_common(app):
     app.register_blueprint(series.bp)
     app.register_blueprint(point.bp)
     app.register_blueprint(observation_dates.bp)
+    app.register_blueprint(disaster_dashboard.bp)
 
 
 def create_app():
@@ -213,6 +216,12 @@ def create_app():
     babel = Babel(app, default_domain='all')
     app.config['BABEL_DEFAULT_LOCALE'] = i18n.DEFAULT_LOCALE
     app.config['BABEL_TRANSLATION_DIRECTORIES'] = 'i18n'
+
+    # load disaster dashboard data frpm GCS
+    if os.environ.get('FLASK_ENV') in ['autopush', 'local', 'dev']:
+        disaster_dashboard_config = get_disaster_dashboard_config(
+            app.config['GCS_BUCKET'])
+        app.config['DISASTER_DASHBOARD_DATA'] = disaster_dashboard_config
 
     # Initialize the AI module.
     app.config['AI_CONTEXT'] = ai.Context()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -37,7 +37,7 @@ from opencensus.trace.samplers import AlwaysOnSampler
 import lib.config as libconfig
 import lib.i18n as i18n
 import lib.util as libutil
-from lib.disaster_dashboard import get_disaster_dashboard_config
+from lib.disaster_dashboard import get_disaster_dashboard_data
 import services.ai as ai
 
 propagator = google_cloud_format.GoogleCloudFormatPropagator()
@@ -217,11 +217,11 @@ def create_app():
     app.config['BABEL_DEFAULT_LOCALE'] = i18n.DEFAULT_LOCALE
     app.config['BABEL_TRANSLATION_DIRECTORIES'] = 'i18n'
 
-    # load disaster dashboard data frpm GCS
+    # load disaster dashboard data from GCS
     if os.environ.get('FLASK_ENV') in ['autopush', 'local', 'dev']:
-        disaster_dashboard_config = get_disaster_dashboard_config(
+        disaster_dashboard_data = get_disaster_dashboard_data(
             app.config['GCS_BUCKET'])
-        app.config['DISASTER_DASHBOARD_DATA'] = disaster_dashboard_config
+        app.config['DISASTER_DASHBOARD_DATA'] = disaster_dashboard_data
 
     # Initialize the AI module.
     app.config['AI_CONTEXT'] = ai.Context()

--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -54,10 +54,12 @@ class StagingConfig(Config):
 class AutopushConfig(Config):
     GA_ACCOUNT = 'G-Y6ZXZ9JK3H'
     ADMIN = True
+    GCS_BUCKET = 'datcom-website-autopush-resources'
     pass
 
 
 class DevConfig(Config):
+    GCS_BUCKET = 'datcom-website-autopush-resources'
     pass
 
 
@@ -110,6 +112,7 @@ class LocalBaseConfig(Config):
     AI_CONFIG_PATH = os.path.abspath(
         os.path.join(os.path.curdir, '..', 'deploy/overlays/local/ai.yaml'))
     SCHEME = 'http'
+    GCS_BUCKET = 'datcom-website-autopush-resources'
 
 
 class LocalConfig(LocalBaseConfig):

--- a/server/lib/disaster_dashboard.py
+++ b/server/lib/disaster_dashboard.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Helper functions for getting disaster dashboard data for the app config"""
 
 from google.cloud import storage

--- a/server/lib/disaster_dashboard.py
+++ b/server/lib/disaster_dashboard.py
@@ -1,0 +1,77 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper functions for getting disaster dashboard data for the app config"""
+
+from google.cloud import storage
+import json
+
+EVENT_TYPE_FILE_NAME = {
+    "EarthquakeEvent": "earthquake_events.json",
+    "WildlandFireEvent": "wildlandfire_events.json",
+    "WildfireEvent": "wildfire_events.json",
+    "CycloneEvent": "cyclone_events.json",
+    "HurricaneTyphoonEvent": "hurricane_typhoon_events.json",
+    "HurricaneEvent": "hurricane_events.json",
+    "TornadoEvent": "tornado_events.json",
+    "FloodEvent": "flood_events.json",
+    "DroughtEvent": "drought_events.json"
+}
+
+
+def get_disaster_dashboard_config(gcs_bucket):
+    """
+    Gets and processes disaster data from gcs.
+
+    Returns
+        A dictionary of event type to dictionary of date (YYYY-MM) to list of
+        events:
+        {
+            [eventType]: {
+                [date]: [
+                    {
+                        eventId: string,
+                        name: string,
+                        startDate: string,
+                        endDate: string
+                        affectedPlaces: list of string,
+                        longitude: number,
+                        latitude: number,
+                        ... other properties depending on the event (e.g., EarthquakeEvent will have magnitude)
+                    },
+                    ...
+                ],
+                ...
+            },
+            ...
+        }
+
+    """
+    result = {}
+    for event_type in EVENT_TYPE_FILE_NAME:
+        storage_client = storage.Client()
+        bucket = storage_client.get_bucket(gcs_bucket)
+        blob = bucket.get_blob(EVENT_TYPE_FILE_NAME[event_type])
+        events_data = json.loads(blob.download_as_bytes())
+        events_by_date = {}
+        for event_data in events_data:
+            start_date = event_data.get("startDate", "")
+            if not start_date:
+                continue
+            start_date_year_month = start_date[0:7]
+            if start_date_year_month not in events_by_date:
+                events_by_date[start_date_year_month] = []
+            events_by_date[start_date_year_month].append(event_data)
+        result[event_type] = events_by_date
+    return result

--- a/server/routes/api/disaster_dashboard.py
+++ b/server/routes/api/disaster_dashboard.py
@@ -39,9 +39,9 @@ def date_range():
     """
     event_type = request.args.get('eventType', '')
     result = {"minDate": "", "maxDate": ""}
-    if event_type in current_app.config['DISASTER_DASHBOARD_DATA']:
-        dates = list(current_app.config['DISASTER_DASHBOARD_DATA'].get(
-            event_type).keys())
+    disaster_data = current_app.config['DISASTER_DASHBOARD_DATA']
+    if event_type in disaster_data:
+        dates = list(disaster_data.get(event_type).keys())
         if dates:
             dates = sorted(dates)
             result = {"minDate": dates[0], "maxDate": dates[-1]}
@@ -69,8 +69,8 @@ def data():
     date = request.args.get('date', '')
     place = request.args.get('place', '')
     result = []
-    for event in current_app.config['DISASTER_DASHBOARD_DATA'].get(
-            event_type, {}).get(date, []):
+    disaster_data = current_app.config['DISASTER_DASHBOARD_DATA']
+    for event in disaster_data.get(event_type, {}).get(date, []):
         if place != EARTH_DCID and not place in event.get("affectedPlaces", []):
             continue
         result.append(event)

--- a/server/routes/api/disaster_dashboard.py
+++ b/server/routes/api/disaster_dashboard.py
@@ -1,0 +1,77 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Endpoints for disaster dashboard"""
+
+from flask import Blueprint, request, current_app
+import services.datacommons as dc
+from lib.gcs import list_blobs
+import json
+
+# Define blueprint
+bp = Blueprint("disaster-dashboard",
+               __name__,
+               url_prefix='/api/disaster-dashboard')
+
+EARTH_DCID = "Earth"
+
+
+@bp.route('/date-range')
+def date_range():
+    """
+    Gets the date range for a specific event type
+
+    Returns: an object with minDate and maxDate
+        {
+            minDate: string,
+            maxDate: string
+        }
+    """
+    event_type = request.args.get('eventType', '')
+    result = {"minDate": "", "maxDate": ""}
+    if event_type in current_app.config['DISASTER_DASHBOARD_DATA']:
+        dates = list(current_app.config['DISASTER_DASHBOARD_DATA'].get(
+            event_type).keys())
+        if dates:
+            dates = sorted(dates)
+            result = {"minDate": dates[0], "maxDate": dates[-1]}
+    return json.dumps(result), 200
+
+
+@bp.route('/data')
+def data():
+    """
+    Gets the data for a given eventType, date, and place
+
+    Returns: a list of events of the following form
+        {
+            eventId: string,
+            name: string,
+            startDate: string,
+            endDate: string
+            affectedPlaces: list of string,
+            longitude: number,
+            latitude: number,
+            ... (optional properties depending on the event (e.g., EarthquakeEvent will have magnitude)
+        }
+    """
+    event_type = request.args.get('eventType', '')
+    date = request.args.get('date', '')
+    place = request.args.get('place', '')
+    result = []
+    for event in current_app.config['DISASTER_DASHBOARD_DATA'].get(
+            event_type, {}).get(date, []):
+        if place != EARTH_DCID and not place in event.get("affectedPlaces", []):
+            continue
+        result.append(event)
+    return json.dumps(result), 200

--- a/server/tests/api/api_disaster_dashboard_test.py
+++ b/server/tests/api/api_disaster_dashboard_test.py
@@ -23,101 +23,111 @@ DATE_1 = "2020-01"
 DATE_2 = "1990-11"
 PLACE_1 = "country/USA"
 EVENT_1 = {
-  "eventId": "event1",
-  "name": "event1",
-  "startDate": "2020-01-01",
-  "endDate": "",
-  "affectedPlaces": [PLACE_1],
-  "longitude": 1,
-  "latitude": 2,
-  "magnitude": 4
+    "eventId": "event1",
+    "name": "event1",
+    "startDate": "2020-01-01",
+    "endDate": "",
+    "affectedPlaces": [PLACE_1],
+    "longitude": 1,
+    "latitude": 2,
+    "magnitude": 4
 }
 EVENT_2 = {
-  "eventId": "event1",
-  "name": "event1",
-  "startDate": "1990-11-01",
-  "endDate": "",
-  "affectedPlaces": [PLACE_1],
-  "longitude": 1,
-  "latitude": 2,
-  "magnitude": 4
+    "eventId": "event1",
+    "name": "event1",
+    "startDate": "1990-11-01",
+    "endDate": "",
+    "affectedPlaces": [PLACE_1],
+    "longitude": 1,
+    "latitude": 2,
+    "magnitude": 4
 }
 EVENT_3 = {
-  "eventId": "event1",
-  "name": "event1",
-  "startDate": "2020-01-09",
-  "endDate": "",
-  "affectedPlaces": [],
-  "longitude": 1,
-  "latitude": 2,
-  "magnitude": 4
-
+    "eventId": "event1",
+    "name": "event1",
+    "startDate": "2020-01-09",
+    "endDate": "",
+    "affectedPlaces": [],
+    "longitude": 1,
+    "latitude": 2,
+    "magnitude": 4
 }
-TEST_DATA = {
-  EVENT_TYPE_1: {
-    DATE_1: [EVENT_1, EVENT_3],
-    DATE_2: [EVENT_2]
-  }
-}
+TEST_DATA = {EVENT_TYPE_1: {DATE_1: [EVENT_1, EVENT_3], DATE_2: [EVENT_2]}}
 EARTH_DCID = "Earth"
 
+
 class TestGetDateRange(unittest.TestCase):
-  def test_has_data(self):
-    with app.app_context():
-      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
-      response = app.test_client().get("/api/disaster-dashboard/date-range?eventType=" + EVENT_TYPE_1)
-      assert response.status_code == 200
-      response_data = json.loads(response.data)
-      assert(response_data.get("maxDate") == DATE_1)
-      assert(response_data.get("minDate") == DATE_2)
-  
-  def test_no_data(self):
-    with app.app_context():
-      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
-      response = app.test_client().get("/api/disaster-dashboard/date-range?eventType=" + "TestEventType")
-      assert response.status_code == 200
-      response_data = json.loads(response.data)
-      assert(response_data.get("maxDate") == "")
-      assert(response_data.get("minDate") == "")
+
+    def test_has_data(self):
+        with app.app_context():
+            app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+            response = app.test_client().get(
+                "/api/disaster-dashboard/date-range?eventType=" + EVENT_TYPE_1)
+            assert response.status_code == 200
+            response_data = json.loads(response.data)
+            assert (response_data.get("maxDate") == DATE_1)
+            assert (response_data.get("minDate") == DATE_2)
+
+    def test_no_data(self):
+        with app.app_context():
+            app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+            response = app.test_client().get(
+                "/api/disaster-dashboard/date-range?eventType=" +
+                "TestEventType")
+            assert response.status_code == 200
+            response_data = json.loads(response.data)
+            assert (response_data.get("maxDate") == "")
+            assert (response_data.get("minDate") == "")
 
 
 class TestGetData(unittest.TestCase):
-  def test_earth_date_1_event_type_1(self):
-    with app.app_context():
-      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
-      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format(EVENT_TYPE_1, DATE_1, EARTH_DCID))
-      assert response.status_code == 200
-      response_data = json.loads(response.data)
-      assert(response_data == TEST_DATA[EVENT_TYPE_1][DATE_1])
 
-  def test_earth_date_new_event_type_1(self):
-    with app.app_context():
-      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
-      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format(EVENT_TYPE_1, "1997-01", EARTH_DCID))
-      assert response.status_code == 200
-      response_data = json.loads(response.data)
-      assert(response_data == [])
+    def test_earth_date_1_event_type_1(self):
+        with app.app_context():
+            app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+            response = app.test_client().get(
+                '/api/disaster-dashboard/data?eventType={}&date={}&place={}'.
+                format(EVENT_TYPE_1, DATE_1, EARTH_DCID))
+            assert response.status_code == 200
+            response_data = json.loads(response.data)
+            assert (response_data == TEST_DATA[EVENT_TYPE_1][DATE_1])
 
-  def test_earth_date_1_event_type_new(self):
-    with app.app_context():
-      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
-      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format("TestEventType", DATE_1, EARTH_DCID))
-      assert response.status_code == 200
-      response_data = json.loads(response.data)
-      assert(response_data == [])
+    def test_earth_date_new_event_type_1(self):
+        with app.app_context():
+            app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+            response = app.test_client().get(
+                '/api/disaster-dashboard/data?eventType={}&date={}&place={}'.
+                format(EVENT_TYPE_1, "1997-01", EARTH_DCID))
+            assert response.status_code == 200
+            response_data = json.loads(response.data)
+            assert (response_data == [])
 
-  def test_place_1_date_1_event_type_1(self):
-    with app.app_context():
-      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
-      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format(EVENT_TYPE_1, DATE_1, PLACE_1))
-      assert response.status_code == 200
-      response_data = json.loads(response.data)
-      assert(response_data == [EVENT_1])
+    def test_earth_date_1_event_type_new(self):
+        with app.app_context():
+            app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+            response = app.test_client().get(
+                '/api/disaster-dashboard/data?eventType={}&date={}&place={}'.
+                format("TestEventType", DATE_1, EARTH_DCID))
+            assert response.status_code == 200
+            response_data = json.loads(response.data)
+            assert (response_data == [])
 
-  def test_place_new_date_1_event_type_1(self):
-    with app.app_context():
-      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
-      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format(EVENT_TYPE_1, DATE_1, "placeTest"))
-      assert response.status_code == 200
-      response_data = json.loads(response.data)
-      assert(response_data == [])
+    def test_place_1_date_1_event_type_1(self):
+        with app.app_context():
+            app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+            response = app.test_client().get(
+                '/api/disaster-dashboard/data?eventType={}&date={}&place={}'.
+                format(EVENT_TYPE_1, DATE_1, PLACE_1))
+            assert response.status_code == 200
+            response_data = json.loads(response.data)
+            assert (response_data == [EVENT_1])
+
+    def test_place_new_date_1_event_type_1(self):
+        with app.app_context():
+            app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+            response = app.test_client().get(
+                '/api/disaster-dashboard/data?eventType={}&date={}&place={}'.
+                format(EVENT_TYPE_1, DATE_1, "placeTest"))
+            assert response.status_code == 200
+            response_data = json.loads(response.data)
+            assert (response_data == [])

--- a/server/tests/api/api_disaster_dashboard_test.py
+++ b/server/tests/api/api_disaster_dashboard_test.py
@@ -1,0 +1,123 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+from unittest.mock import patch
+
+from main import app
+
+EVENT_TYPE_1 = "EarthquakeEvent"
+DATE_1 = "2020-01"
+DATE_2 = "1990-11"
+PLACE_1 = "country/USA"
+EVENT_1 = {
+  "eventId": "event1",
+  "name": "event1",
+  "startDate": "2020-01-01",
+  "endDate": "",
+  "affectedPlaces": [PLACE_1],
+  "longitude": 1,
+  "latitude": 2,
+  "magnitude": 4
+}
+EVENT_2 = {
+  "eventId": "event1",
+  "name": "event1",
+  "startDate": "1990-11-01",
+  "endDate": "",
+  "affectedPlaces": [PLACE_1],
+  "longitude": 1,
+  "latitude": 2,
+  "magnitude": 4
+}
+EVENT_3 = {
+  "eventId": "event1",
+  "name": "event1",
+  "startDate": "2020-01-09",
+  "endDate": "",
+  "affectedPlaces": [],
+  "longitude": 1,
+  "latitude": 2,
+  "magnitude": 4
+
+}
+TEST_DATA = {
+  EVENT_TYPE_1: {
+    DATE_1: [EVENT_1, EVENT_3],
+    DATE_2: [EVENT_2]
+  }
+}
+EARTH_DCID = "Earth"
+
+class TestGetDateRange(unittest.TestCase):
+  def test_has_data(self):
+    with app.app_context():
+      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+      response = app.test_client().get("/api/disaster-dashboard/date-range?eventType=" + EVENT_TYPE_1)
+      assert response.status_code == 200
+      response_data = json.loads(response.data)
+      assert(response_data.get("maxDate") == DATE_1)
+      assert(response_data.get("minDate") == DATE_2)
+  
+  def test_no_data(self):
+    with app.app_context():
+      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+      response = app.test_client().get("/api/disaster-dashboard/date-range?eventType=" + "TestEventType")
+      assert response.status_code == 200
+      response_data = json.loads(response.data)
+      assert(response_data.get("maxDate") == "")
+      assert(response_data.get("minDate") == "")
+
+
+class TestGetData(unittest.TestCase):
+  def test_earth_date_1_event_type_1(self):
+    with app.app_context():
+      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format(EVENT_TYPE_1, DATE_1, EARTH_DCID))
+      assert response.status_code == 200
+      response_data = json.loads(response.data)
+      assert(response_data == TEST_DATA[EVENT_TYPE_1][DATE_1])
+
+  def test_earth_date_new_event_type_1(self):
+    with app.app_context():
+      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format(EVENT_TYPE_1, "1997-01", EARTH_DCID))
+      assert response.status_code == 200
+      response_data = json.loads(response.data)
+      assert(response_data == [])
+
+  def test_earth_date_1_event_type_new(self):
+    with app.app_context():
+      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format("TestEventType", DATE_1, EARTH_DCID))
+      assert response.status_code == 200
+      response_data = json.loads(response.data)
+      assert(response_data == [])
+
+  def test_place_1_date_1_event_type_1(self):
+    with app.app_context():
+      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format(EVENT_TYPE_1, DATE_1, PLACE_1))
+      assert response.status_code == 200
+      response_data = json.loads(response.data)
+      assert(response_data == [EVENT_1])
+
+  def test_place_new_date_1_event_type_1(self):
+    with app.app_context():
+      app.config['DISASTER_DASHBOARD_DATA'] = TEST_DATA
+      response = app.test_client().get('/api/disaster-dashboard/data?eventType={}&date={}&place={}'.format(EVENT_TYPE_1, DATE_1, "placeTest"))
+      assert response.status_code == 200
+      response_data = json.loads(response.data)
+      assert(response_data == [])


### PR DESCRIPTION
add flask endpoints for getting date range and getting data

This is one part of the changes for the disaster dashboard MVP here on dev:
https://dev.datacommons.org/dev/disaster-dashboard