### PR TITLE
Fork ranking into by place and by var. Also improve fallback

### DIFF
--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -123,6 +123,8 @@ def _add_charts(state: PopulateState, places: List[Place],
     # REQUIRES: len(places) == 1
     places_to_check = utils.get_sample_child_places(places[0].dcid,
                                                     state.place_type.value)
+  if not places_to_check:
+    return False
 
   # Map of main SV -> peer SVs
   sv2extensions = variable.extend_svs(utils.get_only_svs(svs))
@@ -173,6 +175,17 @@ def _add_charts(state: PopulateState, places: List[Place],
                    ', '.join(places_to_check), ', '.join(extended_svs))
 
   return found
+
+
+def overview_fallback(state: PopulateState, places: List[Place],
+                      chart_origin: ChartOriginType) -> bool:
+  # Overview chart is a safe fallback.
+  state.block_id += 1
+  chart_vars = ChartVars(svs=[],
+                         block_id=state.block_id,
+                         include_percapita=False)
+  return add_chart_to_utterance(ChartType.PLACE_OVERVIEW, state, chart_vars,
+                                places, chart_origin)
 
 
 def _get_place_dcids(places: List[Place]) -> List[str]:

--- a/server/lib/nl/fulfillment/comparison.py
+++ b/server/lib/nl/fulfillment/comparison.py
@@ -17,6 +17,7 @@ from typing import List
 from lib.nl.detection import Place
 from lib.nl.fulfillment.base import add_chart_to_utterance
 from lib.nl.fulfillment.base import ChartVars
+from lib.nl.fulfillment.base import overview_fallback
 from lib.nl.fulfillment.base import populate_charts_for_places
 from lib.nl.fulfillment.base import PopulateState
 from lib.nl.fulfillment.context import places_for_comparison_from_context
@@ -30,7 +31,7 @@ def populate(uttr: Utterance) -> bool:
   # by directly inferring the list of places to compare.
   state = PopulateState(uttr=uttr,
                         main_cb=_populate_cb,
-                        fallback_cb=_fallback_cb)
+                        fallback_cb=overview_fallback)
   for places_to_compare in places_for_comparison_from_context(uttr):
     if populate_charts_for_places(state, places_to_compare):
       return True
@@ -44,12 +45,3 @@ def _populate_cb(state: PopulateState, chart_vars: ChartVars,
   add_chart_to_utterance(ChartType.BAR_CHART, state, chart_vars, places,
                          chart_origin)
   return True
-
-
-def _fallback_cb(state: PopulateState, places: List[Place],
-                 chart_origin: ChartOriginType) -> bool:
-  # TODO: Poor choice, do better.
-  sv = "Count_Person"
-  state.block_id += 1
-  chart_vars = ChartVars(svs=[sv], block_id=state.block_id)
-  return _populate_cb(state, chart_vars, places, chart_origin)

--- a/server/lib/nl/fulfillment/containedin.py
+++ b/server/lib/nl/fulfillment/containedin.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from typing import List
 
 from lib.nl.detection import ClassificationType

--- a/server/lib/nl/fulfillment/containedin.py
+++ b/server/lib/nl/fulfillment/containedin.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import List
 
 from lib.nl.detection import ClassificationType
@@ -20,6 +21,7 @@ from lib.nl.detection import ContainedInPlaceType
 from lib.nl.detection import Place
 from lib.nl.fulfillment.base import add_chart_to_utterance
 from lib.nl.fulfillment.base import ChartVars
+from lib.nl.fulfillment.base import overview_fallback
 from lib.nl.fulfillment.base import populate_charts
 from lib.nl.fulfillment.base import PopulateState
 from lib.nl.fulfillment.context import classifications_of_type_from_context
@@ -40,7 +42,7 @@ def populate(uttr: Utterance) -> bool:
     if populate_charts(
         PopulateState(uttr=uttr,
                       main_cb=_populate_cb,
-                      fallback_cb=_fallback_cb,
+                      fallback_cb=overview_fallback,
                       place_type=place_type)):
       return True
   # TODO: poor default; should do this based on main place
@@ -48,7 +50,7 @@ def populate(uttr: Utterance) -> bool:
   return populate_charts(
       PopulateState(uttr=uttr,
                     main_cb=_populate_cb,
-                    fallback_cb=_fallback_cb,
+                    fallback_cb=overview_fallback,
                     place_type=place_type))
 
 
@@ -67,12 +69,3 @@ def _populate_cb(state: PopulateState, chart_vars: ChartVars,
   add_chart_to_utterance(ChartType.MAP_CHART, state, chart_vars,
                          contained_places, chart_origin)
   return True
-
-
-def _fallback_cb(state: PopulateState, containing_places: List[Place],
-                 chart_origin: ChartOriginType) -> bool:
-  # TODO: Poor choice, do better.
-  sv = "Count_Person"
-  state.block_id += 1
-  chart_vars = ChartVars(svs=[sv], block_id=state.block_id)
-  return _populate_cb(state, chart_vars, containing_places, chart_origin)

--- a/server/lib/nl/fulfillment/correlation.py
+++ b/server/lib/nl/fulfillment/correlation.py
@@ -67,6 +67,8 @@ def _populate_correlation_for_place(state: PopulateState, place: Place) -> bool:
   # Get child place samples for existence check.
   places_to_check = utils.get_sample_child_places(place.dcid,
                                                   state.place_type.value)
+  if not places_to_check:
+    return False
 
   # For the main SV of correlation, we expect a variable to
   # be detected in this `uttr`

--- a/server/lib/nl/fulfillment/ranking_across_places.py
+++ b/server/lib/nl/fulfillment/ranking_across_places.py
@@ -14,7 +14,6 @@
 
 from typing import List
 
-from lib.nl import utils
 from lib.nl.detection import ClassificationType
 from lib.nl.detection import ContainedInClassificationAttributes
 from lib.nl.detection import ContainedInPlaceType

--- a/server/lib/nl/fulfillment/ranking_across_places.py
+++ b/server/lib/nl/fulfillment/ranking_across_places.py
@@ -24,6 +24,7 @@ from lib.nl.detection import RankingType
 from lib.nl.fulfillment import context
 from lib.nl.fulfillment.base import add_chart_to_utterance
 from lib.nl.fulfillment.base import ChartVars
+from lib.nl.fulfillment.base import overview_fallback
 from lib.nl.fulfillment.base import populate_charts
 from lib.nl.fulfillment.base import PopulateState
 from lib.nl.utterance import ChartOriginType
@@ -32,18 +33,9 @@ from lib.nl.utterance import Utterance
 
 
 #
-# This handles both ranking across places and ranking across SVS.
-#
-# * For ranking across places, we should detect a ranking and contained-in
-#   classification in the current utterance.  For example, [counties with most rainfall],
-#   assuming california is in the context.
-# * For ranking across SVS, we should detect a ranking, but not contained-in
-#   classification in the current utterance.  In the callback, we will also
-#   check that the SVs are part of a peer group (only those are comparable!).
-#   For example, [most grown agricultural things], again assuming california
-#   is in the context.
-#   TODO: consider checking for common units, especially when we rely on
-#         auto-expanded peer groups of SVs.
+# For ranking across places, we should detect a ranking and contained-in
+# classification in the current utterance.  For example, [counties with most rainfall],
+# assuming california is in the context.
 #
 def populate(uttr: Utterance):
   # Get the RANKING classifications from the current utterance. That is what
@@ -68,21 +60,10 @@ def populate(uttr: Utterance):
       if populate_charts(
           PopulateState(uttr=uttr,
                         main_cb=_populate_cb,
-                        fallback_cb=_fallback_cb,
+                        fallback_cb=overview_fallback,
                         place_type=place_type,
                         ranking_types=ranking_types)):
         return True
-    else:
-      # Ranking among stat-vars.
-      if populate_charts(
-          PopulateState(uttr=uttr,
-                        main_cb=_populate_cb,
-                        fallback_cb=_fallback_cb,
-                        ranking_types=ranking_types)):
-        return True
-
-  # TODO: Consider if we want to go inside past contained-in classifications.
-  # That might be a bit non-intuitive though.
 
   # Fallback
   ranking_types = [RankingType.HIGH]
@@ -90,7 +71,7 @@ def populate(uttr: Utterance):
   return populate_charts(
       PopulateState(uttr=uttr,
                     main_cb=_populate_cb,
-                    fallback_cb=_fallback_cb,
+                    fallback_cb=overview_fallback,
                     place_type=place_type,
                     ranking_types=ranking_types))
 
@@ -101,25 +82,10 @@ def _populate_cb(state: PopulateState, chart_vars: ChartVars,
     return False
   if len(places) > 1:
     return False
+  if not state.place_type:
+    return False
+  if len(chart_vars.svs) != 1:
+    return False
 
-  if state.place_type and len(chart_vars.svs) == 1:
-    # Ranking among places.
-    return add_chart_to_utterance(ChartType.RANKING_CHART, state, chart_vars,
-                                  places, chart_origin)
-  elif (not state.place_type and chart_vars.is_topic_peer_group and
-        len(chart_vars.svs) > 1):
-    # Ranking among peer group of SVs.
-    chart_vars.svs = utils.ranked_svs_for_place(places[0].dcid, chart_vars.svs,
-                                                state.ranking_types[0])
-    return add_chart_to_utterance(ChartType.BAR_CHART, state, chart_vars,
-                                  places, chart_origin)
-  return False
-
-
-def _fallback_cb(state: PopulateState, containing_places: List[Place],
-                 chart_origin: ChartOriginType) -> bool:
-  # TODO: Poor choice, do better.
-  sv = "Count_Person"
-  state.block_id += 1
-  chart_vars = ChartVars(svs=[sv], block_id=state.block_id)
-  return _populate_cb(state, chart_vars, containing_places, chart_origin)
+  return add_chart_to_utterance(ChartType.RANKING_CHART, state, chart_vars,
+                                places, chart_origin)

--- a/server/lib/nl/fulfillment/ranking_across_vars.py
+++ b/server/lib/nl/fulfillment/ranking_across_vars.py
@@ -1,0 +1,81 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from lib.nl import utils
+from lib.nl.detection import ClassificationType
+from lib.nl.detection import Place
+from lib.nl.detection import RankingClassificationAttributes
+from lib.nl.fulfillment import context
+from lib.nl.fulfillment.base import add_chart_to_utterance
+from lib.nl.fulfillment.base import ChartVars
+from lib.nl.fulfillment.base import overview_fallback
+from lib.nl.fulfillment.base import populate_charts
+from lib.nl.fulfillment.base import PopulateState
+from lib.nl.utterance import ChartOriginType
+from lib.nl.utterance import ChartType
+from lib.nl.utterance import Utterance
+
+
+#
+# For ranking across vars, we should have detected a ranking, but not contained-in
+# classification in the current utterance.  In the callback, we will also
+# check that the SVs are part of a peer group (only those are comparable!).
+# For example, [most grown agricultural things], again assuming california
+# is in the context.
+# TODO: consider checking for common units, especially when we rely on
+#       auto-expanded peer groups of SVs.
+#
+def populate(uttr: Utterance):
+  # Get the RANKING classifications from the current utterance. That is what
+  # let us infer this is ranking query-type.
+  current_ranking_classification = context.classifications_of_type_from_utterance(
+      uttr, ClassificationType.RANKING)
+
+  if (current_ranking_classification and
+      isinstance(current_ranking_classification[0].attributes,
+                 RankingClassificationAttributes) and
+      current_ranking_classification[0].attributes.ranking_type):
+    ranking_types = current_ranking_classification[0].attributes.ranking_type
+
+    # Ranking among stat-vars.
+    if populate_charts(
+        PopulateState(uttr=uttr,
+                      main_cb=_populate_cb,
+                      fallback_cb=overview_fallback,
+                      ranking_types=ranking_types)):
+      return True
+
+  return False
+
+
+def _populate_cb(state: PopulateState, chart_vars: ChartVars,
+                 places: List[Place], chart_origin: ChartOriginType) -> bool:
+  if not state.ranking_types:
+    return False
+  if len(places) > 1:
+    return False
+  if state.place_type:
+    return False
+  if len(chart_vars.svs) < 2:
+    return False
+  if not chart_vars.is_topic_peer_group:
+    return False
+
+  # Ranking among peer group of SVs.
+  chart_vars.svs = utils.ranked_svs_for_place(places[0].dcid, chart_vars.svs,
+                                              state.ranking_types[0])
+  return add_chart_to_utterance(ChartType.BAR_CHART, state, chart_vars, places,
+                                chart_origin)

--- a/server/lib/nl/fulfillment_next.py
+++ b/server/lib/nl/fulfillment_next.py
@@ -22,7 +22,8 @@ from lib.nl.fulfillment import comparison
 from lib.nl.fulfillment import containedin
 from lib.nl.fulfillment import context
 from lib.nl.fulfillment import correlation
-from lib.nl.fulfillment import ranking
+from lib.nl.fulfillment import ranking_across_places
+from lib.nl.fulfillment import ranking_across_vars
 from lib.nl.fulfillment import simple
 from lib.nl.utterance import Utterance
 
@@ -68,7 +69,12 @@ def fulfill(query_detection: Detection,
   elif (uttr.query_type == ClassificationType.CONTAINED_IN):
     containedin.populate(uttr)
   elif (uttr.query_type == ClassificationType.RANKING):
-    ranking.populate(uttr)
+    current_contained_classification = context.classifications_of_type_from_utterance(
+        uttr, ClassificationType.CONTAINED_IN)
+    if current_contained_classification:
+      ranking_across_places.populate(uttr)
+    else:
+      ranking_across_vars.populate(uttr)
   elif (uttr.query_type == ClassificationType.COMPARISON):
     comparison.populate(uttr)
   rank_charts(uttr)

--- a/server/lib/nl/utils.py
+++ b/server/lib/nl/utils.py
@@ -203,8 +203,8 @@ def get_sample_child_places(main_place_dcid: str,
               '_sample_child_place returning %s',
               ', '.join(child_places[:_NUM_CHILD_PLACES_FOR_EXISTENCE]))
           return child_places[:_NUM_CHILD_PLACES_FOR_EXISTENCE]
-  logging.info('_sample_child_place returning %s', main_place_dcid)
-  return [main_place_dcid]
+  logging.info('_sample_child_place returning empty')
+  return []
 
 
 def get_sv_name(all_svs: List[str]) -> Dict:


### PR DESCRIPTION
Bo had the right intuition earlier today to break up ranking into by places and vars.  With the addition of "time delta" for ranking across vars, this is better.

Also, often times when the ranking, correlation and contained-in fails on a SV a better choice is to show the place rather than attempt some poor fallback of population in county, which invariably also fails.