### PR TITLE
Fix for "<p> cannot be descendant of <p>" errors

### DIFF
--- a/static/js/components/subject_page/category.tsx
+++ b/static/js/components/subject_page/category.tsx
@@ -55,9 +55,7 @@ export function Category(props: CategoryPropType): JSX.Element {
         <h2 className="block-title">{props.config.title}</h2>
       )}
       {props.config.description && (
-        <p>
-          <ReactMarkdown>{props.config.description}</ReactMarkdown>
-        </p>
+        <ReactMarkdown>{props.config.description}</ReactMarkdown>
       )}
       {props.config.blocks.map((block) => {
         const id = randDomId();


### PR DESCRIPTION
Quick fix for the `<p>` descriptions error.