### PR TITLE
[NL Interface] Fixing some query detection bugs

### DIFF
--- a/server/lib/nl_chart_spec.py
+++ b/server/lib/nl_chart_spec.py
@@ -15,6 +15,7 @@
 
 from dataclasses import dataclass
 from typing import Dict, List
+import logging
 import pandas as pd
 
 from lib.nl_detection import ClassificationType, Detection
@@ -194,6 +195,10 @@ def compute(query_detection: Detection):
 
   if sample_child_place:
     all_places.append(sample_child_place)
+
+  if not all_svs:
+    logging.info("No SVs to use for existence.")
+    return chart_spec, selected_svs, extended_svs
 
   sv_existence = dc.observation_existence(all_svs, all_places)
   for sv in all_svs:

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -257,7 +257,9 @@ class Model:
         cutoff_index = i
 
     if cutoff_index == 0:
-      logging.info(f"Not clustering. No SV matching score was > {sv_matching_score_cutoff}")
+      logging.info(
+          f"Not clustering. No SV matching score was > {sv_matching_score_cutoff}"
+      )
       return None
 
     embedding_vectors = []

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -247,11 +247,21 @@ class Model:
       svs_scores,
       sv_embedding_indices,
       cosine_similarity_cutoff=0.4,
+      sv_matching_score_cutoff=0.35,
       prefix_length_cutoff=8) -> Union[NLClassifier, None]:
     """Correlation detection based on clustering. Assumes all input lists are ordered and same length."""
+    # Figure out the score cutoff so that clustering only considers high scoring SV matches.
+    cutoff_index = 0
+    for i in range(len(svs_scores)):
+      if svs_scores[i] > sv_matching_score_cutoff:
+        cutoff_index = i
+
+    if cutoff_index == 0:
+      logging.info(f"Not clustering. No SV matching score was > {sv_matching_score_cutoff}")
+      return None
 
     embedding_vectors = []
-    for i in range(0, len(svs_list)):
+    for i in range(0, cutoff_index):
       vec_index = sv_embedding_indices[i]
       vec = self.dataset_embeddings_maps_to_df[embeddings_build].iloc[
           vec_index].values

--- a/static/js/apps/nl_interface/debug_info.tsx
+++ b/static/js/apps/nl_interface/debug_info.tsx
@@ -222,7 +222,9 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
           <Row>
             <b>All SVs Matched (with scores):</b>
           </Row>
-          <Row>Note: SVs with scores <b>less than 0.4</b> are not used.</Row>
+          <Row>
+            Note: SVs with scores <b>less than 0.4</b> are not used.
+          </Row>
           <Row>
             <Col>{matchScoresElement(debugInfo.svScores)}</Col>
           </Row>

--- a/static/js/apps/nl_interface/debug_info.tsx
+++ b/static/js/apps/nl_interface/debug_info.tsx
@@ -25,11 +25,11 @@ import { Col, Row } from "reactstrap";
 import { DebugInfo, SVScores } from "../../types/app/nl_interface_types";
 
 export const BUILD_OPTIONS = [
+  { value: "us_filtered", text: "Filtered US SVs (PaLM)" },
   {
     value: "curatedJan2022",
     text: "Curated 3.5k+ SVs PaLM(Jan2022) - Default",
   },
-  { value: "us_filtered", text: "Filtered US SVs (PaLM)" },
   { value: "demographics300", text: "Demographics only (300 SVs)" },
   {
     value: "demographics300-withpalmalternatives",
@@ -220,8 +220,9 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
             </Col>
           </Row>
           <Row>
-            <b>SVs Matched (with scores):</b>
+            <b>All SVs Matched (with scores):</b>
           </Row>
+          <Row>Note: SVs with scores <b>less than 0.4</b> are not used.</Row>
           <Row>
             <Col>{matchScoresElement(debugInfo.svScores)}</Col>
           </Row>


### PR DESCRIPTION
1. Returning from charts config function when there are no svs in the list (currently it results in an error from API call to dc)
2. Ensure too low scores for SVs matched do not get passed to the clustering.