### PR TITLE
Custom DC: Add a BT cache module

### DIFF
--- a/deploy/terraform-datacommons-website/modules/bt_cache/fetch_gcf_source.sh
+++ b/deploy/terraform-datacommons-website/modules/bt_cache/fetch_gcf_source.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -x
+
+rm -rf source
+mkdir source
+
+curl -o source/common.go \
+    https://raw.githubusercontent.com/datacommonsorg/tools/6d4171ed471b1d538ee45cdd63f2a7598b442be4/bigtable_automation/gcf/common.go
+
+curl -o source/private.go \
+    https://raw.githubusercontent.com/datacommonsorg/tools/6d4171ed471b1d538ee45cdd63f2a7598b442be4/bigtable_automation/gcf/private.go
+
+curl -o source/dataflow_launcher.go \
+    https://raw.githubusercontent.com/datacommonsorg/tools/6d4171ed471b1d538ee45cdd63f2a7598b442be4/bigtable_automation/gcf/dataflow_launcher.go
+
+curl -o source/go.sum \
+    https://raw.githubusercontent.com/datacommonsorg/tools/6d4171ed471b1d538ee45cdd63f2a7598b442be4/bigtable_automation/gcf/go.sum
+
+curl -o source/go.mod \
+    https://raw.githubusercontent.com/datacommonsorg/tools/6d4171ed471b1d538ee45cdd63f2a7598b442be4/bigtable_automation/gcf/go.mod
+
+cd source
+zip -r bt_automation_go_source.zip .

--- a/deploy/terraform-datacommons-website/modules/bt_cache/main.tf
+++ b/deploy/terraform-datacommons-website/modules/bt_cache/main.tf
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+locals {
+    resource_suffix = (
+        var.resource_suffix != null ?
+        format("-%s", var.resource_suffix) : ""
+    )
+}
+
+# BigTable instance used to store cache tables.
+resource "google_bigtable_instance" "bt_cache" {
+  name           = format("dc-graph%s", local.resource_suffix)
+  project        = var.project_id
+
+  cluster {
+    # There will be one cluster. Constant seems appropriate for now.
+    cluster_id   = "dc-graph-c1"
+    zone         = var.bt_instance_zone
+
+    autoscaling_config {
+      min_nodes  = var.bt_autoscaling_min_nodes
+      max_nodes  = var.bt_autoscaling_max_nodes
+      cpu_target = 75
+    }
+  }
+}
+
+# Download relevant go files from tools repo for Custom DC gcf.
+# Currently uses PrivateBTImportController as entrypoint.
+resource "null_resource" "fetch_gcf_source_from_tools_repo" {
+  provisioner "local-exec" {
+    # Output is "${path.module}/source/bt_automation_go_source.zip"
+    command = "sh fetch_gcf_source.sh"
+    working_dir = path.module
+  }
+}
+
+# Upload zipped go source. Consumed by gcf.
+resource "google_storage_bucket_object" "bt_automation_archieve" {
+    # Relative path in the resource bucket to upload the archieve.
+    name   = "cloud_functions/bt_automation_go_source.zip"
+    source = "${path.module}/source/bt_automation_go_source.zip"
+    bucket = var.dc_resource_bucket
+
+    depends_on = [
+        null_resource.fetch_gcf_source_from_tools_repo
+    ]
+}
+
+resource "google_cloudfunctions_function" "bt_automation" {
+  name        = format(
+      "prophet-cache-trigger-%s%s", var.project_id, local.resource_suffix)
+  project        = var.project_id
+  description = "For triggering BT cache build on gcs file writes."
+  runtime     = "go116"
+  region      = var.region
+
+  timeout                      = 300
+  entry_point                  = "PrivateBTImportController"
+
+  service_account_email        = var.service_account_email
+
+  source_archive_bucket = google_storage_bucket_object.bt_automation_archieve.bucket
+  source_archive_object = google_storage_bucket_object.bt_automation_archieve.name
+
+  dynamic "event_trigger" {
+      for_each  = [1]
+      content {
+          # Triggered on blob write to objects in the resource bucket.
+          event_type = "google.storage.object.finalize"
+          resource   = var.dc_resource_bucket
+      }
+  }
+
+  environment_variables = {
+    projectID        = var.project_id
+    bucket           = var.dc_resource_bucket
+
+    # Variables from BT instance created from this file.
+    instance         = google_bigtable_instance.bt_cache.name
+    cluster          = google_bigtable_instance.bt_cache.cluster[0].cluster_id
+    nodesLow         = google_bigtable_instance.bt_cache.cluster[0].autoscaling_config[0].min_nodes
+    nodesHigh        = google_bigtable_instance.bt_cache.cluster[0].autoscaling_config[0].max_nodes
+
+    dataflowTemplate = var.csv2bt_template_path
+    tempLocation     = format("gs://%s/dataflow/tmp", var.dc_resource_bucket)
+  }
+
+  depends_on = [
+      google_storage_bucket_object.bt_automation_archieve
+  ]
+}

--- a/deploy/terraform-datacommons-website/modules/bt_cache/variables.tf
+++ b/deploy/terraform-datacommons-website/modules/bt_cache/variables.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+variable "resource_suffix" {
+  type        = string
+  description = "Optional suffix to add to GCP resources for uniqueness."
+  default     = null
+}
+
+variable "project_id" {
+  type        = string
+  description = "This is the same GCP project id from the setup step."
+}
+
+variable "region" {
+  type        = string
+  description = "Region to setup the Cloud Function in. Should match the region of the other resources."
+}
+
+variable "dc_resource_bucket" {
+  type        = string
+  description = "Name of the GCS bucket that stores DC resources. Do not include the scheme(gs://)."
+}
+
+variable "csv2bt_template_path" {
+  type        = string
+  description = "Full GCS path, including scheme, to the Dataflow template to load BT cache."
+  default     = "gs://datcom-templates/templates/flex/csv_to_bt.json"
+}
+
+variable "bt_instance_zone" {
+  type        = string
+  description = "Zone to create the BT instance in."
+}
+
+variable "bt_autoscaling_min_nodes" {
+  type        = number
+  description = "Min # of nodes for BT table caches."
+  default     = 1
+}
+
+variable "bt_autoscaling_max_nodes" {
+  type        = number
+  description = "Max # of nodes for BT table caches."
+  default     = 3
+}
+
+variable "service_account_email" {
+  type        = string
+  description = "GCP service account email to be used for BT automation Cloud Function."
+}


### PR DESCRIPTION
This Terraform module defines resources for 
- BT instance
- GCF source code
- GCF

The GCF source code is copied over using curl during terraform apply.

TESTED=with a main.tf, cloud function created below.
https://pantheon.corp.google.com/functions/details/us-central1/prophet-cache-trigger-datcom-website-dev-alex20221215?env=gen1&mods=-monitoring_api_staging&project=datcom-website-dev