### PR TITLE
[disasters] render parent map for places with no enclosedPlaceType

### DIFF
--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -265,6 +265,11 @@ $border-radius: 0.5rem;
     fill: #fff !important;
     stroke: #666;
   }
+
+  path.highlighted {
+    fill: #fff;
+    stroke-width: 2px;
+  }
   
   path.region-highlighted {
     stroke: var(--dark);

--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -184,6 +184,8 @@ function mouseOutAction(domContainerId: string, placeDcid: string): void {
     .select(`#${getPlacePathId(placeDcid)}`)
     .classed(HOVER_HIGHLIGHTED_CLASS_NAME, false)
     .classed(HOVER_HIGHLIGHTED_NO_CLICK_CLASS_NAME, false);
+  // bring original highlighted region back to the top
+  container.select("." + HIGHLIGHTED_CLASS_NAME).raise();
   container.select(`#${TOOLTIP_ID}`).style("display", "none");
 }
 

--- a/static/js/components/tiles/disaster_event_map_tile.tsx
+++ b/static/js/components/tiles/disaster_event_map_tile.tsx
@@ -371,10 +371,7 @@ export function DisasterEventMapTile(
     }
     loadSpinner(spinnerId);
     const geoJsonPromise = shouldFetchGeoJson
-      ? fetchGeoJsonData(
-          placeInfo.selectedPlace.dcid,
-          placeInfo.enclosedPlaceType
-        )
+      ? fetchGeoJsonData(placeInfo)
       : Promise.resolve(mapChartData.geoJson);
     Promise.all([geoJsonPromise, fetchDisasterEventPoints(dataOptions)])
       .then(([geoJson, disasterEventData]) => {
@@ -440,7 +437,7 @@ export function DisasterEventMapTile(
       true /* shouldShowBoundaryLines */,
       projection,
       placeInfo.selectedPlace.dcid,
-      "" /* zoomDcid: no dcid to zoom in on */,
+      placeInfo.selectedPlace.dcid /* zoomDcid */,
       zoomParams
     );
     for (const mapPointsData of Object.values(mapChartData.mapPointsData)) {

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -103,7 +103,6 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
             <table>
               <tbody>
                 {topEvents.map((event, i) => {
-                  console.log(event);
                   return (
                     <tr key={i}>
                       <td className="rank">{i + 1}</td>


### PR DESCRIPTION
- for disaster event map tile, when a place doesn't have a specified contained place type (e.g., counties), render the parent map and highlight the selected place (like map explorer)

![Screenshot 2023-01-25 at 4 25 29 PM](https://user-images.githubusercontent.com/69875368/214725276-3c270b73-1283-4ae9-8763-d181e7a0f39e.png)

![Screenshot 2023-01-25 at 4 25 41 PM](https://user-images.githubusercontent.com/69875368/214725292-f019de6e-d58e-4564-a1c9-ff832baf17cc.png)
