### PR TITLE
[disasters] add flag to enable json loading

### DIFF
--- a/run_server.sh
+++ b/run_server.sh
@@ -28,7 +28,7 @@ function help {
   echo "-e       Run with a specified environment. Options are: lite custom or any configured env. Default: local"
   echo "-p       Run on a specified port. Default: 8080"
   echo "-m       Enable language models"
-  echo "-d       Enable disaster JSON cache"
+  echo "-d       Enable disaster JSON cache in local dev mode"
   exit 1
 }
 

--- a/run_server.sh
+++ b/run_server.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -ex
 
 python3 -m venv .env
 source .env/bin/activate
@@ -28,10 +28,11 @@ function help {
   echo "-e       Run with a specified environment. Options are: lite custom or any configured env. Default: local"
   echo "-p       Run on a specified port. Default: 8080"
   echo "-m       Enable language models"
+  echo "-d       Enable disaster JSON cache"
   exit 1
 }
 
-while getopts ":e:p:m" OPTION; do
+while getopts ":e:p:m:d" OPTION; do
   case $OPTION in
     e)
       ENV=$OPTARG
@@ -41,6 +42,9 @@ while getopts ":e:p:m" OPTION; do
       ;;
     m)
       export ENABLE_MODEL=true
+      ;;
+    d)
+      export ENABLE_DISASTER_JSON=true
       ;;
     *)
       help

--- a/run_server.sh
+++ b/run_server.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex
+set -e
 
 python3 -m venv .env
 source .env/bin/activate

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -86,7 +86,7 @@ def register_routes_custom_dc(app):
   pass
 
 
-def register_routes_stanford_dc(app, is_test):
+def register_routes_stanford_dc(app, is_test, is_local):
   # Install blueprints specific to Stanford DC
   from routes import (disasters, event)
   from routes.api import (disaster_api)
@@ -98,7 +98,7 @@ def register_routes_stanford_dc(app, is_test):
     # load disaster dashboard configs
     disaster_dashboard_configs = libutil.get_disaster_dashboard_configs()
     app.config['DISASTER_DASHBOARD_CONFIGS'] = disaster_dashboard_configs
-    if os.environ.get('ENABLE_DISASTER_JSON') == 'true':
+    if not is_local or os.environ.get('ENABLE_DISASTER_JSON') == 'true':
       disaster_dashboard_data = get_disaster_dashboard_data(
           app.config['GCS_BUCKET'])
       app.config['DISASTER_DASHBOARD_DATA'] = disaster_dashboard_data
@@ -202,11 +202,11 @@ def create_app():
     register_routes_custom_dc(app)
   if cfg.ENV_NAME == 'STANFORD' or os.environ.get(
       'FLASK_ENV') == 'autopush' or cfg.LOCAL and not cfg.LITE:
-    register_routes_stanford_dc(app, cfg.TEST)
+    register_routes_stanford_dc(app, cfg.TEST, cfg.LOCAL)
   if cfg.TEST:
     # disaster dashboard tests require stanford's routes to be registered.
     register_routes_base_dc(app)
-    register_routes_stanford_dc(app, cfg.TEST)
+    register_routes_stanford_dc(app, cfg.TEST, cfg.LOCAL)
   else:
     register_routes_base_dc(app)
   if cfg.ADMIN:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -98,9 +98,10 @@ def register_routes_stanford_dc(app, is_test):
     # load disaster dashboard configs
     disaster_dashboard_configs = libutil.get_disaster_dashboard_configs()
     app.config['DISASTER_DASHBOARD_CONFIGS'] = disaster_dashboard_configs
-    disaster_dashboard_data = get_disaster_dashboard_data(
-        app.config['GCS_BUCKET'])
-    app.config['DISASTER_DASHBOARD_DATA'] = disaster_dashboard_data
+    if os.environ.get('ENABLE_DISASTER_JSON') == 'true':
+      disaster_dashboard_data = get_disaster_dashboard_data(
+          app.config['GCS_BUCKET'])
+      app.config['DISASTER_DASHBOARD_DATA'] = disaster_dashboard_data
 
 
 def register_routes_admin(app):


### PR DESCRIPTION
to load json configs - use `./run_server.sh -d`

we'll need to add this to our deployment configs if we want to load the json's elsewhere (or we can only check for the flag in local mode). thoughts?