### PR TITLE
[Custom DC] Save terraform state to gcs

### DIFF
--- a/deploy/terraform-datacommons-website/examples/setup/main.tf
+++ b/deploy/terraform-datacommons-website/examples/setup/main.tf
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+terraform {
+  backend "gcs" {}
+}
 
 resource "random_id" "rnd" {
   byte_length = 4

--- a/deploy/terraform-datacommons-website/examples/website_v1/main.tf
+++ b/deploy/terraform-datacommons-website/examples/website_v1/main.tf
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+terraform {
+  backend "gcs" {}
+}
+
 locals {
   resource_suffix    = var.use_resource_suffix ? format("-%s", var.resource_suffix) : ""
   web_robot_sa_email = (


### PR DESCRIPTION
- Save Terraform state to gcs (create a terraform state bucket if it does not exist already).
- Only clone if repo does not exist. This makes the script retryable.