### PR TITLE
[nl] add exporting charts for nl

### DIFF
--- a/static/css/place/place.scss
+++ b/static/css/place/place.scss
@@ -15,6 +15,7 @@
  */
 
 @use "../shared/ranking_unit";
+@use "../shared/chart_embed";
 @import "../base";
 @import "../draw";
 @import "../draw_choropleth";
@@ -27,6 +28,14 @@ $vertical-section-border: 1px solid var(--dc-gray-lite);
 $vertical-section-margin: 2rem;
 $sidebar-top-padding: 132px; // Keep in sync with place.ts: Y_SCROLL_LIMIT
 $chart-border: 0.5px solid #dee2e6;
+
+// TODO (chejennifer): move this back to shared modal stylesheet
+.modal-dialog {
+  @include media-breakpoint-down(md) {
+    max-width: calc(100% - 30px);
+    margin: auto;
+  }
+}
 
 #dc-places {
   margin-left: 1.5rem;
@@ -292,32 +301,6 @@ h3 {
 
 .chart-block {
   margin-bottom: 15px;
-}
-
-.modal .modal-chart-container {
-  display: flex;
-  justify-content: center;
-}
-
-.modal .chart-container {
-  display: inline-block;
-}
-
-.modal .outlinks {
-  display: none;
-}
-
-.modal .modal-chart-container>svg {
-  visibility: hidden;
-}
-
-.modal .modal-chart-container img {
-  border-radius: 3px;
-  border: $chart-border;
-}
-
-.modal textarea {
-  height: 8rem;
 }
 
 .landing-link {

--- a/static/css/shared/_chart_embed.scss
+++ b/static/css/shared/_chart_embed.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,36 +14,42 @@
  * limitations under the License.
  */
 
-/* Styles for <BqModal> */
+/**
+ * Styling for chart embed component.
+ */
 
-@import "shared/modal.scss";
+@use "./modal.scss" as modal;
 
-// TODO (chejennifer): move this back to shared modal scss file.
-.modal-dialog {
-  @include media-breakpoint-down(md) {
-    max-width: calc(100% - 30px);
-    margin: auto;
-  }
+.modal .modal-chart-container {
+  display: flex;
+  justify-content: center;
 }
 
-.big-query-modal .modal-content {
-  height: 90vh;
+.modal .chart-container {
+  display: inline-block;
 }
 
-.modal-body {
+.modal .outlinks {
+  display: none;
+}
+
+.modal .modal-chart-container>svg {
+  visibility: hidden;
+}
+
+.modal .modal-chart-container img {
+  border-radius: 3px;
+  border: modal.$border;
+  max-width: 100%;
+}
+
+.modal textarea {
+  height: 8rem;
+  max-width: 100%;
+}
+
+.modal .modal-body {
   display: flex;
   flex-direction: column;
-}
-
-.big-query-modal textarea {
-  width: 100%;
-  height: 100%;
-  flex: 1 1 auto;
-  font-size: .8rem;
-}
-
-.big-query-sql-instructions {
-  word-wrap: break-word;
-  white-space: normal;
-  flex: 0 0 auto;
+  align-items: center;
 }

--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -19,6 +19,7 @@
  */
 
 @forward "ranking_unit";
+@forward "chart_embed";
 @use "../base";
 
 $chart-container-top-margin: 20px;
@@ -37,6 +38,9 @@ $border-radius: 0.5rem;
 
   footer {
     margin-left: inherit !important;
+    margin-right: 0 !important;
+    display: flex;
+    justify-content: space-between;
   }
 }
 

--- a/static/css/shared/modal.scss
+++ b/static/css/shared/modal.scss
@@ -18,13 +18,6 @@
 
 $border: 0.5px solid #dee2e6;
 
-.modal-dialog {
-  @include media-breakpoint-down(md) {
-    max-width: calc(100% - 30px);
-    margin: auto;
-  }
-}
-
 .modal textarea {
   background: #efefef;
   border-radius: 3px;

--- a/static/js/chart/base.ts
+++ b/static/js/chart/base.ts
@@ -365,65 +365,6 @@ export function shouldFillInValues(series: number[][]): boolean {
   return false;
 }
 
-// TODO(beets): Create DataPoints class and add this to that class.
-/**
- * Returns the value associated with the given label in dataPoints, or null.
- */
-function findDataPointOrNull(
-  dataPoints: DataPoint[],
-  label: string
-): number | null {
-  for (const dp of dataPoints) {
-    if (dp.label == label) {
-      return dp.value;
-    }
-  }
-  return null;
-}
-
-// TODO(beets): Also add a dataPointsToCsv function.
-// TODO(beets): Create DataGroups class and add this to that class.
-/**
- * Returns dataGroups as a CSV.
- */
-export function dataGroupsToCsv(dataGroups: DataGroup[]): string {
-  if (!dataGroups || dataGroups.length == 0) {
-    return "";
-  }
-  // Get all the dates
-  let allLabels = new Set<string>();
-  for (const dg of dataGroups) {
-    const dates = dg.value.map((dp) => dp.label);
-    allLabels = new Set([...Array.from(allLabels), ...dates]);
-  }
-  // Create the the header row.
-  const header = ["label"];
-  for (const dg of dataGroups) {
-    header.push(`"${dg.label}"`);
-  }
-
-  // Iterate each year, group, place, stats var to populate data
-  const rows: string[][] = [];
-  for (const label of Array.from(allLabels)) {
-    const row: string[] = [label];
-    for (const dg of dataGroups) {
-      const v = findDataPointOrNull(dg.value, label);
-      if (v) {
-        row.push(String(v));
-      } else {
-        row.push("");
-      }
-    }
-    rows.push(row);
-  }
-  const headerRow = header.join(",") + "\n";
-  let result = headerRow;
-  for (const row of rows) {
-    result += row.join(",") + "\n";
-  }
-  return result;
-}
-
 // Expand an array of DataPoints based on given dates.
 // If a date is not present in the array, add a null data point for it.
 export function expandDataPoints(

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -29,6 +29,7 @@ import { PointApiResponse } from "../../shared/stat_types";
 import { NamedTypedPlace, StatVarSpec } from "../../shared/types";
 import { RankingPoint } from "../../types/ranking_unit_types";
 import { stringifyFn } from "../../utils/axios";
+import { dataGroupsToCsv } from "../../utils/chart_csv_utils";
 import { getPlaceNames } from "../../utils/place_utils";
 import { getStatVarName, ReplacementStrings } from "../../utils/tile_utils";
 import { ChartTileContainer } from "./chart_tile";
@@ -85,6 +86,8 @@ export function BarTile(props: BarTilePropType): JSX.Element {
       sources={barChartData.sources}
       replacementStrings={rs}
       className="bar-chart"
+      allowEmbed={true}
+      getDataCsv={() => dataGroupsToCsv(barChartData.dataGroup)}
     >
       <div id={props.id} className="svg-container"></div>
     </ChartTileContainer>

--- a/static/js/components/tiles/bivariate_tile.tsx
+++ b/static/js/components/tiles/bivariate_tile.tsx
@@ -37,6 +37,7 @@ import {
   shouldShowMapBoundaries,
 } from "../../tools/shared_util";
 import { stringifyFn } from "../../utils/axios";
+import { scatterDataToCsv } from "../../utils/chart_csv_utils";
 import { getStringOrNA } from "../../utils/number_utils";
 import { getPlaceScatterData } from "../../utils/scatter_data_utils";
 import { getStatVarName, ReplacementStrings } from "../../utils/tile_utils";
@@ -116,6 +117,16 @@ export function BivariateTile(props: BivariateTilePropType): JSX.Element {
       sources={bivariateChartData.sources}
       replacementStrings={rs}
       className="bivariate-chart"
+      allowEmbed={true}
+      getDataCsv={() =>
+        scatterDataToCsv(
+          bivariateChartData.xStatVar.statVar,
+          bivariateChartData.xStatVar.denom,
+          bivariateChartData.yStatVar.statVar,
+          bivariateChartData.yStatVar.denom,
+          bivariateChartData.points
+        )
+      }
     >
       <div
         id={props.id}
@@ -146,7 +157,7 @@ function getPopulationPromise(
         params: {
           parent_entity: placeDcid,
           child_type: enclosedPlaceType,
-          variable: variables,
+          variables: variables,
         },
         paramsSerializer: stringifyFn,
       })

--- a/static/js/components/tiles/disaster_event_map_tile.tsx
+++ b/static/js/components/tiles/disaster_event_map_tile.tsx
@@ -175,6 +175,7 @@ export function DisasterEventMapTile(
       sources={mapChartData.sources}
       replacementStrings={rs}
       className={`${CSS_SELECTOR_PREFIX}-tile`}
+      allowEmbed={false}
     >
       <DisasterEventMapSelectors
         breadcrumbPlaces={breadcrumbs}

--- a/static/js/components/tiles/histogram_tile.tsx
+++ b/static/js/components/tiles/histogram_tile.tsx
@@ -29,6 +29,7 @@ import { SeriesApiResponse } from "../../shared/stat_types";
 import { NamedTypedPlace, StatVarSpec } from "../../shared/types";
 import { computeRatio } from "../../tools/shared_util";
 import { stringifyFn } from "../../utils/axios";
+import { dataPointsToCsv } from "../../utils/chart_csv_utils";
 import { ReplacementStrings } from "../../utils/tile_utils";
 import { ChartTileContainer } from "./chart_tile";
 
@@ -83,6 +84,8 @@ export function HistogramTile(props: HistogramTilePropType): JSX.Element {
       sources={histogramData.sources}
       replacementStrings={rs}
       className="histogram-chart"
+      allowEmbed={true}
+      getDataCsv={() => dataPointsToCsv(histogramData.dataPoints)}
     >
       <div id={props.id} className="svg-container" ref={svgContainer}></div>
     </ChartTileContainer>

--- a/static/js/components/tiles/line_tile.tsx
+++ b/static/js/components/tiles/line_tile.tsx
@@ -29,6 +29,7 @@ import { SeriesApiResponse } from "../../shared/stat_types";
 import { NamedTypedPlace, StatVarSpec } from "../../shared/types";
 import { computeRatio } from "../../tools/shared_util";
 import { stringifyFn } from "../../utils/axios";
+import { dataGroupsToCsv } from "../../utils/chart_csv_utils";
 import { getStatVarName, ReplacementStrings } from "../../utils/tile_utils";
 import { ChartTileContainer } from "./chart_tile";
 
@@ -80,6 +81,8 @@ export function LineTile(props: LineTilePropType): JSX.Element {
       sources={lineChartData.sources}
       replacementStrings={rs}
       className="line-chart"
+      allowEmbed={true}
+      getDataCsv={() => dataGroupsToCsv(lineChartData.dataGroup)}
     >
       <div id={props.id} className="svg-container" ref={svgContainer}></div>
     </ChartTileContainer>

--- a/static/js/components/tiles/map_tile.tsx
+++ b/static/js/components/tiles/map_tile.tsx
@@ -49,6 +49,7 @@ import {
   shouldShowMapBoundaries,
 } from "../../tools/shared_util";
 import { stringifyFn } from "../../utils/axios";
+import { mapDataToCsv } from "../../utils/chart_csv_utils";
 import { getDateRange } from "../../utils/string_utils";
 import { ReplacementStrings } from "../../utils/tile_utils";
 import { ChartTileContainer } from "./chart_tile";
@@ -128,6 +129,10 @@ export function MapTile(props: MapTilePropType): JSX.Element {
       sources={mapChartData.sources}
       replacementStrings={rs}
       className="map-chart"
+      allowEmbed={true}
+      getDataCsv={() =>
+        mapDataToCsv(mapChartData.geoJson, mapChartData.dataValues)
+      }
     >
       <div id={props.id} className="svg-container" ref={svgContainer}></div>
     </ChartTileContainer>

--- a/static/js/components/tiles/scatter_tile.tsx
+++ b/static/js/components/tiles/scatter_tile.tsx
@@ -33,6 +33,7 @@ import { PointApiResponse, SeriesApiResponse } from "../../shared/stat_types";
 import { NamedTypedPlace, StatVarSpec } from "../../shared/types";
 import { getStatWithinPlace } from "../../tools/scatter/util";
 import { stringifyFn } from "../../utils/axios";
+import { scatterDataToCsv } from "../../utils/chart_csv_utils";
 import { getStringOrNA } from "../../utils/number_utils";
 import { getPlaceScatterData } from "../../utils/scatter_data_utils";
 import { getStatVarName, ReplacementStrings } from "../../utils/tile_utils";
@@ -102,6 +103,16 @@ export function ScatterTile(props: ScatterTilePropType): JSX.Element {
       sources={scatterChartData.sources}
       replacementStrings={rs}
       className="scatter-chart"
+      allowEmbed={true}
+      getDataCsv={() =>
+        scatterDataToCsv(
+          scatterChartData.xStatVar.statVar,
+          scatterChartData.xStatVar.denom,
+          scatterChartData.yStatVar.statVar,
+          scatterChartData.yStatVar.denom,
+          scatterChartData.points
+        )
+      }
     >
       <div id={props.id} className="scatter-svg-container" ref={svgContainer} />
       <div id="scatter-tooltip" ref={tooltip} />

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -19,12 +19,7 @@ import _ from "lodash";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-import {
-  DataGroup,
-  dataGroupsToCsv,
-  DataPoint,
-  expandDataPoints,
-} from "../chart/base";
+import { DataGroup, DataPoint, expandDataPoints } from "../chart/base";
 import {
   drawGroupBarChart,
   drawLineChart,
@@ -62,6 +57,11 @@ import { getStatsVarLabel } from "../shared/stats_var_labels";
 import { NamedPlace } from "../shared/types";
 import { isDateTooFar, urlToDomain } from "../shared/util";
 import { RankingPoint } from "../types/ranking_unit_types";
+import {
+  dataGroupsToCsv,
+  mapDataToCsv,
+  rankingPointsToCsv,
+} from "../utils/chart_csv_utils";
 import { ChartEmbed } from "./chart_embed";
 import { updatePageLayoutState } from "./place";
 
@@ -408,23 +408,14 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       return;
     }
     if (this.state.choroplethDataGroup && this.state.geoJson) {
-      const data = this.state.choroplethDataGroup;
-      const geo = this.state.geoJson;
-      const rows: string[] = ["place,data"];
-      for (const g of geo["features"]) {
-        const v = g.id in data.data ? data.data[g.id] : "N/A";
-        rows.push(`${g.properties.name},${v}`);
-      }
-      return rows.join("\n");
+      return mapDataToCsv(
+        this.state.geoJson,
+        this.state.choroplethDataGroup.data
+      );
     }
     if (this.state.rankingChartDataGroup) {
       const data = this.state.rankingChartDataGroup.data;
-      const rows = ["rank,place,data"];
-      for (const dp of data) {
-        const placeName = dp.placeName ? dp.placeName : dp.placeDcid;
-        rows.push(`${dp.rank}, ${placeName}, ${dp.value}`);
-      }
-      return rows.join("\n");
+      return rankingPointsToCsv(data);
     }
     return dataGroupsToCsv(this.state.dataGroups);
   }

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -39,6 +39,7 @@ interface ChartEmbedStateType {
   chartTitle: string;
   chartDate: string;
   sources: string[];
+  chartDownloadXml: string;
 }
 
 /**
@@ -46,7 +47,6 @@ interface ChartEmbedStateType {
  * in a Modal
  */
 class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
-  private chartDownloadXml: string;
   private modalId: string;
   private svgContainerElement: React.RefObject<HTMLDivElement>;
   private textareaElement: React.RefObject<HTMLTextAreaElement>;
@@ -62,8 +62,8 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
       chartTitle: "",
       chartDate: "",
       sources: [],
+      chartDownloadXml: "",
     };
-    this.chartDownloadXml = "";
     this.modalId = randDomId();
     this.svgContainerElement = React.createRef();
     this.textareaElement = React.createRef();
@@ -202,12 +202,13 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
     }
 
     if (this.state.svgXml) {
-      this.chartDownloadXml = this.decorateSvgChart();
+      const chartDownloadXml = this.decorateSvgChart();
       const imageElement = document.createElement("img");
       const chartBase64 =
-        "data:image/svg+xml," + encodeURIComponent(this.chartDownloadXml);
+        "data:image/svg+xml," + encodeURIComponent(chartDownloadXml);
       imageElement.src = chartBase64;
       this.svgContainerElement.current.append(imageElement);
+      this.setState({ chartDownloadXml });
     }
   }
 
@@ -226,7 +227,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
    * On click handler for "Copy SVG to clipboard button".
    */
   public onDownloadSvg(): void {
-    saveToFile("chart.svg", this.chartDownloadXml);
+    saveToFile("chart.svg", this.state.chartDownloadXml);
   }
 
   /**
@@ -267,7 +268,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
           ></textarea>
         </ModalBody>
         <ModalFooter>
-          {this.chartDownloadXml && (
+          {this.state.chartDownloadXml && (
             <>
               <Button color="primary" onClick={this.onDownloadSvg}>
                 {intl.formatMessage({

--- a/static/js/tools/scatter/chart_loader.tsx
+++ b/static/js/tools/scatter/chart_loader.tsx
@@ -29,7 +29,6 @@ import { FacetSelectorFacetInfo } from "../../shared/facet_selector";
 import {
   EntityObservation,
   EntityObservationList,
-  Observation,
   PointAllApiResponse,
   PointApiResponse,
   SeriesApiResponse,
@@ -37,6 +36,7 @@ import {
 } from "../../shared/stat_types";
 import { saveToFile } from "../../shared/util";
 import { stringifyFn } from "../../utils/axios";
+import { scatterDataToCsv } from "../../utils/chart_csv_utils";
 import { getPlaceScatterData } from "../../utils/scatter_data_utils";
 import { getUnit } from "../shared_util";
 import { Chart } from "./chart";
@@ -449,30 +449,17 @@ function downloadData(
   place: PlaceInfo,
   points: { [placeDcid: string]: Point }
 ): void {
-  const xStatVar = x.statVarDcid;
-  const yStatVar = y.statVarDcid;
-  const xPopStatVar = DEFAULT_POPULATION_DCID;
-  const yPopStatVar = DEFAULT_POPULATION_DCID;
-
-  // Headers
-  let csv =
-    "placeName," +
-    "placeDCID," +
-    "xDate," +
-    `xValue-${xStatVar},` +
-    "yDate," +
-    `yValue-${yStatVar},` +
-    `xPopulation-${xPopStatVar},` +
-    `yPopulation-${yPopStatVar}\n`;
-  // Data
-  for (const place of Object.keys(points)) {
-    const point = points[place];
-    csv += `${point.place.name},${point.place.dcid},${point.xDate},${point.xVal},${point.yDate},${point.yVal},${point.xPop},${point.yPop}\n`;
-  }
+  const csv = scatterDataToCsv(
+    x.statVarDcid,
+    DEFAULT_POPULATION_DCID,
+    y.statVarDcid,
+    DEFAULT_POPULATION_DCID,
+    points
+  );
 
   saveToFile(
-    `${xStatVar}+` +
-      `${yStatVar}+` +
+    `${x.statVarDcid}+` +
+      `${y.statVarDcid}+` +
       `${place.enclosingPlace.name}+` +
       `${place.enclosedPlaceType}.csv`,
     csv

--- a/static/js/utils/chart_csv_utils.ts
+++ b/static/js/utils/chart_csv_utils.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Util functions for getting csv for charts.
+ */
+
+import { DataGroup, DataPoint } from "../chart/base";
+import { Point } from "../chart/draw_scatter";
+import { GeoJsonData } from "../chart/types";
+import { RankingPoint } from "../types/ranking_unit_types";
+
+// TODO(beets): Create DataPoints class and add this to that class.
+/**
+ * Returns the value associated with the given label in dataPoints, or null.
+ */
+function findDataPointOrNull(
+  dataPoints: DataPoint[],
+  label: string
+): number | null {
+  for (const dp of dataPoints) {
+    if (dp.label == label) {
+      return dp.value;
+    }
+  }
+  return null;
+}
+
+// TODO(beets): Also add a dataPointsToCsv function.
+// TODO(beets): Create DataGroups class and add this to that class.
+/**
+ * Gets the csv (as a string) for a  list of data groups.
+ * @param dataGroups data groups to get the csv for
+ */
+export function dataGroupsToCsv(dataGroups: DataGroup[]): string {
+  if (!dataGroups || dataGroups.length == 0) {
+    return "";
+  }
+  // Get all the dates
+  let allLabels = new Set<string>();
+  for (const dg of dataGroups) {
+    const dates = dg.value.map((dp) => dp.label);
+    allLabels = new Set([...Array.from(allLabels), ...dates]);
+  }
+  // Create the the header row.
+  const header = ["label"];
+  for (const dg of dataGroups) {
+    header.push(`"${dg.label}"`);
+  }
+
+  // Iterate each year, group, place, stats var to populate data
+  const rows: string[][] = [];
+  for (const label of Array.from(allLabels)) {
+    const row: string[] = [label];
+    for (const dg of dataGroups) {
+      const v = findDataPointOrNull(dg.value, label);
+      if (v) {
+        row.push(String(v));
+      } else {
+        row.push("");
+      }
+    }
+    rows.push(row);
+  }
+  const headerRow = header.join(",") + "\n";
+  let result = headerRow;
+  for (const row of rows) {
+    result += row.join(",") + "\n";
+  }
+  return result;
+}
+
+/**
+ * Gets the csv (as a string) for scatter plot data.
+ * @param xStatVar dcid of the stat var for the x axis
+ * @param xDenom dcid of the denominator for the x axis
+ * @param yStatVar dcid of the stat var for the y axis
+ * @param yDenom dcid fo the denominator for the y axis
+ * @param scatterPoints list of scatter plot points
+ */
+export function scatterDataToCsv(
+  xStatVar: string,
+  xDenom: string,
+  yStatVar: string,
+  yDenom: string,
+  scatterPoints: { [placeDcid: string]: Point }
+): string {
+  const rows = [];
+  // Headers
+  let header =
+    "placeName," +
+    "placeDcid," +
+    "xDate," +
+    `xValue-${xStatVar},` +
+    "yDate," +
+    `yValue-${yStatVar}`;
+  if (xDenom) {
+    header += `,xPopulation-${xDenom}`;
+  }
+  if (yDenom) {
+    header += `,yPopulation-${yDenom}`;
+  }
+  rows.push(header);
+  // Data
+  for (const place of Object.keys(scatterPoints)) {
+    const point = scatterPoints[place];
+    let dataRow = `${point.place.name},${point.place.dcid},${point.xDate},${point.xVal},${point.yDate},${point.yVal}`;
+    if (xDenom) {
+      dataRow += `,${point.xPop || "N/A"}`;
+    }
+    if (yDenom) {
+      dataRow += `,${point.yPop || "N/A"}`;
+    }
+    rows.push(dataRow);
+  }
+  return rows.join("\n");
+}
+
+/**
+ * Gets the csv (as a string) for a list of data points.
+ * @param dataPoints data points to get the csv for
+ */
+export function dataPointsToCsv(dataPoints: DataPoint[]): string {
+  const rows = ["label,data"];
+  for (const datapoint of dataPoints) {
+    rows.push(`${datapoint.label},${datapoint.value}`);
+  }
+  return rows.join("\n");
+}
+
+/**
+ * Gets the csv (as a string) for a map chart data
+ * @param geoJson GeoJson used for the map
+ * @param dataValues data values used in the map
+ */
+export function mapDataToCsv(
+  geoJson: GeoJsonData,
+  dataValues: { [placeDcid: string]: number }
+): string {
+  const rows = ["label,data"];
+  for (const geo of geoJson.features) {
+    if (!geo.id) {
+      continue;
+    }
+    const value = geo.id in dataValues ? dataValues[geo.id] : "N/A";
+    const name = geo.properties.name || geo.id;
+    rows.push(`${name},${value}`);
+  }
+  return rows.join("\n");
+}
+
+/**
+ * Gets the csv (as a string) for a list of ranking points
+ * @param rankingPoints ranking points to get the csv for
+ */
+export function rankingPointsToCsv(rankingPoints: RankingPoint[]): string {
+  const rows = ["rank,place,data"];
+  rankingPoints.forEach((point, idx) => {
+    const placeName = point.placeName || point.placeDcid;
+    const rank = point.rank || idx + 1;
+    rows.push(`${rank},${placeName},${point.value}`);
+  });
+  return rows.join("\n");
+}

--- a/static/js/utils/tests/chart_csv_utils.test.ts
+++ b/static/js/utils/tests/chart_csv_utils.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DataGroup, DataPoint } from "../../chart/base";
+import { GeoJsonData } from "../../chart/types";
+import { RankingPoint } from "../../types/ranking_unit_types";
+import {
+  dataGroupsToCsv,
+  dataPointsToCsv,
+  mapDataToCsv,
+  rankingPointsToCsv,
+  scatterDataToCsv,
+} from "../chart_csv_utils";
+
+test("dataGroupsToCsv", () => {
+  const dataGroupA = new DataGroup("dataGroupA", [
+    {
+      label: "2020",
+      value: 1,
+    },
+    {
+      label: "2021",
+      value: 2,
+    },
+  ]);
+  const dataGroupB = new DataGroup("dataGroupB", [
+    {
+      label: "2020",
+      value: 3,
+    },
+    {
+      label: "2021",
+      value: 4,
+    },
+  ]);
+  const cases: {
+    name: string;
+    dataGroups: DataGroup[];
+    expected: string;
+  }[] = [
+    {
+      name: "empty dataGroups",
+      dataGroups: [],
+      expected: "",
+    },
+    {
+      name: "single dataGroup",
+      dataGroups: [dataGroupA],
+      expected: 'label,"dataGroupA"\n2020,1\n2021,2\n',
+    },
+    {
+      name: "mulitple dataGroups",
+      dataGroups: [dataGroupA, dataGroupB],
+      expected: 'label,"dataGroupA","dataGroupB"\n2020,1,3\n2021,2,4\n',
+    },
+  ];
+
+  for (const c of cases) {
+    const csv = dataGroupsToCsv(c.dataGroups);
+    try {
+      expect(csv).toEqual(c.expected);
+    } catch (e) {
+      console.log(`Failed for case: ${c.name}`);
+      throw e;
+    }
+  }
+});
+
+test("scatterDataToCsv", () => {
+  const testPlaceA = {
+    name: "testPlaceA",
+    dcid: "testPlaceAId",
+  };
+  const testPointA = {
+    place: testPlaceA,
+    xVal: 1,
+    yVal: 2,
+    xDate: "2022-01-01",
+    yDate: "2022-01-02",
+    xPop: 3,
+    xPopDate: "2021-01",
+  };
+  const testPoints = {
+    [testPlaceA.dcid]: testPointA,
+  };
+  const xSv = "xSvId";
+  const xDenom = "xDenomId";
+  const ySv = "ySvId";
+  const yDenom = "yDenomId";
+  const cases: {
+    name: string;
+    xSv: string;
+    xDenom: string;
+    ySv: string;
+    yDenom: string;
+    expected: string;
+  }[] = [
+    {
+      name: "with both denoms",
+      xSv: xSv,
+      xDenom: xDenom,
+      ySv: ySv,
+      yDenom: yDenom,
+      expected: [
+        "placeName,placeDcid,xDate,xValue-xSvId,yDate,yValue-ySvId,xPopulation-xDenomId,yPopulation-yDenomId",
+        "testPlaceA,testPlaceAId,2022-01-01,1,2022-01-02,2,3,N/A",
+      ].join("\n"),
+    },
+    {
+      name: "with x denom",
+      xSv: xSv,
+      xDenom: xDenom,
+      ySv: ySv,
+      yDenom: "",
+      expected: [
+        "placeName,placeDcid,xDate,xValue-xSvId,yDate,yValue-ySvId,xPopulation-xDenomId",
+        "testPlaceA,testPlaceAId,2022-01-01,1,2022-01-02,2,3",
+      ].join("\n"),
+    },
+    {
+      name: "with y denom",
+      xSv: xSv,
+      xDenom: "",
+      ySv: ySv,
+      yDenom: yDenom,
+      expected: [
+        "placeName,placeDcid,xDate,xValue-xSvId,yDate,yValue-ySvId,yPopulation-yDenomId",
+        "testPlaceA,testPlaceAId,2022-01-01,1,2022-01-02,2,N/A",
+      ].join("\n"),
+    },
+    {
+      name: "no denom",
+      xSv: xSv,
+      xDenom: "",
+      ySv: ySv,
+      yDenom: "",
+      expected: [
+        "placeName,placeDcid,xDate,xValue-xSvId,yDate,yValue-ySvId",
+        "testPlaceA,testPlaceAId,2022-01-01,1,2022-01-02,2",
+      ].join("\n"),
+    },
+  ];
+
+  for (const c of cases) {
+    const csv = scatterDataToCsv(c.xSv, c.xDenom, c.ySv, c.yDenom, testPoints);
+    try {
+      expect(csv).toEqual(c.expected);
+    } catch (e) {
+      console.log(`Failed for case: ${c.name}`);
+      throw e;
+    }
+  }
+});
+
+test("dataPointsToCsv", () => {
+  const cases: {
+    name: string;
+    dataPoints: DataPoint[];
+    expected: string;
+  }[] = [
+    {
+      name: "non empty data points",
+      dataPoints: [
+        {
+          label: "pointA",
+          value: 1,
+        },
+        {
+          label: "pointB",
+          value: 2,
+        },
+      ],
+      expected: "label,data\npointA,1\npointB,2",
+    },
+    {
+      name: "empty datapoints",
+      dataPoints: [],
+      expected: "label,data",
+    },
+  ];
+
+  for (const c of cases) {
+    const csv = dataPointsToCsv(c.dataPoints);
+    try {
+      expect(csv).toEqual(c.expected);
+    } catch (e) {
+      console.log(`Failed for case: ${c.name}`);
+      throw e;
+    }
+  }
+});
+
+test("mapDataToCsv", () => {
+  const testPlaceA = "placeA";
+  const testPlaceB = "placeB";
+  const testGeoJson: GeoJsonData = {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        id: testPlaceA,
+        properties: {
+          name: "Place A",
+          geoDcid: testPlaceA,
+        },
+        geometry: { type: "MultiPolygon", coordinates: [] },
+      },
+      {
+        type: "Feature",
+        id: testPlaceB,
+        properties: {
+          name: "Place B",
+          geoDcid: testPlaceB,
+        },
+        geometry: { type: "MultiPolygon", coordinates: [] },
+      },
+    ],
+    properties: {
+      current_geo: "test_geo",
+    },
+  };
+  const testDataValues = {
+    [testPlaceA]: 1,
+    [testPlaceB]: 2,
+  };
+  const cases: {
+    name: string;
+    geoJson: GeoJsonData;
+    dataValues: { [placeDcid: string]: number };
+    expected: string;
+  }[] = [
+    {
+      name: "non empty geoJson and dataValues",
+      geoJson: testGeoJson,
+      dataValues: testDataValues,
+      expected: "label,data\nPlace A,1\nPlace B,2",
+    },
+    {
+      name: "empty geoJson",
+      geoJson: {
+        type: "FeatureCollection",
+        features: [],
+        properties: {
+          current_geo: "test_geo",
+        },
+      },
+      dataValues: testDataValues,
+      expected: "label,data",
+    },
+    {
+      name: "empty dataValues",
+      geoJson: testGeoJson,
+      dataValues: {},
+      expected: "label,data\nPlace A,N/A\nPlace B,N/A",
+    },
+  ];
+
+  for (const c of cases) {
+    const csv = mapDataToCsv(c.geoJson, c.dataValues);
+    try {
+      expect(csv).toEqual(c.expected);
+    } catch (e) {
+      console.log(`Failed for case: ${c.name}`);
+      throw e;
+    }
+  }
+});
+
+test("rankingPointsToCsv", () => {
+  const cases: {
+    name: string;
+    rankingPoints: RankingPoint[];
+    expected: string;
+  }[] = [
+    {
+      name: "empty ranking points",
+      rankingPoints: [],
+      expected: "rank,place,data",
+    },
+    {
+      name: "non empty ranking points",
+      rankingPoints: [
+        {
+          placeDcid: "placeAId",
+          placeName: "placeAName",
+          value: 1,
+          rank: 1,
+        },
+        {
+          placeDcid: "placeBId",
+          value: 2,
+          rank: 2,
+        },
+        {
+          placeDcid: "placeCId",
+          placeName: "placeCName",
+          value: 3,
+        },
+      ],
+      expected: [
+        "rank,place,data",
+        "1,placeAName,1",
+        "2,placeBId,2",
+        "3,placeCName,3",
+      ].join("\n"),
+    },
+  ];
+
+  for (const c of cases) {
+    const csv = rankingPointsToCsv(c.rankingPoints);
+    try {
+      expect(csv).toEqual(c.expected);
+    } catch (e) {
+      console.log(`Failed for case: ${c.name}`);
+      throw e;
+    }
+  }
+});


### PR DESCRIPTION
- allow downloading svg and csv data for each chart in a tile

some bug fixes along the way:
- fix data fetch for bivariate tile (param was missing a plural)
- fix "download chart image" only showing up the second time the export button is clicked (here and place charts)

![ezgif com-gif-maker](https://user-images.githubusercontent.com/69875368/211174122-bc528b09-5da8-4bc3-aed5-d87f1758e624.gif)
