### PR TITLE
[stanford] add gcs bucket to stanford config

### DIFF
--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -80,6 +80,7 @@ class StanfordConfig(CustomConfig):
   ENV_NAME = 'STANFORD'
   ENABLE_BLOCKLIST = True
   BASE_HTML_PATH = 'custom_dc/stanford/base.html'
+  GCS_BUCKET = 'datcom-stanford-resources'
 
 
 class StanfordStagingConfig(StanfordConfig):
@@ -119,7 +120,6 @@ class LocalBaseConfig(Config):
   AI_CONFIG_PATH = os.path.abspath(
       os.path.join(os.path.curdir, '..', 'deploy/overlays/local/ai.yaml'))
   SCHEME = 'http'
-  GCS_BUCKET = 'datcom-website-autopush-resources'
 
 
 class LocalConfig(LocalBaseConfig):

--- a/server/lib/disaster_dashboard.py
+++ b/server/lib/disaster_dashboard.py
@@ -22,6 +22,7 @@ EVENT_TYPES = [
     "HurricaneTyphoonEvent", "HurricaneEvent", "TornadoEvent", "FloodEvent",
     "DroughtEvent"
 ]
+DISASTER_DATA_FOLDER = "disaster_dashboard/"
 
 
 def get_disaster_dashboard_data(gcs_bucket):
@@ -57,7 +58,7 @@ def get_disaster_dashboard_data(gcs_bucket):
     storage_client = storage.Client()
     bucket = storage_client.get_bucket(gcs_bucket)
     file_name = re.sub('(?!^)([A-Z]+)', r'_\1', event_type).lower() + ".json"
-    blob = bucket.get_blob(file_name)
+    blob = bucket.get_blob(DISASTER_DATA_FOLDER + file_name)
     if not blob:
       continue
     events_data = json.loads(blob.download_as_bytes())


### PR DESCRIPTION
On server start up, if the ENV is stanford, local-stanford, or autopush, we need to read disaster data files from the GCS bucket