### PR TITLE
[subject page] Add support for multiple pages

### DIFF
--- a/static/css/nl_interface.scss
+++ b/static/css/nl_interface.scss
@@ -207,6 +207,7 @@ h3,
 .category p,
 .block .block-footer,
 .disaster-event-map-selectors-section,
+.disaster-event-map-severity-filters .disaster-type-filters,
 .nl-query-error p {
   color: white;
 }

--- a/static/js/apps/disaster_dashboard/app.tsx
+++ b/static/js/apps/disaster_dashboard/app.tsx
@@ -27,6 +27,8 @@ import { SubjectPageConfig } from "../../types/subject_page_proto_types";
 import { ChildPlaces } from "./child_places";
 import { ParentBreadcrumbs } from "./parent_breadcrumbs";
 
+const PAGE_ID = "disaster";
+
 interface AppPropType {
   /**
    * The place to show the dashboard for.
@@ -47,7 +49,10 @@ export function App(props: AppPropType): JSX.Element {
     <>
       <div className="row">
         <div className="col-md-3x col-lg-2 order-last order-lg-0">
-          <SubjectPageSidebar categories={props.dashboardConfig.categories} />
+          <SubjectPageSidebar
+            id={PAGE_ID}
+            categories={props.dashboardConfig.categories}
+          />
           <ChildPlaces parentPlace={props.place}></ChildPlaces>
         </div>
         <div className="col-md-9x col-lg-10">
@@ -57,6 +62,7 @@ export function App(props: AppPropType): JSX.Element {
             parentPlaces={props.parentPlaces}
           ></ParentBreadcrumbs>
           <SubjectPageMainPane
+            id={PAGE_ID}
             place={props.place}
             pageConfig={props.dashboardConfig}
             parentPlaces={props.parentPlaces}

--- a/static/js/apps/nl_interface/query_result.tsx
+++ b/static/js/apps/nl_interface/query_result.tsx
@@ -143,6 +143,7 @@ export const QueryResult = memo(function QueryResult(
           {debugData && <DebugInfo debugData={debugData}></DebugInfo>}
           {chartsData && chartsData.config && (
             <SubjectPageMainPane
+              id={`pg${props.queryIdx}`}
               place={chartsData.place}
               pageConfig={chartsData.config}
               svgChartHeight={SVG_CHART_HEIGHT}

--- a/static/js/apps/topic_page/app.tsx
+++ b/static/js/apps/topic_page/app.tsx
@@ -47,12 +47,17 @@ interface AppPropType {
   topicsSummary: TopicsSummary;
 }
 
+const PAGE_ID = "topic";
+
 export function App(props: AppPropType): JSX.Element {
   return (
     <>
       <div className="row">
         <div className="col-md-3x col-lg-2 order-last order-lg-0">
-          <SubjectPageSidebar categories={props.pageConfig.categories} />
+          <SubjectPageSidebar
+            id={PAGE_ID}
+            categories={props.pageConfig.categories}
+          />
         </div>
         <div className="row col-md-9x col-lg-10">
           <PageSelector
@@ -61,6 +66,7 @@ export function App(props: AppPropType): JSX.Element {
             topicsSummary={props.topicsSummary}
           />
           <SubjectPageMainPane
+            id={PAGE_ID}
             place={props.place}
             pageConfig={props.pageConfig}
           />

--- a/static/js/chart/draw_bivariate.ts
+++ b/static/js/chart/draw_bivariate.ts
@@ -280,7 +280,7 @@ export interface BivariateProperties {
  * @param getTooltipHtml function to get the html to show in the tooltip
  */
 export function drawBivariate(
-  containerId: string,
+  containerRef: React.RefObject<HTMLDivElement>,
   legendRef: React.RefObject<HTMLDivElement>,
   points: { [placeDcid: string]: Point },
   geoJson: GeoJsonData,
@@ -330,7 +330,7 @@ export function drawBivariate(
     properties.height
   );
   drawD3Map(
-    containerId,
+    containerRef.current,
     geoJson,
     properties.height,
     properties.width,

--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -20,14 +20,18 @@
 
 import React from "react";
 
-import { HIDE_TILE_CLASS } from "../../constants/subject_page_constants";
+import {
+  COLUMN_ID_PREFIX,
+  HIDE_TILE_CLASS,
+  TILE_ID_PREFIX,
+} from "../../constants/subject_page_constants";
 import { NamedTypedPlace } from "../../shared/types";
-import { randDomId } from "../../shared/util";
 import { ColumnConfig, TileConfig } from "../../types/subject_page_proto_types";
 import { isNlInterface } from "../../utils/nl_interface_utils";
 import {
   getColumnTileClassName,
   getColumnWidth,
+  getId,
   getMinTileIdxToHide,
 } from "../../utils/subject_page_utils";
 import { BarTile } from "../tiles/bar_tile";
@@ -70,7 +74,7 @@ export function Block(props: BlockPropType): JSX.Element {
       <div className="block-body row">
         {props.columns &&
           props.columns.map((column, idx) => {
-            const id = `${props.id}col${idx}`;
+            const id = getId(props.id, COLUMN_ID_PREFIX, idx);
             const columnTileClassName = getColumnTileClassName(column);
             return (
               <Column
@@ -81,6 +85,7 @@ export function Block(props: BlockPropType): JSX.Element {
                 tiles={renderTiles(
                   column.tiles,
                   props,
+                  id,
                   minIdxToHide,
                   columnTileClassName
                 )}
@@ -95,6 +100,7 @@ export function Block(props: BlockPropType): JSX.Element {
 function renderTiles(
   tiles: TileConfig[],
   props: BlockPropType,
+  columnId: string,
   minIdxToHide: number,
   tileClassName?: string
 ): JSX.Element {
@@ -102,7 +108,7 @@ function renderTiles(
     return <></>;
   }
   const tilesJsx = tiles.map((tile, i) => {
-    const id = randDomId();
+    const id = getId(columnId, TILE_ID_PREFIX, i);
     const enclosedPlaceType = props.enclosedPlaceType;
     const classNameList = [];
     if (tileClassName) {

--- a/static/js/components/subject_page/category.tsx
+++ b/static/js/components/subject_page/category.tsx
@@ -21,13 +21,14 @@
 import React, { memo } from "react";
 import ReactMarkdown from "react-markdown";
 
+import { BLOCK_ID_PREFIX } from "../../constants/subject_page_constants";
 import { NamedTypedPlace } from "../../shared/types";
 import { randDomId } from "../../shared/util";
 import {
   CategoryConfig,
   EventTypeSpec,
 } from "../../types/subject_page_proto_types";
-import { getRelLink } from "../../utils/subject_page_utils";
+import { getId, getRelLink } from "../../utils/subject_page_utils";
 import { ErrorBoundary } from "../error_boundary";
 import { Block } from "./block";
 import { DisasterEventBlock } from "./disaster_event_block";
@@ -51,10 +52,7 @@ export const Category = memo(function Category(
 ): JSX.Element {
   const svProvider = new StatVarProvider(props.config.statVarSpec);
   return (
-    <article
-      className="category col-12"
-      id={props.config.title ? getRelLink(props.config.title) : randDomId()}
-    >
+    <article className="category col-12" id={props.id}>
       {props.config.title && (
         <h2 className="block-title">{props.config.title}</h2>
       )}
@@ -74,7 +72,7 @@ function renderBlocks(
     return <></>;
   }
   const blocksJsx = props.config.blocks.map((block, i) => {
-    const id = block.title ? getRelLink(block.title) : `${props.id}blk${i}`;
+    const id = getId(props.id, BLOCK_ID_PREFIX, i);
     switch (block.type) {
       case "DISASTER_EVENT":
         return (

--- a/static/js/components/subject_page/disaster_event_block.tsx
+++ b/static/js/components/subject_page/disaster_event_block.tsx
@@ -21,7 +21,11 @@
 import _ from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 
-import { HIDE_TILE_CLASS } from "../../constants/subject_page_constants";
+import {
+  COLUMN_ID_PREFIX,
+  HIDE_TILE_CLASS,
+  TILE_ID_PREFIX,
+} from "../../constants/subject_page_constants";
 import { NamedTypedPlace } from "../../shared/types";
 import { loadSpinner, removeSpinner } from "../../shared/util";
 import {
@@ -42,6 +46,7 @@ import {
 import {
   getColumnTileClassName,
   getColumnWidth,
+  getId,
   getMinTileIdxToHide,
 } from "../../utils/subject_page_utils";
 import { DisasterEventMapFilters } from "../tiles/disaster_event_map_filters";
@@ -135,7 +140,7 @@ export function DisasterEventBlock(
         <div className="block-column-container row">
           {props.columns &&
             props.columns.map((column, idx) => {
-              const id = `${props.id}col${idx}`;
+              const id = getId(props.id, COLUMN_ID_PREFIX, idx);
               const columnTileClassName = getColumnTileClassName(column);
               return (
                 <Column
@@ -146,6 +151,7 @@ export function DisasterEventBlock(
                   tiles={renderTiles(
                     column.tiles,
                     props,
+                    id,
                     minIdxToHide,
                     disasterEventData,
                     columnTileClassName
@@ -238,6 +244,7 @@ function getBlockEventTypeSpecs(
 function renderTiles(
   tiles: TileConfig[],
   props: DisasterEventBlockPropType,
+  columnId: string,
   minIdxToHide: number,
   disasterEventData: Record<string, DisasterEventPointData>,
   tileClassName?: string
@@ -246,7 +253,7 @@ function renderTiles(
     return <></>;
   }
   const tilesJsx = tiles.map((tile, i) => {
-    const id = `${props.id}tile${i}`;
+    const id = getId(columnId, TILE_ID_PREFIX, -1);
     const enclosedPlaceType = props.enclosedPlaceType;
     const classNameList = [];
     if (tileClassName) {

--- a/static/js/components/subject_page/main_pane.tsx
+++ b/static/js/components/subject_page/main_pane.tsx
@@ -21,15 +21,18 @@
 import _ from "lodash";
 import React, { memo, useEffect, useState } from "react";
 
+import { CATEGORY_ID_PREFIX } from "../../constants/subject_page_constants";
 import { SVG_CHART_HEIGHT } from "../../constants/tile_constants";
 import { NamedPlace, NamedTypedPlace } from "../../shared/types";
 import { SubjectPageConfig } from "../../types/subject_page_proto_types";
-import { fetchGeoJsonData } from "../../utils/subject_page_utils";
+import { fetchGeoJsonData, getId } from "../../utils/subject_page_utils";
 import { ErrorBoundary } from "../error_boundary";
 import { Category } from "./category";
 import { DataContext } from "./data_context";
 
 interface SubjectPageMainPanePropType {
+  // Id for this subject page.
+  id: string;
   // The place to show the page for.
   place: NamedTypedPlace;
   // Config of the page
@@ -71,7 +74,7 @@ export const SubjectPageMainPane = memo(function SubjectPageMainPane(
     <div id="subject-page-main-pane">
       {!_.isEmpty(props.pageConfig) &&
         props.pageConfig.categories.map((category, idx) => {
-          const id = `cat${idx}`;
+          const id = getId(props.id, CATEGORY_ID_PREFIX, idx);
           return (
             <DataContext.Provider key={id} value={{ geoJsonData }}>
               <ErrorBoundary>

--- a/static/js/components/subject_page/sidebar.tsx
+++ b/static/js/components/subject_page/sidebar.tsx
@@ -21,11 +21,16 @@
 import _ from "lodash";
 import React from "react";
 
+import {
+  BLOCK_ID_PREFIX,
+  CATEGORY_ID_PREFIX,
+} from "../../constants/subject_page_constants";
 import { randDomId } from "../../shared/util";
 import { CategoryConfig } from "../../types/subject_page_proto_types";
-import { getRelLink } from "../../utils/subject_page_utils";
+import { getId } from "../../utils/subject_page_utils";
 
 interface SubjectPageSidebarPropType {
+  id: string;
   /**
    * Categories from the page config.
    */
@@ -39,13 +44,15 @@ export function SubjectPageSidebar(
     <div id="subject-page-sidebar">
       <ul id="nav-topics" className="nav flex-column accordion">
         {!_.isEmpty(props.categories) &&
-          props.categories.map((category) => {
+          props.categories.map((category, idx) => {
+            const categoryId = getId(props.id, CATEGORY_ID_PREFIX, idx);
             // Add the category
-            const elements = [renderItem(category.title, true)];
+            const elements = [renderItem(category.title, true, categoryId)];
             // Add all child blocks
-            category.blocks.forEach((block) => {
+            category.blocks.forEach((block, idx) => {
+              const blockId = getId(categoryId, BLOCK_ID_PREFIX, idx);
               if (block.title) {
-                elements.push(renderItem(block.title, false));
+                elements.push(renderItem(block.title, false, blockId));
               }
             });
             return elements;
@@ -55,7 +62,11 @@ export function SubjectPageSidebar(
   );
 }
 
-function renderItem(title: string, isCategory: boolean): JSX.Element {
+function renderItem(
+  title: string,
+  isCategory: boolean,
+  redirectItemId: string
+): JSX.Element {
   if (!title) {
     return null;
   }
@@ -64,7 +75,7 @@ function renderItem(title: string, isCategory: boolean): JSX.Element {
       key={randDomId()}
       className={`nav-item ${isCategory ? "category" : ""}`}
     >
-      <a href={`#${getRelLink(title)}`}>{title}</a>
+      <a href={`#${redirectItemId}`}>{title}</a>
     </li>
   );
 }

--- a/static/js/components/tiles/bivariate_tile.tsx
+++ b/static/js/components/tiles/bivariate_tile.tsx
@@ -340,7 +340,7 @@ function draw(
   };
 
   drawBivariate(
-    props.id,
+    svgContainer,
     legend,
     chartData.points,
     chartData.geoJson,

--- a/static/js/components/tiles/disaster_event_map_tile.tsx
+++ b/static/js/components/tiles/disaster_event_map_tile.tsx
@@ -114,7 +114,7 @@ export function DisasterEventMapTile(
     }
   }, [placeInfo, geoJsonData, props.disasterEventData]);
 
-  if (geoJsonData == null) {
+  if (geoJsonData == null || !placeInfo) {
     return null;
   }
 
@@ -227,7 +227,6 @@ export function DisasterEventMapTile(
       zoomInButtonId: ZOOM_IN_BUTTON_ID,
       zoomOutButtonId: ZOOM_OUT_BUTTON_ID,
     };
-    document.getElementById(props.id).innerHTML = "";
     const isUsaPlace = isChildPlaceOf(
       placeInfo.selectedPlace.dcid,
       USA_PLACE_DCID,
@@ -240,7 +239,7 @@ export function DisasterEventMapTile(
       height
     );
     drawD3Map(
-      props.id,
+      svgContainerRef.current,
       geoJsonData,
       height,
       width,
@@ -264,7 +263,7 @@ export function DisasterEventMapTile(
     );
     for (const mapPointsData of Object.values(allMapPointsData)) {
       const pointsLayer = addMapPoints(
-        props.id,
+        svgContainerRef.current,
         mapPointsData.points,
         mapPointsData.values,
         projection,

--- a/static/js/components/tiles/map_tile.tsx
+++ b/static/js/components/tiles/map_tile.tsx
@@ -84,7 +84,7 @@ interface MapChartData {
 }
 
 export function MapTile(props: MapTilePropType): JSX.Element {
-  const svgContainer = useRef(null);
+  const svgContainer = useRef<HTMLDivElement>(null);
   const [rawData, setRawData] = useState<RawData | undefined>(null);
   const [mapChartData, setMapChartData] = useState<MapChartData | undefined>(
     null
@@ -276,7 +276,7 @@ function processData(
 function draw(
   chartData: MapChartData,
   props: MapTilePropType,
-  svgContainer: React.RefObject<HTMLElement>
+  svgContainer: React.RefObject<HTMLDivElement>
 ): void {
   const mainStatVar = props.statVarSpec.statVar;
   const width = svgContainer.current.offsetWidth;
@@ -322,7 +322,7 @@ function draw(
     height
   );
   drawD3Map(
-    props.id,
+    svgContainer.current,
     chartData.geoJson,
     height,
     width,

--- a/static/js/constants/subject_page_constants.ts
+++ b/static/js/constants/subject_page_constants.ts
@@ -22,3 +22,8 @@
 export const DEFAULT_PAGE_PLACE_TYPE = "Place";
 // Class name for hidden tiles.
 export const HIDE_TILE_CLASS = "tile-hidden";
+// Id prefixes for each type of subject page component
+export const CATEGORY_ID_PREFIX = "cat";
+export const BLOCK_ID_PREFIX = "blk";
+export const COLUMN_ID_PREFIX = "col";
+export const TILE_ID_PREFIX = "tile";

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -515,7 +515,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
         CHART_HEIGHT
       );
       drawD3Map(
-        this.props.id,
+        this.svgContainerElement.current,
         this.state.geoJson,
         CHART_HEIGHT,
         elem.offsetWidth,

--- a/static/js/tools/map/d3_map.tsx
+++ b/static/js/tools/map/d3_map.tsx
@@ -78,7 +78,8 @@ export function D3Map(props: D3MapProps): JSX.Element {
   const { placeInfo, statVar, display } = useContext(Context);
 
   const [errorMessage, setErrorMessage] = useState("");
-  const chartContainerRef = useRef<HTMLDivElement>();
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const mapContainerRef = useRef<HTMLDivElement>(null);
 
   const draw = useCallback(() => {
     if (
@@ -150,7 +151,7 @@ export function D3Map(props: D3MapProps): JSX.Element {
     );
     document.getElementById(MAP_CONTAINER_ID).innerHTML = "";
     drawD3Map(
-      MAP_CONTAINER_ID,
+      mapContainerRef.current,
       props.geoJsonData,
       height,
       width - legendWidth,
@@ -187,7 +188,7 @@ export function D3Map(props: D3MapProps): JSX.Element {
         return point.placeDcid in props.mapPointValues;
       });
       addMapPoints(
-        MAP_CONTAINER_ID,
+        mapContainerRef.current,
         filteredMapPoints,
         props.mapPointValues,
         projection,
@@ -249,7 +250,7 @@ export function D3Map(props: D3MapProps): JSX.Element {
     return (
       <div className="map-section-container">
         <div id={CHART_CONTAINER_ID} ref={chartContainerRef}>
-          <div id={MAP_CONTAINER_ID}></div>
+          <div id={MAP_CONTAINER_ID} ref={mapContainerRef}></div>
           <div id={LEGEND_CONTAINER_ID}></div>
         </div>
         <div className="zoom-button-section">

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -272,7 +272,7 @@ function plot(
       ),
     };
     drawBivariate(
-      SVG_CONTAINER_ID,
+      svgContainerRef,
       mapLegendRef,
       props.points,
       geoJsonData,

--- a/static/js/utils/subject_page_utils.ts
+++ b/static/js/utils/subject_page_utils.ts
@@ -41,6 +41,20 @@ export function getRelLink(title: string) {
 }
 
 /**
+ * Gets the id for a specific component on a subject page.
+ * @param parentId id of the parent component.
+ * @param componentIdPrefix prefix for this component's part of the id.
+ * @param componentIdx the index of this component within the parent component.
+ */
+export function getId(
+  parentId: string,
+  componentIdPrefix: string,
+  componentIdx: number
+): string {
+  return `${parentId}${componentIdPrefix}${componentIdx}`;
+}
+
+/**
  * Gets the minimum tile index that should be hidden.
  */
 export function getMinTileIdxToHide(): number {


### PR DESCRIPTION
- get unique id for each component when there are multiple subject pages
- update draw_d3_map to take a ref element instead of an element id

small css fix:
- update font color for severity filters (for disaster event tiles) on nl interface to white