### PR TITLE
Add cookies support in NL interface; Clean up page data

### DIFF
--- a/server/routes/nl_interface.py
+++ b/server/routes/nl_interface.py
@@ -420,11 +420,7 @@ def page():
   if (os.environ.get('FLASK_ENV') == 'production' or
       not current_app.config['NL_MODEL']):
     flask.abort(404)
-  return render_template('/nl_interface.html',
-                         place_type="",
-                         place_name="",
-                         place_dcid="",
-                         config={})
+  return render_template('/nl_interface.html')
 
 
 @bp.route('/data')

--- a/server/templates/nl_interface.html
+++ b/server/templates/nl_interface.html
@@ -26,11 +26,6 @@
 {% block content %}
 <div id="body" class="container-fluid">
 </div>
-<div id="metadata" class="d-none" data-place-dcid="{{ place_dcid }}">
-  <div id="place-name" data-pn="{{ place_name }}"></div>
-  <div id="place-type" data-pt="{{ place_type }}"></div>
-  <div id="config" data-config="{{ config }}"></div>
-</div>
 {% endblock %}
 
 {% block footer %}

--- a/static/js/apps/nl_interface/app.tsx
+++ b/static/js/apps/nl_interface/app.tsx
@@ -20,6 +20,7 @@
 
 import axios from "axios";
 import React, { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
 import { Col, Container, Row } from "reactstrap";
 
 import { SubjectPageMainPane } from "../../components/subject_page/main_pane";
@@ -71,9 +72,10 @@ export function App(): JSX.Element {
   const [searchText, setSearchText] = useState<string>();
   const [debugInfo, setDebugInfo] = useState<DebugInfo | undefined>();
   const [selectedBuild, setSelectedBuild] = useState(buildOptions[0].value);
-  const showDebugInfo = true;
-
   const [loading, setLoading] = useState(false);
+  const [cookies, setCookie] = useCookies();
+
+  const showDebugInfo = true;
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -162,6 +164,9 @@ export function App(): JSX.Element {
                       null,
                       `/nl?q=${q}&build=${selectedBuild}`
                     );
+                    const queries: string[] = cookies["q"] || [];
+                    queries.push(q);
+                    setCookie("q", queries);
                     fetchData(`q=${q}`);
                   }}
                   initialValue={searchText}

--- a/static/js/apps/nl_interface/main.ts
+++ b/static/js/apps/nl_interface/main.ts
@@ -19,9 +19,9 @@
  */
 
 import React from "react";
+import { CookiesProvider } from "react-cookie";
 import ReactDOM from "react-dom";
 
-import { NamedTypedPlace } from "../../shared/types";
 import { App } from "./app";
 
 window.onload = () => {
@@ -29,24 +29,8 @@ window.onload = () => {
 };
 
 function renderPage(): void {
-  const dcid = document.getElementById("metadata").dataset.placeDcid;
-  const placeName = document.getElementById("place-name").dataset.pn;
-  const placeType = document.getElementById("place-type").dataset.pt;
-  const pageConfig = JSON.parse(
-    document.getElementById("config").dataset.config
-  );
-
-  const place: NamedTypedPlace = {
-    dcid,
-    name: placeName || dcid,
-    types: [placeType],
-  };
-
   ReactDOM.render(
-    React.createElement(App, {
-      place,
-      pageConfig,
-    }),
+    React.createElement(CookiesProvider, {}, React.createElement(App)),
     document.getElementById("body")
   );
 }

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -44,6 +44,7 @@
         "qs": "^6.11.0",
         "react": "^16.13.1",
         "react-collapsible": "2.8.3",
+        "react-cookie": "^4.1.1",
         "react-csv": "^2.2.2",
         "react-dom": "^16.13.1",
         "react-intl": "^6.0.4",
@@ -5047,6 +5048,11 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "node_modules/@types/d3": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.7.2.tgz",
@@ -8011,6 +8017,14 @@
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dependencies": {
         "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/copy-concurrently": {
@@ -18301,6 +18315,19 @@
         "react-dom": "~15 || ~16 || ~17"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-csv": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.2.2.tgz",
@@ -21183,6 +21210,15 @@
       "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "node_modules/universalify": {
@@ -26046,6 +26082,11 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/d3": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.7.2.tgz",
@@ -28487,6 +28528,11 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -36670,6 +36716,16 @@
       "integrity": "sha512-SiVsLZW8qeh09eARzJ9/fwrwOlPWfAdu+vUJGQaTqVYH61XBnKqnwcTDeGZjL005hatmJSkk2CAtYtb4rz14fA==",
       "requires": {}
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-csv": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.2.2.tgz",
@@ -38867,6 +38923,15 @@
       "peer": true,
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "universalify": {

--- a/static/package.json
+++ b/static/package.json
@@ -54,6 +54,7 @@
     "qs": "^6.11.0",
     "react": "^16.13.1",
     "react-collapsible": "2.8.3",
+    "react-cookie": "^4.1.1",
     "react-csv": "^2.2.2",
     "react-dom": "^16.13.1",
     "react-intl": "^6.0.4",


### PR DESCRIPTION
* The cookie is used within the /nl page only.
* The html data is not needed since the data is fetched from the client after page loads now.