### PR TITLE
Custom DC: Add BT automation and initial reference data to install script

### DIFF
--- a/deploy/terraform-datacommons-website/examples/setup/main.tf
+++ b/deploy/terraform-datacommons-website/examples/setup/main.tf
@@ -44,6 +44,7 @@ module "enabled_google_apis" {
   activate_apis = [
     "apikeys.googleapis.com",
     "binaryauthorization.googleapis.com",
+    "cloudfunctions.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
     "containerregistry.googleapis.com",

--- a/deploy/terraform-datacommons-website/examples/setup/main.tf
+++ b/deploy/terraform-datacommons-website/examples/setup/main.tf
@@ -33,7 +33,7 @@ locals {
   dc_website_domain = coalesce(
     var.dc_website_domain, format("%s-datacommons.com", var.project_id))
 
-  resource_suffx = var.use_resource_suffix ? format("-%s", random_id.rnd.hex) : ""
+  resource_suffix = var.use_resource_suffix ? format("-%s", random_id.rnd.hex) : ""
 }
 
 module "enabled_google_apis" {
@@ -70,14 +70,14 @@ resource "google_service_account" "web_robot" {
 }
 
 resource "google_compute_global_address" "dc_website_ingress_ip" {
-  name         = format("dc-website-ip%s", local.resource_suffx)
+  name         = format("dc-website-ip%s", local.resource_suffix)
   project      = var.project_id
 
   depends_on   = [module.enabled_google_apis]
 }
 
 resource "google_dns_managed_zone" "datacommons_zone" {
-  name          = format("datacommons%s", local.resource_suffx)
+  name          = format("datacommons%s", local.resource_suffix)
   dns_name      = format("%s.", local.dc_website_domain)
   project       = var.project_id
   dynamic "dnssec_config" {
@@ -141,4 +141,27 @@ resource "null_resource" "cloud_domain" {
   depends_on = [
     google_dns_managed_zone.datacommons_zone
   ]
+}
+
+locals {
+  resource_bucket_name = local.resource_suffix != "" ? format(
+    "%s-%s-resources", var.project_id, local.resource_suffix) : format("%s-resources", var.project_id)
+}
+
+# The resource bucket will hold
+# 1) Custom DC raw data (csv, tmcf)
+# 2) Compact cache (in csv) that will feed into BT tables.
+# 3) Various artifacts such as dataflow temp artifacts, state files.
+resource "google_storage_bucket" "dc_resource_bucket" {
+  name          = local.resource_bucket_name
+  location      = var.resource_bucket_location
+  project       = var.project_id
+
+  # Bucket cannot be deleted while objects are still in it.
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  # Do not expose any object to the internet.
+  public_access_prevention = "enforced"
 }

--- a/deploy/terraform-datacommons-website/examples/setup/variables.tf
+++ b/deploy/terraform-datacommons-website/examples/setup/variables.tf
@@ -110,3 +110,9 @@ variable "use_resource_suffix" {
   description = "If true then add a random suffix to the ending of GCP resource names to avoid name collision."
   default     = false
 }
+
+variable "resource_bucket_location" {
+  type        = string
+  description = "The location of the resource buckets. Can either be regional or multi-regional."
+  default     = "us"
+}

--- a/deploy/terraform-datacommons-website/examples/website_v1/main.tf
+++ b/deploy/terraform-datacommons-website/examples/website_v1/main.tf
@@ -39,6 +39,17 @@ resource "google_project_iam_member" "web_robot_iam" {
   project = var.project_id
 }
 
+# For controller to communicate with and write data to resource bucket.
+resource "google_project_iam_member" "datcom_iam" {
+  for_each = toset([
+    "roles/pubsub.subscriber",
+    "roles/storage.admin"
+  ])
+  role    = each.key
+  member  = "serviceAccount:datcom@system.gserviceaccount.com"
+  project = var.project_id
+}
+
 module "apikeys" {
   source                   =  "../../modules/apikeys"
   project_id               = var.project_id

--- a/scripts/install_custom_dc.sh
+++ b/scripts/install_custom_dc.sh
@@ -97,7 +97,8 @@ cd tools/bigtable_automation/terraform
 terraform init && terraform apply \
   -var="project_id=$PROJECT_ID" \
   -var="service_account_email=$WEBSITE_ROBOT" \
-  -var="dc_resource_bucket=$RESOURCE_BUCKET"
+  -var="dc_resource_bucket=$RESOURCE_BUCKET" \
+  -auto-approve
 
 # Copy over sample tmcfs/csvs from reference resource bucket.
 gsutil cp -r \

--- a/scripts/install_custom_dc.sh
+++ b/scripts/install_custom_dc.sh
@@ -90,7 +90,7 @@ cd $ROOT
 git clone https://github.com/datacommonsorg/tools
 
 # TODO(alex): support custom robot SA and resource bucket name.
-WEBSITE_ROBOT="website-robot@$PROJECT_ID.google.com.iam.gserviceaccount.com"
+WEBSITE_ROBOT="website-robot@$PROJECT_ID.iam.gserviceaccount.com"
 RESOURCE_BUCKET="$PROJECT_ID-resources"
 
 cd tools/bigtable_automation/terraform


### PR DESCRIPTION
Clone tools repo and call BT automation Terraform module. Also copy from the reference folder in datcom-public bucket into a folder called "reference" in custom dc resource bucket. 

Note that the reference bucket is currently empty and will be filled with actual sample tmcf shortly.