### PR TITLE
Fix a few key/value error issues

### DIFF
--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -14,6 +14,7 @@
 
 import collections
 import json
+import logging
 import urllib.parse
 
 from flask import Blueprint, request, Response, url_for, g, current_app
@@ -132,6 +133,7 @@ def api_name():
     try:
         return names(dcids)
     except Exception as e:
+        logging.error(e)
         return 'error fetching names for {}'.format(dcids), 400
 
 

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -128,9 +128,11 @@ def get_place_type(place_dcid):
 @bp.route('/name')
 def api_name():
     """Get place names."""
-    dcids = request.args.getlist('dcid')
-    result = names(dcids)
-    return Response(json.dumps(result), 200, mimetype='application/json')
+    dcids = request.args.getlist('dcids')
+    try:
+        return names(dcids)
+    except Exception as e:
+        return '{}'.format(e), 400
 
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -132,7 +132,7 @@ def api_name():
     try:
         return names(dcids)
     except Exception as e:
-        return '{}'.format(e), 400
+        return 'error fetching names for {}'.format(dcids), 400
 
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -134,7 +134,7 @@ def api_name():
         return names(dcids)
     except Exception as e:
         logging.error(e)
-        return 'error fetching names for {}'.format(dcids), 400
+        return 'error fetching names for the given places', 400
 
 
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.

--- a/server/routes/api/point.py
+++ b/server/routes/api/point.py
@@ -24,7 +24,7 @@ def compact_point(point_resp, all_facets):
         'facets': point_resp.get('facets', {}),
     }
     data = {}
-    for obs_by_variable in point_resp['observationsByVariable']:
+    for obs_by_variable in point_resp.get('observationsByVariable', []):
         var = obs_by_variable['variable']
         data[var] = {}
         for obs_by_entity in obs_by_variable['observationsByEntity']:

--- a/server/routes/api/series.py
+++ b/server/routes/api/series.py
@@ -25,7 +25,7 @@ def compact_series(series_resp, all_facets):
         'facets': series_resp.get('facets', {}),
     }
     data = {}
-    for obs_by_variable in series_resp['observationsByVariable']:
+    for obs_by_variable in series_resp.get('observationsByVariable', []):
         var = obs_by_variable['variable']
         data[var] = {}
         for obs_by_entity in obs_by_variable['observationsByEntity']:

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -93,10 +93,9 @@ def post_wrapper(path, req_str):
     response = requests.post(url, json=req, headers=headers)
     if response.status_code != 200:
         raise ValueError(
-            'Response error: An HTTP {} code ({}) was returned by the mixer.'
-            'Printing response:\n{}'.format(response.status_code,
-                                            response.reason,
-                                            response.json()['message']))
+            'An HTTP {} code ({}) was returned by the mixer:{}'.format(
+                response.status_code, response.reason,
+                response.json()['message']))
     return response.json()
 
 

--- a/server/tests/api/api_place_test.py
+++ b/server/tests/api/api_place_test.py
@@ -137,7 +137,7 @@ class TestApiPlaceName(unittest.TestCase):
         }
 
         response = app.test_client().get(
-            '/api/place/name?dcid=geoId/06&dcid=geoId/07&dcid=geoId/08')
+            '/api/place/name?dcids=geoId/06&dcids=geoId/07&dcids=geoId/08')
         assert response.status_code == 200
         assert json.loads(response.data) == {
             'geoId/06': 'California',

--- a/static/js/tools/download/mock_functions.ts
+++ b/static/js/tools/download/mock_functions.ts
@@ -106,7 +106,7 @@ export function axios_mock(): void {
 
   // get place names, geoId/06
   when(axios.get)
-    .calledWith("/api/place/name?dcid=geoId/06")
+    .calledWith("/api/place/name?dcids=geoId/06")
     .mockResolvedValue({ data: { "geoId/06": "California" } });
 
   // get root stat var group

--- a/static/js/tools/timeline/mock_functions.tsx
+++ b/static/js/tools/timeline/mock_functions.tsx
@@ -138,7 +138,12 @@ export function axios_mock(): void {
 
   // get place names, geoId/05
   when(axios.get)
-    .calledWith("/api/place/name?dcids=geoId/05")
+    .calledWith("/api/place/name", {
+      params: {
+        dcids: ["geoId/05"],
+      },
+      paramsSerializer: stringifyFn,
+    })
     .mockResolvedValue({ data: { "geoId/05": "Place" } });
 
   // get data, geoId/05,Count_Person

--- a/static/js/tools/timeline/mock_functions.tsx
+++ b/static/js/tools/timeline/mock_functions.tsx
@@ -138,7 +138,7 @@ export function axios_mock(): void {
 
   // get place names, geoId/05
   when(axios.get)
-    .calledWith("/api/place/name?dcid=geoId/05")
+    .calledWith("/api/place/name?dcids=geoId/05")
     .mockResolvedValue({ data: { "geoId/05": "Place" } });
 
   // get data, geoId/05,Count_Person

--- a/static/js/utils/place_utils.ts
+++ b/static/js/utils/place_utils.ts
@@ -23,6 +23,8 @@ import {
 } from "../shared/constants";
 import { NamedPlace, NamedTypedPlace } from "../shared/types";
 import { ALL_MAP_PLACE_TYPES } from "../tools/map/util";
+import { stringifyFn } from "./axios";
+
 let ps: google.maps.places.PlacesService;
 
 const DEFAULT_SAMPLE_SIZE = 50;
@@ -170,6 +172,7 @@ export function getPlaceNames(
       params: {
         dcids: dcids,
       },
+      paramsSerializer: stringifyFn,
     })
     .then((resp) => {
       return resp.data;

--- a/static/js/utils/place_utils.ts
+++ b/static/js/utils/place_utils.ts
@@ -143,7 +143,7 @@ export function getNamedTypedPlace(
     .get(`/api/place/type/${placeDcid}`)
     .then((resp) => resp.data);
   const placeNamePromise = axios
-    .get(`/api/place/name?dcid=${placeDcid}`)
+    .get(`/api/place/name?dcids=${placeDcid}`)
     .then((resp) => resp.data);
   return Promise.all([placeTypePromise, placeNamePromise])
     .then(([placeType, placeName]) => {
@@ -165,15 +165,15 @@ export function getPlaceNames(
   if (!dcids.length) {
     return Promise.resolve({});
   }
-  let url = "/api/place/name?";
-  const urls = [];
-  for (const place of dcids) {
-    urls.push(`dcid=${place}`);
-  }
-  url += urls.join("&");
-  return axios.get(url).then((resp) => {
-    return resp.data;
-  });
+  return axios
+    .get("/api/place/name", {
+      params: {
+        dcids: dcids,
+      },
+    })
+    .then((resp) => {
+      return resp.data;
+    });
 }
 
 /**


### PR DESCRIPTION
* These errors are found from Error Reporting in GCP. We should set up alerts for such errors.
* All Flask endpoint should do "try/catch" to handle any errors from mixer response. This PR updates one such case from error reporting logs.
* Changed "dcid" to "dcids" in name fetch endpoint for better readability and consistency. 