### PR TITLE
[NL Interface] Replacing SV search and NER place search with the new server API endpoints

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -100,15 +100,6 @@ for iitm data commons.
 To start multiple instances, bind each server instance to a different port.
 The following example will start localhost on port 8081. The default is 8080.
 
-### Start NL Server
-
-Natural language models are hosted on a separate server. For features that
-depend on it, need to bring it up locally:
-
-```bash
-./run_server.sh -p 6060
-```
-
 Please note the strict syntax requirements for the script, and leave a space
 after the flag. So: `./run_server.sh -p 8081` but not `./run_server.sh -p=8081`.
 
@@ -117,6 +108,17 @@ To enable language models
 ```bash
 ./run_server.sh -m
 ```
+
+### Start NL Server
+
+Natural language models are hosted on a separate server. For features that
+depend on it (all NL-based interfaces and endpoints), the NL server needs
+to be brought up locally (in a separate process):
+
+```bash
+./run_nl_server.sh -p 6060
+```
+By default the NL server runs on port 6060. 
 
 ## Deploy local changes to dev insance in GCP
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -299,9 +299,7 @@ def create_app():
     classification_types = [
         'ranking', 'temporal', 'contained_in', 'correlation'
     ]
-    nl_model = nl.Model(libnl.CLASSIFICATION_INFO,
-                        classification_types,
-                        ner_model=None)
+    nl_model = nl.Model(libnl.CLASSIFICATION_INFO, classification_types)
     app.config['NL_MODEL'] = nl_model
     if app.config['LOCAL']:
       with Cache(cache.directory) as reference:

--- a/server/lib/nl/nl_place_detection.py
+++ b/server/lib/nl/nl_place_detection.py
@@ -15,8 +15,6 @@
 from typing import List
 from services import datacommons as dc
 
-import en_core_web_md
-import json
 import logging
 
 import lib.nl.nl_constants as nl_constants

--- a/server/lib/nl/nl_place_detection.py
+++ b/server/lib/nl/nl_place_detection.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 from typing import List
+from services import datacommons as dc
+
 import en_core_web_md
+import json
 import logging
 
 import lib.nl.nl_constants as nl_constants
@@ -21,44 +24,10 @@ import lib.nl.nl_utils as nl_utils
 
 
 class NLPlaceDetector:
-  """Performs all place detection for the NL modules.
-    
-    Attributes:
-        ner_model: the Named Entity Recognition model, e.g. the ones made available
-            by the spaCy library: https://github.com/explosion/spacy-models/ 
-            By default, it is the `en_core_web_md` model.
-    """
-
-  def __init__(self, ner_model=None) -> None:
-    self.ner_model = ner_model
-    if self.ner_model is None:
-      self.ner_model = en_core_web_md.load()
+  """Performs all place detection for the NL modules."""
 
   def detect_place_ner(self, query: str) -> List[str]:
-    """Use the NER model to detect places in `query`.
-        
-        Raises an Exception if the NER model fails on the query.
-        """
-    try:
-      doc = self.ner_model(query)
-    except Exception as e:
-      raise Exception(e)
-
-    places_found_loc_gpe = []
-    places_found_fac = []
-    for e in doc.ents:
-      # Preference is given to LOC and GPE types over FAC.
-      # List of entity types recognized by the spaCy library
-      # is here: https://towardsdatascience.com/explorations-in-named-entity-recognition-and-was-eleanor-roosevelt-right-671271117218
-      # We only use the location/place types.
-      if e.label_ in ["GPE", "LOC"]:
-        places_found_loc_gpe.append(str(e))
-      if e.label_ in ["FAC"]:
-        places_found_fac.append(str(e))
-
-    if places_found_loc_gpe:
-      return places_found_loc_gpe
-    return places_found_fac
+    return dc.nl_detect_place_ner(query)
 
   def detect_places_heuristics(self, query: str) -> List[str]:
     """Returns all strings in the `query` detectd as places."""

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -37,8 +37,4 @@ geojson_rewind==1.0.1
 markupsafe==2.0.1
 python-dateutil==2.8.2
 pandas==1.3.5
-# Downloading the named-entity recognition (NER) library spacy and the large EN model
-# using the guidelines here: https://spacy.io/usage/models#production
-spacy==3.4.4
-en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.4.1/en_core_web_md-3.4.1-py3-none-any.whl
 scikit-learn==1.0.2

--- a/server/routes/nl_interface_next.py
+++ b/server/routes/nl_interface_next.py
@@ -181,7 +181,7 @@ def _result_with_debug_info(data_dict, status, embeddings_build,
   return data_dict
 
 
-def _detection(orig_query, cleaned_query, embeddings_build) -> Detection:
+def _detection(orig_query, cleaned_query) -> Detection:
   model = current_app.config['NL_MODEL']
 
   # Step 1: find all relevant places and the name/type of the main place found.
@@ -219,7 +219,7 @@ def _detection(orig_query, cleaned_query, embeddings_build) -> Detection:
   # Step 3: Identify the SV matched based on the query.
   svs_scores_dict = _empty_svs_score_dict()
   try:
-    svs_scores_dict = model.detect_svs(query, embeddings_build)
+    svs_scores_dict = model.detect_svs(query)
   except ValueError as e:
     logging.info(e)
     logging.info("Using an empty svs_scores_dict")
@@ -319,14 +319,12 @@ def data():
   if not query:
     logging.info("Query was empty")
     return _result_with_debug_info(res, "Aborted: Query was Empty.",
-                                   embeddings_build,
-                                   _detection("", "", embeddings_build),
+                                   embeddings_build, _detection("", ""),
                                    escaped_context_history)
 
   # Query detection routine:
   # Returns detection for Place, SVs and Query Classifications.
-  query_detection = _detection(str(escape(original_query)), query,
-                               embeddings_build)
+  query_detection = _detection(str(escape(original_query)), query)
 
   # Generate new utterance.
   prev_utterance = nl_utterance.load_utterance(context_history)

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -33,7 +33,6 @@ import lib.nl.nl_utils as nl_utils
 
 from typing import Dict, List, Union
 
-import json
 import os
 import numpy as np
 import pandas as pd

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -26,12 +26,14 @@ from lib.nl.nl_detection import RankingClassificationAttributes, RankingType
 from lib.nl.nl_detection import PeriodType, TemporalClassificationAttributes
 from lib.nl.nl_training import NLQueryClassificationData, NLQueryClassificationModel
 from lib.nl.nl_training import NLQueryClusteringDetectionModel
+from services import datacommons as dc
 
 import lib.nl.nl_constants as nl_constants
 import lib.nl.nl_utils as nl_utils
 
 from typing import Dict, List, Union
 
+import json
 import os
 import numpy as np
 import pandas as pd
@@ -88,12 +90,11 @@ def _prefix_length(s1, s2):
 class Model:
   """Holds clients for the language model"""
 
-  def __init__(self,
-               query_classification_data: Dict[str, NLQueryClassificationData],
-               classification_types_supported: List[str],
-               ner_model=None):
+  def __init__(self, query_classification_data: Dict[str,
+                                                     NLQueryClassificationData],
+               classification_types_supported: List[str]):
     self.model = SentenceTransformer(MODEL_NAME)
-    self.place_detector: NLPlaceDetector = NLPlaceDetector(ner_model=ner_model)
+    self.place_detector: NLPlaceDetector = NLPlaceDetector()
     self.dataset_embeddings_maps = {}
     # For clustering, need the DataFrame objects.
     self.dataset_embeddings_maps_to_df = {}
@@ -463,64 +464,14 @@ class Model:
       return self._clustering_classification([])
     return None
 
-  def detect_svs(self, query, embeddings_build):
+  def detect_svs(self, query) -> Dict[str, Union[Dict, List]]:
     # Remove stop words.
     logging.info(f"SV Detection: Query provided to SV Detection: {query}")
     query = nl_utils.remove_stop_words(query, ALL_STOP_WORDS)
     logging.info(f"SV Detection: Query used after removing stop words: {query}")
-    query_embeddings = self.model.encode([query])
-    if embeddings_build not in self.dataset_embeddings_maps:
-      raise ValueError(f'Embeddings Build: {embeddings_build} was not found.')
-    hits = semantic_search(query_embeddings,
-                           self.dataset_embeddings_maps[embeddings_build],
-                           top_k=20)
 
-    # Note: multiple results may map to the same DCID. As well, the same string may
-    # map to multiple DCIDs with the same score.
-    sv2score = {}
-    # Also track the sv to index so that embeddings can later be retrieved.
-    sv2index = {}
-    # Also add the full list of SVs and sentences that matched (for debugging).
-    all_svs_sentences: Dict[str, List[str]] = {}
-    for e in hits[0]:
-      for d in self.dcid_maps[embeddings_build][e['corpus_id']].split(','):
-        s = e['score']
-        ind = e['corpus_id']
-        sentence = ""
-        try:
-          sentence = self.sentence_maps[embeddings_build][
-              e['corpus_id']] + f" ({s})"
-        except Exception as exp:
-          logging.info(exp)
-        # Prefer the top score.
-        if d not in sv2score:
-          sv2score[d] = s
-          sv2index[d] = ind
-
-        # Add to the debug map anyway.
-        existing_sentences = []
-        if d in all_svs_sentences:
-          existing_sentences = all_svs_sentences[d]
-
-        if sentence not in existing_sentences:
-          existing_sentences.append(sentence)
-        all_svs_sentences[d] = existing_sentences
-
-    # Sort by scores
-    sv2score_sorted = sorted(sv2score.items(),
-                             key=lambda item: item[1],
-                             reverse=True)
-    svs_sorted = [k for (k, _) in sv2score_sorted]
-    scores_sorted = [v for (_, v) in sv2score_sorted]
-
-    sv_index_sorted = [sv2index[k] for (k, _) in sv2score_sorted]
-
-    return {
-        'SV': svs_sorted,
-        'CosineScore': scores_sorted,
-        'EmbeddingIndex': sv_index_sorted,
-        'SV_to_Sentences': all_svs_sentences,
-    }
+    # Make API call to the NL models/embeddings server.
+    return dc.nl_search_sv(query)
 
   def detect_place(self, query):
     return self.place_detector.detect_places_heuristics(query)


### PR DESCRIPTION
This PR replaces the previous SV search (on embeddings) and NER place search with the new NL models server API calls. 

Note: for now, the dependence on the embeddings models and builds is not completely removed. This will need one more API end point first (returning the embeddings vector for individual queries). This will be done in the next PR.