### PR TITLE
Custom DC: make resource suffix optional in setup flow

### DIFF
--- a/deploy/terraform-datacommons-website/examples/setup/main.tf
+++ b/deploy/terraform-datacommons-website/examples/setup/main.tf
@@ -29,6 +29,8 @@ locals {
   # <<<<< END Important note >>>>>
   dc_website_domain = coalesce(
     var.dc_website_domain, format("%s-datacommons.com", var.project_id))
+
+  resource_suffx = var.use_resource_suffix ? format("-%s", random_id.rnd.hex) : ""
 }
 
 module "enabled_google_apis" {
@@ -63,14 +65,14 @@ resource "google_service_account" "web_robot" {
 }
 
 resource "google_compute_global_address" "dc_website_ingress_ip" {
-  name         = format("dc-website-ip-%s", random_id.rnd.hex)
+  name         = format("dc-website-ip%s", local.resource_suffx)
   project      = var.project_id
 
   depends_on   = [module.enabled_google_apis]
 }
 
 resource "google_dns_managed_zone" "datacommons_zone" {
-  name          = format("datacommons-%s", random_id.rnd.hex)
+  name          = format("datacommons%s", local.resource_suffx)
   dns_name      = format("%s.", local.dc_website_domain)
   project       = var.project_id
   dynamic "dnssec_config" {

--- a/deploy/terraform-datacommons-website/examples/setup/variables.tf
+++ b/deploy/terraform-datacommons-website/examples/setup/variables.tf
@@ -104,3 +104,9 @@ Ex2: 'Jane Done','John Doe'
 EOF
   default = "'Datacommons Team'"
 }
+
+variable "use_resource_suffix" {
+  type        = bool
+  description = "If true then add a random suffix to the ending of GCP resource names to avoid name collision."
+  default     = false
+}


### PR DESCRIPTION
Tested with terraform apply command. See DNS zone for example.

https://pantheon.corp.google.com/net-services/dns/zones/datacommons/details?mods=-monitoring_api_staging&project=datcom-website-dev