### PR TITLE
[NL Next] Add Time-Deltas classifier

### DIFF
--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -205,6 +205,16 @@ QUERY_CLASSIFICATION_HEURISTICS: Dict[str, Union[List[str], Dict[
             "vs",
             "versus",
         ],
+        "TimeDelta": {
+            "Increase": [
+                "grow(n|th)",
+                "increased?",
+            ],
+            "Decrease": [
+                "decreased?",
+                "shr(ink|unk)",
+            ],
+        },
     }
 
 PLACE_TYPE_TO_PLURALS: Dict[str, str] = {

--- a/server/lib/nl/detection.py
+++ b/server/lib/nl/detection.py
@@ -100,6 +100,12 @@ class PeriodType(Enum):
   FROM = 3
 
 
+class TimeDeltaType(Enum):
+  """Indicates whether query refers to an increase or decrease in SV values."""
+  INCREASE = 0
+  DECREASE = 1
+
+
 class ClassificationAttributes(ABC):
   """Abstract class to hold classification attributes."""
   pass
@@ -171,6 +177,16 @@ class CorrelationClassificationAttributes(ClassificationAttributes):
   correlation_trigger_words: str
 
 
+@dataclass
+class TimeDeltaClassificationAttributes(ClassificationAttributes):
+  """Time Delta classification attributes."""
+  time_delta_type: List[TimeDeltaType]
+
+  # List of words which made this a time-delta query:
+  # e.g. "increase", "decrease", "growth", etc
+  time_delta_trigger_words: List[str]
+
+
 class ClassificationType(IntEnum):
   OTHER = 0
   SIMPLE = 1
@@ -180,7 +196,8 @@ class ClassificationType(IntEnum):
   CORRELATION = 5
   CLUSTERING = 6
   COMPARISON = 7
-  UNKNOWN = 8
+  TIME_DELTA = 8
+  UNKNOWN = 9
 
 
 # The supported classifications in order. Later entry is preferred.
@@ -190,6 +207,7 @@ RANKED_CLASSIFICATION_TYPES = [
     ClassificationType.CONTAINED_IN,
     ClassificationType.RANKING,
     ClassificationType.CORRELATION,
+    ClassificationType.TIME_DELTA,
 ]
 
 

--- a/server/lib/nl/detection.py
+++ b/server/lib/nl/detection.py
@@ -180,7 +180,7 @@ class CorrelationClassificationAttributes(ClassificationAttributes):
 @dataclass
 class TimeDeltaClassificationAttributes(ClassificationAttributes):
   """Time Delta classification attributes."""
-  time_delta_type: List[TimeDeltaType]
+  time_delta_types: List[TimeDeltaType]
 
   # List of words which made this a time-delta query:
   # e.g. "increase", "decrease", "growth", etc

--- a/server/routes/nl_interface_next.py
+++ b/server/routes/nl_interface_next.py
@@ -131,6 +131,7 @@ def _result_with_debug_info(data_dict, status, query_detection: Detection,
 
   ranking_classification = "<None>"
   temporal_classification = "<None>"
+  time_delta_classification = "<None>"
   contained_in_classification = "<None>"
   correlation_classification = "<None>"
   clustering_classification = "<None>"
@@ -140,6 +141,8 @@ def _result_with_debug_info(data_dict, status, query_detection: Detection,
       ranking_classification = str(classification.attributes.ranking_type)
     elif classification.type == ClassificationType.TEMPORAL:
       temporal_classification = str(classification.type)
+    elif classification.type == ClassificationType.TIME_DELTA:
+      time_delta_classification = str(classification.attributes.time_delta_type)
     elif classification.type == ClassificationType.CONTAINED_IN:
       contained_in_classification = str(classification.type)
       contained_in_classification = \
@@ -162,6 +165,7 @@ def _result_with_debug_info(data_dict, status, query_detection: Detection,
       'svs_to_sentences': svs_to_sentences,
       'ranking_classification': ranking_classification,
       'temporal_classification': temporal_classification,
+      'time_delta_classification': time_delta_classification,
       'contained_in_classification': contained_in_classification,
       'clustering_classification': clustering_classification,
       'correlation_classification': correlation_classification,
@@ -243,11 +247,13 @@ def _detection(orig_query, cleaned_query) -> Detection:
   ranking_classification = model.heuristic_ranking_classification(query)
   comparison_classification = model.comparison_classification(query)
   temporal_classification = model.query_classification("temporal", query)
+  time_delta_classification = model.heuristic_time_delta_classification(query)
   contained_in_classification = model.query_classification(
       "contained_in", query)
   logging.info(f'Ranking classification: {ranking_classification}')
   logging.info(f'Comparison classification: {comparison_classification}')
   logging.info(f'Temporal classification: {temporal_classification}')
+  logging.info(f'TimeDelta classification: {time_delta_classification}')
   logging.info(f'ContainedIn classification: {contained_in_classification}')
 
   # Set the Classifications list.
@@ -258,6 +264,8 @@ def _detection(orig_query, cleaned_query) -> Detection:
     classifications.append(comparison_classification)
   if contained_in_classification is not None:
     classifications.append(contained_in_classification)
+  if time_delta_classification is not None:
+    classifications.append(time_delta_classification)
 
   # Correlation classification
   correlation_classification = model.heuristic_correlation_classification(query)

--- a/server/routes/nl_interface_next.py
+++ b/server/routes/nl_interface_next.py
@@ -142,7 +142,8 @@ def _result_with_debug_info(data_dict, status, query_detection: Detection,
     elif classification.type == ClassificationType.TEMPORAL:
       temporal_classification = str(classification.type)
     elif classification.type == ClassificationType.TIME_DELTA:
-      time_delta_classification = str(classification.attributes.time_delta_type)
+      time_delta_classification = str(
+          classification.attributes.time_delta_types)
     elif classification.type == ClassificationType.CONTAINED_IN:
       contained_in_classification = str(classification.type)
       contained_in_classification = \

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -230,7 +230,7 @@ class Model:
         subtypes_matched.append(subtype_map[subtype])
       trigger_words += type_trigger_words
 
-    # If no matches, this query is not a ranking query
+    # If no matches, this query is not a time-delta query
     if len(trigger_words) == 0:
       return None
 

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -211,7 +211,7 @@ class Model:
         "Increase": TimeDeltaType.INCREASE,
         "Decrease": TimeDeltaType.DECREASE,
     }
-    
+
     query = query.lower()
     subtypes_matched = []
     trigger_words = []

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -213,16 +213,17 @@ class Model:
         "Increase": TimeDeltaType.INCREASE,
         "Decrease": TimeDeltaType.DECREASE,
     }
-
+    time_delta_heuristics = constants.QUERY_CLASSIFICATION_HEURISTICS[
+        "TimeDelta"]
+    time_delta_subtypes = time_delta_heuristics.keys()
     query = query.lower()
     subtypes_matched = []
     trigger_words = []
-    for subtype in constants.QUERY_CLASSIFICATION_HEURISTICS["TimeDelta"].keys(
-    ):
+    for subtype in time_delta_subtypes:
       type_trigger_words = []
 
-      for keyword in constants.QUERY_CLASSIFICATION_HEURISTICS["TimeDelta"][
-          subtype]:
+      for keyword in time_delta_heuristics[subtype]:
+        # look for keyword surrounded by spaces or start/end delimiters
         regex = r"(^|\W)" + keyword + r"($|\W)"
         type_trigger_words += [w.group() for w in re.finditer(regex, query)]
 
@@ -235,7 +236,7 @@ class Model:
       return None
 
     attributes = TimeDeltaClassificationAttributes(
-        time_delta_type=subtypes_matched,
+        time_delta_types=subtypes_matched,
         time_delta_trigger_words=trigger_words)
     return NLClassifier(type=ClassificationType.TIME_DELTA,
                         attributes=attributes)

--- a/static/js/apps/nl_interface/debug_info.tsx
+++ b/static/js/apps/nl_interface/debug_info.tsx
@@ -108,6 +108,7 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
     svSentences: props.debugData["svs_to_sentences"],
     rankingClassification: props.debugData["ranking_classification"],
     temporalClassification: props.debugData["temporal_classification"],
+    timeDeltaClassification: props.debugData["time_delta_classification"],
     containedInClassification: props.debugData["contained_in_classification"],
     correlationClassification: props.debugData["correlation_classification"],
     dataSpec: props.debugData["data_spec"],
@@ -164,6 +165,11 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
           <Row>
             <Col>
               Temporal classification: {debugInfo.temporalClassification}
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              TimeDelta classification: {debugInfo.timeDeltaClassification}
             </Col>
           </Row>
           <Row>


### PR DESCRIPTION
Adds a classifier for "time-delta" queries to the NL interface.
This would identify queries that ask for a change in a statvar over time, e.g. "Which places have seen the most increase in population?"

This is an initial classifier to unblock downstream tasks, improved classifiers to follow in future PRs.

Example Screenshots:
<img width="964" alt="Screenshot 2023-02-01 at 3 32 43 PM" src="https://user-images.githubusercontent.com/4034366/216191525-f1b29593-7383-4359-9986-1da04f25267b.png">

<img width="959" alt="Screenshot 2023-02-01 at 3 33 48 PM" src="https://user-images.githubusercontent.com/4034366/216191653-38510ada-00a4-42f9-a893-fe0734575913.png">
