### PR TITLE
Add a script to manually verify the flow of NLP features

### DIFF
--- a/server/routes/nl_interface.py
+++ b/server/routes/nl_interface.py
@@ -353,7 +353,7 @@ def _infer_place_dcid(places_found):
 
 
 def _empty_svs_score_dict():
-  return {"SV": [], "CosineScore": []}
+  return {"SV": [], "CosineScore": [], "SV_to_Sentences": {}}
 
 
 def _result_with_debug_info(data_dict,
@@ -364,7 +364,8 @@ def _result_with_debug_info(data_dict,
   """Using data_dict and query_detection, format the dictionary response."""
   svs_dict = {
       'SV': query_detection.svs_detected.sv_dcids,
-      'CosineScore': query_detection.svs_detected.sv_scores
+      'CosineScore': query_detection.svs_detected.sv_scores,
+      'SV_to_Sentences': query_detection.svs_detected.svs_to_sentences
   }
   svs_to_sentences = query_detection.svs_detected.svs_to_sentences
 

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -37,7 +37,7 @@ import re
 import string
 
 BUILDS = [
-    'demographics300',  #'uncurated3000', 
+    'demographics300',  #'uncurated3000',
     'demographics300-withpalmalternatives',
     'curatedJan2022',
     'us_filtered',
@@ -425,7 +425,7 @@ class Model:
       type_string: (str) This is the sentence classification type, e.g.
         "ranking", "temporal", "contained_in". Full list is in lib.nl_training.py
       query: (str) The query string supplied.
-    
+
     Returns:
       The NLClassifier object or None.
     """
@@ -462,7 +462,7 @@ class Model:
   def detect_svs(self, query, embeddings_build):
     query_embeddings = self.model.encode([query])
     if embeddings_build not in self.dataset_embeddings_maps:
-      return ValueError(f'Embeddings Build: {embeddings_build} was not found.')
+      raise ValueError(f'Embeddings Build: {embeddings_build} was not found.')
     hits = semantic_search(query_embeddings,
                            self.dataset_embeddings_maps[embeddings_build],
                            top_k=20)

--- a/server/test_nlp_manual.py
+++ b/server/test_nlp_manual.py
@@ -1,0 +1,53 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Script to test flow of nlp features.
+
+How to run locally:
+FLASK_ENV=local python test_nlp_manual.py
+"""
+import urllib.parse
+from main import app
+
+def _print_success(msg: str):
+  print('=' * 80)
+  print(msg)
+  print('=' * 80)
+
+def _encoded_q(query: str, embedding: str = 'us_filtered'):
+   return urllib.parse.urlencode({'q': query, 'build': embedding})
+
+def test_palo_alto_flow():
+  query = "tell me about Palo Alto"
+  response = app.test_client().post(
+    f'/nl/data?{_encoded_q(query)}',
+    json={'contextHistory': []},
+    content_type='application/json'
+  )
+
+  assert response.status_code == 200
+  assert 'config' in response.json
+
+  config = response.json['config']
+  assert 'metadata' in config and 'placeDcid' in config['metadata']
+
+  place_dcid = config['metadata']['placeDcid']
+  assert place_dcid and place_dcid[0] == 'geoId/0655282'
+
+def main():
+  test_palo_alto_flow()
+  _print_success('Palo Alto flow is succsesful.')
+
+if __name__ == '__main__':
+  main()

--- a/server/test_nlp_manual.py
+++ b/server/test_nlp_manual.py
@@ -20,21 +20,22 @@ FLASK_ENV=local python test_nlp_manual.py
 import urllib.parse
 from main import app
 
+
 def _print_success(msg: str):
   print('=' * 80)
   print(msg)
   print('=' * 80)
 
+
 def _encoded_q(query: str, embedding: str = 'us_filtered'):
-   return urllib.parse.urlencode({'q': query, 'build': embedding})
+  return urllib.parse.urlencode({'q': query, 'build': embedding})
+
 
 def test_palo_alto_flow():
   query = "tell me about Palo Alto"
-  response = app.test_client().post(
-    f'/nl/data?{_encoded_q(query)}',
-    json={'contextHistory': []},
-    content_type='application/json'
-  )
+  response = app.test_client().post(f'/nl/data?{_encoded_q(query)}',
+                                    json={'contextHistory': []},
+                                    content_type='application/json')
 
   assert response.status_code == 200
   assert 'config' in response.json
@@ -45,9 +46,11 @@ def test_palo_alto_flow():
   place_dcid = config['metadata']['placeDcid']
   assert place_dcid and place_dcid[0] == 'geoId/0655282'
 
+
 def main():
   test_palo_alto_flow()
   _print_success('Palo Alto flow is succsesful.')
+
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
Since the flow is fixed and we have fast merging PRs, it would be nice to have a way to verify the flow end to end with a script. This PR only verifies Palo Alto is correctly detected. The rest of the flow will be followed.

The goal is to test: query -> nl/data API response, with contexts in between.