### PR TITLE
[NL] fix line tile

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -908,7 +908,12 @@ function drawLineChart(
 
   const xScale = d3
     .scaleTime()
-    .domain(d3.extent(dataGroups[0].value, (d) => d.time))
+    .domain(
+      d3.extent(
+        dataGroups.flatMap((dg) => dg.value),
+        (d) => d.time
+      )
+    )
     .range([leftWidth, width - MARGIN.right]);
 
   let singlePointLabel = null;


### PR DESCRIPTION
for the example query on nl interface (family earnings in california)

on autopush: https://screenshot.googleplex.com/7i8eTxghosJG6yC
with this fix: https://screenshot.googleplex.com/8CZA5A3QA8FsdZM
