### PR TITLE
[NL Interface] Correlation Detection - First Version

### DIFF
--- a/server/lib/nl_training.py
+++ b/server/lib/nl_training.py
@@ -56,7 +56,6 @@ class NLQueryCorrelationDetectionModel:
     self.clustering_model = AgglomerativeClustering(n_clusters=2,
                                                     affinity='cosine',
                                                     linkage='average')
-    self.cosine_similarity_cutoff = 0.4
 
 
 # Query Sentence Classification Types and associated training data.

--- a/server/lib/nl_training.py
+++ b/server/lib/nl_training.py
@@ -15,6 +15,7 @@
 # The following dictionaries are used by the NL query classification under
 # the path server.services.nl and also invoked from the server/__init__.py
 from dataclasses import dataclass
+from sklearn.cluster import AgglomerativeClustering
 from sklearn.linear_model import LogisticRegression
 from typing import Any, Dict, List
 
@@ -43,6 +44,19 @@ class NLQueryClassificationModel:
     self.classification_type = classification_type
     self.classification_model = LogisticRegression(max_iter=1000,
                                                    random_state=123)
+
+
+@dataclass
+class NLQueryCorrelationDetectionModel:
+  """Attributes for the NL Query Correlation classification."""
+  clustering_model: Any
+  cosine_similarity_cutoff: float
+
+  def __init__(self):
+    self.clustering_model = AgglomerativeClustering(n_clusters=2,
+                                                    affinity='cosine',
+                                                    linkage='average')
+    self.cosine_similarity_cutoff = 0.4
 
 
 # Query Sentence Classification Types and associated training data.

--- a/server/routes/nl_interface.py
+++ b/server/routes/nl_interface.py
@@ -34,6 +34,7 @@ MAPS_API = "https://maps.googleapis.com/maps/api/place/textsearch/json?"
 FIXED_PREFIXES = ['md=', 'mq=', 'st=', 'mp=', 'pt=']
 FIXED_PROPS = set([p[:-1] for p in FIXED_PREFIXES])
 
+COSINE_SIMILARITY_CUTOFF = 0.4
 
 def _is_vertical_svg(svg):
   return '_' not in svg
@@ -538,7 +539,7 @@ def _detection(orig_query, cleaned_query, embeddings_build) -> Detection:
     # Correlation classification step (needs the SV Detection first.)
     correlation_classification = model.query_correlation_detection(
         embeddings_build, query, svs_scores_dict['SV'],
-        svs_scores_dict['CosineScore'], sv_index_sorted)
+        svs_scores_dict['CosineScore'], sv_index_sorted, COSINE_SIMILARITY_CUTOFF)
     logging.info(f'Correlation classification: {correlation_classification}')
     if correlation_classification is not None:
       classifications.append(correlation_classification)

--- a/server/routes/nl_interface.py
+++ b/server/routes/nl_interface.py
@@ -39,9 +39,6 @@ FIXED_PROPS = set([p[:-1] for p in FIXED_PREFIXES])
 
 COSINE_SIMILARITY_CUTOFF = 0.4
 
-def _is_vertical_svg(svg):
-  return '_' not in svg
-
 
 def _get_preferred_type(types):
   for t in ['Country', 'State', 'County', 'City']:

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -196,7 +196,7 @@ class Model:
 
   def query_correlation_detection(
       self, embeddings_build, query, svs_list, svs_scores,
-      sv_embedding_indices) -> Union[NLClassifier, None]:
+      sv_embedding_indices, cosine_similarity_cutoff=0.4) -> Union[NLClassifier, None]:
     """Correlation detection based on clustering. Assumes all input lists are ordered and same length."""
 
     embedding_vectors = []
@@ -238,7 +238,7 @@ class Model:
     sim_score = cos_sim(embedding_vectors[cluster_zero_best_sv_index],
                         embedding_vectors[cluster_one_best_sv_index])
 
-    if sim_score < self._correlation_detection.cosine_similarity_cutoff:
+    if sim_score < cosine_similarity_cutoff:
       logging.info(
           f"Correlation Query. Best SVs in the two clusters were far apart. Cosine Score = {sim_score}"
       )

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -202,7 +202,8 @@ class Model:
     embedding_vectors = []
     for i in range(0, len(svs_list)):
       vec_index = sv_embedding_indices[i]
-      vec = self.dataset_embeddings_maps_to_df[embeddings_build].iloc[vec_index].values
+      vec = self.dataset_embeddings_maps_to_df[embeddings_build].iloc[
+          vec_index].values
 
       embedding_vectors.append(np.array(vec))
 

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -23,15 +23,17 @@ from lib.nl_detection import ContainedInClassificationAttributes, ContainedInPla
 from lib.nl_detection import RankingClassificationAttributes, RankingType
 from lib.nl_detection import PeriodType, TemporalClassificationAttributes
 from lib.nl_training import NLQueryClassificationData, NLQueryClassificationModel
+from lib.nl_training import NLQueryCorrelationDetectionModel
 from typing import Dict, List, Union
 import os
+import numpy as np
 import pandas as pd
 import torch
 from datasets import load_dataset
 import logging
 
 BUILDS = [
-    'demographics300',  #'uncurated3000',
+    'demographics300',  #'uncurated3000', 
     'demographics300-withpalmalternatives',
     'curatedJan2022',
     'combined_all'
@@ -70,6 +72,8 @@ class Model:
     self.model = SentenceTransformer(MODEL_NAME)
     self.ner_model = ner_model
     self.dataset_embeddings_maps = {}
+    # For clustering, need the DataFrame objects.
+    self.dataset_embeddings_maps_to_df = {}
     self._download_embeddings()
     self.dcid_maps = {}
     for build in BUILDS:
@@ -82,11 +86,15 @@ class Model:
       df = df.drop('dcid', axis=1)
       self.dataset_embeddings_maps[build] = torch.from_numpy(df.to_numpy()).to(
           torch.float)
+      self.dataset_embeddings_maps_to_df[build] = df
 
     # Classification models and training.
     self.classification_models: Dict[str, NLQueryClassificationModel] = {}
     self._classification_data_to_models(query_classification_data,
                                         classification_types_supported)
+
+    # Set the Correlations Detection Model.
+    self._correlation_detection = NLQueryCorrelationDetectionModel()
 
   def _download_embeddings(self):
     storage_client = storage.Client()
@@ -186,6 +194,70 @@ class Model:
     return NLClassifier(type=ClassificationType.CONTAINED_IN,
                         attributes=attributes)
 
+  def query_correlation_detection(
+      self, embeddings_build, query, svs_list, svs_scores,
+      sv_embedding_indices) -> Union[NLClassifier, None]:
+    """Correlation detection based on clustering. Assumes all input lists are ordered and same length."""
+
+    embedding_vectors = []
+    for i in range(0, len(svs_list)):
+      vec_index = sv_embedding_indices[i]
+      vec = self.dataset_embeddings_maps_to_df[embeddings_build].iloc[vec_index].values
+
+      embedding_vectors.append(np.array(vec))
+
+    # Cluster the embedding vectors.
+    self._correlation_detection.clustering_model.fit(embedding_vectors)
+    labels = self._correlation_detection.clustering_model.labels_
+    logging.info("Clustering in to two clusters done.")
+
+    cluster_zero_indices = [ind for ind, x in enumerate(labels) if x == 0]
+    cluster_one_indices = [ind for ind, x in enumerate(labels) if x == 1]
+
+    # Pick the highest scoring SVs in the two clusters.
+    def _index_with_max_score(cluster_indices):
+      max_s = -1.0
+      max_index = -1
+      for ci in cluster_indices:
+        if svs_scores[ci] > max_s:
+          max_s = svs_scores[ci]
+          max_index = ci
+      return max_index
+
+    cluster_zero_best_sv_index = _index_with_max_score(cluster_zero_indices)
+    cluster_one_best_sv_index = _index_with_max_score(cluster_one_indices)
+
+    # Cosine Score between the two.
+    def cos_sim(a, b):
+      return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
+
+    # If this score is high, it means that the two highest scored (matched) SVs
+    # are similar and we cannot be sure that this is a correlation query based
+    # on how different the two clusters are.
+    sim_score = cos_sim(embedding_vectors[cluster_zero_best_sv_index],
+                        embedding_vectors[cluster_one_best_sv_index])
+
+    if sim_score < self._correlation_detection.cosine_similarity_cutoff:
+      logging.info(
+          f"Correlation Query. Best SVs in the two clusters were far apart. Cosine Score = {sim_score}"
+      )
+      attributes = CorrelationClassificationAttributes(
+          sv_dcid_1=svs_list[cluster_zero_best_sv_index],
+          sv_dcid_2=svs_list[cluster_one_best_sv_index],
+          is_using_clusters=True,
+          # TODO: also look at trigger words.
+          correlation_trigger_words="",
+          cluster_1_svs=[svs_list[i] for i in cluster_zero_indices],
+          cluster_2_svs=[svs_list[i] for i in cluster_one_indices],
+      )
+      return NLClassifier(type=ClassificationType.CORRELATION,
+                          attributes=attributes)
+    else:
+      logging.info(
+          f"Not Correlation Query. Best SVs in the two clusters were too similar. Cosine Score > {sim_score}"
+      )
+    return None
+
   def query_classification(self, type_string: str,
                            query: str) -> Union[NLClassifier, None]:
     """Check if query can be classified according to 'type_string' model.
@@ -194,7 +266,7 @@ class Model:
       type_string: (str) This is the sentence classification type, e.g.
         "ranking", "temporal", "contained_in". Full list is in lib.nl_training.py
       query: (str) The query string supplied.
-
+    
     Returns:
       The NLClassifier object or None.
     """
@@ -234,17 +306,20 @@ class Model:
       return ValueError(f'Embeddings Build: {embeddings_build} was not found.')
     hits = semantic_search(query_embeddings,
                            self.dataset_embeddings_maps[embeddings_build],
-                           top_k=10)
+                           top_k=20)
 
     # Note: multiple results may map to the same DCID. As well, the same string may
     # map to multiple DCIDs with the same score.
     sv2score = {}
+    # Also track the sv to index so that embeddings can later be retrieved.
+    sv2index = {}
     for e in hits[0]:
       for d in self.dcid_maps[embeddings_build][e['corpus_id']].split(','):
         s = e['score']
         # Prefer the top score.
         if d not in sv2score:
           sv2score[d] = s
+          sv2index[d] = e['corpus_id']
 
     # Sort by scores
     sv2score_sorted = sorted(sv2score.items(),
@@ -253,7 +328,13 @@ class Model:
     svs_sorted = [k for (k, _) in sv2score_sorted]
     scores_sorted = [v for (_, v) in sv2score_sorted]
 
-    return {'SV': svs_sorted, 'CosineScore': scores_sorted}
+    sv_index_sorted = [sv2index[k] for (k, _) in sv2score_sorted]
+
+    return {
+        'SV': svs_sorted,
+        'CosineScore': scores_sorted,
+        'EmbeddingIndex': sv_index_sorted
+    }
 
   def detect_place(self, query):
     doc = self.ner_model(query)

--- a/static/js/apps/nl_interface/debug_info.tsx
+++ b/static/js/apps/nl_interface/debug_info.tsx
@@ -92,6 +92,7 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
     rankingClassification: props.debugData["ranking_classification"],
     temporalClassification: props.debugData["temporal_classification"],
     containedInClassification: props.debugData["contained_in_classification"],
+    correlationClassification: props.debugData["correlation_classification"],
     chartSpec: props.debugData["chart_spec"],
   };
 
@@ -176,6 +177,11 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
           <Row>
             <Col>
               ContainedIn classification: {debugInfo.containedInClassification}
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              Correlation classification: {debugInfo.correlationClassification}
             </Col>
           </Row>
           <Row>

--- a/static/js/types/app/nl_interface_types.ts
+++ b/static/js/types/app/nl_interface_types.ts
@@ -43,4 +43,5 @@ export interface DebugInfo {
   rankingClassification: string;
   temporalClassification: string;
   containedInClassification: string;
+  correlationClassification: string;
 }


### PR DESCRIPTION
This PR adds:

1. Basic clustering-based correlation detection. It mostly only works when the query matches two very distinct set of SVs, e.g. "median income and auto theft California". 
2. The Detection object has all the attributes set.
3. Increased the number of SV matches we get from the embeddings matcher (from 10 to 20). The reason is that we now have a growing number of sentence alternatives for each SV and as a result the matching produces many duplicates. 
4. For the debugInfo rendered on the website, I have concatenated everything in a string. It is not the best rendering but for now, actual detection is perhaps more important than the formatting of the debugInfo. See attached image for now the debugInfo looks like: 

<img width="1033" alt="Screenshot 2023-01-08 at 5 58 19 PM" src="https://user-images.githubusercontent.com/1021616/211231670-9652a7e7-5519-47a7-bb3e-f761b4a20461.png">
