### PR TITLE
[disasters] render AA2 maps for AA1 places

### DIFF
--- a/server/config/disaster_dashboard/Earth.textproto
+++ b/server/config/disaster_dashboard/Earth.textproto
@@ -30,10 +30,6 @@ metadata {
     key: "AdministrativeArea1"
     value: "AdministrativeArea2"
   }
-  contained_place_types {
-    key: "State"
-    value: "County"
-  }
   event_type_spec {
     key: "flood"
     value {

--- a/server/routes/disasters.py
+++ b/server/routes/disasters.py
@@ -65,11 +65,11 @@ def disaster_dashboard(place_dcid=DEFAULT_PLACE_DCID):
     # Use the default config instead
     dashboard_config = default_config
 
-  place_type = DEFAULT_PLACE_TYPE
+  place_types = [DEFAULT_PLACE_TYPE]
   if place_dcid != DEFAULT_PLACE_DCID:
-    place_type = place_api.get_place_type(place_dcid)
-    if not place_type:
-      place_type = "Place"
+    place_types = dc.property_values([place_dcid], 'typeOf')[place_dcid]
+    if not place_types:
+      place_types = ["Place"]
   place_name = place_api.get_i18n_name([place_dcid
                                        ]).get(place_dcid, escape(place_dcid))
 
@@ -88,7 +88,7 @@ def disaster_dashboard(place_dcid=DEFAULT_PLACE_DCID):
             dashboard_config, stat_var, tile_type)
 
   return flask.render_template('custom_dc/stanford/disaster_dashboard.html',
-                               place_type=place_type,
+                               place_type=json.dumps(place_types),
                                place_name=place_name,
                                place_dcid=place_dcid,
                                config=MessageToJson(dashboard_config))

--- a/static/js/apps/disaster_dashboard/main.ts
+++ b/static/js/apps/disaster_dashboard/main.ts
@@ -30,11 +30,12 @@ window.onload = () => {
 function renderPage(): void {
   const placeDcid = document.getElementById("place").dataset.dcid;
   const placeName = document.getElementById("place").dataset.name || placeDcid;
-  const placeType = document.getElementById("place").dataset.type;
+  const placeTypes =
+    JSON.parse(document.getElementById("place").dataset.type) || [];
   const dashboardConfig = JSON.parse(
     document.getElementById("dashboard-config").dataset.config
   );
-  const place = { dcid: placeDcid, name: placeName, types: [placeType] };
+  const place = { dcid: placeDcid, name: placeName, types: placeTypes };
 
   ReactDOM.render(
     React.createElement(App, {

--- a/static/js/components/disaster_dashboard/parent_breadcrumbs.tsx
+++ b/static/js/components/disaster_dashboard/parent_breadcrumbs.tsx
@@ -42,6 +42,16 @@ export function ParentBreadcrumbs(
     );
   }, []);
 
+  let placeType = props.place.types[0];
+  for (const type of props.place.types) {
+    // prefer to use specific type like "State" or "County" over
+    // of "AdministrativeArea"
+    if (!type.startsWith("AdministrativeArea") && type != "Place") {
+      placeType = type;
+      break;
+    }
+  }
+
   let breadcrumbs: JSX.Element[];
   if (parentPlaces) {
     const num = parentPlaces.length;
@@ -63,8 +73,7 @@ export function ParentBreadcrumbs(
     <>
       {props.place.types[0] != "Planet" && parentPlaces ? (
         <h3>
-          {props.place.types[0]}{" "}
-          {props.place.types[0] == "Country" ? "on" : "in"} {breadcrumbs}
+          {placeType} {placeType == "Country" ? "on" : "in"} {breadcrumbs}
         </h3>
       ) : (
         <h3 className="invisible"></h3>

--- a/static/js/components/subject_page/main_pane.tsx
+++ b/static/js/components/subject_page/main_pane.tsx
@@ -43,10 +43,13 @@ export const SubjectPageMainPane = memo(function SubjectPageMainPane(
   // TODO(shifucun): Further clean up default place type, child place type etc
   // from subject page client components. The component should respect whatever
   // the input prop is.
-  const placeType = props.place.types[0];
-  const enclosedPlaceType = props.pageConfig.metadata.containedPlaceTypes
-    ? props.pageConfig.metadata.containedPlaceTypes[placeType]
-    : "";
+  let enclosedPlaceType = "";
+  for (const placeType of props.place.types) {
+    if (placeType in props.pageConfig.metadata.containedPlaceTypes) {
+      enclosedPlaceType =
+        props.pageConfig.metadata.containedPlaceTypes[placeType];
+    }
+  }
   return (
     <div id="subject-page-main-pane">
       {!_.isEmpty(props.pageConfig) &&


### PR DESCRIPTION
- for the maps that are rendered, render AA2 for AA1 places
- in the breadcrumbs, prefer to show "State" or "County" over "AdministrativeArea" as the place type