### PR TITLE
[NL] Display extended stat vars as comparison charts

### DIFF
--- a/server/lib/nl/nl_page_config.py
+++ b/server/lib/nl/nl_page_config.py
@@ -32,6 +32,7 @@ def pluralize_place_type(place_type: str) -> str:
 
 
 def get_sv_name(svs):
+  svs = list(set(svs))
   sv2name_raw = dc.property_values(svs, 'name')
   uncurated_names = {
       sv: names[0] if names else sv for sv, names in sv2name_raw.items()
@@ -108,7 +109,8 @@ def _single_place_single_var_timeline_block(sv_dcid, sv2name):
 
 def _single_place_multiple_var_timeline_block(svs, sv2name):
   """A column with two chart, all stat vars and per capita"""
-  block = subject_page_pb2.Block(columns=[subject_page_pb2.Block.Column()])
+  block = subject_page_pb2.Block(title="Compare with Other Variables",
+                                 columns=[subject_page_pb2.Block.Column()])
   stat_var_spec_map = {}
 
   # Line chart for the stat var
@@ -143,7 +145,7 @@ def _single_place_multiple_var_timeline_block(svs, sv2name):
 
 def _multiple_place_bar_block(places: List[Place], svs: List[str], sv2name):
   """A column with two charts, main stat var and per capita"""
-  block = subject_page_pb2.Block(title="")
+  block = subject_page_pb2.Block(title="Compare with Other Places")
   column = block.columns.add()
   stat_var_spec_map = {}
   # Total

--- a/server/lib/nl/nl_variable.py
+++ b/server/lib/nl/nl_variable.py
@@ -148,6 +148,8 @@ def extend_svs(svs: Dict[str, List[str]]):
             continue
           if curr_sv_obj.pt != sv_obj.pt:
             continue
+          if curr_sv_obj.md != sv_obj.md:
+            continue
           if len(curr_sv_obj.pvs) != len(sv_obj.pvs):
             continue
           res[sv].append(sv_info['id'])

--- a/server/lib/nl/nl_variable.py
+++ b/server/lib/nl/nl_variable.py
@@ -14,11 +14,25 @@
 """Module for NL page variable"""
 
 from abc import ABC
-from dataclasses import dataclass
-from enum import Enum
-from typing import List
+from dataclasses import dataclass, field
+from typing import Dict, List
 
 import services.datacommons as dc
+
+
+@dataclass
+class SV:
+  mp: str = ''
+  st: str = ''
+  pt: str = ''
+  pvs: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class SVG:
+  pt: str = ''
+  pvs: Dict[str, str] = field(default_factory=dict)
+  p: str = ''
 
 
 class Entry(ABC):
@@ -43,38 +57,82 @@ class VariableStore:
   entries: List[Entry]
 
 
-def expand_svg(svgs: List[str]):
-  """Expand svg"""
-  result = {}
-  svg2svs = dc.property_values(svgs, "memberOf", False)
-  # svgs_l2 is to search one more level
-  svgs_l2 = []
-  for svg, svs in svg2svs.items():
-    if not svs:
-      svgs_l2.append(svg)
-      result[svg] = []
+def parse_sv(sv_definition: str) -> SV:
+  res = SV()
+  parts = sv_definition.split(",")
+  for part in parts:
+    k, v = part.split("=")
+    if k == "pt":
+      res.pt = v
+    elif k == "mp":
+      res.mp = v
+    elif k == "st":
+      res.st = v
     else:
-      result[svg] = svs
-  if svgs_l2:
-    child_svgs = []
-    svg2childsvgs = dc.property_values(svgs_l2, "specializationOf", False)
-    all_child_svgs = []
-    for svg, child_svgs in svg2childsvgs.items():
-      all_child_svgs.extend(child_svgs)
-    childsvg2svs = dc.property_values(all_child_svgs, "memberOf", False)
-    for svg, child_svgs in svg2childsvgs.items():
-      for child_svg in child_svgs:
-        result[svg].extend(childsvg2svs[child_svg])
-  return result
+      res.pvs[k] = v
+  return res
 
 
-def extend_svs(svs: List[str]):
-  """Extend all svs with siblings svs under the same svg.
+def parse_svg(svg_dcid: str) -> SVG:
+  res = SVG()
+  body = svg_dcid[len("dc/g/"):]
+  parts = body.split("_")
+  if len(parts) == 1:
+    return res
+  res.pt = parts[0]
+  for part in parts[1:]:
+    if "-" in part:
+      p, v = part.split("-")
+      p_lower = p.replace(p[0], p[0].lower(), 1)
+      res.pvs[p_lower] = v
+    else:
+      res.p = part.replace(part[0], part[0].lower(), 1)
+  return res
+
+
+def extend_svs(svs: Dict[str, List[str]]):
+  """Extend all svs with siblings svs.
   """
+  if not svs:
+    return {}
   sv2svgs = dc.property_values(svs, "memberOf", True)
   sv2svg = {sv: svg[0] for sv, svg in sv2svgs.items() if svg}
-  svg2children = dc.property_values(sv2svg.values(), "memberOf", False)
-  result = {}
+  svg2childsvs = {}
+  svginfo = dc.get_variable_group_info(list(sv2svg.values()), [])
+  for item in svginfo['data']:
+    svg2childsvs[item['node']] = item['info']['childStatVars']
+
+  res = {}
   for sv, svg in sv2svg.items():
-    result[sv] = svg2children.get(svg, [])
-  return result
+    res[sv] = []
+    svg_obj = parse_svg(svg)
+    sv_obj = None
+    for child_sv in svg2childsvs[svg]:
+      if child_sv['id'] == sv:
+        sv_obj = parse_sv(child_sv['definition'])
+        break
+    if not sv_obj:
+      continue
+    if len(svg_obj.pvs) == len(sv_obj.pvs):
+      # There are no direct siblings of this sv in the current svg.
+      # need to look for in-direct siblings
+      svg_parent = dc.property_values([svg], "specializationOf", True)[svg][0]
+      svg_siblings = dc.property_values([svg_parent], "specializationOf",
+                                        False)[svg_parent]
+      svg_siblings_info = dc.get_variable_group_info(svg_siblings, [])
+      for item in svg_siblings_info['data']:
+        for sv_info in item['info'].get('childStatVars', []):
+          curr_sv_obj = parse_sv(sv_info['definition'])
+          if curr_sv_obj.mp != sv_obj.mp:
+            continue
+          if curr_sv_obj.st != sv_obj.st:
+            continue
+          if curr_sv_obj.pt != sv_obj.pt:
+            continue
+          if len(curr_sv_obj.pvs) != len(sv_obj.pvs):
+            continue
+          res[sv].append(sv_info['id'])
+    else:
+      # Can use the direct siblings of this sv
+      res[sv] = list(map(lambda x: x['id'], svg2childsvs[svg]))
+  return res

--- a/server/lib/nl/nl_variable.py
+++ b/server/lib/nl/nl_variable.py
@@ -25,6 +25,7 @@ class SV:
   mp: str = ''
   st: str = ''
   pt: str = ''
+  md: str = ''
   pvs: Dict[str, str] = field(default_factory=dict)
 
 
@@ -68,6 +69,8 @@ def parse_sv(sv_definition: str) -> SV:
       res.mp = v
     elif k == "st":
       res.st = v
+    elif k == "md":
+      res.mv = v
     else:
       res.pvs[k] = v
   return res
@@ -91,7 +94,23 @@ def parse_svg(svg_dcid: str) -> SVG:
 
 
 def extend_svs(svs: Dict[str, List[str]]):
-  """Extend all svs with siblings svs.
+  """Extend stat vars by finding siblings.
+
+    Each SV has a parent SVG associated. Extending an SV would need to trace to
+    its parent SVG.
+
+    There are two types of SVGs:
+
+    1)
+    https://datacommons.org/browser/dc/g/Person_Gender-Female_Race-AsianAlone,
+    which has same set of PVs as its child SV. In this case, its child SVs are
+    not siblings as they differ by stat type or other properties. To find
+    siblings of a child SV, it's really a task to find this SVG's sibling
+    SVGs and get corresponding child SV from each of them.
+
+    2) https://datacommons.org/browser/dc/g/Person_Gender-Female_Race, which has
+    PVs and an EXTRA P, so this represents a set of SVs, its child SVs can be
+    directly used as siblings.
   """
   if not svs:
     return {}

--- a/server/lib/nl/nl_variable.py
+++ b/server/lib/nl/nl_variable.py
@@ -70,7 +70,7 @@ def parse_sv(sv_definition: str) -> SV:
     elif k == "st":
       res.st = v
     elif k == "md":
-      res.mv = v
+      res.md = v
     else:
       res.pvs[k] = v
   return res

--- a/server/routes/nl_interface.py
+++ b/server/routes/nl_interface.py
@@ -19,7 +19,7 @@ import json
 
 import flask
 from flask import Blueprint, current_app, render_template, escape, request
-from google.protobuf.json_format import MessageToJson, ParseDict
+from google.protobuf.json_format import MessageToJson
 from lib.nl.nl_detection import ClassificationType, ContainedInPlaceType, Detection, NLClassifier, Place, PlaceDetection, SVDetection, SimpleClassificationAttributes
 from typing import Dict, Union
 import pandas as pd
@@ -30,7 +30,6 @@ import services.datacommons as dc
 import lib.nl.nl_data_spec as nl_data_spec
 import lib.nl.nl_page_config as nl_page_config
 import lib.nl.nl_variable as nl_variable
-from config import subject_page_pb2
 
 bp = Blueprint('nl', __name__, url_prefix='/nl')
 
@@ -427,10 +426,6 @@ def _result_with_debug_info(data_dict,
               clustering_classification,
           'correlation_classification':
               correlation_classification,
-          'primary_sv':
-              data_spec.primary_sv,
-          'primary_sv_siblings':
-              data_spec.primary_sv_siblings,
           'data_spec':
               data_spec,
       },
@@ -621,7 +616,7 @@ def data():
                                embeddings_build, recent_context)
 
   # Get Data Spec
-  data_spec = nl_data_spec.compute(query_detection)
+  data_spec = nl_data_spec.compute(query_detection, context_history)
   page_config_pb = nl_page_config.build_page_config(query_detection, data_spec,
                                                     context_history)
   page_config = json.loads(MessageToJson(page_config_pb))


### PR DESCRIPTION
* Remove unused codes: related places, other commented codes
* Use "extended_sv_maps" as how topic branch works. The major change is to find extended svs robustly by inspecting direct siblings or remote siblings.
* Simplify context by using `data_spec` directly