### PR TITLE
[NL Next] A few fulfillment fixes

### DIFF
--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -178,6 +178,8 @@ def _add_charts(state: PopulateState, places: List[Place],
       logging.info('Existence check failed for %s - %s',
                    ', '.join(places_to_check), ', '.join(extended_svs))
 
+  logging.info("Add chart %s %s returning %r" %
+               (', '.join(_get_place_names(places)), svs, found))
   return found
 
 

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -115,7 +115,7 @@ def populate_charts_for_places(state: PopulateState,
 # TODO: Batch existence check calls
 def _add_charts(state: PopulateState, places: List[Place],
                 svs: List[str]) -> bool:
-  print("Add chart %s %s" % (', '.join(_get_place_names(places)), svs))
+  logging.info("Add chart %s %s" % (', '.join(_get_place_names(places)), svs))
 
   # If there is a child place_type, get child place samples for existence check.
   places_to_check = _get_place_dcids(places)
@@ -138,10 +138,12 @@ def _add_charts(state: PopulateState, places: List[Place],
   for rank, sv in enumerate(svs):
 
     # Infer charts for the main SV/Topic.
-    chart_vars_list = _svg_or_topic_to_svs(state, sv, rank)
+    chart_vars_list = _build_chart_vars(state, sv, rank)
     for chart_vars in chart_vars_list:
       exist_svs = utils.sv_existence_for_places(places_to_check, chart_vars.svs)
       if exist_svs:
+        logging.info('Existence check succeeded for %s - %s',
+                     ', '.join(places_to_check), ', '.join(exist_svs))
         chart_vars.svs = exist_svs
         # Now that we've found existing vars, call the per-chart-type callback.
         if state.main_cb(state, chart_vars, places,
@@ -206,8 +208,8 @@ def _get_place_names(places: List[Place]) -> List[str]:
 # Returns a list of ChartVars, where each ChartVars may be a single SV or
 # group of SVs.
 #
-def _svg_or_topic_to_svs(state: PopulateState, sv: str,
-                         rank: int) -> List[ChartVars]:
+def _build_chart_vars(state: PopulateState, sv: str,
+                      rank: int) -> List[ChartVars]:
   if utils.is_sv(sv):
     state.block_id += 1
     return [ChartVars(svs=[sv], block_id=state.block_id)]
@@ -245,5 +247,40 @@ def _svg_or_topic_to_svs(state: PopulateState, sv: str,
                     title=title,
                     is_topic_peer_group=True))
     return charts
+
+  return []
+
+
+def open_topics_ordered(svs: List[str]) -> List[str]:
+  opened_svs = []
+  sv_set = set()
+  for rank, sv in enumerate(svs):
+    for sv in _open_topic_in_var(sv, rank):
+      if sv not in sv_set:
+        opened_svs.append(sv)
+        sv_set.add(sv)
+  return opened_svs
+
+
+def _open_topic_in_var(sv: str, rank: int) -> List[str]:
+  if utils.is_sv(sv):
+    return [sv]
+  if utils.is_topic(sv):
+    topic_vars = topic.get_topic_vars(sv, rank)
+    peer_groups = topic.get_topic_peers(topic_vars)
+
+    # Classify into two lists.
+    just_svs = []
+    svpgs = []
+    for v in topic_vars:
+      if v in peer_groups and peer_groups[v]:
+        title = topic.svpg_name(v)
+        svpgs.append((title, peer_groups[v]))
+      else:
+        just_svs.append(v)
+
+    svs = just_svs
+    for (title, svpg) in svpgs:
+      svs.extend(svpg)
 
   return []

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -286,5 +286,6 @@ def _open_topic_in_var(sv: str, rank: int) -> List[str]:
     svs = just_svs
     for (title, svpg) in svpgs:
       svs.extend(svpg)
+    return svs
 
   return []

--- a/server/lib/nl/fulfillment/comparison.py
+++ b/server/lib/nl/fulfillment/comparison.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import List
 
 from lib.nl.detection import Place
@@ -40,6 +41,7 @@ def populate(uttr: Utterance) -> bool:
 
 def _populate_cb(state: PopulateState, chart_vars: ChartVars,
                  places: List[Place], chart_origin: ChartOriginType) -> bool:
+  logging.info('populate_cb for comparison')
   if len(places) < 2:
     return False
   add_chart_to_utterance(ChartType.BAR_CHART, state, chart_vars, places,

--- a/server/lib/nl/fulfillment/containedin.py
+++ b/server/lib/nl/fulfillment/containedin.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import List
 
 from lib.nl.detection import ClassificationType
@@ -56,6 +57,8 @@ def populate(uttr: Utterance) -> bool:
 def _populate_cb(state: PopulateState, chart_vars: ChartVars,
                  contained_places: List[Place],
                  chart_origin: ChartOriginType) -> bool:
+  logging.info('populate_cb for contained-in')
+
   if not state.place_type:
     return False
   if not chart_vars:

--- a/server/lib/nl/fulfillment/containedin.py
+++ b/server/lib/nl/fulfillment/containedin.py
@@ -62,9 +62,10 @@ def _populate_cb(state: PopulateState, chart_vars: ChartVars,
     return False
   if len(contained_places) > 1:
     return False
-  if len(chart_vars.svs) > 1:
-    # We don't handle peer group SVs
-    return False
-  add_chart_to_utterance(ChartType.MAP_CHART, state, chart_vars,
-                         contained_places, chart_origin)
+
+  for sv in chart_vars.svs:
+    cv = chart_vars
+    cv.svs = [sv]
+    add_chart_to_utterance(ChartType.MAP_CHART, state, cv, contained_places,
+                           chart_origin)
   return True

--- a/server/lib/nl/fulfillment/correlation.py
+++ b/server/lib/nl/fulfillment/correlation.py
@@ -29,7 +29,6 @@ from lib.nl.utterance import ChartOriginType
 from lib.nl.utterance import ChartType
 from lib.nl.utterance import Utterance
 
-
 _MAX_CONTEXT_SVS = 3
 _MAX_MAIN_SVS = 5
 
@@ -102,7 +101,8 @@ def _populate_correlation_for_place(state: PopulateState, place: Place) -> bool:
   found = False
   for main_sv in main_svs:
     for context_sv in context_svs:
-      if main_sv == context_sv: continue
+      if main_sv == context_sv:
+        continue
       found |= _populate_correlation_chart(state, place, main_sv, context_sv)
   return found
 

--- a/server/lib/nl/fulfillment/simple.py
+++ b/server/lib/nl/fulfillment/simple.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import List
 
 from lib.nl import utils
@@ -35,6 +36,7 @@ def populate(uttr: Utterance) -> bool:
 
 def _populate_cb(state: PopulateState, chart_vars: ChartVars,
                  places: List[Place], chart_origin: ChartOriginType) -> bool:
+  logging.info('populate_cb for simple')
   if len(chart_vars.svs) <= _MAX_VARS_PER_CHART:
     # For fewer SVs, comparing trends over time is nicer.
     chart_type = ChartType.TIMELINE_CHART

--- a/server/lib/nl/fulfillment/simple.py
+++ b/server/lib/nl/fulfillment/simple.py
@@ -14,6 +14,7 @@
 
 from typing import List
 
+from lib.nl import utils
 from lib.nl.detection import Place
 from lib.nl.fulfillment.base import add_chart_to_utterance
 from lib.nl.fulfillment.base import ChartVars
@@ -41,6 +42,11 @@ def _populate_cb(state: PopulateState, chart_vars: ChartVars,
     # When there are too many, comparing latest values is better
     # (than, say, breaking it into multiple timeline charts)
     chart_type = ChartType.BAR_CHART
+  if chart_type == ChartType.TIMELINE_CHART:
+    if utils.has_series_with_single_datapoint(places[0].dcid, chart_vars.svs):
+      # Demote to bar chart if single point.
+      # TODO: eventually for single SV case, make it a highlight chart
+      chart_type = ChartType.BAR_CHART
   return add_chart_to_utterance(chart_type, state, chart_vars, places,
                                 chart_origin)
 

--- a/server/lib/nl/fulfillment/time_delta.py
+++ b/server/lib/nl/fulfillment/time_delta.py
@@ -37,8 +37,6 @@ from lib.nl.utterance import Utterance
 def populate(uttr: Utterance):
   time_delta_classification = context.classifications_of_type_from_utterance(
       uttr, ClassificationType.TIME_DELTA)
-  logging.info('In Time-delta')
-
   # Get time delta type
   if (not time_delta_classification or
       not isinstance(time_delta_classification[0].attributes,
@@ -67,7 +65,7 @@ def populate(uttr: Utterance):
 
 def _populate_cb(state: PopulateState, chart_vars: ChartVars,
                  places: List[Place], chart_origin: ChartOriginType) -> bool:
-  logging.info('In Time-delta callback')
+  logging.info('populate_cb for time_delta')
   if not state.time_delta_types:
     return False
   if len(places) > 1:

--- a/server/lib/nl/fulfillment_next.py
+++ b/server/lib/nl/fulfillment_next.py
@@ -54,7 +54,6 @@ def fulfill(query_detection: Detection,
   # If we could not detect query_type from user-query, infer from past context.
   if (uttr.query_type == ClassificationType.UNKNOWN):
     uttr.query_type = context.query_type_from_context(uttr)
-  logging.info(uttr.query_type)
 
   # Add detected places.
   if (query_detection.places_detected):
@@ -63,6 +62,7 @@ def fulfill(query_detection: Detection,
   # Each query-type has its own handler. Each knows what arguments it needs and
   # will call on the *_from_context() routines to obtain missing arguments.
   #
+  logging.info(uttr.query_type)
   if (uttr.query_type == ClassificationType.SIMPLE):
     simple.populate(uttr)
   elif (uttr.query_type == ClassificationType.CORRELATION):
@@ -90,7 +90,7 @@ def fulfill(query_detection: Detection,
 # TODO: Maybe improve in future.
 def rank_charts(utterance: Utterance):
   for chart in utterance.chartCandidates:
-    print("Chart: %s %s\n" % (chart.places, chart.svs))
+    logging.info("Chart: %s %s\n" % (chart.places, chart.svs))
   utterance.rankedCharts = utterance.chartCandidates
 
 

--- a/server/lib/nl/utils.py
+++ b/server/lib/nl/utils.py
@@ -306,7 +306,6 @@ def _datestr_to_date(datestr: str) -> datetime.date:
   elif len(parts) == 3:
     return datetime.date(int(parts[0]), int(parts[1]), int(parts[2]))
   raise ValueError(f'Unable to parse date {datestr}')
->>>>>>> 3e1bf14f374d6450265fb5f6c09c5bf1472e13f4
 
 
 #

--- a/server/lib/nl/utils.py
+++ b/server/lib/nl/utils.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Set, Union
 import lib.nl.constants as constants
 import lib.nl.detection as detection
 import lib.util as util
+from routes.api.series import series_core
 import services.datacommons as dc
 
 _CHART_TITLE_CONFIG_RELATIVE_PATH = "../../config/nl_page/chart_titles_by_sv.json"
@@ -165,6 +166,19 @@ def ranked_svs_for_place(place: str, svs: List[str],
                          key=lambda pair: pair[1],
                          reverse=reverse)
   return [sv for sv, _ in svs_with_vals]
+
+
+def has_series_with_single_datapoint(place: str, svs: List[str]):
+  series_data = series_core(entities=[place], variables=svs, all_facets=False)
+  for _, place_data in series_data['data'].items():
+    if place not in place_data:
+      continue
+    series = place_data[place]['series']
+    if len(series) < 2:
+      logging.info('Found single data point series in %s - %s', place,
+                   ', '.join(svs))
+      return True
+  return False
 
 
 #

--- a/server/tests/lib/nl/fulfillment_next_test.py
+++ b/server/tests/lib/nl/fulfillment_next_test.py
@@ -303,7 +303,7 @@ class TestDataSpecNext(unittest.TestCase):
   # Example: [what are the most grown agricultural things?]
   @patch.object(variable, 'extend_svs')
   @patch.object(utils, 'rank_svs_by_growth_rate')
-  @patch.object(base, '_svg_or_topic_to_svs')
+  @patch.object(base, '_build_chart_vars')
   @patch.object(utils, 'sv_existence_for_places')
   def test_time_delta(self, mock_sv_existence, mock_topic_to_svs, mock_rank_svs,
                       mock_extend_svs):

--- a/server/tests/lib/nl/fulfillment_next_test.py
+++ b/server/tests/lib/nl/fulfillment_next_test.py
@@ -47,7 +47,7 @@ from tests.lib.nl.test_utterance import SIMPLE_WITH_TOPIC_UTTR
 # - variable.extend_svs
 # - utils.sv_existence_for_places
 # - utils.get_sample_child_places
-# - fulfillment.base._svg_or_topic_to_svs
+# - fulfillment.base._build_chart_vars
 #
 class TestDataSpecNext(unittest.TestCase):
 
@@ -211,7 +211,7 @@ class TestDataSpecNext(unittest.TestCase):
 
   # This exercises Topic expansion.
   @patch.object(variable, 'extend_svs')
-  @patch.object(base, '_svg_or_topic_to_svs')
+  @patch.object(base, '_build_chart_vars')
   @patch.object(utils, 'sv_existence_for_places')
   def test_simple_with_topic(self, mock_sv_existence, mock_topic_to_svs,
                              mock_extend_svs):
@@ -257,7 +257,7 @@ class TestDataSpecNext(unittest.TestCase):
   # Example: [what are the most grown agricultural things?]
   @patch.object(variable, 'extend_svs')
   @patch.object(utils, 'ranked_svs_for_place')
-  @patch.object(base, '_svg_or_topic_to_svs')
+  @patch.object(base, '_build_chart_vars')
   @patch.object(utils, 'sv_existence_for_places')
   def test_ranking_across_svs(self, mock_sv_existence, mock_topic_to_svs,
                               mock_ranked_svs, mock_extend_svs):

--- a/server/tests/lib/nl/page_config_next_test.py
+++ b/server/tests/lib/nl/page_config_next_test.py
@@ -352,6 +352,20 @@ CONTAINED_IN_CONFIG = """
        }
      }
    }
+   blocks {
+     columns {
+       tiles {
+         title: "Income_Farm"
+         type: MAP
+         stat_var_key: "Income_Farm"
+       }
+       tiles {
+         title: "Income_Farm - Per Capita"
+         type: MAP
+         stat_var_key: "Income_Farm_pc"
+       }
+     }
+   }
    stat_var_spec {
      key: "Count_Farm"
      value {
@@ -369,7 +383,24 @@ CONTAINED_IN_CONFIG = """
        name: "Count_Farm"
      }
    }
- }
+   stat_var_spec {
+     key: "Income_Farm"
+     value {
+       stat_var: "Income_Farm"
+       name: "Income_Farm"
+     }
+   }
+   stat_var_spec {
+     key: "Income_Farm_pc"
+     value {
+       stat_var: "Income_Farm"
+       denom: "Count_Person"
+       unit: "%"
+       scaling: 100.0
+       name: "Income_Farm"
+     }
+   }
+  }
 """
 
 CORRELATION_CONFIG = """
@@ -391,6 +422,16 @@ CORRELATION_CONFIG = """
        }
      }
    }
+   blocks {
+     columns {
+       tiles {
+         title: "Income_Farm vs. Mean_Precipitation"
+         type: SCATTER
+         stat_var_key: "Income_Farm_scatter"
+         stat_var_key: "Mean_Precipitation_scatter"
+       }
+     }
+   }
    stat_var_spec {
      key: "Count_Farm_scatter"
      value {
@@ -405,7 +446,14 @@ CORRELATION_CONFIG = """
        name: "Mean_Precipitation"
      }
    }
- }
+   stat_var_spec {
+     key: "Income_Farm_scatter"
+     value {
+       stat_var: "Income_Farm"
+       name: "Income_Farm"
+     }
+   }
+}
 """
 
 RANKING_ACROSS_PLACES_CONFIG = """

--- a/server/tests/lib/nl/test_utterance.py
+++ b/server/tests/lib/nl/test_utterance.py
@@ -286,8 +286,24 @@ CONTAINED_IN_UTTR = {
             'place_type': 'State'
         }],
         'svs': ['Count_Farm']
+    }, {
+        'attr': {
+            'block_id': 2,
+            'class': ChartOriginType.PRIMARY_CHART,
+            'include_percapita': True,
+            'place_type': 'County',
+            'ranking_types': [],
+            'title': ''
+        },
+        'chart_type': 1,
+        'places': [{
+            'dcid': 'geoId/06',
+            'name': 'Foo Place',
+            'place_type': 'State'
+        }],
+        'svs': ['Income_Farm']
     }],
-    'svs': ['Count_Farm']
+    'svs': ['Count_Farm', 'Income_Farm']
 }
 
 # Utterance for correlation wrt previous SV.
@@ -315,6 +331,22 @@ CORRELATION_UTTR = {
             'place_type': 'State'
         }],
         'svs': ['Count_Farm', 'Mean_Precipitation']
+    }, {
+        'attr': {
+            'block_id': 2,
+            'class': ChartOriginType.PRIMARY_CHART,
+            'include_percapita': False,
+            'place_type': 'County',
+            'ranking_types': [],
+            'title': ''
+        },
+        'chart_type': ChartType.SCATTER_CHART,
+        'places': [{
+            'dcid': 'geoId/06',
+            'name': 'Foo Place',
+            'place_type': 'State'
+        }],
+        'svs': ['Income_Farm', 'Mean_Precipitation']
     }],
     'svs': ['Mean_Precipitation']
 }
@@ -443,4 +475,50 @@ TIME_DELTA_UTTR = {
         'svs': ['FarmInventory_Wheat']
     }],
     'svs': ['dc/topic/AgricultureProduction']
+}
+
+# Sample as SIMPLE_UTTR, but TIMELINE_CHARTs turned into BAR_CHARTs.
+SIMPLE_BAR_DOWNGRADE_UTTR = {
+    'classifications': [],
+    'places': [{
+        'dcid': 'geoId/06',
+        'name': 'Foo Place',
+        'place_type': 'State'
+    }],
+    'query': 'foo sv in place',
+    'query_type': ClassificationType.SIMPLE,
+    'ranked_charts': [{
+        'attr': {
+            'block_id': 1,
+            'class': ChartOriginType.PRIMARY_CHART,
+            'include_percapita': True,
+            'place_type': None,
+            'ranking_types': [],
+            'title': ''
+        },
+        'chart_type': ChartType.BAR_CHART,
+        'places': [{
+            'dcid': 'geoId/06',
+            'name': 'Foo Place',
+            'place_type': 'State'
+        }],
+        'svs': ['Count_Person_Male']
+    }, {
+        'attr': {
+            'block_id': 2,
+            'class': ChartOriginType.PRIMARY_CHART,
+            'include_percapita': True,
+            'place_type': None,
+            'ranking_types': [],
+            'title': ''
+        },
+        'chart_type': ChartType.BAR_CHART,
+        'places': [{
+            'dcid': 'geoId/06',
+            'name': 'Foo Place',
+            'place_type': 'State'
+        }],
+        'svs': ['Count_Person_Female']
+    }],
+    'svs': ['Count_Person_Male', 'Count_Person_Female']
 }


### PR DESCRIPTION
1. Downgrade single point time-series to bar charts
2. Open up topics in correlation, and include multiple SVs from current utterance and past context
3. Show contained-in maps for peer-group SVs
4. Sprinkle more debug logs

This improves on Jan script, in these ways:

(1) [agriculture in california] contained single-dot timeline charts
![Screenshot 2023-02-02 at 12 11 47 PM](https://user-images.githubusercontent.com/4375037/216439383-ae288e5c-392c-43d1-8cac-4ca345cf4ef8.png)

(2) There used to be only one correlation chart
![Screenshot 2023-02-02 at 12 12 22 PM](https://user-images.githubusercontent.com/4375037/216439518-06b4f6d9-0258-4aea-aa67-c5c4f4a170a0.png)
