### PR TITLE
Miscellaneous fixes for new script

### DIFF
--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -303,3 +303,9 @@ EVENT_TYPE_TO_DISPLAY_NAME = {
     EventType.HEAT: "Exteme Heat Events",
     EventType.WETBULB: "High Wet-bulb Temperature Events",
 }
+
+CHILD_PLACES_TYPES = {
+    "Country": "State",
+    "State": "County",
+    "County": "City",
+}

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -17,6 +17,7 @@ from dataclasses import field
 import logging
 from typing import Dict, List
 
+from lib.nl import constants
 from lib.nl import topic
 from lib.nl import utils
 from lib.nl import variable
@@ -115,6 +116,8 @@ def populate_charts(state: PopulateState) -> bool:
 # Populate charts given a place.
 def populate_charts_for_places(state: PopulateState,
                                places: List[Place]) -> bool:
+  maybe_handle_contained_in_fallback(state, places)
+
   if (len(state.uttr.svs) > 0):
     if _add_charts(state, places, state.uttr.svs):
       return True
@@ -354,3 +357,14 @@ def _open_topic_in_var(sv: str, rank: int, counters: Dict) -> List[str]:
     return svs
 
   return []
+
+
+def maybe_handle_contained_in_fallback(state: PopulateState,
+                                       places: List[Place]):
+  if utils.get_contained_in_type(
+      state.uttr) == ContainedInPlaceType.ACROSS and len(places) == 1:
+    ptype = places[0].place_type
+    state.place_type = ContainedInPlaceType(
+        constants.CHILD_PLACES_TYPES.get(ptype, 'County'))
+    utils.update_counter(state.uttr.counters, 'contained_in_across_fallback',
+                         state.place_type.value)

--- a/server/lib/nl/fulfillment/correlation.py
+++ b/server/lib/nl/fulfillment/correlation.py
@@ -20,6 +20,7 @@ from lib.nl.detection import ContainedInClassificationAttributes
 from lib.nl.detection import Place
 from lib.nl.fulfillment.base import add_chart_to_utterance
 from lib.nl.fulfillment.base import ChartVars
+from lib.nl.fulfillment.base import maybe_handle_contained_in_fallback
 from lib.nl.fulfillment.base import open_top_topics_ordered
 from lib.nl.fulfillment.base import PopulateState
 from lib.nl.fulfillment.context import classifications_of_type_from_context
@@ -78,6 +79,8 @@ def _populate_correlation_for_place_type(state: PopulateState) -> bool:
 
 
 def _populate_correlation_for_place(state: PopulateState, place: Place) -> bool:
+  maybe_handle_contained_in_fallback(state, [place])
+
   # Get child place samples for existence check.
   places_to_check = utils.get_sample_child_places(place.dcid,
                                                   state.place_type.value,

--- a/server/lib/nl/fulfillment/ranking_across_places.py
+++ b/server/lib/nl/fulfillment/ranking_across_places.py
@@ -15,7 +15,6 @@
 import logging
 from typing import List
 
-from lib.nl import topic
 from lib.nl import utils
 from lib.nl.detection import ContainedInPlaceType
 from lib.nl.detection import Place

--- a/server/lib/nl/fulfillment/ranking_across_vars.py
+++ b/server/lib/nl/fulfillment/ranking_across_vars.py
@@ -16,10 +16,7 @@ import logging
 from typing import List
 
 from lib.nl import utils
-from lib.nl.detection import ClassificationType
 from lib.nl.detection import Place
-from lib.nl.detection import RankingClassificationAttributes
-from lib.nl.fulfillment import context
 from lib.nl.fulfillment.base import add_chart_to_utterance
 from lib.nl.fulfillment.base import ChartVars
 from lib.nl.fulfillment.base import overview_fallback
@@ -42,15 +39,8 @@ from lib.nl.utterance import Utterance
 def populate(uttr: Utterance):
   # Get the RANKING classifications from the current utterance. That is what
   # let us infer this is ranking query-type.
-  current_ranking_classification = context.classifications_of_type_from_utterance(
-      uttr, ClassificationType.RANKING)
-
-  if (current_ranking_classification and
-      isinstance(current_ranking_classification[0].attributes,
-                 RankingClassificationAttributes) and
-      current_ranking_classification[0].attributes.ranking_type):
-    ranking_types = current_ranking_classification[0].attributes.ranking_type
-
+  ranking_types = utils.get_ranking_types(uttr)
+  if ranking_types:
     # Ranking among stat-vars.
     if populate_charts(
         PopulateState(uttr=uttr,

--- a/server/lib/nl/fulfillment/time_delta.py
+++ b/server/lib/nl/fulfillment/time_delta.py
@@ -16,11 +16,7 @@ import logging
 from typing import List
 
 from lib.nl import utils
-from lib.nl.detection import ClassificationType
 from lib.nl.detection import Place
-from lib.nl.detection import RankingClassificationAttributes
-from lib.nl.detection import TimeDeltaClassificationAttributes
-from lib.nl.fulfillment import context
 from lib.nl.fulfillment.base import add_chart_to_utterance
 from lib.nl.fulfillment.base import ChartVars
 from lib.nl.fulfillment.base import overview_fallback
@@ -35,26 +31,10 @@ from lib.nl.utterance import Utterance
 # Computes growth rate and ranks charts of comparable peer SVs.
 #
 def populate(uttr: Utterance):
-  time_delta_classification = context.classifications_of_type_from_utterance(
-      uttr, ClassificationType.TIME_DELTA)
-  # Get time delta type
-  if (not time_delta_classification or
-      not isinstance(time_delta_classification[0].attributes,
-                     TimeDeltaClassificationAttributes) or
-      not time_delta_classification[0].attributes.time_delta_types):
+  time_delta = utils.get_time_delta_types(uttr)
+  if not time_delta:
     return False
-  time_delta = time_delta_classification[0].attributes.time_delta_types
-
-  # Get potential ranking type
-  current_ranking_classification = context.classifications_of_type_from_utterance(
-      uttr, ClassificationType.RANKING)
-  ranking_types = []
-  if (current_ranking_classification and
-      isinstance(current_ranking_classification[0].attributes,
-                 RankingClassificationAttributes) and
-      current_ranking_classification[0].attributes.ranking_type):
-    ranking_types = current_ranking_classification[0].attributes.ranking_type
-
+  ranking_types = utils.get_ranking_types(uttr)
   return populate_charts(
       PopulateState(uttr=uttr,
                     main_cb=_populate_cb,

--- a/server/lib/nl/topic.py
+++ b/server/lib/nl/topic.py
@@ -95,13 +95,13 @@ _PEER_GROUP_TO_OVERRIDE = {
         "Count_Worker_NAICSWholesaleTrade",
         "Count_Worker_NAICSProfessionalScientificTechnicalServices",
         "Count_Worker_NAICSPublicAdministration",
-        "Count_Worker_NAICSManagementOfCompaniesEnterprises",
 
         # This is an almost dup of
         # Count_Worker_NAICSAdministrativeSupportWasteManagementRemediationServices
         # "dc/f18sq8w498j4f",
         # Subsumed by Retail Trade
         # "dc/4mm2p1rxr5wz4",
+        # "Count_Worker_NAICSManagementOfCompaniesEnterprises",
     ],
     "dc/svpg/MedicalConditionsPeerGroup": [
         "Percent_Person_WithArthritis",

--- a/server/tests/lib/nl/page_config_next_test.py
+++ b/server/tests/lib/nl/page_config_next_test.py
@@ -522,6 +522,15 @@ RANKING_ACROSS_PLACES_CONFIG = """
          }
        }
        tiles {
+         title: "Count_Agricultural_Workers-name"
+         type: MAP
+         stat_var_key: "Count_Agricultural_Workers"
+       }
+      }
+    }
+    blocks {
+      columns {
+       tiles {
          title: "Per Capita Count_Agricultural_Workers-name in Foo Place"
          type: RANKING
          stat_var_key: "Count_Agricultural_Workers_pc"
@@ -529,6 +538,11 @@ RANKING_ACROSS_PLACES_CONFIG = """
            show_highest: true
            ranking_count: 10
          }
+       }
+       tiles {
+         title: "Count_Agricultural_Workers-name - Per Capita"
+         type: MAP
+         stat_var_key: "Count_Agricultural_Workers_pc"
        }
      }
    }

--- a/static/js/shared/util.ts
+++ b/static/js/shared/util.ts
@@ -39,6 +39,9 @@ const NO_DATE_CAP_RCP_STATVARS = [
   // These stat vars compare against historical observed data, so we do not want
   // to hardcode the default date.
   "DifferenceRelativeToObservationalData_",
+  // These SVs are not a time-series, but a single value across multi-decadal time-horizons.
+  "ProjectedMax_Until_",
+  "ProjectedMin_Until_",
 ];
 
 // used to set fields in an object
@@ -113,8 +116,6 @@ export function getCappedStatVarDate(statVar: string): string {
     statVar.includes("AggregateMax_Percentile") ||
     statVar.includes("AggregateMin_Median") ||
     statVar.includes("AggregateMax_Median") ||
-    statVar.includes("ProjectedMax_Until") ||
-    statVar.includes("ProjectedMin_Until") ||
     statVar.includes("NumberOfMonths_")
   ) {
     return MAX_YEAR;


### PR DESCRIPTION
(1) Support fulfillment of ACROSS contained-in type by resolving to a place-type based on the place considered
(2) Support fulfillment of EXTREME ranking type by deciding whether to show lowest based on SV name
(3) Prune some SV names per Guha request (a hack for now)
(4) Modify the RANKING chart display to always show an adjoining map on the same row
(5) Drop a weird jobs SV from topic
(6) Make and use helper functions for getting {ranking-type, contained-in, time-delta-types} from utterance
(7) Fix the temperature hack properly to avoid pinned max dates

Sorry that (6) is in this PR.  I have tested both the old and new scripts with this though.

For the main UI change of ranking-across-places results, here is an example screenshot.

![Screenshot 2023-02-03 at 10 06 25 PM](https://user-images.githubusercontent.com/4375037/216752535-5ccf7600-f5dc-45f3-86ec-9bc4b033b8d5.png)
