### PR TITLE
Custom DC: Terraform for storage project IAM

### DIFF
--- a/deploy/terraform-datacommons-website/examples/base_storage_permissions/README.md
+++ b/deploy/terraform-datacommons-website/examples/base_storage_permissions/README.md
@@ -1,0 +1,13 @@
+# Datacommons storage permission setup
+
+This script exists to allow custom DC instances to access base BT/BQ and is meant
+to be run by the owners of the DC storage project.
+
+## Steps
+
+Run the following script and make sure to replace the custom DC robot SA email.
+
+```sh
+export ROBOT_EMAIL=<custom DC robot sa email>
+terraform init && terraform apply -var="custom_dc_web_robot_email=$ROBOT_EMAIL" -auto-approve
+```

--- a/deploy/terraform-datacommons-website/examples/base_storage_permissions/main.tf
+++ b/deploy/terraform-datacommons-website/examples/base_storage_permissions/main.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_project_iam_member" "web_robot_storage_roles" {
+  for_each = toset([
+    "roles/bigquery.admin",   # BigQuery
+    "roles/bigtable.reader",  # Bigtable
+    "roles/storage.objectViewer",  # Branch Cache Read
+    "roles/pubsub.editor" # Branch Cache Subscription
+  ])
+  role = each.key
+  member = "serviceAccount:${var.custom_dc_web_robot_email}"
+  project = var.base_storage_project_id
+}

--- a/deploy/terraform-datacommons-website/examples/base_storage_permissions/variables.tf
+++ b/deploy/terraform-datacommons-website/examples/base_storage_permissions/variables.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# This is the full email of the custom DC service account.
+# By default, it should follow the following format if the custom DC
+# instance was set up using the "setup" example under
+# terraform-datacommons-website.
+# website-robot@<custom DC project id>.iam.gserviceaccount.com
+#
+# However, if it is not, then any GCP Service Account can also work.
+# In such cases, the format should still follow:
+# <prefix>@<custom DC project id>.iam.gserviceaccount.com
+variable "custom_dc_web_robot_email" {
+  type        = string
+  description = "The GCP Service Account that will be running the custom DC web container."
+}
+
+variable "base_storage_project_id" {
+  type        = string
+  description = "The GCP project id where base BT cache and BQ datasets are located in."
+  default     = "datcom-store"
+}


### PR DESCRIPTION
This step is to be run by the storage project owners to allow the custom DC service account to access base storage layers directly.