### PR TITLE
[nl] various formatting fixes

### DIFF
--- a/static/css/nl_interface.scss
+++ b/static/css/nl_interface.scss
@@ -130,17 +130,10 @@ $answer-min-height: 100vh;
     gap: 16px;
   }
 
-  .block-column {
-    flex-direction: row !important;
-    flex-wrap: wrap;
-    gap: 16px;
-  }
-
   .chart-container {
     background: white;
     margin-top: 0;
     padding: 10px;
-    width: 30%;
 
     h4 {
       margin-bottom: 0;
@@ -155,10 +148,6 @@ $answer-min-height: 100vh;
     }
   }
 
-  .chart-container.place-overview-tile {
-    width: 100%;
-  }
-
   .block-title {
     display: none;
   }
@@ -167,6 +156,18 @@ $answer-min-height: 100vh;
     position: absolute;
     top: -10000px;
     visibility: hidden;
+  }
+
+  .tile-lg {
+    width: 100%;
+  }
+
+  .tile-md {
+    width: calc((100% - 16px)/2);
+  }
+
+  .tile-sm {
+    width: calc((100% - 32px)/3);
   }
 }
 

--- a/static/css/shared/_ranking_unit.scss
+++ b/static/css/shared/_ranking_unit.scss
@@ -36,6 +36,7 @@
 
   td.stat {
     width: 25%;
+    text-align: right;
   }
   
   .bold {

--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -111,9 +111,12 @@ $border-radius: 0.5rem;
 
 .ranking-tile {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
   grid-column-gap: $chart-container-top-margin;
   grid-row-gap: $chart-container-top-margin;
+}
+
+.ranking-unit-container {
+  padding: 0 0.5rem;
 }
 
 /**

--- a/static/js/apps/nl_interface/query_search.tsx
+++ b/static/js/apps/nl_interface/query_search.tsx
@@ -72,7 +72,11 @@ export function QuerySearch(props: QuerySearchPropType): JSX.Element {
                 props.onQuerySearched(q);
               }}
               initialValue=""
-              placeholder='For example "family earnings in california"'
+              placeholder={
+                _.isEmpty(props.queries)
+                  ? 'For example "family earnings in california"'
+                  : ""
+              }
               shouldAutoFocus={true}
               clearValueOnSearch={true}
             />

--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -20,6 +20,11 @@
 
 import React from "react";
 
+import {
+  NL_LARGE_TILE_CLASS,
+  NL_MED_TILE_CLASS,
+  NL_SMALL_TILE_CLASS,
+} from "../../constants/app/nl_interface_constants";
 import { NamedTypedPlace } from "../../shared/types";
 import { randDomId } from "../../shared/util";
 import {
@@ -75,6 +80,19 @@ export function Block(props: BlockPropType): JSX.Element {
         {props.columns &&
           props.columns.map((column, idx) => {
             const parentId = `${props.id}-col-${idx}`;
+            let tileClassName = "";
+            // HACK for NL tile layout. Regularly, tile size should depend on
+            // number of columns in config.
+            if (isNlInterface()) {
+              if (column.tiles.length > 2) {
+                tileClassName = NL_SMALL_TILE_CLASS;
+              } else {
+                tileClassName =
+                  column.tiles.length === 1
+                    ? NL_LARGE_TILE_CLASS
+                    : NL_MED_TILE_CLASS;
+              }
+            }
             return (
               <div
                 key={parentId}
@@ -82,7 +100,7 @@ export function Block(props: BlockPropType): JSX.Element {
                 className="block-column"
                 style={{ width: columnWidth }}
               >
-                {renderTiles(column.tiles, props, minIdxToHide)}
+                {renderTiles(column.tiles, props, minIdxToHide, tileClassName)}
                 {showExpando && column.tiles.length > NUM_TILES_SHOWN && (
                   <a className="expando" onClick={expandoCallback}>
                     Show more
@@ -114,7 +132,8 @@ const expandoCallback = function (e) {
 function renderTiles(
   tiles: TileConfig[],
   props: BlockPropType,
-  minIdxToHide: number
+  minIdxToHide: number,
+  tileClassName?: string
 ): JSX.Element {
   if (!tiles) {
     return <></>;
@@ -122,7 +141,14 @@ function renderTiles(
   const tilesJsx = tiles.map((tile, i) => {
     const id = randDomId();
     const enclosedPlaceType = props.enclosedPlaceType;
-    const className = i >= minIdxToHide ? HIDE_TILE_CLASS : "";
+    const classNameList = [];
+    if (tileClassName) {
+      classNameList.push(tileClassName);
+    }
+    if (i >= minIdxToHide) {
+      classNameList.push(HIDE_TILE_CLASS);
+    }
+    const className = classNameList.join(" ");
     switch (tile.type) {
       case "HIGHLIGHT":
         return (

--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -64,10 +64,18 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
     fetchData(props, setRankingData);
   }, [props]);
 
+  const numRankingLists = getNumRankingLists(
+    props.rankingMetadata,
+    rankingData
+  );
   return (
     <div
       className={`chart-container ranking-tile ${props.className}`}
       ref={chartContainer}
+      style={{
+        gridTemplateColumns:
+          numRankingLists > 1 ? "repeat(2, 1fr)" : "repeat(1, 1fr)",
+      }}
     >
       {rankingData &&
         Object.keys(rankingData).map((statVar) => {
@@ -79,7 +87,7 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
           return (
             <React.Fragment key={statVar}>
               {props.rankingMetadata.showHighest && (
-                <div>
+                <div className="ranking-unit-container">
                   <RankingUnit
                     key={`${statVar}-highest`}
                     unit={unit}
@@ -242,4 +250,23 @@ function fetchData(
         setRankingData(rankingData);
       });
     });
+}
+
+/**
+ * Gets the number of ranking lists that will be shown
+ * @param rankingTileSpec ranking tile specifications
+ * @param rankingData ranking data to be shown
+ */
+function getNumRankingLists(
+  rankingTileSpec: RankingTileSpec,
+  rankingData: { [sv: string]: RankingGroup }
+): number {
+  let numListsPerSv = 0;
+  if (rankingTileSpec.showHighest) {
+    numListsPerSv++;
+  }
+  if (rankingTileSpec.showLowest) {
+    numListsPerSv++;
+  }
+  return rankingData ? Object.keys(rankingData).length * numListsPerSv : 0;
 }

--- a/static/js/constants/app/nl_interface_constants.ts
+++ b/static/js/constants/app/nl_interface_constants.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Constants used by nl_interface.
+ */
+
+export const NL_SMALL_TILE_CLASS = "tile-sm";
+export const NL_MED_TILE_CLASS = "tile-md";
+export const NL_LARGE_TILE_CLASS = "tile-lg";


### PR DESCRIPTION
- fix ranking tile layout (before: [screenshot](https://screenshot.googleplex.com/8AfnUWB58qeaey4))
<img width="838" alt="Screenshot 2023-01-10 at 5 03 51 PM" src="https://user-images.githubusercontent.com/69875368/211694011-efdcc600-a0cc-40e4-a799-c5d22c8b035a.png">

- make tiles span whole width of the page when there are less than 3 tiles
<img width="997" alt="Screenshot 2023-01-10 at 5 04 58 PM" src="https://user-images.githubusercontent.com/69875368/211694138-300b0182-cdf1-4ba2-b95d-1ad35d0a632b.png">

- clear search text box placeholder after first query has been searched