### PR TITLE
pointing to the stanford subdomain for stanford custom DC

### DIFF
--- a/deploy/gke/stanford.yaml
+++ b/deploy/gke/stanford.yaml
@@ -17,7 +17,7 @@
 # Copy this file to `config.yaml` and use that.
 project: datcom-stanford
 ip: 34.111.26.86
-domain: stanford.datacommons.org
+domain: datacommons.stanford.edu
 region:
   primary: us-central1
 nodes: 1


### PR DESCRIPTION
The Stanford IT admin has now mapped this subdomain (datacommons.stanford.edu) to our Stanford static ip.