### PR TITLE
Add startupProbe for NL server; Update all the Kubernetes probers

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -66,13 +66,15 @@ spec:
               path: /healthz
               port: 8080
             failureThreshold: 30
-            periodSeconds: 10
+
           readinessProbe:
             httpGet:
               path: /healthz
               port: 8080
-            failureThreshold: 1
-            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
           resources:
             limits:
               memory: "3G"
@@ -164,16 +166,13 @@ spec:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:12345"]
             failureThreshold: 30
-            periodSeconds: 10
+
           readinessProbe:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:12345"]
-            periodSeconds: 10
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:12345"]
-            periodSeconds: 10
-            initialDelaySeconds: 10
         - name: nl
           image: gcr.io/datcom-ci/datacommons-nl:abcxyz
           resources:
@@ -190,17 +189,19 @@ spec:
           volumeMounts:
             - name: model-config
               mountPath: /datacommons/model
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 6060
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /healthz
               port: 6060
-            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /healthz
               port: 6060
-            periodSeconds: 5
-            initialDelaySeconds: 5
           ports:
             - containerPort: 6060
         - name: esp


### PR DESCRIPTION
NL server restarts a few times now due to the lack of startup probe.

Removes initialDelaySeconds=10 as it is default value.