### PR TITLE
[NL Next] Add time-delta classifiers to utterances

### DIFF
--- a/server/lib/nl/detection.py
+++ b/server/lib/nl/detection.py
@@ -100,7 +100,7 @@ class PeriodType(Enum):
   FROM = 3
 
 
-class TimeDeltaType(Enum):
+class TimeDeltaType(IntEnum):
   """Indicates whether query refers to an increase or decrease in SV values."""
   INCREASE = 0
   DECREASE = 1

--- a/server/lib/nl/utterance.py
+++ b/server/lib/nl/utterance.py
@@ -29,6 +29,8 @@ from lib.nl.detection import NLClassifier
 from lib.nl.detection import Place
 from lib.nl.detection import RankingClassificationAttributes
 from lib.nl.detection import RankingType
+from lib.nl.detection import TimeDeltaClassificationAttributes
+from lib.nl.detection import TimeDeltaType
 from lib.nl.detection import SimpleClassificationAttributes
 
 # How far back does the context go back.
@@ -140,6 +142,8 @@ def _classification_to_dict(classifications: List[NLClassifier]) -> List[Dict]:
         cdict['contained_in_place_type'] = cip
     elif isinstance(c.attributes, RankingClassificationAttributes):
       cdict['ranking_type'] = c.attributes.ranking_type
+    elif isinstance(c.attributes, TimeDeltaClassificationAttributes):
+      cdict['time_delta_type'] = c.attributes.time_delta_types
 
     classifications_dict.append(cdict)
   return classifications_dict
@@ -158,6 +162,10 @@ def _dict_to_classification(
       attributes = RankingClassificationAttributes(
           ranking_type=[RankingType(r) for r in cdict['ranking_type']],
           ranking_trigger_words=[])
+    elif 'time_delta_type' in cdict:
+      attributes = TimeDeltaClassificationAttributes(
+        time_delta_types=[TimeDeltaType(t) for t in cdict['time_delta_type']],
+        time_delta_trigger_words=[])
     classifications.append(
         NLClassifier(type=ClassificationType(cdict['type']),
                      attributes=attributes))

--- a/server/lib/nl/utterance.py
+++ b/server/lib/nl/utterance.py
@@ -29,9 +29,9 @@ from lib.nl.detection import NLClassifier
 from lib.nl.detection import Place
 from lib.nl.detection import RankingClassificationAttributes
 from lib.nl.detection import RankingType
+from lib.nl.detection import SimpleClassificationAttributes
 from lib.nl.detection import TimeDeltaClassificationAttributes
 from lib.nl.detection import TimeDeltaType
-from lib.nl.detection import SimpleClassificationAttributes
 
 # How far back does the context go back.
 CTX_LOOKBACK_LIMIT = 5
@@ -164,8 +164,8 @@ def _dict_to_classification(
           ranking_trigger_words=[])
     elif 'time_delta_type' in cdict:
       attributes = TimeDeltaClassificationAttributes(
-        time_delta_types=[TimeDeltaType(t) for t in cdict['time_delta_type']],
-        time_delta_trigger_words=[])
+          time_delta_types=[TimeDeltaType(t) for t in cdict['time_delta_type']],
+          time_delta_trigger_words=[])
     classifications.append(
         NLClassifier(type=ClassificationType(cdict['type']),
                      attributes=attributes))


### PR DESCRIPTION
This PR:

1. Adds Time-Delta classifiers to utterances, as followup to [this PR comment](https://github.com/datacommonsorg/website/pull/2150#pullrequestreview-1280041268)

2. Makes quick fix for JSON serializability errors for the TimeDeltaType object.
