### PR TITLE
[Disaster Dashboard] Improve info card titles

### DIFF
--- a/static/js/components/subject_page/category.tsx
+++ b/static/js/components/subject_page/category.tsx
@@ -55,9 +55,7 @@ export function Category(props: CategoryPropType): JSX.Element {
         <h2 className="block-title">{props.config.title}</h2>
       )}
       {props.config.description && (
-        <p>
-          <ReactMarkdown>{props.config.description}</ReactMarkdown>
-        </p>
+        <ReactMarkdown>{props.config.description}</ReactMarkdown>
       )}
       {props.config.blocks.map((block) => {
         const id = randDomId();

--- a/static/js/components/tiles/disaster_event_map_info_card.tsx
+++ b/static/js/components/tiles/disaster_event_map_info_card.tsx
@@ -55,7 +55,7 @@ export function DisasterEventMapInfoCard(
             );
           })}
         <span>
-          <a href={`/event/${props.eventData.placeDcid}`}>More info</a>
+          <a href={`/browser/${props.eventData.placeDcid}`}>More info</a>
         </span>
       </div>
     </div>

--- a/static/js/types/disaster_event_map_types.ts
+++ b/static/js/types/disaster_event_map_types.ts
@@ -45,7 +45,7 @@ interface EventApiGeoLocation {
 }
 
 // Information about an event as represented in the event API response.
-interface EventApiEventInfo {
+export interface EventApiEventInfo {
   dcid: string;
   dates: string[];
   places: string[];


### PR DESCRIPTION
Adds preprocessing to the event names to add the event type and handle non-user-friendly names.

Now instead of `DroughtEvent that started on 2022-08 within grid_1/37_-121`, the info card title is `Drought: Unnamed`.

And instead of `Ian`, the info card title is `Storm: Ian`

Also makes some quick fixes:
* Updates the "more info" link in info cards to point to a graph browser page, instead of the unfinished event pages.
* Remove extra `<p>` in category descriptions