### PR TITLE
[Disaster Dashboard] Binning histogram to latest year

### DIFF
--- a/server/routes/api/series.py
+++ b/server/routes/api/series.py
@@ -15,6 +15,7 @@
 from flask import Blueprint, request
 from cache import cache
 import services.datacommons as dc
+import logging
 
 # Define blueprint
 bp = Blueprint("series", __name__, url_prefix='/api/observations/series')
@@ -56,6 +57,59 @@ def series_core(entities, variables, all_facets):
 def series_within_core(parent_entity, child_type, variables, all_facets):
   resp = dc.obs_series_within(parent_entity, child_type, variables, all_facets)
   return compact_series(resp, all_facets)
+
+
+# TODO(juliawu): Handle case where dates are not "YYYY-MM"
+# TODO(juliawu): We should adjust how we bin based on the data,
+#                instead of cutting it off.
+def get_binned_series(entities, variables, year):
+  """Get observation series for entities and variables, for a given year.
+  
+  Bins observations from a series for plotting in the histogram tile.
+  Currently, binning is done by only returning observations for a given year.
+  This is done by assuming the dates of the series are in 'YYYY-MM' format,
+  filtering for observations from the given year, and then imputing 0 for
+  any months missing, up to the end of the series. 
+
+  Note: This assumes the dates of the series are in 'YYYY-MM' format.
+
+  Args:
+    entities (list): DCIDs of entities to query
+    variables (list): DCIDs of variables to query
+    year (str): year in "YYYY" format to get observations for
+  
+  Returns:
+    JSON response from server, with series containing only observations from 
+    the specified year.
+  """
+  # Get raw series from mixer
+  data = series_core(entities, variables, False)
+
+  
+  for stat_var in variables:
+    for location in data['data'][stat_var].keys():
+
+      # filter series to just observations from the selected year
+      series = data['data'][stat_var][location]['series']
+      pruned_series = []
+      dates_with_data = []
+      for obs in series:
+        if obs['date'][:4] == year:
+          pruned_series.append(obs)
+          dates_with_data.append(obs['date'])
+      
+      if len(pruned_series) > 0:
+        # fill in missing periods with 0s, from January to end of series
+        last_month = int(dates_with_data[-1][-2:])
+        months_to_fill = [str(mm).zfill(2) for mm in range(1, last_month+1)]
+        for month in months_to_fill:
+          date = f"{year}-{month}"
+          if date not in dates_with_data:
+            pruned_series.append({'date': date, 'value': 0})
+        pruned_series.sort(key=lambda x: x['date'])
+      
+      data['data'][stat_var][location]['series'] = pruned_series
+  return data
 
 
 @bp.route('', strict_slashes=False)
@@ -122,3 +176,27 @@ def series_within_all():
   if not variables:
     return 'error: must provide a `variables` field', 400
   return series_within_core(parent_entity, child_type, variables, True)
+
+
+@bp.route('/binned')
+@bp.route('/binned/<path:year>')
+def series_binned(year='2022'):
+  """Get observations binned by time-period.
+  
+  Used for pre-binning data for the histogram tile. Currently only "bins" data
+  by returning only observations from a specific year.
+
+  Args:
+    year: the year to get observations for
+  
+  Returns:
+    JSON response from server, with series containing only observations from 
+    the specified year.
+  """
+  entities = list(filter(lambda x: x != "", request.args.getlist('entities')))
+  variables = list(filter(lambda x: x != "", request.args.getlist('variables')))
+  if not entities:
+    return 'error: must provide a `entities` field', 400
+  if not variables:
+    return 'error: must provide a `variables` field', 400
+  return get_binned_series(entities, variables, year)

--- a/server/routes/api/series.py
+++ b/server/routes/api/series.py
@@ -85,7 +85,6 @@ def get_binned_series(entities, variables, year):
   # Get raw series from mixer
   data = series_core(entities, variables, False)
 
-  
   for stat_var in variables:
     for location in data['data'][stat_var].keys():
 
@@ -97,17 +96,17 @@ def get_binned_series(entities, variables, year):
         if obs['date'][:4] == year:
           pruned_series.append(obs)
           dates_with_data.append(obs['date'])
-      
+
       if len(pruned_series) > 0:
         # fill in missing periods with 0s, from January to end of series
         last_month = int(dates_with_data[-1][-2:])
-        months_to_fill = [str(mm).zfill(2) for mm in range(1, last_month+1)]
+        months_to_fill = [str(mm).zfill(2) for mm in range(1, last_month + 1)]
         for month in months_to_fill:
           date = f"{year}-{month}"
           if date not in dates_with_data:
             pruned_series.append({'date': date, 'value': 0})
         pruned_series.sort(key=lambda x: x['date'])
-      
+
       data['data'][stat_var][location]['series'] = pruned_series
   return data
 

--- a/static/js/components/tiles/histogram_tile.tsx
+++ b/static/js/components/tiles/histogram_tile.tsx
@@ -109,7 +109,7 @@ function fetchData(
     }
   }
   axios
-    .get("/api/observations/series", {
+    .get("/api/observations/series/binned", {
       // Fetch both numerator stat vars and denominator stat vars
       params: {
         variables: statVars,


### PR DESCRIPTION
This PR:
* Adds a server endpoint that filters observation series to data for a specific year.
* Use that endpoint to have histogram tiles only show data from 2022.

This allows us to pre-bin the data used in the histogram tile to a specific year, as a quick workaround to the rendering issues seen when trying to show histograms for long historical timeseries.

Allowing for multiple types of binning (by decade, year, month) and either allowing this to be set in a config or dynamically chosen based on the data can come in a future PR.

Current:
![Screenshot 2023-01-19 at 4 58 24 PM](https://user-images.githubusercontent.com/4034366/213596305-f2efc6dd-7a3a-4841-92c3-43369ad8ca62.png)

Proposed:
![Screenshot 2023-01-19 at 4 58 15 PM](https://user-images.githubusercontent.com/4034366/213596316-e758bb2a-b4f0-42a5-a40e-14d77e66edf0.png)
