### PR TITLE
[disaster] make heat and cold event data available

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -204,7 +204,7 @@ def create_app():
   if cfg.CUSTOM:
     register_routes_custom_dc(app)
   if cfg.ENV_NAME == 'STANFORD' or os.environ.get(
-      'FLASK_ENV') == 'autopush' or cfg.LOCAL:
+      'FLASK_ENV') == 'autopush' or cfg.LOCAL and not cfg.LITE:
     register_routes_stanford_dc(app, cfg.TEST)
   if cfg.TEST:
     # disaster dashboard tests require stanford's routes to be registered.

--- a/server/lib/disaster_dashboard.py
+++ b/server/lib/disaster_dashboard.py
@@ -21,7 +21,7 @@ import logging
 EVENT_TYPES = [
     "FireEvent", "WildlandFireEvent", "WildfireEvent", "CycloneEvent",
     "HurricaneTyphoonEvent", "HurricaneEvent", "TornadoEvent", "FloodEvent",
-    "DroughtEvent", "WetBulbTemperatureEvent"
+    "DroughtEvent", "WetBulbTemperatureEvent", "ColdEvent", "HeatEvent"
 ]
 DISASTER_DATA_FOLDER = "disaster_dashboard/"
 


### PR DESCRIPTION
- made heat and cold event data available to be used, but NOT added to config
- don't read disaster data from GCS bucket if running lite server