### PR TITLE
Stanford Staging: Do not inherit Stanford prod config

### DIFF
--- a/server/configmodule.py
+++ b/server/configmodule.py
@@ -83,8 +83,12 @@ class StanfordConfig(CustomConfig):
   GCS_BUCKET = 'datcom-stanford-resources'
 
 
-class StanfordStagingConfig(StanfordConfig):
+class StanfordStagingConfig(CustomConfig):
   NAME = "Google Stanford Data Commons (Staging)"
+  ENV_NAME = 'STANFORD'
+  ENABLE_BLOCKLIST = True
+  BASE_HTML_PATH = 'custom_dc/stanford/base.html'
+  GCS_BUCKET = 'datcom-stanford-staging-resources'
   API_PROJECT = 'datcom-mixer-statvar'
   SECRET_PROJECT = 'datcom-stanford-staging'
 


### PR DESCRIPTION
It is easy to make mistakes if the staging config is inherited from prod config. For example, the staging instance is currently trying to read the prod GCS bucket because the GCS bucket is not set explicitly in config.

![image](https://user-images.githubusercontent.com/8507196/208184003-d817889a-f604-4b58-a009-812d3c63a2ff.png)
