### PR TITLE
[NL Interface] Use heuristics-based ranking query classifier

### DIFF
--- a/server/lib/nl_detection.py
+++ b/server/lib/nl_detection.py
@@ -102,7 +102,7 @@ class SimpleClassificationAttributes(ClassificationAttributes):
 @dataclass
 class RankingClassificationAttributes(ClassificationAttributes):
   """Ranking classification attributes."""
-  ranking_type: RankingType
+  ranking_type: List[RankingType]
 
   # List of words which made this a ranking query:
   # e.g. "top", "most", "least", "highest" etc

--- a/server/routes/nl_interface.py
+++ b/server/routes/nl_interface.py
@@ -316,7 +316,7 @@ def _dc_recon(place_ids):
 
 def _remove_punctuations(s):
   s = s.replace('\'s', '')
-  s = re.sub(r'[^\w\s]', '', s)
+  s = re.sub(r'[^\w\s]', ' ', s)
   return s
 
 
@@ -428,7 +428,7 @@ def _result_with_debug_info(data_dict,
   data_dict.update(debug_info)
   charts_config = data_dict.pop('config', {})
   return {'context': data_dict, 'config': charts_config}
-  
+
 
 def _detection(orig_query, cleaned_query, embeddings_build) -> Detection:
   default_place = "United States"

--- a/server/routes/nl_interface.py
+++ b/server/routes/nl_interface.py
@@ -428,7 +428,7 @@ def _result_with_debug_info(data_dict,
   data_dict.update(debug_info)
   charts_config = data_dict.pop('config', {})
   return {'context': data_dict, 'config': charts_config}
-
+  
 
 def _detection(orig_query, cleaned_query, embeddings_build) -> Detection:
   default_place = "United States"
@@ -488,7 +488,7 @@ def _detection(orig_query, cleaned_query, embeddings_build) -> Detection:
       svs_to_sentences=svs_scores_dict['SV_to_Sentences'])
 
   # Step 4: find query classifiers.
-  ranking_classification = model.query_classification("ranking", query)
+  ranking_classification = model.heuristic_ranking_classification(query)
   temporal_classification = model.query_classification("temporal", query)
   contained_in_classification = model.query_classification(
       "contained_in", query)

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -50,20 +50,19 @@ MODEL_NAME = 'all-MiniLM-L6-v2'
 QUERY_CLASSIFICATION_HEURISTICS = {
     "Ranking": {
         "High": [
-          "most",
-          "top",
-          "best",
-          "highest",
-          "smallest",
-          "tallest",
-          "strongest",
-          "oldest",
-          "furthest",
-          "descending",
-          "top to bottom",
-          "highest to lowest",
+            "most",
+            "top",
+            "best",
+            "highest",
+            "smallest",
+            "tallest",
+            "strongest",
+            "oldest",
+            "furthest",
+            "descending",
+            "top to bottom",
+            "highest to lowest",
         ],
-
         "Low": [
             "least",
             "bottom",
@@ -202,7 +201,8 @@ class Model:
         logging.info(
             f'Classification Model {key} could not be trained. Error: {e}')
 
-  def heuristic_ranking_classification(self, query) -> Union[NLClassifier, None]:
+  def heuristic_ranking_classification(self,
+                                       query) -> Union[NLClassifier, None]:
     """Determine if query is a ranking type.
 
     Uses heuristics instead of ML-based classification.
@@ -213,9 +213,7 @@ class Model:
     Returns:
       NLClassifier with RankingClassificationAttributes
     """
-    # remove punctuation and make query lowercase
-    translator = str.maketrans('', '', string.punctuation)
-    query = query.translate(translator)
+    # make query lowercase for str matching
     query = query.lower()
 
     ranking_type = []
@@ -239,9 +237,9 @@ class Model:
     trigger_words = high_matches + low_matches
     if len(trigger_words) == 0:
       ranking_type = [RankingType.NONE]
-    
-    attributes = RankingClassificationAttributes(ranking_type=ranking_type,
-                                                 ranking_trigger_words=trigger_words)
+
+    attributes = RankingClassificationAttributes(
+        ranking_type=ranking_type, ranking_trigger_words=trigger_words)
     return NLClassifier(type=ClassificationType.RANKING, attributes=attributes)
 
   def _ranking_classification(self, prediction) -> Union[NLClassifier, None]:

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -54,11 +54,12 @@ QUERY_CLASSIFICATION_HEURISTICS = {
             "top",
             "best",
             "highest",
+            "high",
             "smallest",
-            "tallest",
             "strongest",
-            "oldest",
-            "furthest",
+            "richest",
+            "sickest",
+            "illest",
             "descending",
             "top to bottom",
             "highest to lowest",
@@ -68,11 +69,11 @@ QUERY_CLASSIFICATION_HEURISTICS = {
             "bottom",
             "worst",
             "lowest",
+            "low",
             "largest",
-            "shortest",
             "weakest",
             "youngest",
-            "closest",
+            "poorest",
             "ascending",
             "bottom to top",
             "lowest to highest",
@@ -201,6 +202,7 @@ class Model:
         logging.info(
             f'Classification Model {key} could not be trained. Error: {e}')
 
+  # TODO (juliawu): Add unit-testing
   def heuristic_ranking_classification(self,
                                        query) -> Union[NLClassifier, None]:
     """Determine if query is a ranking type.


### PR DESCRIPTION
Changes the ranking query classification to use heuristics instead of a ML-model.

Note that this also:

(1) Changes the spec of `RankingClassificationAttributes`

(2) Changes query preprocessing to replace punctuation with spaces.