### PR TITLE
Fix ranking sort issue when NaN is present

### DIFF
--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -218,7 +218,10 @@ function fetchData(
             continue;
           }
           if (spec.denom) {
-            if (spec.denom in statData.data) {
+            if (
+              spec.denom in statData.data &&
+              statData.data[spec.denom][place].value > 0
+            ) {
               rankingPoint.value /= statData.data[spec.denom][place].value;
             } else {
               console.log(`Skipping ${place}, missing ${spec.denom}`);

--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -220,7 +220,7 @@ function fetchData(
           if (spec.denom) {
             if (
               spec.denom in statData.data &&
-              statData.data[spec.denom][place].value > 0
+              statData.data[spec.denom][place].value != 0
             ) {
               rankingPoint.value /= statData.data[spec.denom][place].value;
             } else {


### PR DESCRIPTION
When NaN is present,  javascript array sort does not work at all.

Before Fix:
![image](https://user-images.githubusercontent.com/5951856/212994859-5a056a89-5e98-4c4d-b38c-dbc9436285d3.png)
After Fix:
![image](https://user-images.githubusercontent.com/5951856/212994907-fea44d34-3287-4618-a5d7-9b7e1caddad1.png)
