### PR TITLE
[disaster dashboard] initial page set up

### DIFF
--- a/server/routes/dev.py
+++ b/server/routes/dev.py
@@ -37,3 +37,11 @@ def screenshot(folder):
         flask.abort(404)
     images = list_png(SCREENSHOT_BUCKET, folder)
     return flask.render_template('dev/screenshot.html', images=images)
+
+
+@bp.route('/disaster-dashboard')
+def disaster_dashboard():
+    if os.environ.get('FLASK_ENV') != 'autopush' and os.environ.get(
+            'FLASK_ENV') != 'local' and os.environ.get('FLASK_ENV') != 'dev':
+        flask.abort(404)
+    return flask.render_template('dev/disaster_dashboard.html')

--- a/server/routes/dev.py
+++ b/server/routes/dev.py
@@ -41,7 +41,6 @@ def screenshot(folder):
 
 @bp.route('/disaster-dashboard')
 def disaster_dashboard():
-    if os.environ.get('FLASK_ENV') != 'autopush' and os.environ.get(
-            'FLASK_ENV') != 'local' and os.environ.get('FLASK_ENV') != 'dev':
+    if not os.environ.get('FLASK_ENV') in ['autopush', 'local', 'dev']:
         flask.abort(404)
     return flask.render_template('dev/disaster_dashboard.html')

--- a/server/templates/dev/disaster_dashboard.html
+++ b/server/templates/dev/disaster_dashboard.html
@@ -1,0 +1,36 @@
+{#
+  Copyright 2022 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{%- extends BASE_HTML -%}
+
+{% set is_hide_full_footer = true %}
+{% set title = "Disaster Dashboard" %}
+{% set main_id = 'main-disaster-dashboard' %}
+{% set page_id = 'page-disaster-dashboard' %}
+
+{% block head %}
+  <link rel="stylesheet" href={{url_for('static', filename='css/disaster_dashboard.min.css')}} >
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
+{% endblock %}
+
+{% block content %}
+  <div id="main-pane"></div>
+{% endblock %}
+
+{% block footer %}
+  <script src={{url_for('static', filename='disaster_dashboard.js', t=config['VERSION'])}}></script>
+{% endblock %}

--- a/static/css/disaster_dashboard.scss
+++ b/static/css/disaster_dashboard.scss
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ @import "base";

--- a/static/js/disaster_dashboard/constants.ts
+++ b/static/js/disaster_dashboard/constants.ts
@@ -17,3 +17,20 @@
 /**
  * Constants used across components in Disaster Dashboard
  */
+
+import { DisasterType } from "./types";
+
+// Map of Disaster type to event types encompassed by the disaster type
+export const DISASTER_EVENT_TYPES = {
+  [DisasterType.EARTHQUAKE]: ["EarthquakeEvent"],
+  [DisasterType.FIRE]: ["WildlandFireEvent", "WildfireEvent"],
+  [DisasterType.STORM]: [
+    "CycloneEvent",
+    "HurricaneTyphoonEvent",
+    "HurricaneEvent",
+    "TornadoEvent",
+  ],
+  [DisasterType.FLOOD]: ["FloodEvent"],
+  [DisasterType.DROUGHT]: ["DroughtEvent"],
+};
+

--- a/static/js/disaster_dashboard/constants.ts
+++ b/static/js/disaster_dashboard/constants.ts
@@ -33,4 +33,3 @@ export const DISASTER_EVENT_TYPES = {
   [DisasterType.FLOOD]: ["FloodEvent"],
   [DisasterType.DROUGHT]: ["DroughtEvent"],
 };
-

--- a/static/js/disaster_dashboard/constants.ts
+++ b/static/js/disaster_dashboard/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Constants used across components in Disaster Dashboard
+ */

--- a/static/js/disaster_dashboard/constants.ts
+++ b/static/js/disaster_dashboard/constants.ts
@@ -18,7 +18,14 @@
  * Constants used across components in Disaster Dashboard
  */
 
-import { DisasterType } from "./types";
+export enum DisasterType {
+  ALL = "All",
+  EARTHQUAKE = "Earthquake",
+  FIRE = "Fire",
+  STORM = "Storm",
+  FLOOD = "Flood",
+  DROUGHT = "Drought",
+}
 
 // Map of Disaster type to event types encompassed by the disaster type
 export const DISASTER_EVENT_TYPES = {
@@ -32,4 +39,10 @@ export const DISASTER_EVENT_TYPES = {
   ],
   [DisasterType.FLOOD]: ["FloodEvent"],
   [DisasterType.DROUGHT]: ["DroughtEvent"],
+};
+
+// Map of Disaster type to intensity props used for each disaster type
+export const DISASTER_EVENT_INTENSITIES = {
+  [DisasterType.EARTHQUAKE]: ["magnitude"],
+  [DisasterType.DROUGHT]: ["directDeaths", "directInjuries"],
 };

--- a/static/js/disaster_dashboard/disaster_dashboard.ts
+++ b/static/js/disaster_dashboard/disaster_dashboard.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * disaster dashboard
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { Page } from "./page";
+
+window.onload = () => {
+  ReactDOM.render(
+    React.createElement(Page),
+    document.getElementById("main-pane")
+  );
+};

--- a/static/js/disaster_dashboard/page.tsx
+++ b/static/js/disaster_dashboard/page.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Main component for the disaster dashboard.
+ */
+
+import React from "react";
+
+export function Page(): JSX.Element {
+  return <div></div>;
+}

--- a/static/js/disaster_dashboard/types.ts
+++ b/static/js/disaster_dashboard/types.ts
@@ -15,19 +15,11 @@
  */
 
 import { MapPoint } from "../chart/types";
+import { DisasterType } from "./constants";
 
 /**
  * Types specific to Disaster Dashboard
  */
-
-export enum DisasterType {
-  ALL = "All",
-  EARTHQUAKE = "Earthquake",
-  FIRE = "Fire",
-  STORM = "Storm",
-  FLOOD = "Flood",
-  DROUGHT = "Drought",
-}
 
 export interface DisasterEventPoint extends MapPoint {
   disasterType: DisasterType;

--- a/static/js/disaster_dashboard/types.ts
+++ b/static/js/disaster_dashboard/types.ts
@@ -15,8 +15,23 @@
  */
 
 import { MapPoint } from "../chart/types";
-import { NamedPlace, NamedTypedPlace } from "../shared/types";
 
 /**
  * Types specific to Disaster Dashboard
  */
+
+export enum DisasterType {
+  ALL = "All",
+  EARTHQUAKE = "Earthquake",
+  FIRE = "Fire",
+  STORM = "Storm",
+  FLOOD = "Flood",
+  DROUGHT = "Drought",
+}
+
+export interface DisasterEventPoint extends MapPoint {
+  disasterType: DisasterType;
+  startDate: string;
+  intensity: { [prop: string]: number };
+  endDate?: string;
+}

--- a/static/js/disaster_dashboard/types.ts
+++ b/static/js/disaster_dashboard/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MapPoint } from "../chart/types";
+import { NamedPlace, NamedTypedPlace } from "../shared/types";
+
+/**
+ * Types specific to Disaster Dashboard
+ */

--- a/static/webpack.config.js
+++ b/static/webpack.config.js
@@ -93,6 +93,10 @@ const config = {
       __dirname + "/css/import_wizard2.scss",
     ],
     user: [__dirname + "/js/user/user.ts", __dirname + "/css/user.scss"],
+    disaster_dashboard: [
+      __dirname + "/js/disaster_dashboard/disaster_dashboard.ts",
+      __dirname + "/css/disaster_dashboard.scss",
+    ]
   },
   output: {
     path: path.resolve(__dirname, "../") + "/server/dist",


### PR DESCRIPTION
set up skeleton for the new disaster dashboard page (so future PRs can be submitted in parallel)

This is one part of the changes for the disaster dashboard MVP here on dev:
https://dev.datacommons.org/dev/disaster-dashboard