### PR TITLE
[disasters] various updates

### DIFF
--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -509,6 +509,7 @@ export function addMapPoints(
       .range([minDotSize, minDotSize * 3]);
   }
   const mapPointsLayer = d3
+    .select(`#${domContainerId}`)
     .select(`#${MAP_ITEMS_GROUP_ID}`)
     .append("g")
     .attr("class", "map-points-layer")

--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -261,6 +261,7 @@ function renderTiles(
             place={props.place}
             enclosedPlaceType={enclosedPlaceType}
             eventTypeSpec={eventTypeSpec}
+            blockId={props.id}
           />
         );
       }
@@ -276,6 +277,7 @@ function renderTiles(
             topEventMetadata={tile.topEventTileSpec}
             className={className}
             eventTypeSpec={eventTypeSpec}
+            blockId={props.id}
           />
         );
       }

--- a/static/js/components/subject_page/category.tsx
+++ b/static/js/components/subject_page/category.tsx
@@ -33,6 +33,7 @@ import { Block } from "./block";
 import { StatVarProvider } from "./stat_var_provider";
 
 export interface CategoryPropType {
+  id: string;
   config: CategoryConfig;
   /**
    * The place to show the page for.
@@ -57,12 +58,14 @@ export function Category(props: CategoryPropType): JSX.Element {
       {props.config.description && (
         <ReactMarkdown>{props.config.description}</ReactMarkdown>
       )}
-      {props.config.blocks.map((block) => {
-        const id = randDomId();
+      {props.config.blocks.map((block, idx) => {
+        const id = block.title
+          ? getRelLink(block.title)
+          : `${props.id}blk${idx}`;
         return (
           <ErrorBoundary key={id}>
             <Block
-              id={block.title ? getRelLink(block.title) : randDomId()}
+              id={id}
               place={props.place}
               enclosedPlaceType={props.enclosedPlaceType}
               title={block.title}

--- a/static/js/components/subject_page/main_pane.tsx
+++ b/static/js/components/subject_page/main_pane.tsx
@@ -53,11 +53,12 @@ export const SubjectPageMainPane = memo(function SubjectPageMainPane(
   return (
     <div id="subject-page-main-pane">
       {!_.isEmpty(props.pageConfig) &&
-        props.pageConfig.categories.map((category) => {
-          const id = randDomId();
+        props.pageConfig.categories.map((category, idx) => {
+          const id = `cat${idx}`;
           return (
             <ErrorBoundary key={id}>
               <Category
+                id={id}
                 place={props.place}
                 enclosedPlaceType={enclosedPlaceType}
                 config={category}

--- a/static/js/components/tiles/disaster_event_map_filters.tsx
+++ b/static/js/components/tiles/disaster_event_map_filters.tsx
@@ -34,12 +34,17 @@ interface DisasterEventMapFiltersPropType {
   eventTypeSpec: Record<string, EventTypeSpec>;
   // height to set this component to.
   height: number;
+  // id of the block this component is in.
+  blockId: string;
 }
 
 export function DisasterEventMapFilters(
   props: DisasterEventMapFiltersPropType
 ): JSX.Element {
-  const severityFilters = getSeverityFilters(props.eventTypeSpec);
+  const severityFilters = getSeverityFilters(
+    props.eventTypeSpec,
+    props.blockId
+  );
 
   function onFilterInputChanged(
     disasterType: string,
@@ -56,7 +61,11 @@ export function DisasterEventMapFilters(
       updatedSeverityFilters[disasterType].lowerLimit = newVal;
     }
     const severityFiltersString = JSON.stringify(updatedSeverityFilters);
-    setUrlHash(URL_HASH_PARAM_KEYS.SEVERITY_FILTER, severityFiltersString);
+    setUrlHash(
+      URL_HASH_PARAM_KEYS.SEVERITY_FILTER,
+      severityFiltersString,
+      props.blockId
+    );
   }
 
   return (

--- a/static/js/components/tiles/disaster_event_map_selectors.tsx
+++ b/static/js/components/tiles/disaster_event_map_selectors.tsx
@@ -41,6 +41,8 @@ interface DisasterEventMapSelectorsPropType {
   dateOptions: string[];
   // Callback when new place is selected
   onPlaceSelected: (place: NamedPlace) => void;
+  // id of the block this component is in.
+  blockId: string;
   children?: React.ReactNode;
 }
 
@@ -54,9 +56,9 @@ export function DisasterEventMapSelectors(
         <CustomInput
           id="disaster-event-map-date-selector-input"
           type="select"
-          value={getDate()}
+          value={getDate(props.blockId)}
           onChange={(e) => {
-            setUrlHash(URL_HASH_PARAM_KEYS.DATE, e.target.value);
+            setUrlHash(URL_HASH_PARAM_KEYS.DATE, e.target.value, props.blockId);
           }}
         >
           {props.dateOptions.map((date) => {

--- a/static/js/utils/disaster_event_map_utils.tsx
+++ b/static/js/utils/disaster_event_map_utils.tsx
@@ -405,44 +405,62 @@ export function onPointClicked(
 }
 
 /**
- * Sets the url hash with the given key and value
+ * Sets the url hash with the given key, value, and block
  * @param paramKey the param key to update in the hash
  * @param paramValue the value to use in the hash
  */
-export function setUrlHash(paramKey: string, paramValue: string): void {
+export function setUrlHash(
+  paramKey: string,
+  paramValue: string,
+  blockId: string
+): void {
   // TODO (chejennifer): Right now we are assuming each subject page only has
   // one disaster event map tile. Find a way to handle the url hash for
   // mulitple disaster event map tiles.
   const urlParams = new URLSearchParams(window.location.hash.split("#")[1]);
-  urlParams.set(paramKey, paramValue);
+  const blockParamString = urlParams.get(blockId) || "";
+  let blockParamVal = {};
+  if (blockParamString) {
+    blockParamVal = JSON.parse(blockParamString);
+  }
+  blockParamVal[paramKey] = paramValue;
+  urlParams.set(blockId, JSON.stringify(blockParamVal));
   window.location.hash = urlParams.toString();
 }
 
 /**
- * Gets the hash value for a url param key.
+ * Gets the hash value for a url param key for a specific block.
+ *
  */
-export function getHashValue(paramKey: string): string {
+export function getHashValue(paramKey: string, blockId: string): string {
   const urlParams = new URLSearchParams(window.location.hash.split("#")[1]);
-  return urlParams.get(paramKey) || "";
+  const blockParamString = urlParams.get(blockId) || "";
+  let blockParamVal = {};
+  if (blockParamString) {
+    blockParamVal = JSON.parse(blockParamString);
+  }
+  return blockParamVal[paramKey] || "";
 }
 
 /**
  * Gets the date for a disaster event map using url params.
  */
-export function getDate(): string {
-  return getHashValue(URL_HASH_PARAM_KEYS.DATE) || DATE_OPTION_1Y_KEY;
+export function getDate(blockId: string): string {
+  return getHashValue(URL_HASH_PARAM_KEYS.DATE, blockId) || DATE_OPTION_1Y_KEY;
 }
 
 /**
  * Gets the severity filters for a disaster event map using url params.
  * @param eventTypeSpec the event type spec for the disaster event map
+ * @param blockId the id of the block to get severity filters for
  */
 export function getSeverityFilters(
-  eventTypeSpec: Record<string, EventTypeSpec>
+  eventTypeSpec: Record<string, EventTypeSpec>,
+  blockId: string
 ): Record<string, SeverityFilter> {
-  const urlParams = new URLSearchParams(window.location.hash.split("#")[1]);
-  const urlSeverityFilterVal = urlParams.get(
-    URL_HASH_PARAM_KEYS.SEVERITY_FILTER
+  const urlSeverityFilterVal = getHashValue(
+    URL_HASH_PARAM_KEYS.SEVERITY_FILTER,
+    blockId
   );
   let severityFilters = {};
   if (urlSeverityFilterVal) {
@@ -458,6 +476,15 @@ export function getSeverityFilters(
     severityFilters[spec.id] = spec.defaultSeverityFilter;
   }
   return severityFilters;
+}
+
+/**
+ * Gets whether or not to use cache from url params.
+ */
+export function getUseCache(): boolean {
+  const urlParams = new URLSearchParams(window.location.hash.split("#")[1]);
+  const useCacheVal = urlParams.get(URL_HASH_PARAM_KEYS.USE_CACHE) || "";
+  return useCacheVal === "1";
 }
 
 /**


### PR DESCRIPTION
- event ranking tile embed
<img width="1413" alt="Screenshot 2023-01-20 at 11 19 01 PM" src="https://user-images.githubusercontent.com/69875368/213848602-5e4c45d4-de4f-4cce-afd9-6e7fe077c8e2.png">

- event ranking tile use url params
- updates to allow multiple disaster event maps on one page (config changes to show the multiple event maps will be in a separate PR in case we don't want to include those changes because it slows down the page)
<img width="1450" alt="Screenshot 2023-01-20 at 11 20 08 PM" src="https://user-images.githubusercontent.com/69875368/213848630-ff24c25d-8c2b-4dfb-806b-a4e8fa7942cd.png">


