### PR TITLE
Add link to event pages to tooltips

### DIFF
--- a/static/js/components/tiles/disaster_event_map_info_card.tsx
+++ b/static/js/components/tiles/disaster_event_map_info_card.tsx
@@ -54,6 +54,9 @@ export function DisasterEventMapInfoCard(
               </span>
             );
           })}
+        <span>
+          <a href={`/event/${props.eventData.placeDcid}`}>More info</a>
+        </span>
       </div>
     </div>
   );

--- a/static/js/components/tiles/disaster_event_map_tile.tsx
+++ b/static/js/components/tiles/disaster_event_map_tile.tsx
@@ -488,18 +488,14 @@ export function DisasterEventMapTile(
         return props.eventTypeSpec[point.disasterType].color;
       }
     );
-    pointsLayer
-      .on("click", (point: DisasterEventPoint) =>
-        onPointClicked(
-          infoCardRef.current,
-          svgContainerRef.current,
-          point,
-          d3.event
-        )
+    pointsLayer.on("click", (point: DisasterEventPoint) =>
+      onPointClicked(
+        infoCardRef.current,
+        svgContainerRef.current,
+        point,
+        d3.event
       )
-      .on("blur", () => {
-        d3.select(infoCardRef.current).style("visibility", "hidden");
-      });
+    );
   }
 
   /**


### PR DESCRIPTION
This PR:
 1. Adds a "More info" link to the bottom of tooltips on the disaster dashboard
 2. Changes behavior of tooltips to only close when the "x" is clicked, or when a different dot is selected.
 
<img width="299" alt="Screenshot 2023-01-05 at 1 45 43 PM" src="https://user-images.githubusercontent.com/4034366/210886000-6b4d9860-c5cf-41e1-b5cb-6e429f06cce7.png">
