### PR TITLE
[NL Next] Add event classifier

### DIFF
--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -214,6 +214,24 @@ QUERY_CLASSIFICATION_HEURISTICS: Dict[str, Union[List[str], Dict[
             "vs",
             "versus",
         ],
+        "Event": {
+            "Fire": ["(wild)?fires?",],
+            "Drought": ["droughts?",],
+            "Flood": ["floods?",],
+            "Cyclone": [
+                "tropical storms?",
+                "cyclones?",
+                "hurricanes?",
+                "typhoons?",
+            ],
+            "ExtremeHeat": [
+                "(extreme )?heat",
+                "extreme(ly)? hot",
+            ],
+            "ExtremeCold": ["(extreme(ly)? )?cold",],
+            "WetBulb": ["wet(\W?)bulb",],
+            "Earthquake": ["earthquakes?",]
+        },
         "TimeDelta": {
             "Increase": [
                 "grow(n|th)",

--- a/server/lib/nl/detection.py
+++ b/server/lib/nl/detection.py
@@ -92,6 +92,18 @@ class ContainedInPlaceType(Enum):
   ZIP = "CensusZipCodeTabulationArea"
 
 
+class EventType(IntEnum):
+  """Indicates which type of event(s) a query is referring to."""
+  COLD = 0  # ColdTemperatureEvent
+  CYCLONE = 1  # CycloneEvent
+  EARTHQUAKE = 2  # EarthquakeEvent
+  DROUGHT = 3  # DroughtEvent
+  FIRE = 4  # WildfireEvent or WildlandFireEvent
+  FLOOD = 5  # FloodEvent
+  HEAT = 6  # HeatTemperatureEvent
+  WETBULB = 7  # WetBulbTemperatureEvent
+
+
 class PeriodType(Enum):
   """PeriodType indicates the type of date range specified."""
   NONE = 0
@@ -178,6 +190,15 @@ class CorrelationClassificationAttributes(ClassificationAttributes):
 
 
 @dataclass
+class EventClassificationAttributes(ClassificationAttributes):
+  """Event classification attributes"""
+  event_types: List[EventType]
+
+  # Words that made this a event query
+  event_trigger_words: List[str]
+
+
+@dataclass
 class TimeDeltaClassificationAttributes(ClassificationAttributes):
   """Time Delta classification attributes."""
   time_delta_types: List[TimeDeltaType]
@@ -197,7 +218,8 @@ class ClassificationType(IntEnum):
   CLUSTERING = 6
   COMPARISON = 7
   TIME_DELTA = 8
-  UNKNOWN = 9
+  EVENT = 9
+  UNKNOWN = 10
 
 
 # The supported classifications in order. Later entry is preferred.
@@ -208,6 +230,7 @@ RANKED_CLASSIFICATION_TYPES = [
     ClassificationType.RANKING,
     ClassificationType.CORRELATION,
     ClassificationType.TIME_DELTA,
+    ClassificationType.EVENT,
 ]
 
 

--- a/server/routes/nl_interface_next.py
+++ b/server/routes/nl_interface_next.py
@@ -136,6 +136,7 @@ def _result_with_debug_info(data_dict, status, query_detection: Detection,
   contained_in_classification = "<None>"
   correlation_classification = "<None>"
   clustering_classification = "<None>"
+  event_classification = "<None>"
 
   for classification in query_detection.classifications:
     if classification.type == ClassificationType.RANKING:
@@ -145,6 +146,8 @@ def _result_with_debug_info(data_dict, status, query_detection: Detection,
     elif classification.type == ClassificationType.TIME_DELTA:
       time_delta_classification = str(
           classification.attributes.time_delta_types)
+    elif classification.type == ClassificationType.EVENT:
+      event_classification = str(classification.attributes.event_types)
     elif classification.type == ClassificationType.COMPARISON:
       comparison_classification = str(classification.type)
     elif classification.type == ClassificationType.CONTAINED_IN:
@@ -174,6 +177,7 @@ def _result_with_debug_info(data_dict, status, query_detection: Detection,
       'clustering_classification': clustering_classification,
       'comparison_classification': comparison_classification,
       'correlation_classification': correlation_classification,
+      'event_classification': event_classification,
       'data_spec': context_history,
   }
   if query_detection.places_detected:
@@ -255,11 +259,13 @@ def _detection(orig_query, cleaned_query) -> Detection:
   time_delta_classification = model.heuristic_time_delta_classification(query)
   contained_in_classification = model.query_classification(
       "contained_in", query)
+  event_classification = model.heuristic_event_classification(query)
   logging.info(f'Ranking classification: {ranking_classification}')
   logging.info(f'Comparison classification: {comparison_classification}')
   logging.info(f'Temporal classification: {temporal_classification}')
   logging.info(f'TimeDelta classification: {time_delta_classification}')
   logging.info(f'ContainedIn classification: {contained_in_classification}')
+  logging.info(f'Event Classification: {event_classification}')
 
   # Set the Classifications list.
   classifications = []
@@ -271,6 +277,8 @@ def _detection(orig_query, cleaned_query) -> Detection:
     classifications.append(contained_in_classification)
   if time_delta_classification is not None:
     classifications.append(time_delta_classification)
+  if event_classification is not None:
+    classifications.append(event_classification)
 
   # Correlation classification
   correlation_classification = model.heuristic_correlation_classification(query)

--- a/static/js/apps/nl_interface/debug_info.tsx
+++ b/static/js/apps/nl_interface/debug_info.tsx
@@ -112,6 +112,7 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
     comparisonClassification: props.debugData["comparison_classification"],
     containedInClassification: props.debugData["contained_in_classification"],
     correlationClassification: props.debugData["correlation_classification"],
+    eventClassification: props.debugData["event_classification"],
     dataSpec: props.debugData["data_spec"],
   };
 
@@ -187,6 +188,9 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
             <Col>
               Correlation classification: {debugInfo.correlationClassification}
             </Col>
+          </Row>
+          <Row>
+            <Col>Event classification: {debugInfo.eventClassification}</Col>
           </Row>
           <Row>
             <b>All SVs Matched (with scores):</b>


### PR DESCRIPTION
Adds the event classifier to query detection

Supports rudimentary heuristics for:
* Fires
* Floods
* Drought
* Cyclones
* Extreme heat
* Extreme cold
* Wetbulb temperatures

Examples:
<img width="535" alt="Screenshot 2023-02-01 at 7 13 33 PM" src="https://user-images.githubusercontent.com/4034366/216222507-eaed18fb-ebd9-4119-9ad7-e3be4c84dcdd.png">
<img width="544" alt="Screenshot 2023-02-01 at 7 13 58 PM" src="https://user-images.githubusercontent.com/4034366/216222552-bc7f66f0-2a62-4536-bbd5-11dc8ceef09b.png">
<img width="538" alt="Screenshot 2023-02-01 at 7 17 08 PM" src="https://user-images.githubusercontent.com/4034366/216223030-e7f3c81b-de97-4e13-8539-1f25552e7a8d.png">
