### PR TITLE
[NL Next] Add support for 'major' in rankings

### DIFF
--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -169,7 +169,7 @@ QUERY_CLASSIFICATION_HEURISTICS: Dict[str, Union[List[str], Dict[
                 "largest",
                 "biggest",
                 "greatest",
-                "strongest?",
+                "strongest",
                 "richest",
                 "sickest",
                 "illest",

--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -169,11 +169,12 @@ QUERY_CLASSIFICATION_HEURISTICS: Dict[str, Union[List[str], Dict[
                 "largest",
                 "biggest",
                 "greatest",
-                "strongest",
+                "strongest?",
                 "richest",
                 "sickest",
                 "illest",
                 "oldest",
+                "major",  # as in 'major storms'
                 "descending",
                 "top to bottom",
                 "highest to lowest",

--- a/server/tests/lib/nl/heuristics_test.py
+++ b/server/tests/lib/nl/heuristics_test.py
@@ -162,6 +162,8 @@ class TestHeuristicRankingClassifier(unittest.TestCase):
       ("Richest countries by GDP"),
       ("Give me a top to bottom ranking of cities by population"),
       ("CO2 emissions by country, highest to lowest"),
+      ("major fires in california"),
+      ("what are the major causes of poverty in the world?"),
   ])
   def test_detect_highs(self, query: str):
     expected = [RankingType.HIGH]


### PR DESCRIPTION
Add support for 'major' triggering a high ranking classification, including test cases. This allows for queries like "which were the major earthquakes in california?"

Similar additions like "large", "big", "small", "minor" were tested, but prone to false positives, so leaving those out for now.