### PR TITLE
[disaster] filter delay fix

### DIFF
--- a/static/js/components/tiles/disaster_event_map_filters.tsx
+++ b/static/js/components/tiles/disaster_event_map_filters.tsx
@@ -118,7 +118,7 @@ export function DisasterEventMapFilters(
                   }
                   value={severityFilter.lowerLimit}
                   onBlur={() => updateFilterHash()}
-                  onKeyPress={() => updateFilterHash()}
+                  onKeyPress={(e) => e.key === "Enter" && updateFilterHash()}
                 />
               </div>
               <div className="prop-filter-input">
@@ -134,7 +134,7 @@ export function DisasterEventMapFilters(
                   }
                   value={severityFilter.upperLimit}
                   onBlur={() => updateFilterHash()}
-                  onKeyPress={() => updateFilterHash()}
+                  onKeyPress={(e) => e.key === "Enter" && updateFilterHash()}
                 />
               </div>
             </div>


### PR DESCRIPTION
- when updating filter on key press, only update if "enter" is pressed