### PR TITLE
Reduce image size by removing pip cache and nvidia lib

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,7 +20,9 @@ ENV ENV=${ENV}
 WORKDIR /workspace
 
 COPY server/requirements.txt /workspace/server/requirements.txt
-RUN pip3 install -r /workspace/server/requirements.txt
+# --no-cache-dir removes ~/.cache files, which can be a few GB.
+RUN pip3 install --no-cache-dir \
+    -r /workspace/server/requirements.txt
 
 COPY static/package.json /workspace/static/package.json
 COPY static/package-lock.json /workspace/static/package-lock.json

--- a/build/ci/cloudbuild.deploy.yaml
+++ b/build/ci/cloudbuild.deploy.yaml
@@ -49,4 +49,4 @@ steps:
 timeout: 3600s
 
 options:
-  machineType: "E2_HIGHCPU_32"
+  machineType: "E2_HIGHCPU_8"

--- a/build/ci/cloudbuild.push_image.yaml
+++ b/build/ci/cloudbuild.push_image.yaml
@@ -30,4 +30,4 @@ substitutions:
 timeout: 3600s
 options:
   dynamic_substitutions: true
-  machineType: "N1_HIGHCPU_8"
+  machineType: "E2_HIGHCPU_8"

--- a/scripts/push_image.sh
+++ b/scripts/push_image.sh
@@ -22,6 +22,7 @@ ROOT="$(dirname "$DIR")"
 
 cd $ROOT
 gcloud builds submit . \
+  --async \
   --project=datcom-ci \
   --config=build/ci/cloudbuild.push_image.yaml \
-  --substitutions=_TAG=$(git rev-parse --short=7 HEAD)
+  --substitutions=_TAG=$1

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -28,7 +28,7 @@ selenium==3.141.0
 sentence_transformers==2.2.2
 six==1.16.0
 typing_extensions==3.10.0.0
-torch==1.13.1
+torch==1.12.1 # torch 1.13 or higher brings in nvidia lib, which  is 1.5GB.
 Werkzeug==1.0.1
 wheel==0.36.2
 yapf==0.31.0


### PR DESCRIPTION
This PR removes things that can be removed without changing functionality. 

Debate of where to put the language model and the torch library aside, there are immediate improvements that can be made to reduce the compressed image size from 5.5G to 2.1G (over 60% reduction). This saves both build and deploy time. Cloud build now runs in ~9min, which is an improvement from ~14min. It is further observed that 8CPU machine and 32CPU machine doesn't seem to make a difference.

Pip cache takes 2.7G: 
<img width="515" alt="Screen Shot 2022-12-23 at 3 47 19 PM" src="https://user-images.githubusercontent.com/8507196/209585208-67ac7a3b-127e-4929-bd71-cad326855702.png">


Nvidia takes 1.4G:
<img width="659" alt="Screen Shot 2022-12-23 at 3 38 03 PM" src="https://user-images.githubusercontent.com/8507196/209585145-d9df2b7f-a5ef-4e03-83a7-76d22978d88f.png">

Note that this is still not ideal as our image size is still > 3times larger than before and this has a noticeable difference in both build and deploy times. Next steps would be to discuss whether we can move nlp features to a separate container, and launched together like mixer and esp.

Tested with scripts/push_image.sh: [Cloud run took 8min 6sec](https://pantheon.corp.google.com/cloud-build/builds;region=global/34368def-85df-4b6c-97a3-d2056e9ef963;tab=detail?mods=-monitoring_api_staging&project=datcom-ci), [image is 2.1G](https://pantheon.corp.google.com/gcr/images/datcom-ci/global/datacommons-website@sha256:7c2f207630f7ecbc979f296bf741536151f9d35a7111aa28e7ba89016d56145d/details?mods=-monitoring_api_staging&project=datcom-ci)
