### PR TITLE
[Devops] ESP 2G -> 1G memory to fit another pod in a node

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -220,9 +220,9 @@ spec:
                   key: serviceName
           resources:
             limits:
-              memory: "2G"
+              memory: "1G"
             requests:
-              memory: "2G"
+              memory: "1G"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -47,4 +47,4 @@ patchesStrategicMerge:
     metadata:
       name: website-app
     spec:
-      replicas: 3
+      replicas: 6


### PR DESCRIPTION
Decreasing this changes memory requirement from 15G -> 14G per pod. Nodes currently have ~29G of memory and this allows 2 pods to fit in a node as opposed to 1.