### PR TITLE
[Flask Server] Use repo root as module root

### DIFF
--- a/build/nl_server/Dockerfile
+++ b/build/nl_server/Dockerfile
@@ -19,6 +19,7 @@ ENV ENV=${ENV}
 
 WORKDIR /workspace
 
+COPY nl_app.py /workspace/nl_app.py
 COPY nl_server/requirements.txt /workspace/nl_server/requirements.txt
 # --no-cache-dir removes ~/.cache files, which can be a few GB.
 RUN pip3 install --no-cache-dir \
@@ -27,5 +28,5 @@ RUN pip3 install --no-cache-dir \
 COPY nl_server/. /workspace/nl_server/
 
 # Run server
-WORKDIR /workspace/nl_server
-CMD exec gunicorn --timeout 60 --bind :6060 main:app
+WORKDIR /workspace
+CMD exec gunicorn --timeout 60 --bind :6060 nl_app:app

--- a/build/web_server/Dockerfile
+++ b/build/web_server/Dockerfile
@@ -19,6 +19,7 @@ ENV ENV=${ENV}
 
 WORKDIR /workspace
 
+COPY web_app.py /workspace/web_app.py
 COPY server/requirements.txt /workspace/server/requirements.txt
 # --no-cache-dir removes ~/.cache files, which can be a few GB.
 RUN pip3 install --no-cache-dir \
@@ -37,5 +38,5 @@ COPY static/. /workspace/static/
 RUN npm run-script build
 
 # Run server
-WORKDIR /workspace/server
-CMD exec gunicorn --timeout 60 --bind :8080 main:app
+WORKDIR /workspace
+CMD exec gunicorn --timeout 60 --bind :8080 web_app:app

--- a/nl_app.py
+++ b/nl_app.py
@@ -15,7 +15,7 @@
 
 import logging
 
-from __init__ import create_app
+from nl_server.__init__ import create_app
 
 logging.basicConfig(
     level=logging.INFO,

--- a/nl_server/__init__.py
+++ b/nl_server/__init__.py
@@ -16,9 +16,10 @@ import logging
 import os
 
 from flask import Flask
-import loader
-import routes
 import yaml
+
+import nl_server.loader as loader
+import nl_server.routes as routes
 
 
 def create_app():

--- a/nl_server/embeddings.py
+++ b/nl_server/embeddings.py
@@ -17,11 +17,12 @@ import os
 from typing import Dict, List, Union
 
 from datasets import load_dataset
-import gcs
 from google.cloud import storage
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.util import semantic_search
 import torch
+
+import nl_server.gcs as gcs
 
 TEMP_DIR = '/tmp/'
 MODEL_NAME = 'all-MiniLM-L6-v2'

--- a/nl_server/loader.py
+++ b/nl_server/loader.py
@@ -15,8 +15,8 @@
 import logging
 import os
 
-from embeddings import Embeddings
-from ner_place_model import NERPlaces
+from nl_server.embeddings import Embeddings
+from nl_server.ner_place_model import NERPlaces
 
 nl_embeddings_cache_key = 'nl_embeddings'
 nl_ner_cache_key = 'nl_ner'

--- a/nl_server/pubsub.py
+++ b/nl_server/pubsub.py
@@ -14,10 +14,11 @@
 
 import json
 
-import gcs
 from google.cloud import pubsub_v1
 from google.cloud import storage
-import loader
+
+from nl_server import gcs
+from nl_server import loader
 
 AUTOPUSH_FOLDER = 'autopush/'
 TOPIC_NAME = 'projects/datcom-204919/topics/nl-models-update'

--- a/nl_server/tests/embeddings_test.py
+++ b/nl_server/tests/embeddings_test.py
@@ -17,12 +17,13 @@ import os
 import unittest
 
 from diskcache import Cache
-from embeddings import Embeddings
-from loader import nl_cache_path
-from loader import nl_embeddings_cache_key
 from parameterized import parameterized
 from sklearn.metrics.pairwise import cosine_similarity
 import yaml
+
+from nl_server.embeddings import Embeddings
+from nl_server.loader import nl_cache_path
+from nl_server.loader import nl_embeddings_cache_key
 
 _root_dir = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/nl_server/tests/ner_place_model_test.py
+++ b/nl_server/tests/ner_place_model_test.py
@@ -16,10 +16,11 @@
 import unittest
 
 from diskcache import Cache
-from loader import nl_cache_path
-from loader import nl_ner_cache_key
-from ner_place_model import NERPlaces
 from parameterized import parameterized
+
+from nl_server.loader import nl_cache_path
+from nl_server.loader import nl_ner_cache_key
+from nl_server.ner_place_model import NERPlaces
 
 
 class TestNERPlaces(unittest.TestCase):

--- a/run_nl_server.sh
+++ b/run_nl_server.sh
@@ -30,6 +30,6 @@ python3 -m pip install --upgrade pip
 echo "nl_server custom requirements installation: starting."
 ./requirements_install.sh
 echo "nl_server custom requirements installation: done."
-
-python3 main.py $PORT
 cd ..
+
+python3 nl_app.py $PORT

--- a/run_server.sh
+++ b/run_server.sh
@@ -81,7 +81,5 @@ echo "Starting localhost with FLASK_ENV='$FLASK_ENV' on port='$PORT'"
 
 python3 -m pip install --upgrade pip
 pip3 install -r server/requirements.txt -q
-cd server
-protoc -I=./config/ --python_out=./config ./config/subject_page.proto
-python3 main.py $PORT
-cd ..
+protoc -I=./server/config/ --python_out=./server/config ./server/config/subject_page.proto
+python3 web_app.py $PORT

--- a/run_test.sh
+++ b/run_test.sh
@@ -32,16 +32,16 @@ function setup_python {
 
   # Downloading the named-entity recognition (NER) library spacy and the large EN model
   # using the guidelines here: https://spacy.io/usage/models#production
-  # Unfortunately, pip is not able to recognize this data (as a library) as part of 
+  # Unfortunately, pip is not able to recognize this data (as a library) as part of
   # requirements.txt and will try to download a new version every single time.
   # Reason for doing this here is that if the library is already installed, no need
-  # to download > 560Mb file. 
+  # to download > 560Mb file.
   if python3 -c "import en_core_web_lg" &> /dev/null; then
       echo 'NER model (en_core_web_lg) already installed.'
   else
       echo 'Installing the NER model: en_core_web_lg'
       pip3 install $(spacy info en_core_web_lg --url)
-fi  
+fi
 }
 
 # Run test for client side code.
@@ -104,9 +104,7 @@ function run_npm_build () {
 function run_py_test {
   setup_python
   export FLASK_ENV=test
-  cd server
-  python3 -m pytest tests/ -s --ignore=sustainability
-  cd ..
+  python3 -m pytest server/tests/ -s --ignore=sustainability
 
   # TODO(beets): add tests for other private dc instances
   # export FLASK_ENV=test-sustainability
@@ -117,9 +115,9 @@ function run_py_test {
   echo "nl_server custom requirements installation: starting."
   ./requirements_install.sh
   echo "nl_server custom requirements installation: done."
-  python3 -m pytest tests/ -s
   cd ..
-  
+  python3 -m pytest nl_server/tests/ -s
+
   echo -e "#### Checking Python style"
   if ! yapf --recursive --diff --style='{based_on_style: google, indent_width: 2}' -p server/ nl_server/ tools/ -e=*pb2.py; then
     echo "Fix Python lint errors by running ./run_test.sh -f"
@@ -137,16 +135,14 @@ function run_py_test {
 function run_webdriver_test {
   printf '\n\e[1;35m%-6s\e[m\n\n' "!!! Have you generated the prod client packages? Run './run_test.sh -b' first to do so"
   setup_python
-  cd server
-  if [ ! -d dist  ]
+  if [ ! -d server/dist  ]
   then
     echo "no dist folder, please run ./run_test.sh -b to build js first."
     exit 1
   fi
   export FLASK_ENV=webdriver
   export GOOGLE_CLOUD_PROJECT=datcom-website-dev
-  python3 -m pytest -n 10 --reruns 3 webdriver_tests/tests/
-  cd ..
+  python3 -m pytest -n 10 --reruns 3 server/webdriver_tests/tests/
 }
 
 function run_all_tests {

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -16,7 +16,6 @@ import json
 import logging
 import os
 import tempfile
-import urllib.request
 
 import firebase_admin
 from firebase_admin import credentials
@@ -28,16 +27,17 @@ from flask import request
 from flask_babel import Babel
 from google.cloud import secretmanager
 from google_auth_oauthlib.flow import Flow
-import lib.config as libconfig
-from lib.disaster_dashboard import get_disaster_dashboard_data
-import lib.i18n as i18n
-import lib.util as libutil
 from opencensus.ext.flask.flask_middleware import FlaskMiddleware
 from opencensus.ext.stackdriver.trace_exporter import StackdriverExporter
 from opencensus.trace.propagation import google_cloud_format
 from opencensus.trace.samplers import AlwaysOnSampler
-from services.discovery import configure_endpoints_from_ingress
-from services.discovery import get_health_check_urls
+
+import server.lib.config as libconfig
+from server.lib.disaster_dashboard import get_disaster_dashboard_data
+import server.lib.i18n as i18n
+import server.lib.util as libutil
+from server.services.discovery import configure_endpoints_from_ingress
+from server.services.discovery import get_health_check_urls
 
 propagator = google_cloud_format.GoogleCloudFormatPropagator()
 
@@ -54,14 +54,14 @@ def createMiddleWare(app, exporter):
 
 def register_routes_base_dc(app):
   # apply the blueprints for all apps
-  from routes import dev
-  from routes import disease
-  from routes import import_wizard
-  from routes import placelist
-  from routes import protein
-  from routes import redirects
-  from routes import special_announcement
-  from routes import topic_page
+  from server.routes import dev
+  from server.routes import disease
+  from server.routes import import_wizard
+  from server.routes import placelist
+  from server.routes import protein
+  from server.routes import redirects
+  from server.routes import special_announcement
+  from server.routes import topic_page
   app.register_blueprint(dev.bp)
   app.register_blueprint(disease.bp)
   app.register_blueprint(placelist.bp)
@@ -70,9 +70,9 @@ def register_routes_base_dc(app):
   app.register_blueprint(special_announcement.bp)
   app.register_blueprint(topic_page.bp)
 
-  from routes.api import disease as disease_api
-  from routes.api import protein as protein_api
-  from routes.api.import_detection import detection as detection_api
+  from server.routes.api import disease as disease_api
+  from server.routes.api import protein as protein_api
+  from server.routes.api.import_detection import detection as detection_api
   app.register_blueprint(detection_api.bp)
   app.register_blueprint(disease_api.bp)
   app.register_blueprint(import_wizard.bp)
@@ -86,9 +86,9 @@ def register_routes_custom_dc(app):
 
 def register_routes_stanford_dc(app, is_test, is_local):
   # Install blueprints specific to Stanford DC
-  from routes import disasters
-  from routes import event
-  from routes.api import disaster_api
+  from server.routes import disasters
+  from server.routes import event
+  from server.routes.api import disaster_api
   app.register_blueprint(disasters.bp)
   app.register_blueprint(disaster_api.bp)
   app.register_blueprint(event.bp)
@@ -104,23 +104,23 @@ def register_routes_stanford_dc(app, is_test, is_local):
 
 
 def register_routes_admin(app):
-  from routes import user
+  from server.routes import user
   app.register_blueprint(user.bp)
-  from routes.api import user as user_api
+  from server.routes.api import user as user_api
   app.register_blueprint(user_api.bp)
 
 
 def register_routes_common(app):
   # apply the blueprints for main app
-  from routes import browser
-  from routes import factcheck
-  from routes import nl_interface
-  from routes import nl_interface_next
-  from routes import place
-  from routes import ranking
-  from routes import search
-  from routes import static
-  from routes import tools
+  from server.routes import browser
+  from server.routes import factcheck
+  from server.routes import nl_interface
+  from server.routes import nl_interface_next
+  from server.routes import place
+  from server.routes import ranking
+  from server.routes import search
+  from server.routes import static
+  from server.routes import tools
   app.register_blueprint(browser.bp)
   app.register_blueprint(nl_interface.bp)
   app.register_blueprint(nl_interface_next.bp)
@@ -130,22 +130,22 @@ def register_routes_common(app):
   app.register_blueprint(static.bp)
   app.register_blueprint(tools.bp)
   # TODO: Extract more out to base_dc
-  from routes.api import browser as browser_api
-  from routes.api import choropleth
-  from routes.api import csv
-  from routes.api import facets
-  from routes.api import landing_page
-  from routes.api import node
-  from routes.api import observation_dates
-  from routes.api import observation_existence
-  from routes.api import place as place_api
-  from routes.api import point
-  from routes.api import ranking as ranking_api
-  from routes.api import series
-  from routes.api import stats
-  from routes.api import translator
-  from routes.api import variable
-  from routes.api import variable_group
+  from server.routes.api import browser as browser_api
+  from server.routes.api import choropleth
+  from server.routes.api import csv
+  from server.routes.api import facets
+  from server.routes.api import landing_page
+  from server.routes.api import node
+  from server.routes.api import observation_dates
+  from server.routes.api import observation_existence
+  from server.routes.api import place as place_api
+  from server.routes.api import point
+  from server.routes.api import ranking as ranking_api
+  from server.routes.api import series
+  from server.routes.api import stats
+  from server.routes.api import translator
+  from server.routes.api import variable
+  from server.routes.api import variable_group
   app.register_blueprint(browser_api.bp)
   app.register_blueprint(choropleth.bp)
   app.register_blueprint(csv.bp)
@@ -190,7 +190,7 @@ def create_app():
     app.config['API_ROOT'] = 'http://127.0.0.1:8081'
 
   # Init extentions
-  from cache import cache
+  from server.cache import cache
 
   # For some instance with fast updated data, we may not want to use memcache.
   if app.config['USE_MEMCACHE']:
@@ -286,8 +286,8 @@ def create_app():
   if os.environ.get('ENABLE_MODEL') == 'true':
     libutil.check_backend_ready([app.config['NL_ROOT'] + '/healthz'])
     # Some specific imports for the NL Interface.
-    import lib.nl.training as libnl
-    import services.nl as nl
+    import server.lib.nl.training as libnl
+    import server.services.nl as nl
 
     # For the classification types available, check lib.training (libnl).
     classification_types = [

--- a/server/lib/config.py
+++ b/server/lib/config.py
@@ -54,7 +54,7 @@ def map_config_string(env):
   env_list[index + 1] = env[index + 1].upper()
   env_list[0] = env[0].upper()
   env_updated = "".join(env_list).replace('-', '')
-  return 'configmodule.{}Config'.format(env_updated)
+  return 'server.configmodule.{}Config'.format(env_updated)
 
 
 def get_config():

--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -15,7 +15,7 @@
 
 from typing import Dict, List, Set, Union
 
-from lib.nl.detection import EventType
+from server.lib.nl.detection import EventType
 
 STOP_WORDS: Set[str] = {
     'ourselves',

--- a/server/lib/nl/data_spec.py
+++ b/server/lib/nl/data_spec.py
@@ -17,12 +17,13 @@ from dataclasses import dataclass
 import logging
 from typing import Dict, List
 
-from lib.nl import topic
-from lib.nl import variable
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import Detection
 import pandas as pd
-import services.datacommons as dc
+
+from server.lib.nl import topic
+from server.lib.nl import variable
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import Detection
+import server.services.datacommons as dc
 
 
 @dataclass

--- a/server/lib/nl/descriptions.py
+++ b/server/lib/nl/descriptions.py
@@ -20,15 +20,15 @@ import logging
 import random
 from typing import List
 
-from lib.nl import detection
-from lib.nl import topic
-from lib.nl import utils
-from lib.nl.constants import EVENT_TYPE_TO_DISPLAY_NAME
-from lib.nl.detection import ContainedInClassificationAttributes
-from lib.nl.detection import EventClassificationAttributes
-import lib.nl.fulfillment.context as ctx
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import detection
+from server.lib.nl import topic
+from server.lib.nl import utils
+from server.lib.nl.constants import EVENT_TYPE_TO_DISPLAY_NAME
+from server.lib.nl.detection import ContainedInClassificationAttributes
+from server.lib.nl.detection import EventClassificationAttributes
+import server.lib.nl.fulfillment.context as ctx
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 INFO_SYNONYMS = ["an overview of", "some information about", "some data about"]
 

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -17,20 +17,20 @@ from dataclasses import field
 import logging
 from typing import Dict, List
 
-from lib.nl import constants
-from lib.nl import topic
-from lib.nl import utils
-from lib.nl import variable
-from lib.nl.detection import ContainedInPlaceType
-from lib.nl.detection import EventType
-from lib.nl.detection import Place
-from lib.nl.detection import RankingType
-from lib.nl.detection import TimeDeltaType
-from lib.nl.fulfillment import context
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartSpec
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import constants
+from server.lib.nl import topic
+from server.lib.nl import utils
+from server.lib.nl import variable
+from server.lib.nl.detection import ContainedInPlaceType
+from server.lib.nl.detection import EventType
+from server.lib.nl.detection import Place
+from server.lib.nl.detection import RankingType
+from server.lib.nl.detection import TimeDeltaType
+from server.lib.nl.fulfillment import context
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartSpec
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 # TODO: Factor classification processing functions into a common place.
 

--- a/server/lib/nl/fulfillment/comparison.py
+++ b/server/lib/nl/fulfillment/comparison.py
@@ -15,17 +15,18 @@
 import logging
 from typing import List
 
-from lib.nl import utils
-from lib.nl.detection import Place
-from lib.nl.fulfillment.base import add_chart_to_utterance
-from lib.nl.fulfillment.base import ChartVars
-from lib.nl.fulfillment.base import overview_fallback
-from lib.nl.fulfillment.base import populate_charts_for_places
-from lib.nl.fulfillment.base import PopulateState
-from lib.nl.fulfillment.context import places_for_comparison_from_context
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import utils
+from server.lib.nl.detection import Place
+from server.lib.nl.fulfillment.base import add_chart_to_utterance
+from server.lib.nl.fulfillment.base import ChartVars
+from server.lib.nl.fulfillment.base import overview_fallback
+from server.lib.nl.fulfillment.base import populate_charts_for_places
+from server.lib.nl.fulfillment.base import PopulateState
+from server.lib.nl.fulfillment.context import \
+    places_for_comparison_from_context
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 
 def populate(uttr: Utterance) -> bool:

--- a/server/lib/nl/fulfillment/containedin.py
+++ b/server/lib/nl/fulfillment/containedin.py
@@ -15,20 +15,21 @@
 import logging
 from typing import List
 
-from lib.nl import utils
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import ContainedInClassificationAttributes
-from lib.nl.detection import ContainedInPlaceType
-from lib.nl.detection import Place
-from lib.nl.fulfillment.base import add_chart_to_utterance
-from lib.nl.fulfillment.base import ChartVars
-from lib.nl.fulfillment.base import overview_fallback
-from lib.nl.fulfillment.base import populate_charts
-from lib.nl.fulfillment.base import PopulateState
-from lib.nl.fulfillment.context import classifications_of_type_from_context
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import utils
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import ContainedInClassificationAttributes
+from server.lib.nl.detection import ContainedInPlaceType
+from server.lib.nl.detection import Place
+from server.lib.nl.fulfillment.base import add_chart_to_utterance
+from server.lib.nl.fulfillment.base import ChartVars
+from server.lib.nl.fulfillment.base import overview_fallback
+from server.lib.nl.fulfillment.base import populate_charts
+from server.lib.nl.fulfillment.base import PopulateState
+from server.lib.nl.fulfillment.context import \
+    classifications_of_type_from_context
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 
 def populate(uttr: Utterance) -> bool:

--- a/server/lib/nl/fulfillment/context.py
+++ b/server/lib/nl/fulfillment/context.py
@@ -14,11 +14,11 @@
 
 from typing import List
 
-from lib.nl.detection import ClassificationAttributes
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import Place
-from lib.nl.utterance import CTX_LOOKBACK_LIMIT
-from lib.nl.utterance import Utterance
+from server.lib.nl.detection import ClassificationAttributes
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import Place
+from server.lib.nl.utterance import CTX_LOOKBACK_LIMIT
+from server.lib.nl.utterance import Utterance
 
 #
 # General utilities for retrieving stuff from past context.

--- a/server/lib/nl/fulfillment/correlation.py
+++ b/server/lib/nl/fulfillment/correlation.py
@@ -14,21 +14,22 @@
 
 import logging
 
-from lib.nl import utils
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import ContainedInClassificationAttributes
-from lib.nl.detection import Place
-from lib.nl.fulfillment.base import add_chart_to_utterance
-from lib.nl.fulfillment.base import ChartVars
-from lib.nl.fulfillment.base import maybe_handle_contained_in_fallback
-from lib.nl.fulfillment.base import open_top_topics_ordered
-from lib.nl.fulfillment.base import PopulateState
-from lib.nl.fulfillment.context import classifications_of_type_from_context
-from lib.nl.fulfillment.context import places_from_context
-from lib.nl.fulfillment.context import svs_from_context
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import utils
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import ContainedInClassificationAttributes
+from server.lib.nl.detection import Place
+from server.lib.nl.fulfillment.base import add_chart_to_utterance
+from server.lib.nl.fulfillment.base import ChartVars
+from server.lib.nl.fulfillment.base import maybe_handle_contained_in_fallback
+from server.lib.nl.fulfillment.base import open_top_topics_ordered
+from server.lib.nl.fulfillment.base import PopulateState
+from server.lib.nl.fulfillment.context import \
+    classifications_of_type_from_context
+from server.lib.nl.fulfillment.context import places_from_context
+from server.lib.nl.fulfillment.context import svs_from_context
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 _MAX_CONTEXT_SVS = 3
 _MAX_MAIN_SVS = 5

--- a/server/lib/nl/fulfillment/event.py
+++ b/server/lib/nl/fulfillment/event.py
@@ -14,11 +14,11 @@
 
 from typing import List
 
-from lib.nl import detection
-from lib.nl import utils
-import lib.nl.fulfillment.base as base
-import lib.nl.fulfillment.context as ctx
-import lib.nl.utterance as nl_uttr
+from server.lib.nl import detection
+from server.lib.nl import utils
+import server.lib.nl.fulfillment.base as base
+import server.lib.nl.fulfillment.context as ctx
+import server.lib.nl.utterance as nl_uttr
 
 #
 # Handler for Event queries.

--- a/server/lib/nl/fulfillment/overview.py
+++ b/server/lib/nl/fulfillment/overview.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from lib.nl import utils
-from lib.nl.detection import Place
-from lib.nl.fulfillment.base import add_chart_to_utterance
-from lib.nl.fulfillment.base import ChartVars
-from lib.nl.fulfillment.base import PopulateState
-import lib.nl.fulfillment.context as ctx
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import utils
+from server.lib.nl.detection import Place
+from server.lib.nl.fulfillment import context as ctx
+from server.lib.nl.fulfillment.base import add_chart_to_utterance
+from server.lib.nl.fulfillment.base import ChartVars
+from server.lib.nl.fulfillment.base import PopulateState
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 # A simple fulfiller to add a PLACE_OVERVIEW chart by finding places in context.
 

--- a/server/lib/nl/fulfillment/ranking_across_places.py
+++ b/server/lib/nl/fulfillment/ranking_across_places.py
@@ -15,18 +15,18 @@
 import logging
 from typing import List
 
-from lib.nl import utils
-from lib.nl.detection import ContainedInPlaceType
-from lib.nl.detection import Place
-from lib.nl.detection import RankingType
-from lib.nl.fulfillment.base import add_chart_to_utterance
-from lib.nl.fulfillment.base import ChartVars
-from lib.nl.fulfillment.base import overview_fallback
-from lib.nl.fulfillment.base import populate_charts
-from lib.nl.fulfillment.base import PopulateState
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import utils
+from server.lib.nl.detection import ContainedInPlaceType
+from server.lib.nl.detection import Place
+from server.lib.nl.detection import RankingType
+from server.lib.nl.fulfillment.base import add_chart_to_utterance
+from server.lib.nl.fulfillment.base import ChartVars
+from server.lib.nl.fulfillment.base import overview_fallback
+from server.lib.nl.fulfillment.base import populate_charts
+from server.lib.nl.fulfillment.base import PopulateState
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 
 #

--- a/server/lib/nl/fulfillment/ranking_across_vars.py
+++ b/server/lib/nl/fulfillment/ranking_across_vars.py
@@ -15,16 +15,16 @@
 import logging
 from typing import List
 
-from lib.nl import utils
-from lib.nl.detection import Place
-from lib.nl.fulfillment.base import add_chart_to_utterance
-from lib.nl.fulfillment.base import ChartVars
-from lib.nl.fulfillment.base import overview_fallback
-from lib.nl.fulfillment.base import populate_charts
-from lib.nl.fulfillment.base import PopulateState
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import utils
+from server.lib.nl.detection import Place
+from server.lib.nl.fulfillment.base import add_chart_to_utterance
+from server.lib.nl.fulfillment.base import ChartVars
+from server.lib.nl.fulfillment.base import overview_fallback
+from server.lib.nl.fulfillment.base import populate_charts
+from server.lib.nl.fulfillment.base import PopulateState
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 
 #

--- a/server/lib/nl/fulfillment/simple.py
+++ b/server/lib/nl/fulfillment/simple.py
@@ -15,15 +15,15 @@
 import logging
 from typing import List
 
-from lib.nl import utils
-from lib.nl.detection import Place
-from lib.nl.fulfillment.base import add_chart_to_utterance
-from lib.nl.fulfillment.base import ChartVars
-from lib.nl.fulfillment.base import populate_charts
-from lib.nl.fulfillment.base import PopulateState
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import utils
+from server.lib.nl.detection import Place
+from server.lib.nl.fulfillment.base import add_chart_to_utterance
+from server.lib.nl.fulfillment.base import ChartVars
+from server.lib.nl.fulfillment.base import populate_charts
+from server.lib.nl.fulfillment.base import PopulateState
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 # Number of variables to plot in a chart (largely Timeline chart)
 _MAX_VARS_PER_CHART = 5

--- a/server/lib/nl/fulfillment/time_delta.py
+++ b/server/lib/nl/fulfillment/time_delta.py
@@ -15,16 +15,16 @@
 import logging
 from typing import List
 
-from lib.nl import utils
-from lib.nl.detection import Place
-from lib.nl.fulfillment.base import add_chart_to_utterance
-from lib.nl.fulfillment.base import ChartVars
-from lib.nl.fulfillment.base import overview_fallback
-from lib.nl.fulfillment.base import populate_charts
-from lib.nl.fulfillment.base import PopulateState
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import Utterance
+from server.lib.nl import utils
+from server.lib.nl.detection import Place
+from server.lib.nl.fulfillment.base import add_chart_to_utterance
+from server.lib.nl.fulfillment.base import ChartVars
+from server.lib.nl.fulfillment.base import overview_fallback
+from server.lib.nl.fulfillment.base import populate_charts
+from server.lib.nl.fulfillment.base import PopulateState
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
 
 
 #

--- a/server/lib/nl/fulfillment_next.py
+++ b/server/lib/nl/fulfillment_next.py
@@ -16,20 +16,19 @@
 import logging
 from typing import List
 
-from lib.nl import utils
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import Detection
-from lib.nl.fulfillment import comparison
-from lib.nl.fulfillment import containedin
-from lib.nl.fulfillment import context
-from lib.nl.fulfillment import correlation
-from lib.nl.fulfillment import event
-from lib.nl.fulfillment import overview
-from lib.nl.fulfillment import ranking_across_places
-from lib.nl.fulfillment import ranking_across_vars
-from lib.nl.fulfillment import simple
-from lib.nl.fulfillment import time_delta
-from lib.nl.utterance import Utterance
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import Detection
+from server.lib.nl.fulfillment import comparison
+from server.lib.nl.fulfillment import containedin
+from server.lib.nl.fulfillment import context
+from server.lib.nl.fulfillment import correlation
+from server.lib.nl.fulfillment import event
+from server.lib.nl.fulfillment import overview
+from server.lib.nl.fulfillment import ranking_across_places
+from server.lib.nl.fulfillment import ranking_across_vars
+from server.lib.nl.fulfillment import simple
+from server.lib.nl.fulfillment import time_delta
+from server.lib.nl.utterance import Utterance
 
 # We will ignore SV detections that are below this threshold
 _SV_THRESHOLD = 0.5

--- a/server/lib/nl/page_config.py
+++ b/server/lib/nl/page_config.py
@@ -16,16 +16,16 @@ import json
 import os
 from typing import Dict, List
 
-from config import subject_page_pb2
-from lib.nl import topic
-from lib.nl.constants import PLACE_TYPE_TO_PLURALS
-from lib.nl.data_spec import DataSpec
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import Detection
-from lib.nl.detection import NLClassifier
-from lib.nl.detection import Place
-from lib.nl.detection import RankingType
-from services import datacommons as dc
+from server.config import subject_page_pb2
+from server.lib.nl import topic
+from server.lib.nl.constants import PLACE_TYPE_TO_PLURALS
+from server.lib.nl.data_spec import DataSpec
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import Detection
+from server.lib.nl.detection import NLClassifier
+from server.lib.nl.detection import Place
+from server.lib.nl.detection import RankingType
+from server.services import datacommons as dc
 
 CHART_TITLE_CONFIG_RELATIVE_PATH = "../../config/nl_page/chart_titles_by_sv.json"
 

--- a/server/lib/nl/page_config_next.py
+++ b/server/lib/nl/page_config_next.py
@@ -15,22 +15,22 @@
 import logging
 from typing import Dict, List
 
-from config.subject_page_pb2 import Block
-from config.subject_page_pb2 import RankingTileSpec
-from config.subject_page_pb2 import StatVarSpec
-from config.subject_page_pb2 import SubjectPageConfig
-from config.subject_page_pb2 import Tile
-from lib.nl import utils
-import lib.nl.constants as constants
-import lib.nl.descriptions as lib_desc
-from lib.nl.detection import EventType
-from lib.nl.detection import Place
-from lib.nl.detection import RankingType
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartSpec
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import ClassificationType
-from lib.nl.utterance import Utterance
+from server.config.subject_page_pb2 import Block
+from server.config.subject_page_pb2 import RankingTileSpec
+from server.config.subject_page_pb2 import StatVarSpec
+from server.config.subject_page_pb2 import SubjectPageConfig
+from server.config.subject_page_pb2 import Tile
+from server.lib.nl import utils
+import server.lib.nl.constants as constants
+import server.lib.nl.descriptions as lib_desc
+from server.lib.nl.detection import EventType
+from server.lib.nl.detection import Place
+from server.lib.nl.detection import RankingType
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartSpec
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import ClassificationType
+from server.lib.nl.utterance import Utterance
 
 
 class PageConfigBuilder:

--- a/server/lib/nl/place_detection.py
+++ b/server/lib/nl/place_detection.py
@@ -15,9 +15,9 @@
 import logging
 from typing import List
 
-import lib.nl.constants as constants
-import lib.nl.utils as utils
-from services import datacommons as dc
+import server.lib.nl.constants as constants
+import server.lib.nl.utils as utils
+from server.services import datacommons as dc
 
 
 class NLPlaceDetector:

--- a/server/lib/nl/topic.py
+++ b/server/lib/nl/topic.py
@@ -15,8 +15,8 @@
 
 from typing import List
 
-from lib.nl import utils
-import services.datacommons as dc
+from server.lib.nl import utils
+import server.services.datacommons as dc
 
 _MIN_TOPIC_RANK = 2
 

--- a/server/lib/nl/training.py
+++ b/server/lib/nl/training.py
@@ -17,9 +17,10 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-from lib.nl.detection import BinaryClassificationResultType
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.linear_model import LogisticRegression
+
+from server.lib.nl.detection import BinaryClassificationResultType
 
 
 @dataclass

--- a/server/lib/nl/utils.py
+++ b/server/lib/nl/utils.py
@@ -21,12 +21,12 @@ import os
 import re
 from typing import Dict, List, Set, Union
 
-import lib.nl.constants as constants
-import lib.nl.detection as detection
-import lib.nl.fulfillment.context as ctx
-import lib.nl.utterance as nl_uttr
-import lib.util as util
-import services.datacommons as dc
+import server.lib.nl.constants as constants
+import server.lib.nl.detection as detection
+import server.lib.nl.fulfillment.context as ctx
+import server.lib.nl.utterance as nl_uttr
+import server.lib.util as util
+import server.services.datacommons as dc
 
 # TODO: This is reading the file on every call.  Improve it!
 _CHART_TITLE_CONFIG_RELATIVE_PATH = "../../config/nl_page/chart_titles_by_sv.json"

--- a/server/lib/nl/utterance.py
+++ b/server/lib/nl/utterance.py
@@ -22,19 +22,19 @@ from enum import IntEnum
 import logging
 from typing import Dict, List
 
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import ContainedInClassificationAttributes
-from lib.nl.detection import ContainedInPlaceType
-from lib.nl.detection import Detection
-from lib.nl.detection import EventClassificationAttributes
-from lib.nl.detection import EventType
-from lib.nl.detection import NLClassifier
-from lib.nl.detection import Place
-from lib.nl.detection import RankingClassificationAttributes
-from lib.nl.detection import RankingType
-from lib.nl.detection import SimpleClassificationAttributes
-from lib.nl.detection import TimeDeltaClassificationAttributes
-from lib.nl.detection import TimeDeltaType
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import ContainedInClassificationAttributes
+from server.lib.nl.detection import ContainedInPlaceType
+from server.lib.nl.detection import Detection
+from server.lib.nl.detection import EventClassificationAttributes
+from server.lib.nl.detection import EventType
+from server.lib.nl.detection import NLClassifier
+from server.lib.nl.detection import Place
+from server.lib.nl.detection import RankingClassificationAttributes
+from server.lib.nl.detection import RankingType
+from server.lib.nl.detection import SimpleClassificationAttributes
+from server.lib.nl.detection import TimeDeltaClassificationAttributes
+from server.lib.nl.detection import TimeDeltaType
 
 # How far back does the context go back.
 CTX_LOOKBACK_LIMIT = 8

--- a/server/lib/nl/variable.py
+++ b/server/lib/nl/variable.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Dict, List
 
-import services.datacommons as dc
+import server.services.datacommons as dc
 
 
 @dataclass

--- a/server/lib/util.py
+++ b/server/lib/util.py
@@ -21,9 +21,10 @@ import time
 from typing import List
 import urllib
 
-from config import subject_page_pb2
 from google.protobuf import text_format
-import services.datacommons as dc
+
+from server.config import subject_page_pb2
+import server.services.datacommons as dc
 
 _ready_check_timeout = 120  # seconds
 _ready_check_sleep_seconds = 5

--- a/server/routes/api/browser.py
+++ b/server/routes/api/browser.py
@@ -15,11 +15,12 @@
 
 import json
 
-from cache import cache
 import flask
 from flask import request
 from flask import Response
-import services.datacommons as dc
+
+from server.cache import cache
+import server.services.datacommons as dc
 
 bp = flask.Blueprint('api.browser', __name__, url_prefix='/api/browser')
 

--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -16,7 +16,6 @@
 import json
 import urllib.parse
 
-from cache import cache
 from flask import Blueprint
 from flask import current_app
 from flask import g
@@ -26,15 +25,15 @@ from flask import Response
 from flask import send_file
 from flask import url_for
 from geojson_rewind import rewind
-import lib.util as lib_util
-import routes.api.landing_page as landing_page_api
-from routes.api.place import EQUIVALENT_PLACE_TYPES
-import routes.api.place as place_api
-import routes.api.point as point_api
-import routes.api.series as series_api
-from routes.api.shared import is_float
-import routes.api.shared as shared_api
-import services.datacommons as dc
+
+from server.cache import cache
+import server.lib.util as lib_util
+import server.routes.api.landing_page as landing_page_api
+from server.routes.api.place import EQUIVALENT_PLACE_TYPES
+import server.routes.api.place as place_api
+from server.routes.api.shared import is_float
+import server.routes.api.shared as shared_api
+import server.services.datacommons as dc
 
 # Define blueprint
 bp = Blueprint("choropleth", __name__, url_prefix='/api/choropleth')

--- a/server/routes/api/csv.py
+++ b/server/routes/api/csv.py
@@ -20,11 +20,12 @@ import io
 from flask import Blueprint
 from flask import make_response
 from flask import request
-from routes.api.shared import date_greater_equal_min
-from routes.api.shared import date_lesser_equal_max
-from routes.api.shared import is_valid_date
-from routes.api.shared import names
-import services.datacommons as dc
+
+from server.routes.api.shared import date_greater_equal_min
+from server.routes.api.shared import date_lesser_equal_max
+from server.routes.api.shared import is_valid_date
+from server.routes.api.shared import names
+import server.services.datacommons as dc
 
 # Define blueprint
 bp = Blueprint("csv", __name__, url_prefix='/api/csv')

--- a/server/routes/api/disaster_api.py
+++ b/server/routes/api/disaster_api.py
@@ -20,7 +20,8 @@ from flask import Blueprint
 from flask import current_app
 from flask import request
 from flask import Response
-import services.datacommons as dc
+
+import server.services.datacommons as dc
 
 # Define blueprint
 bp = Blueprint("disaster_api", __name__, url_prefix='/api/disaster-dashboard')

--- a/server/routes/api/disease.py
+++ b/server/routes/api/disease.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Disease browser related handlers."""
 
-from cache import cache
 import flask
-import services.datacommons as dc_service
+
+from server.cache import cache
+import server.services.datacommons as dc_service
 
 bp = flask.Blueprint('api.disease', __name__, url_prefix='/api/disease')
 

--- a/server/routes/api/facets.py
+++ b/server/routes/api/facets.py
@@ -16,7 +16,8 @@ import re
 
 from flask import Blueprint
 from flask import request
-import services.datacommons as dc
+
+import server.services.datacommons as dc
 
 bp = Blueprint("facets", __name__, url_prefix='/api/facets')
 

--- a/server/routes/api/import_detection/country_state_detector.py
+++ b/server/routes/api/import_detection/country_state_detector.py
@@ -15,12 +15,12 @@
 
 from typing import Dict, List, Optional, Set
 
-from routes.api.import_detection.detection_types import DCProperty
-from routes.api.import_detection.detection_types import DCType
-from routes.api.import_detection.detection_types import TypeProperty
-from routes.api.import_detection.place_detector_abstract import \
+from server.routes.api.import_detection.detection_types import DCProperty
+from server.routes.api.import_detection.detection_types import DCType
+from server.routes.api.import_detection.detection_types import TypeProperty
+from server.routes.api.import_detection.place_detector_abstract import \
     PlaceDetectorInterface
-import routes.api.import_detection.utils as utils
+import server.routes.api.import_detection.utils as utils
 
 
 class CountryStateDetector(PlaceDetectorInterface):

--- a/server/routes/api/import_detection/detection.py
+++ b/server/routes/api/import_detection/detection.py
@@ -19,14 +19,15 @@ from typing import Dict, List, Optional
 from flask import Blueprint
 from flask import request
 from flask import Response
-import routes.api.import_detection.date_detection as date_detector
-from routes.api.import_detection.detection_types import Column
-from routes.api.import_detection.detection_types import MappedThing
-from routes.api.import_detection.detection_types import MappingType
-from routes.api.import_detection.detection_types import MappingVal
-from routes.api.import_detection.detection_types import TypeProperty
-import routes.api.import_detection.place_detection as place_detector
-import routes.api.import_detection.utils as utils
+
+import server.routes.api.import_detection.date_detection as date_detector
+from server.routes.api.import_detection.detection_types import Column
+from server.routes.api.import_detection.detection_types import MappedThing
+from server.routes.api.import_detection.detection_types import MappingType
+from server.routes.api.import_detection.detection_types import MappingVal
+from server.routes.api.import_detection.detection_types import TypeProperty
+import server.routes.api.import_detection.place_detection as place_detector
+import server.routes.api.import_detection.utils as utils
 
 SUCCESS_CODE: int = 200
 BAD_REQUEST_CODE: int = 400

--- a/server/routes/api/import_detection/detection_types.py
+++ b/server/routes/api/import_detection/detection_types.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
 
-from routes.api.import_detection.utils import Consts as c
+from server.routes.api.import_detection.utils import Consts as c
 
 
 # Helper Enums and Data Classes for Detection.

--- a/server/routes/api/import_detection/place_detection.py
+++ b/server/routes/api/import_detection/place_detection.py
@@ -15,13 +15,13 @@
 
 from typing import Dict, List, Optional, Tuple
 
-from routes.api.import_detection.country_state_detector import \
+from server.routes.api.import_detection.country_state_detector import \
     CountryStateDetector
-from routes.api.import_detection.detection_types import TypeProperty
-from routes.api.import_detection.place_detector_abstract import \
+from server.routes.api.import_detection.detection_types import TypeProperty
+from server.routes.api.import_detection.place_detector_abstract import \
     PlaceDetectorInterface
-from routes.api.import_detection.utils import Consts as c
-import routes.api.import_detection.utils as utils
+from server.routes.api.import_detection.utils import Consts as c
+import server.routes.api.import_detection.utils as utils
 
 _MIN_HIGH_CONF_DETECT: float = 0.4
 

--- a/server/routes/api/import_detection/place_detector_abstract.py
+++ b/server/routes/api/import_detection/place_detector_abstract.py
@@ -17,10 +17,10 @@ from abc import ABC
 from abc import abstractmethod
 from typing import List, Optional, Set
 
-from routes.api.import_detection.detection_types import DCProperty
-from routes.api.import_detection.detection_types import DCType
-from routes.api.import_detection.detection_types import TypeProperty
-import routes.api.import_detection.utils as utils
+from server.routes.api.import_detection.detection_types import DCProperty
+from server.routes.api.import_detection.detection_types import DCType
+from server.routes.api.import_detection.detection_types import TypeProperty
+import server.routes.api.import_detection.utils as utils
 
 
 class PlaceDetectorInterface(ABC):

--- a/server/routes/api/landing_page.py
+++ b/server/routes/api/landing_page.py
@@ -24,7 +24,6 @@ import logging
 import time
 import urllib.parse
 
-from cache import cache
 from flask import Blueprint
 from flask import current_app
 from flask import g
@@ -32,9 +31,11 @@ from flask import request
 from flask import Response
 from flask import url_for
 from flask_babel import gettext
-import lib.range as lib_range
-import routes.api.place as place_api
-import services.datacommons as dc
+
+from server.cache import cache
+import server.lib.range as lib_range
+import server.routes.api.place as place_api
+import server.services.datacommons as dc
 
 # Define blueprint
 bp = Blueprint("api.landing_page", __name__, url_prefix='/api/landingpage')

--- a/server/routes/api/node.py
+++ b/server/routes/api/node.py
@@ -16,7 +16,8 @@
 import json
 
 import flask
-import services.datacommons as dc
+
+import server.services.datacommons as dc
 
 bp = flask.Blueprint('api.node', __name__, url_prefix='/api/node')
 

--- a/server/routes/api/observation_dates.py
+++ b/server/routes/api/observation_dates.py
@@ -14,7 +14,8 @@
 
 from flask import Blueprint
 from flask import request
-import services.datacommons as dc
+
+import server.services.datacommons as dc
 
 # Define blueprint
 bp = Blueprint("observation_dates", __name__)

--- a/server/routes/api/observation_existence.py
+++ b/server/routes/api/observation_existence.py
@@ -16,7 +16,8 @@ import json
 
 from flask import Blueprint
 from flask import request
-import services.datacommons as dc
+
+import server.services.datacommons as dc
 
 # Define blueprint
 bp = Blueprint("observation_existence", __name__)

--- a/server/routes/api/place.py
+++ b/server/routes/api/place.py
@@ -17,7 +17,6 @@ import json
 import logging
 import urllib.parse
 
-from cache import cache
 from flask import Blueprint
 from flask import current_app
 from flask import g
@@ -25,11 +24,13 @@ from flask import request
 from flask import Response
 from flask import url_for
 from flask_babel import gettext
-import lib.i18n as i18n
-from routes.api.shared import names
-import routes.api.shared as shared_api
-from services.datacommons import fetch_data
-import services.datacommons as dc
+
+from server.cache import cache
+import server.lib.i18n as i18n
+from server.routes.api.shared import names
+import server.routes.api.shared as shared_api
+from server.services.datacommons import fetch_data
+import server.services.datacommons as dc
 
 CHILD_PLACE_LIMIT = 50
 

--- a/server/routes/api/point.py
+++ b/server/routes/api/point.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cache import cache
 from flask import Blueprint
 from flask import request
-import lib.util as util
-import services.datacommons as dc
+
+from server.cache import cache
+import server.lib.util as util
 
 # Define blueprint
 bp = Blueprint('point', __name__, url_prefix='/api/observations/point')

--- a/server/routes/api/protein.py
+++ b/server/routes/api/protein.py
@@ -16,12 +16,13 @@
 import json
 import logging
 
-from cache import cache
 from flask import Blueprint
 from flask import escape
 from flask import request
 from flask import Response
-import services.datacommons as dc
+
+from server.cache import cache
+import server.services.datacommons as dc
 
 BIO_DCID_PREFIX = 'bio/'
 LOGGING_PREFIX_PPI = 'Protein browser PPI'

--- a/server/routes/api/ranking.py
+++ b/server/routes/api/ranking.py
@@ -16,8 +16,9 @@
 import json
 
 import flask
-import routes.api.place as place_api
-import services.datacommons as dc
+
+import server.routes.api.place as place_api
+import server.services.datacommons as dc
 
 bp = flask.Blueprint('api.ranking', __name__, url_prefix='/api/ranking')
 

--- a/server/routes/api/series.py
+++ b/server/routes/api/series.py
@@ -17,7 +17,6 @@ from flask import request
 
 from server.cache import cache
 from server.lib import util
-import server.services.datacommons as dc
 
 # Define blueprint
 bp = Blueprint("series", __name__, url_prefix='/api/observations/series')

--- a/server/routes/api/series.py
+++ b/server/routes/api/series.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cache import cache
 from flask import Blueprint
 from flask import request
-from lib import util
-import services.datacommons as dc
+
+from server.cache import cache
+from server.lib import util
+import server.services.datacommons as dc
 
 # Define blueprint
 bp = Blueprint("series", __name__, url_prefix='/api/observations/series')
@@ -27,12 +28,12 @@ bp = Blueprint("series", __name__, url_prefix='/api/observations/series')
 #                instead of cutting it off.
 def get_binned_series(entities, variables, year):
   """Get observation series for entities and variables, for a given year.
-  
+
   Bins observations from a series for plotting in the histogram tile.
   Currently, binning is done by only returning observations for a given year.
   This is done by assuming the dates of the series are in 'YYYY-MM' format,
   filtering for observations from the given year, and then imputing 0 for
-  any months missing, up to the end of the series. 
+  any months missing, up to the end of the series.
 
   Note: This assumes the dates of the series are in 'YYYY-MM' format.
 
@@ -40,9 +41,9 @@ def get_binned_series(entities, variables, year):
     entities (list): DCIDs of entities to query
     variables (list): DCIDs of variables to query
     year (str): year in "YYYY" format to get observations for
-  
+
   Returns:
-    JSON response from server, with series containing only observations from 
+    JSON response from server, with series containing only observations from
     the specified year.
   """
   # Get raw series from mixer
@@ -144,15 +145,15 @@ def series_within_all():
 @bp.route('/binned/<path:year>')
 def series_binned(year='2022'):
   """Get observations binned by time-period.
-  
+
   Used for pre-binning data for the histogram tile. Currently only "bins" data
   by returning only observations from a specific year.
 
   Args:
     year: the year to get observations for
-  
+
   Returns:
-    JSON response from server, with series containing only observations from 
+    JSON response from server, with series containing only observations from
     the specified year.
   """
   entities = list(filter(lambda x: x != "", request.args.getlist('entities')))

--- a/server/routes/api/shared.py
+++ b/server/routes/api/shared.py
@@ -15,7 +15,7 @@
 
 import re
 
-import services.datacommons as dc
+import server.services.datacommons as dc
 
 
 def names(dcids):

--- a/server/routes/api/stats.py
+++ b/server/routes/api/stats.py
@@ -14,13 +14,14 @@
 
 import json
 
-from cache import cache
 from flask import Blueprint
 from flask import current_app
 from flask import request
 from flask import Response
-import services.ai as ai
-import services.datacommons as dc
+
+from server.cache import cache
+import server.services.ai as ai
+import server.services.datacommons as dc
 
 # TODO(shifucun): add unittest for this module
 

--- a/server/routes/api/translator.py
+++ b/server/routes/api/translator.py
@@ -14,7 +14,8 @@
 
 from flask import Blueprint
 from flask import request
-from services import datacommons as dc
+
+from server.services import datacommons as dc
 
 # Define blueprint
 bp = Blueprint("misc", __name__)

--- a/server/routes/api/variable.py
+++ b/server/routes/api/variable.py
@@ -17,7 +17,8 @@ import json
 from flask import Blueprint
 from flask import escape
 from flask import request
-import services.datacommons as dc
+
+import server.services.datacommons as dc
 
 bp = Blueprint("variable", __name__, url_prefix='/api/variable')
 

--- a/server/routes/api/variable_group.py
+++ b/server/routes/api/variable_group.py
@@ -15,7 +15,8 @@
 from flask import Blueprint
 from flask import current_app
 from flask import request
-import services.datacommons as dc
+
+import server.services.datacommons as dc
 
 bp = Blueprint("variable-group", __name__, url_prefix='/api/variable-group')
 

--- a/server/routes/browser.py
+++ b/server/routes/browser.py
@@ -20,7 +20,8 @@ from flask import Blueprint
 from flask import current_app
 from flask import g
 from flask import render_template
-import routes.api.shared as shared_api
+
+import server.routes.api.shared as shared_api
 
 bp = Blueprint('browser', __name__, url_prefix='/browser')
 

--- a/server/routes/dev.py
+++ b/server/routes/dev.py
@@ -15,8 +15,8 @@
 import os
 
 import flask
-from lib.gcs import list_png
-import services.datacommons as dc
+
+from server.lib.gcs import list_png
 
 SCREENSHOT_BUCKET = 'datcom-browser-screenshot'
 

--- a/server/routes/disasters.py
+++ b/server/routes/disasters.py
@@ -15,16 +15,17 @@
 
 import json
 
-from config import subject_page_pb2
 import flask
 from flask import Blueprint
 from flask import current_app
 from flask import escape
 from google.protobuf.json_format import MessageToJson
-import lib.subject_page_config as lib_subject_page_config
-import lib.util
-import routes.api.place as place_api
-import services.datacommons as dc
+
+from server.config import subject_page_pb2
+import server.lib.subject_page_config as lib_subject_page_config
+import server.lib.util
+import server.routes.api.place as place_api
+import server.services.datacommons as dc
 
 DEFAULT_PLACE_DCID = "Earth"
 DEFAULT_PLACE_TYPE = "Planet"
@@ -48,7 +49,7 @@ def disaster_dashboard(place_dcid=DEFAULT_PLACE_DCID):
   if current_app.config['LOCAL']:
     # Reload configs for faster local iteration.
     # TODO: Delete this when we are close to launch
-    all_configs = lib.util.get_disaster_dashboard_configs()
+    all_configs = server.lib.util.get_disaster_dashboard_configs()
 
   if len(all_configs) < 1:
     return "Error: no config installed"

--- a/server/routes/disease.py
+++ b/server/routes/disease.py
@@ -19,7 +19,8 @@ import os
 import flask
 from flask import Blueprint
 from flask import render_template
-import routes.api.shared as shared_api
+
+import server.routes.api.shared as shared_api
 
 bp = Blueprint('disease', __name__, url_prefix='/bio/disease')
 

--- a/server/routes/event.py
+++ b/server/routes/event.py
@@ -20,8 +20,9 @@ from flask import abort
 from flask import Blueprint
 from flask import escape
 from flask import render_template
-import routes.api.node as node_api
-import routes.api.shared as shared_api
+
+import server.routes.api.node as node_api
+import server.routes.api.shared as shared_api
 
 DEFAULT_EVENT_DCID = ""
 
@@ -31,15 +32,15 @@ bp = Blueprint("event", __name__, url_prefix='/event')
 
 def get_properties(dcid):
   """Get and parse response from triples API.
-  
+
   Args:
     dcid: DCID of the node to get properties for
-  
+
   Returns:
     A list of properties and their values in the form of:
       {dcid: property_dcid, value: <nodes>}
     where <nodes> map to the "nodes" key in the triples API response.
-  
+
   The returned list is used to render property values in the event pages.
   """
   response = node_api.triples('out', dcid)

--- a/server/routes/factcheck.py
+++ b/server/routes/factcheck.py
@@ -14,7 +14,8 @@
 
 from flask import Blueprint
 from flask import render_template
-from lib.gcs import list_blobs
+
+from server.lib.gcs import list_blobs
 
 _MAX_BLOBS = 1
 _FC_FEEDS_BUCKET = 'datacommons-feeds'

--- a/server/routes/nl_interface.py
+++ b/server/routes/nl_interface.py
@@ -25,19 +25,20 @@ from flask import escape
 from flask import render_template
 from flask import request
 from google.protobuf.json_format import MessageToJson
-import lib.nl.data_spec as nl_data_spec
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import ContainedInPlaceType
-from lib.nl.detection import Detection
-from lib.nl.detection import NLClassifier
-from lib.nl.detection import Place
-from lib.nl.detection import PlaceDetection
-from lib.nl.detection import SimpleClassificationAttributes
-from lib.nl.detection import SVDetection
-import lib.nl.page_config as nl_page_config
-import lib.nl.utils as utils
 import requests
-import services.datacommons as dc
+
+import server.lib.nl.data_spec as nl_data_spec
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import ContainedInPlaceType
+from server.lib.nl.detection import Detection
+from server.lib.nl.detection import NLClassifier
+from server.lib.nl.detection import Place
+from server.lib.nl.detection import PlaceDetection
+from server.lib.nl.detection import SimpleClassificationAttributes
+from server.lib.nl.detection import SVDetection
+import server.lib.nl.page_config as nl_page_config
+import server.lib.nl.utils as utils
+import server.services.datacommons as dc
 
 bp = Blueprint('nl', __name__, url_prefix='/nl')
 

--- a/server/routes/nl_interface_next.py
+++ b/server/routes/nl_interface_next.py
@@ -25,21 +25,22 @@ from flask import escape
 from flask import render_template
 from flask import request
 from google.protobuf.json_format import MessageToJson
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import Detection
-from lib.nl.detection import NLClassifier
-from lib.nl.detection import Place
-from lib.nl.detection import PlaceDetection
-from lib.nl.detection import RANKED_CLASSIFICATION_TYPES
-from lib.nl.detection import SimpleClassificationAttributes
-from lib.nl.detection import SVDetection
-import lib.nl.fulfillment_next as fulfillment
-import lib.nl.page_config_next as nl_page_config
-import lib.nl.utils as utils
-import lib.nl.utterance as nl_utterance
-from lib.util import get_disaster_dashboard_configs
 import requests
-import services.datacommons as dc
+
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import Detection
+from server.lib.nl.detection import NLClassifier
+from server.lib.nl.detection import Place
+from server.lib.nl.detection import PlaceDetection
+from server.lib.nl.detection import RANKED_CLASSIFICATION_TYPES
+from server.lib.nl.detection import SimpleClassificationAttributes
+from server.lib.nl.detection import SVDetection
+import server.lib.nl.fulfillment_next as fulfillment
+import server.lib.nl.page_config_next as nl_page_config
+import server.lib.nl.utils as utils
+import server.lib.nl.utterance as nl_utterance
+from server.lib.util import get_disaster_dashboard_configs
+import server.services.datacommons as dc
 
 bp = Blueprint('nl_next', __name__, url_prefix='/nlnext')
 

--- a/server/routes/place.py
+++ b/server/routes/place.py
@@ -16,7 +16,8 @@
 import flask
 from flask import current_app
 from flask import g
-import routes.api.place as place_api
+
+import server.routes.api.place as place_api
 
 bp = flask.Blueprint('place', __name__, url_prefix='/place')
 

--- a/server/routes/placelist.py
+++ b/server/routes/placelist.py
@@ -14,11 +14,12 @@
 
 import collections
 
-from cache import cache
 from flask import Blueprint
 from flask import render_template
-from routes.api.place import child_fetch
-from services.datacommons import fetch_data
+
+from server.cache import cache
+from server.routes.api.place import child_fetch
+from server.services.datacommons import fetch_data
 
 # Define blueprint
 bp = Blueprint(

--- a/server/routes/protein.py
+++ b/server/routes/protein.py
@@ -19,7 +19,8 @@ import os
 import flask
 from flask import Blueprint
 from flask import render_template
-import routes.api.shared as shared_api
+
+import server.routes.api.shared as shared_api
 
 bp = Blueprint('protein', __name__, url_prefix='/bio/protein')
 

--- a/server/routes/ranking.py
+++ b/server/routes/ranking.py
@@ -14,7 +14,8 @@
 """Place Ranking related handlers."""
 
 import flask
-import routes.api.place as place_api
+
+import server.routes.api.place as place_api
 
 bp = flask.Blueprint('ranking', __name__, url_prefix='/ranking')
 

--- a/server/routes/search.py
+++ b/server/routes/search.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 """Data Commons search related routes."""
 
-import os
-
 import flask
 from flask import Blueprint
 from flask import current_app
 from flask import request
-import services.ai as ai
-import services.datacommons as dc
+
+import server.services.ai as ai
+import server.services.datacommons as dc
 
 bp = Blueprint('search', __name__)
 

--- a/server/routes/special_announcement.py
+++ b/server/routes/special_announcement.py
@@ -15,7 +15,8 @@
 
 from flask import Blueprint
 from flask import render_template
-from lib.gcs import list_blobs
+
+from server.lib.gcs import list_blobs
 
 _SA_FEED_BUCKET = 'datacommons-frog-feed'
 _MAX_BLOBS = 1

--- a/server/routes/static.py
+++ b/server/routes/static.py
@@ -20,7 +20,8 @@ import babel.dates as babel_dates
 from flask import Blueprint
 from flask import g
 from flask import render_template
-from services import datacommons as dc
+
+from server.services import datacommons as dc
 
 bp = Blueprint('static', __name__)
 

--- a/server/routes/topic_page.py
+++ b/server/routes/topic_page.py
@@ -19,8 +19,9 @@ import os
 import flask
 from flask import current_app
 from google.protobuf.json_format import MessageToJson
-import lib.util as libutil
-import routes.api.place as place_api
+
+import server.lib.util as libutil
+import server.routes.api.place as place_api
 
 bp = flask.Blueprint('topic_page', __name__, url_prefix='/topic')
 

--- a/server/routes/user.py
+++ b/server/routes/user.py
@@ -27,9 +27,10 @@ import google.auth.transport.requests
 from google.cloud import exceptions
 from google.cloud import storage
 from google.oauth2 import id_token
-import lib.util as libutil
 import requests
-import routes.api.user as user_api
+
+import server.lib.util as libutil
+import server.routes.api.user as user_api
 
 bp = Blueprint('user', __name__, url_prefix='/user')
 

--- a/server/services/ai.py
+++ b/server/services/ai.py
@@ -17,14 +17,15 @@ import json
 import logging
 import math
 import re
-from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple
+from typing import Iterator, Mapping, Optional, Sequence, Tuple
 
 import google.auth
 from google.cloud import language_v1
-import lib.config as libconfig
 import requests
-import services.datacommons as dc
 import yaml
+
+import server.lib.config as libconfig
+import server.services.datacommons as dc
 
 cfg = libconfig.get_config()
 

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -21,12 +21,13 @@ from typing import Dict, List
 import urllib.parse
 import zlib
 
-from cache import cache
 from flask import current_app
-import lib.config as libconfig
 import requests
-from services.discovery import get_health_check_urls
-from services.discovery import get_service_url
+
+from server.cache import cache
+import server.lib.config as libconfig
+from server.services.discovery import get_health_check_urls
+from server.services.discovery import get_service_url
 
 cfg = libconfig.get_config()
 

--- a/server/services/discovery.py
+++ b/server/services/discovery.py
@@ -29,8 +29,9 @@ Default behaviour:
 import itertools
 from typing import Dict, List, Union
 
-import lib.config as libconfig
 import yaml
+
+import server.lib.config as libconfig
 
 cfg = libconfig.get_config()
 

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -18,32 +18,33 @@ import logging
 import re
 from typing import Dict, List, Union
 
-import lib.nl.constants as constants
-from lib.nl.detection import BinaryClassificationResultType
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import ClusteringClassificationAttributes
-from lib.nl.detection import ComparisonClassificationAttributes
-from lib.nl.detection import ContainedInClassificationAttributes
-from lib.nl.detection import ContainedInPlaceType
-from lib.nl.detection import CorrelationClassificationAttributes
-from lib.nl.detection import EventClassificationAttributes
-from lib.nl.detection import EventType
-from lib.nl.detection import NLClassifier
-from lib.nl.detection import OverviewClassificationAttributes
-from lib.nl.detection import PeriodType
-from lib.nl.detection import RankingClassificationAttributes
-from lib.nl.detection import RankingType
-from lib.nl.detection import TemporalClassificationAttributes
-from lib.nl.detection import TimeDeltaClassificationAttributes
-from lib.nl.detection import TimeDeltaType
-from lib.nl.place_detection import NLPlaceDetector
-from lib.nl.training import NLQueryClassificationData
-from lib.nl.training import NLQueryClassificationModel
-from lib.nl.training import NLQueryClusteringDetectionModel
-import lib.nl.utils as utils
 import numpy as np
 import pandas as pd
-from services import datacommons as dc
+
+import server.lib.nl.constants as constants
+from server.lib.nl.detection import BinaryClassificationResultType
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import ClusteringClassificationAttributes
+from server.lib.nl.detection import ComparisonClassificationAttributes
+from server.lib.nl.detection import ContainedInClassificationAttributes
+from server.lib.nl.detection import ContainedInPlaceType
+from server.lib.nl.detection import CorrelationClassificationAttributes
+from server.lib.nl.detection import EventClassificationAttributes
+from server.lib.nl.detection import EventType
+from server.lib.nl.detection import NLClassifier
+from server.lib.nl.detection import OverviewClassificationAttributes
+from server.lib.nl.detection import PeriodType
+from server.lib.nl.detection import RankingClassificationAttributes
+from server.lib.nl.detection import RankingType
+from server.lib.nl.detection import TemporalClassificationAttributes
+from server.lib.nl.detection import TimeDeltaClassificationAttributes
+from server.lib.nl.detection import TimeDeltaType
+from server.lib.nl.place_detection import NLPlaceDetector
+from server.lib.nl.training import NLQueryClassificationData
+from server.lib.nl.training import NLQueryClassificationModel
+from server.lib.nl.training import NLQueryClusteringDetectionModel
+import server.lib.nl.utils as utils
+from server.services import datacommons as dc
 
 ALL_STOP_WORDS = utils.combine_stop_words()
 
@@ -541,7 +542,7 @@ class Model:
 
     Args:
       type_string: (str) This is the sentence classification type, e.g.
-        "ranking", "temporal", "contained_in". Full list is in lib.nl_training.py
+        "ranking", "temporal", "contained_in". Full list is in server.lib.nl_training.py
       query: (str) The query string supplied.
 
     Returns:

--- a/server/test_nlp_manual.py
+++ b/server/test_nlp_manual.py
@@ -23,7 +23,7 @@ import sys
 from typing import Dict, List, Optional
 import urllib.parse
 
-from main import app
+from web_app import app
 
 PALO_ALTO_DCID = 'geoId/0655282'
 BOSTON_DICD = 'geoId/2507000'

--- a/server/tests/chart_config_test.py
+++ b/server/tests/chart_config_test.py
@@ -16,8 +16,8 @@ import json
 import os
 import unittest
 
-import lib.range as lib_range
-import lib.util as lib_util
+import server.lib.range as lib_range
+import server.lib.util as lib_util
 
 
 class TestChart(unittest.TestCase):

--- a/server/tests/i18n_test.py
+++ b/server/tests/i18n_test.py
@@ -16,7 +16,8 @@ import unittest
 from unittest.mock import patch
 
 from flask import g
-from main import app
+
+from web_app import app
 
 
 class TestHlParamSelection(unittest.TestCase):
@@ -39,7 +40,7 @@ class TestHlParamSelection(unittest.TestCase):
       assert (g.locale == 'ru')
       assert (g.locale_choices == ['ru', 'en'])
 
-  @patch('lib.i18n.AVAILABLE_LANGUAGES', ['en', 'pt-br', 'pt'])
+  @patch('server.lib.i18n.AVAILABLE_LANGUAGES', ['en', 'pt-br', 'pt'])
   def test_complex_hl(self):
     with app.test_client() as c:
       c.get('/?hl=pt-BR')

--- a/server/tests/lib/config_test.py
+++ b/server/tests/lib/config_test.py
@@ -16,34 +16,35 @@ import os
 import unittest
 from unittest.mock import patch
 
-import lib.config as libconfig
 from parameterized import parameterized
 from werkzeug.utils import import_string
+
+import server.lib.config as libconfig
 
 
 class TestConfigModule(unittest.TestCase):
 
   @parameterized.expand([
-      ("production", "configmodule.ProductionConfig"),
-      ('staging', "configmodule.StagingConfig"),
-      ('autopush', "configmodule.AutopushConfig"),
-      ('dev', "configmodule.DevConfig"),
-      ('feedingamerica', "configmodule.FeedingamericaConfig"),
-      ('custom', "configmodule.CustomConfig"),
-      ('stanford', "configmodule.StanfordConfig"),
-      ('stanford-staging', "configmodule.StanfordStagingConfig"),
-      ('tidal', "configmodule.TidalConfig"),
-      ('iitm', "configmodule.IitmConfig"),
-      ('dev', "configmodule.DevConfig"),
-      ('test', "configmodule.TestConfig"),
-      ('webdriver', "configmodule.WebdriverConfig"),
-      ('minikube', "configmodule.MinikubeConfig"),
-      ('local', "configmodule.LocalConfig"),
-      ('local-lite', "configmodule.LocalLiteConfig"),
-      ('local-feedingamerica', "configmodule.LocalFeedingamericaConfig"),
-      ('local-stanford', "configmodule.LocalStanfordConfig"),
-      ('local-custom', "configmodule.LocalCustomConfig"),
-      ('local-iitm', "configmodule.LocalIitmConfig"),
+      ("production", "server.configmodule.ProductionConfig"),
+      ('staging', "server.configmodule.StagingConfig"),
+      ('autopush', "server.configmodule.AutopushConfig"),
+      ('dev', "server.configmodule.DevConfig"),
+      ('feedingamerica', "server.configmodule.FeedingamericaConfig"),
+      ('custom', "server.configmodule.CustomConfig"),
+      ('stanford', "server.configmodule.StanfordConfig"),
+      ('stanford-staging', "server.configmodule.StanfordStagingConfig"),
+      ('tidal', "server.configmodule.TidalConfig"),
+      ('iitm', "server.configmodule.IitmConfig"),
+      ('dev', "server.configmodule.DevConfig"),
+      ('test', "server.configmodule.TestConfig"),
+      ('webdriver', "server.configmodule.WebdriverConfig"),
+      ('minikube', "server.configmodule.MinikubeConfig"),
+      ('local', "server.configmodule.LocalConfig"),
+      ('local-lite', "server.configmodule.LocalLiteConfig"),
+      ('local-feedingamerica', "server.configmodule.LocalFeedingamericaConfig"),
+      ('local-stanford', "server.configmodule.LocalStanfordConfig"),
+      ('local-custom', "server.configmodule.LocalCustomConfig"),
+      ('local-iitm', "server.configmodule.LocalIitmConfig"),
   ])
   def test_config_string(self, env, expected):
     with patch.dict(os.environ, {

--- a/server/tests/lib/nl/fulfillment_next_test.py
+++ b/server/tests/lib/nl/fulfillment_next_test.py
@@ -17,33 +17,33 @@ from typing import Dict, List
 import unittest
 from unittest.mock import patch
 
-from lib.nl import fulfillment_next
-from lib.nl import utils
-from lib.nl import utterance
-from lib.nl import variable
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import ContainedInPlaceType
-from lib.nl.detection import Detection
-from lib.nl.detection import NLClassifier
-from lib.nl.detection import Place
-from lib.nl.detection import PlaceDetection
-from lib.nl.detection import RankingType
-from lib.nl.detection import SVDetection
-import lib.nl.detection as nl_detection
-from lib.nl.fulfillment import base
-from tests.lib.nl.test_utterance import COMPARISON_UTTR
-from tests.lib.nl.test_utterance import CONTAINED_IN_UTTR
-from tests.lib.nl.test_utterance import CORRELATION_UTTR
-from tests.lib.nl.test_utterance import EVENT_UTTR
-from tests.lib.nl.test_utterance import OVERVIEW_PLACE_ONLY_UTTR
-from tests.lib.nl.test_utterance import RANKING_ACROSS_PLACES_UTTR
-from tests.lib.nl.test_utterance import RANKING_ACROSS_SVS_UTTR
-from tests.lib.nl.test_utterance import SIMPLE_BAR_DOWNGRADE_UTTR
-from tests.lib.nl.test_utterance import SIMPLE_PLACE_ONLY_UTTR
-from tests.lib.nl.test_utterance import SIMPLE_UTTR
-from tests.lib.nl.test_utterance import SIMPLE_WITH_SV_EXT_UTTR
-from tests.lib.nl.test_utterance import SIMPLE_WITH_TOPIC_UTTR
-from tests.lib.nl.test_utterance import TIME_DELTA_UTTR
+from server.lib.nl import fulfillment_next
+from server.lib.nl import utils
+from server.lib.nl import utterance
+from server.lib.nl import variable
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import ContainedInPlaceType
+from server.lib.nl.detection import Detection
+from server.lib.nl.detection import NLClassifier
+from server.lib.nl.detection import Place
+from server.lib.nl.detection import PlaceDetection
+from server.lib.nl.detection import RankingType
+from server.lib.nl.detection import SVDetection
+import server.lib.nl.detection as nl_detection
+from server.lib.nl.fulfillment import base
+from server.tests.lib.nl.test_utterance import COMPARISON_UTTR
+from server.tests.lib.nl.test_utterance import CONTAINED_IN_UTTR
+from server.tests.lib.nl.test_utterance import CORRELATION_UTTR
+from server.tests.lib.nl.test_utterance import EVENT_UTTR
+from server.tests.lib.nl.test_utterance import OVERVIEW_PLACE_ONLY_UTTR
+from server.tests.lib.nl.test_utterance import RANKING_ACROSS_PLACES_UTTR
+from server.tests.lib.nl.test_utterance import RANKING_ACROSS_SVS_UTTR
+from server.tests.lib.nl.test_utterance import SIMPLE_BAR_DOWNGRADE_UTTR
+from server.tests.lib.nl.test_utterance import SIMPLE_PLACE_ONLY_UTTR
+from server.tests.lib.nl.test_utterance import SIMPLE_UTTR
+from server.tests.lib.nl.test_utterance import SIMPLE_WITH_SV_EXT_UTTR
+from server.tests.lib.nl.test_utterance import SIMPLE_WITH_TOPIC_UTTR
+from server.tests.lib.nl.test_utterance import TIME_DELTA_UTTR
 
 
 #

--- a/server/tests/lib/nl/heuristics_test.py
+++ b/server/tests/lib/nl/heuristics_test.py
@@ -15,12 +15,13 @@
 
 import unittest
 
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import EventType
-from lib.nl.detection import RankingType
-from lib.nl.detection import TimeDeltaType
 from parameterized import parameterized
-from services.nl import Model
+
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import EventType
+from server.lib.nl.detection import RankingType
+from server.lib.nl.detection import TimeDeltaType
+from server.services.nl import Model
 
 
 class TestHeuristicEventClassifier(unittest.TestCase):

--- a/server/tests/lib/nl/page_config_next_test.py
+++ b/server/tests/lib/nl/page_config_next_test.py
@@ -18,23 +18,24 @@ from typing import Dict
 import unittest
 from unittest.mock import patch
 
-from config.subject_page_pb2 import SubjectPageConfig
 from google.protobuf import text_format
-from lib.nl import page_config_next
-from lib.nl import topic
-from lib.nl import utils
-from lib.nl import utterance
 from parameterized import parameterized
-from tests.lib.nl.test_utterance import COMPARISON_UTTR
-from tests.lib.nl.test_utterance import CONTAINED_IN_UTTR
-from tests.lib.nl.test_utterance import CORRELATION_UTTR
-from tests.lib.nl.test_utterance import EVENT_UTTR
-from tests.lib.nl.test_utterance import RANKING_ACROSS_PLACES_UTTR
-from tests.lib.nl.test_utterance import RANKING_ACROSS_SVS_UTTR
-from tests.lib.nl.test_utterance import SIMPLE_PLACE_ONLY_UTTR
-from tests.lib.nl.test_utterance import SIMPLE_UTTR
-from tests.lib.nl.test_utterance import SIMPLE_WITH_SV_EXT_UTTR
-from tests.lib.nl.test_utterance import SIMPLE_WITH_TOPIC_UTTR
+
+from server.config.subject_page_pb2 import SubjectPageConfig
+from server.lib.nl import page_config_next
+from server.lib.nl import topic
+from server.lib.nl import utils
+from server.lib.nl import utterance
+from server.tests.lib.nl.test_utterance import COMPARISON_UTTR
+from server.tests.lib.nl.test_utterance import CONTAINED_IN_UTTR
+from server.tests.lib.nl.test_utterance import CORRELATION_UTTR
+from server.tests.lib.nl.test_utterance import EVENT_UTTR
+from server.tests.lib.nl.test_utterance import RANKING_ACROSS_PLACES_UTTR
+from server.tests.lib.nl.test_utterance import RANKING_ACROSS_SVS_UTTR
+from server.tests.lib.nl.test_utterance import SIMPLE_PLACE_ONLY_UTTR
+from server.tests.lib.nl.test_utterance import SIMPLE_UTTR
+from server.tests.lib.nl.test_utterance import SIMPLE_WITH_SV_EXT_UTTR
+from server.tests.lib.nl.test_utterance import SIMPLE_WITH_TOPIC_UTTR
 
 # TODO: Move these configs to test_data/*.textproto
 
@@ -512,7 +513,7 @@ RANKING_ACROSS_PLACES_CONFIG = """
  categories {
   description: "Here are some ranking tables about Count_Agricultural_Workers-name in Foo Place."
    blocks {
-     title: "Count_Agricultural_Workers-name"      
+     title: "Count_Agricultural_Workers-name"
      columns {
        tiles {
          title: "Count_Agricultural_Workers-name in Foo Place"

--- a/server/tests/lib/nl/place_detection_test.py
+++ b/server/tests/lib/nl/place_detection_test.py
@@ -16,8 +16,9 @@
 import unittest
 from unittest.mock import patch
 
-from lib.nl.place_detection import NLPlaceDetector
 from parameterized import parameterized
+
+from server.lib.nl.place_detection import NLPlaceDetector
 
 
 class TestPlaceDetector(unittest.TestCase):

--- a/server/tests/lib/nl/test_utterance.py
+++ b/server/tests/lib/nl/test_utterance.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 """Utterance JSONs for tests."""
 
-from lib.nl.detection import ClassificationType
-from lib.nl.detection import EventType
-from lib.nl.detection import RankingType
-from lib.nl.utterance import ChartOriginType
-from lib.nl.utterance import ChartType
-from lib.nl.utterance import TimeDeltaType
+from server.lib.nl.detection import ClassificationType
+from server.lib.nl.detection import EventType
+from server.lib.nl.detection import RankingType
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import TimeDeltaType
 
 # Utterance for Place Overview.
 SIMPLE_PLACE_ONLY_UTTR = {

--- a/server/tests/lib/nl/utils_test.py
+++ b/server/tests/lib/nl/utils_test.py
@@ -15,9 +15,10 @@
 
 import unittest
 
-import lib.nl.constants as constants
-import lib.nl.utils as utils
 from parameterized import parameterized
+
+import server.lib.nl.constants as constants
+import server.lib.nl.utils as utils
 
 
 class TestNLUtilsAddToSet(unittest.TestCase):

--- a/server/tests/lib/range_test.py
+++ b/server/tests/lib/range_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-import lib.range as lib_range
+import server.lib.range as lib_range
 
 
 class TestAggregate(unittest.TestCase):

--- a/server/tests/lib/subject_page_config_content_test.py
+++ b/server/tests/lib/subject_page_config_content_test.py
@@ -14,8 +14,8 @@
 
 import unittest
 
-from config import subject_page_pb2
-import lib.util as libutil
+from server.config import subject_page_pb2
+import server.lib.util as libutil
 
 TileType = subject_page_pb2.Tile.TileType
 BlockType = subject_page_pb2.Block.BlockType

--- a/server/tests/lib/subject_page_config_test.py
+++ b/server/tests/lib/subject_page_config_test.py
@@ -14,10 +14,11 @@
 
 import unittest
 
-from config import subject_page_pb2
 from google.protobuf import text_format
-import lib.subject_page_config as lib_subject_page_config
-import lib.util as lib_util
+
+from server.config import subject_page_pb2
+import server.lib.subject_page_config as lib_subject_page_config
+import server.lib.util as lib_util
 
 
 class TestGetAllVariables(unittest.TestCase):
@@ -37,7 +38,7 @@ class TestGetAllVariables(unittest.TestCase):
         'StandardizedPrecipitationIndex_Atmosphere_3MonthPeriod'
     ]
     config = lib_util.get_subject_page_config(
-        "tests/test_data/disaster.textproto")
+        "server/tests/test_data/disaster.textproto")
     assert sorted(lib_subject_page_config.get_all_variables(config)) == expected
 
 
@@ -45,7 +46,7 @@ class TestTrimConfig(unittest.TestCase):
 
   def test_trim_tiles(self):
     config = lib_util.get_subject_page_config(
-        "tests/test_data/disaster.textproto")
+        "server/tests/test_data/disaster.textproto")
     config = lib_subject_page_config.trim_config(
         config, "Count_fireEvent", subject_page_pb2.Tile.TileType.HISTOGRAM)
     config = lib_subject_page_config.trim_config(

--- a/server/tests/lib/util_test.py
+++ b/server/tests/lib/util_test.py
@@ -15,7 +15,7 @@
 import datetime
 import unittest
 
-import lib.util as lib_util
+import server.lib.util as lib_util
 
 
 class TestParseDate(unittest.TestCase):

--- a/server/tests/main_test.py
+++ b/server/tests/main_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from main import app
+from web_app import app
 
 
 class TestRoute(unittest.TestCase):

--- a/server/tests/routes/api/browser_test.py
+++ b/server/tests/routes/api/browser_test.py
@@ -16,7 +16,7 @@ import json
 import unittest
 from unittest.mock import patch
 
-from main import app
+from web_app import app
 
 
 class TestObservationId(unittest.TestCase):
@@ -35,7 +35,7 @@ class TestObservationId(unittest.TestCase):
         '/api/browser/observation-id?statVar=testStatVar&place=country/USA')
     assert no_date.status_code == 400
 
-  @patch('routes.api.browser.dc.query')
+  @patch('server.routes.api.browser.dc.query')
   def test_observation_node_dcid_returned(self, mock_query):
     expected_query = '''
 SELECT ?dcid ?mmethod ?obsPeriod
@@ -74,7 +74,7 @@ WHERE {
     assert response.status_code == 200
     assert json.loads(response.data) == expected_obs_id
 
-  @patch('routes.api.browser.dc.query')
+  @patch('server.routes.api.browser.dc.query')
   def test_with_optional_predicates(self, mock_query):
     expected_query = '''
 SELECT ?dcid ?mmethod ?obsPeriod

--- a/server/tests/routes/api/choropleth_test.py
+++ b/server/tests/routes/api/choropleth_test.py
@@ -16,15 +16,15 @@ import json
 import unittest
 from unittest.mock import patch
 
-from main import app
-import routes.api.choropleth as choropleth_api
-import routes.api.shared as shared_api
+import server.routes.api.choropleth as choropleth_api
+import server.routes.api.shared as shared_api
+from web_app import app
 
 
 class TestChoroplethPlaces(unittest.TestCase):
 
-  @patch('routes.api.choropleth.place_api.parent_places')
-  @patch('routes.api.choropleth.place_api.get_place_type')
+  @patch('server.routes.api.choropleth.place_api.parent_places')
+  @patch('server.routes.api.choropleth.place_api.get_place_type')
   def test_get_choropleth_display_level_has_display_level(
       self, mock_place_type, mock_parents):
     dcid = "test_dcid1"
@@ -33,8 +33,8 @@ class TestChoroplethPlaces(unittest.TestCase):
     result = choropleth_api.get_choropleth_display_level(dcid)
     assert result == (dcid, "AdministrativeArea1")
 
-  @patch('routes.api.choropleth.place_api.parent_places')
-  @patch('routes.api.choropleth.place_api.get_place_type')
+  @patch('server.routes.api.choropleth.place_api.parent_places')
+  @patch('server.routes.api.choropleth.place_api.get_place_type')
   def test_get_choropleth_display_level_equivalent_has_display_level(
       self, mock_place_type, mock_parents):
     dcid = "test_dcid2"
@@ -43,8 +43,8 @@ class TestChoroplethPlaces(unittest.TestCase):
     result = choropleth_api.get_choropleth_display_level(dcid)
     assert result == (dcid, "AdministrativeArea2")
 
-  @patch('routes.api.choropleth.place_api.parent_places')
-  @patch('routes.api.choropleth.place_api.get_place_type')
+  @patch('server.routes.api.choropleth.place_api.parent_places')
+  @patch('server.routes.api.choropleth.place_api.get_place_type')
   def test_get_choropleth_display_level_has_no_display_level(
       self, mock_place_type, mock_parents):
     dcid = "test_dcid3"
@@ -60,8 +60,8 @@ class TestChoroplethPlaces(unittest.TestCase):
     result = choropleth_api.get_choropleth_display_level(dcid)
     assert result == (None, None)
 
-  @patch('routes.api.choropleth.place_api.parent_places')
-  @patch('routes.api.choropleth.place_api.get_place_type')
+  @patch('server.routes.api.choropleth.place_api.parent_places')
+  @patch('server.routes.api.choropleth.place_api.get_place_type')
   def test_get_choropleth_display_level_parent_places(self, mock_place_type,
                                                       mock_parents):
     dcid = "test_dcid4"
@@ -77,8 +77,8 @@ class TestChoroplethPlaces(unittest.TestCase):
     result = choropleth_api.get_choropleth_display_level(dcid)
     assert result == (parent_dcid, "County")
 
-  @patch('routes.api.choropleth.place_api.parent_places')
-  @patch('routes.api.choropleth.place_api.get_place_type')
+  @patch('server.routes.api.choropleth.place_api.parent_places')
+  @patch('server.routes.api.choropleth.place_api.get_place_type')
   def test_get_choropleth_display_level_parent_has_equivalent(
       self, mock_place_type, mock_parents):
     dcid = "test_dcid5"
@@ -100,11 +100,11 @@ class TestChoroplethPlaces(unittest.TestCase):
     def side_effect(*args):
       return args[0]
 
-    @patch('routes.api.choropleth.dc.get_places_in')
-    @patch('routes.api.choropleth.coerce_geojson_to_righthand_rule')
-    @patch('routes.api.choropleth.dc.property_values')
-    @patch('routes.api.choropleth.place_api.get_display_name')
-    @patch('routes.api.choropleth.get_choropleth_display_level')
+    @patch('server.routes.api.choropleth.dc.get_places_in')
+    @patch('server.routes.api.choropleth.coerce_geojson_to_righthand_rule')
+    @patch('server.routes.api.choropleth.dc.property_values')
+    @patch('server.routes.api.choropleth.place_api.get_display_name')
+    @patch('server.routes.api.choropleth.get_choropleth_display_level')
     def test_get_geojson(self, mock_display_level, mock_display_name,
                          mock_geojson_values, mock_choropleth_helper,
                          mock_places):
@@ -138,10 +138,10 @@ class TestChoroplethPlaces(unittest.TestCase):
       assert len(response_data['features']) == 2
       assert len(response_data['properties']['current_geo']) == dcid1
 
-    @patch('routes.api.choropleth.dc.get_places_in')
-    @patch('routes.api.choropleth.coerce_geojson_to_righthand_rule')
-    @patch('routes.api.choropleth.dc.property_values')
-    @patch('routes.api.choropleth.place_api.get_display_name')
+    @patch('server.routes.api.choropleth.dc.get_places_in')
+    @patch('server.routes.api.choropleth.coerce_geojson_to_righthand_rule')
+    @patch('server.routes.api.choropleth.dc.property_values')
+    @patch('server.routes.api.choropleth.place_api.get_display_name')
     def test_get_geojson_with_place_type(self, mock_display_name,
                                          mock_geojson_values,
                                          mock_choropleth_helper, mock_places):
@@ -303,12 +303,12 @@ class TestChoroplethDataHelpers(unittest.TestCase):
 
 class TestChoroplethData(unittest.TestCase):
 
-  @patch('routes.api.choropleth.dc.get_places_in')
-  @patch('routes.api.choropleth.lib_util.point_within_core')
-  @patch('routes.api.choropleth.lib_util.series_core')
-  @patch('routes.api.choropleth.get_choropleth_display_level')
-  @patch('routes.api.choropleth.get_choropleth_configs')
-  @patch('routes.api.shared.get_stat_vars')
+  @patch('server.routes.api.choropleth.dc.get_places_in')
+  @patch('server.routes.api.choropleth.lib_util.point_within_core')
+  @patch('server.routes.api.choropleth.lib_util.series_core')
+  @patch('server.routes.api.choropleth.get_choropleth_display_level')
+  @patch('server.routes.api.choropleth.get_choropleth_configs')
+  @patch('server.routes.api.shared.get_stat_vars')
   def testRoute(self, mock_stat_vars, mock_configs, mock_display_level,
                 mock_denom_data, mock_num_data, mock_places_in):
     test_dcid = 'test_dcid'

--- a/server/tests/routes/api/csv_test.py
+++ b/server/tests/routes/api/csv_test.py
@@ -15,8 +15,8 @@
 import unittest
 from unittest import mock
 
-from main import app
-import tests.routes.api.mock_data as mock_data
+import server.tests.routes.api.mock_data as mock_data
+from web_app import app
 
 
 class TestGetStatsWithinPlaceCsv(unittest.TestCase):
@@ -44,8 +44,8 @@ class TestGetStatsWithinPlaceCsv(unittest.TestCase):
                                           })
     assert no_stat_vars.status_code == 400
 
-  @mock.patch('routes.api.csv.dc.obs_point_within')
-  @mock.patch('routes.api.csv.names')
+  @mock.patch('server.routes.api.csv.dc.obs_point_within')
+  @mock.patch('server.routes.api.csv.names')
   def test_single_date(self, mock_place_names, mock_point_within):
     expected_parent_place = "country/USA"
     expected_child_type = "State"
@@ -153,8 +153,8 @@ class TestGetStatsWithinPlaceCsv(unittest.TestCase):
         "geoId/06,California,2015,9931715,https://www.census.gov/programs-surveys/popest.html,2015,3.7,https://www.bls.gov/lau/\r\n"
     )
 
-  @mock.patch('routes.api.csv.dc.obs_series_within')
-  @mock.patch('routes.api.csv.names')
+  @mock.patch('server.routes.api.csv.dc.obs_series_within')
+  @mock.patch('server.routes.api.csv.names')
   def test_date_range(self, mock_place_names, mock_series_within):
     expected_parent_place = "country/USA"
     expected_child_type = "State"

--- a/server/tests/routes/api/detection_test.py
+++ b/server/tests/routes/api/detection_test.py
@@ -17,7 +17,7 @@ import json
 from typing import Any, List
 import unittest
 
-from main import app
+from web_app import app
 
 
 class TestDetection(unittest.TestCase):

--- a/server/tests/routes/api/disaster_test.py
+++ b/server/tests/routes/api/disaster_test.py
@@ -17,7 +17,7 @@ import json
 import unittest
 from unittest import mock
 
-from main import app
+from web_app import app
 
 TEST_PLACE_DCID = "Earth"
 TEST_EVENT_TYPE = "EarthquakeEvent"
@@ -157,7 +157,7 @@ EVENT_DATA_2 = {
 
 class TestGetDateRange(unittest.TestCase):
 
-  @mock.patch('routes.api.disaster_api.dc.get_event_collection_date')
+  @mock.patch('server.routes.api.disaster_api.dc.get_event_collection_date')
   def test_has_dates(self, mock_event_collection_date):
 
     def date_side_effect(event_type, affected_place):
@@ -176,7 +176,7 @@ class TestGetDateRange(unittest.TestCase):
     assert (response_data.get("maxDate") == DATE_LIST[-1])
     assert (response_data.get("minDate") == DATE_LIST[0])
 
-  @mock.patch('routes.api.disaster_api.dc.get_event_collection_date')
+  @mock.patch('server.routes.api.disaster_api.dc.get_event_collection_date')
   def test_no_dates(self, mock_event_collection_date):
 
     def date_side_effect(event_type, affected_place):
@@ -222,7 +222,7 @@ class TestGetDateRange(unittest.TestCase):
 
 class TestGetData(unittest.TestCase):
 
-  @mock.patch('routes.api.disaster_api.dc.get_event_collection')
+  @mock.patch('server.routes.api.disaster_api.dc.get_event_collection')
   def test_yyyy(self, mock_event_collection):
 
     def event_side_effect(event_type, affected_place, date, filter_prop,
@@ -251,7 +251,7 @@ class TestGetData(unittest.TestCase):
         }
     }
 
-  @mock.patch('routes.api.disaster_api.dc.get_event_collection')
+  @mock.patch('server.routes.api.disaster_api.dc.get_event_collection')
   def test_yyyy_no_data(self, mock_event_collection):
 
     def event_side_effect(event_type, affected_place, date, filter_prop,
@@ -271,7 +271,7 @@ class TestGetData(unittest.TestCase):
     assert response.status_code == 200
     assert json.loads(response.data) == {}
 
-  @mock.patch('routes.api.disaster_api.dc.get_event_collection')
+  @mock.patch('server.routes.api.disaster_api.dc.get_event_collection')
   def test_yyyymm(self, mock_event_collection):
 
     def event_side_effect(event_type, affected_place, date, filter_prop,
@@ -292,7 +292,7 @@ class TestGetData(unittest.TestCase):
     assert response.status_code == 200
     assert json.loads(response.data) == EVENT_DATA
 
-  @mock.patch('routes.api.disaster_api.dc.get_event_collection')
+  @mock.patch('server.routes.api.disaster_api.dc.get_event_collection')
   def test_yyyymm_no_data(self, mock_event_collection):
 
     def event_side_effect(event_type, affected_place, date, filter_prop,
@@ -311,7 +311,7 @@ class TestGetData(unittest.TestCase):
     assert response.status_code == 200
     assert json.loads(response.data) == {}
 
-  @mock.patch('routes.api.disaster_api.dc.get_event_collection')
+  @mock.patch('server.routes.api.disaster_api.dc.get_event_collection')
   def test_date_range(self, mock_event_collection):
 
     def event_side_effect(event_type, affected_place, date, filter_prop,
@@ -339,7 +339,7 @@ class TestGetData(unittest.TestCase):
         }
     }
 
-  @mock.patch('routes.api.disaster_api.dc.get_event_collection')
+  @mock.patch('server.routes.api.disaster_api.dc.get_event_collection')
   def test_with_filter(self, mock_event_collection):
 
     def event_side_effect(event_type, affected_place, date, filter_prop,

--- a/server/tests/routes/api/facets_test.py
+++ b/server/tests/routes/api/facets_test.py
@@ -15,8 +15,8 @@
 import unittest
 from unittest import mock
 
-from main import app
-import tests.routes.api.mock_data as mock_data
+import server.tests.routes.api.mock_data as mock_data
+from web_app import app
 
 
 class TestGetFacetsWithinPlace(unittest.TestCase):
@@ -44,7 +44,7 @@ class TestGetFacetsWithinPlace(unittest.TestCase):
                                          })
     assert no_stat_vars.status_code == 400
 
-  @mock.patch('routes.api.facets.dc.obs_point_within')
+  @mock.patch('server.routes.api.facets.dc.obs_point_within')
   def test_single_date(self, mock_point_within):
     expected_parent_place = "country/USA"
     expected_child_type = "State"
@@ -86,7 +86,7 @@ class TestGetFacetsWithinPlace(unittest.TestCase):
     assert single_date.status_code == 200
     assert single_date.data == b'{"Count_Person":{"2176550201":{"importName":"USCensusPEP_Annual_Population","measurementMethod":"CensusPEPSurvey","observationPeriod":"P1Y","provenanceUrl":"https://www2.census.gov/programs-surveys/popest/tables"},"2517965213":{"importName":"CensusPEP","measurementMethod":"CensusPEPSurvey","provenanceUrl":"https://www.census.gov/programs-surveys/popest.html"}},"UnemploymentRate_Person":{"2978659163":{"importName":"BLS_LAUS","measurementMethod":"BLSSeasonallyUnadjusted","observationPeriod":"P1Y","provenanceUrl":"https://www.bls.gov/lau/"}}}\n'
 
-  @mock.patch('routes.api.facets.dc.obs_series_within')
+  @mock.patch('server.routes.api.facets.dc.obs_series_within')
   def test_date_range(self, mock_series_within):
     expected_parent_place = "country/USA"
     expected_child_type = "State"

--- a/server/tests/routes/api/import_detection/date_detection_test.py
+++ b/server/tests/routes/api/import_detection/date_detection_test.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from typing import Any, List
 import unittest
 
-import routes.api.import_detection.date_detection as dd
+import server.routes.api.import_detection.date_detection as dd
 
 
 class TestDateDetection(unittest.TestCase):

--- a/server/tests/routes/api/import_detection/detection_test.py
+++ b/server/tests/routes/api/import_detection/detection_test.py
@@ -17,9 +17,9 @@ import json
 from typing import Dict, List, Optional
 import unittest
 
-import routes.api.import_detection.detection as detection
-from routes.api.import_detection.detection_types import Column
-from routes.api.import_detection.detection_types import DCProperty
+import server.routes.api.import_detection.detection as detection
+from server.routes.api.import_detection.detection_types import Column
+from server.routes.api.import_detection.detection_types import DCProperty
 
 
 class TestDetection(unittest.TestCase):

--- a/server/tests/routes/api/import_detection/place_detection_test.py
+++ b/server/tests/routes/api/import_detection/place_detection_test.py
@@ -16,11 +16,11 @@ from dataclasses import dataclass
 from typing import Dict, List
 import unittest
 
-from routes.api.import_detection.detection_types import DCProperty
-from routes.api.import_detection.detection_types import DCType
-from routes.api.import_detection.detection_types import TypeProperty
-import routes.api.import_detection.place_detection as pd
-import routes.api.import_detection.utils as utils
+from server.routes.api.import_detection.detection_types import DCProperty
+from server.routes.api.import_detection.detection_types import DCType
+from server.routes.api.import_detection.detection_types import TypeProperty
+import server.routes.api.import_detection.place_detection as pd
+import server.routes.api.import_detection.utils as utils
 
 
 class TestPlaceDetection(unittest.TestCase):

--- a/server/tests/routes/api/landing_page_test.py
+++ b/server/tests/routes/api/landing_page_test.py
@@ -18,9 +18,10 @@ from unittest.mock import patch
 
 from flask import Flask
 from flask_babel import Babel
-import lib.util as libutil
-from main import app
-import routes.api.landing_page as landing_page
+
+import server.lib.util as libutil
+import server.routes.api.landing_page as landing_page
+from web_app import app
 
 # TODO(shifucun): add test for api endpoint.
 
@@ -69,7 +70,7 @@ class TestBuildSpec(unittest.TestCase):
     }]
     with self.context:
       result = landing_page.build_spec(chart_config, target_category="Overview")
-      with open('tests/test_data/golden_config.json') as f:
+      with open('server/tests/test_data/golden_config.json') as f:
         expected = json.load(f)
         assert expected == result
 
@@ -82,7 +83,8 @@ class TestBuildSpec(unittest.TestCase):
       for topic, configs in topic_data.items():
         got[category][topic] = [c['title'] for c in configs]
     # Get expected text
-    with open('tests/test_data/golden_menu_text.json', encoding='utf-8') as f:
+    with open('server/tests/test_data/golden_menu_text.json',
+              encoding='utf-8') as f:
       expect = json.load(f)
       self.assertEqual(got, expect)
 
@@ -120,7 +122,7 @@ class TestI18n(unittest.TestCase):
         "geoId/0684536": {}
     }
 
-  @patch('routes.api.place.fetch_data')
+  @patch('server.routes.api.place.fetch_data')
   def test_child_places_i18n(self, mock_fetch_data):
     mock_fetch_data.side_effect = self.side_effect
 

--- a/server/tests/routes/api/place_test.py
+++ b/server/tests/routes/api/place_test.py
@@ -16,16 +16,14 @@ import json
 import unittest
 from unittest.mock import patch
 
-from main import app
-import routes.api.place as place_api
-from services import datacommons as dc
+from web_app import app
 
 
 class TestCoords2Places(unittest.TestCase):
 
-  @patch('routes.api.place.dc.resolve_coordinates')
-  @patch('routes.api.place.names')
-  @patch('routes.api.place.dc.property_values')
+  @patch('server.routes.api.place.dc.resolve_coordinates')
+  @patch('server.routes.api.place.names')
+  @patch('server.routes.api.place.dc.property_values')
   def test_get_places_for_coords(self, mock_property_values, mock_place_names,
                                  mock_resolve_coordinates):
     test_coordinates = [{

--- a/server/tests/routes/api/point_test.py
+++ b/server/tests/routes/api/point_test.py
@@ -16,8 +16,8 @@ import json
 import unittest
 from unittest import mock
 
-from main import app
-import tests.routes.api.mock_data as mock_data
+import server.tests.routes.api.mock_data as mock_data
+from web_app import app
 
 
 class TestApiPointWithin(unittest.TestCase):
@@ -45,7 +45,7 @@ class TestApiPointWithin(unittest.TestCase):
                                         })
     assert no_stat_var.status_code == 400
 
-  @mock.patch('services.datacommons.post')
+  @mock.patch('server.services.datacommons.post')
   def test_api_observations_point_within(self, post):
     result = {
         'data': {

--- a/server/tests/routes/api/series_test.py
+++ b/server/tests/routes/api/series_test.py
@@ -15,8 +15,8 @@ import json
 import unittest
 from unittest import mock
 
-from main import app
-import tests.routes.api.mock_data as mock_data
+import server.tests.routes.api.mock_data as mock_data
+from web_app import app
 
 
 class TestApiSeriesWithin(unittest.TestCase):
@@ -44,7 +44,7 @@ class TestApiSeriesWithin(unittest.TestCase):
                                         })
     assert no_stat_var.status_code == 400
 
-  @mock.patch('services.datacommons.post')
+  @mock.patch('server.services.datacommons.post')
   def test_api_observations_series_within_all(self, post):
     result = {
         'data': {

--- a/server/tests/routes/api/shared_test.py
+++ b/server/tests/routes/api/shared_test.py
@@ -15,12 +15,12 @@
 import unittest
 from unittest.mock import patch
 
-import routes.api.shared as shared
+import server.routes.api.shared as shared
 
 
 class TestNames(unittest.TestCase):
 
-  @patch('routes.api.shared.dc.property_values')
+  @patch('server.routes.api.shared.dc.property_values')
   def test_names(self, mock_property_values_func):
     dcid1 = 'geoId/06'
     dcid2 = 'geoId/07'

--- a/server/tests/routes/api/stats_test.py
+++ b/server/tests/routes/api/stats_test.py
@@ -16,12 +16,12 @@ import json
 import unittest
 from unittest import mock
 
-from main import app
+from web_app import app
 
 
 class TestApiStatsProperty(unittest.TestCase):
 
-  @mock.patch('services.datacommons.send_request')
+  @mock.patch('server.services.datacommons.send_request')
   def test_api_get_stats_property(self, send_request):
 
     def side_effect(req_url,
@@ -204,7 +204,7 @@ class TestApiStatsProperty(unittest.TestCase):
 
 class TestSearchStatVar(unittest.TestCase):
 
-  @mock.patch('routes.api.stats.dc.search_statvar')
+  @mock.patch('server.routes.api.stats.dc.search_statvar')
   def test_search_statvar_single_token(self, mock_search_result):
     expected_query = 'person'
     expected_places = ["geoId/06"]

--- a/server/tests/routes/api/varable_group_test.py
+++ b/server/tests/routes/api/varable_group_test.py
@@ -16,12 +16,12 @@ import json
 import unittest
 from unittest import mock
 
-from main import app
+from web_app import app
 
 
 class TestGetVariableGroupInfo(unittest.TestCase):
 
-  @mock.patch('routes.api.variable_group.dc.get_variable_group_info')
+  @mock.patch('server.routes.api.variable_group.dc.get_variable_group_info')
   def test_statvar_path(self, mock_result):
     expected_result = {
         "absoluteName":

--- a/server/tests/routes/api/variable_test.py
+++ b/server/tests/routes/api/variable_test.py
@@ -16,12 +16,12 @@ import json
 import unittest
 from unittest import mock
 
-from main import app
+from web_app import app
 
 
 class TestVariablePath(unittest.TestCase):
 
-  @mock.patch('routes.api.variable.dc.get_variable_ancestors')
+  @mock.patch('server.routes.api.variable.dc.get_variable_ancestors')
   def test_variable_path(self, mock_result):
 
     def side_effect(dcid):

--- a/server/tests/routes/browser_test.py
+++ b/server/tests/routes/browser_test.py
@@ -15,7 +15,7 @@
 import unittest
 from unittest.mock import patch
 
-from main import app
+from web_app import app
 
 
 class TestStaticPage(unittest.TestCase):
@@ -25,7 +25,7 @@ class TestStaticPage(unittest.TestCase):
     assert response.status_code == 200
     assert b"The Data Commons Graph is constructed by" in response.data
 
-  @patch('routes.api.shared.names')
+  @patch('server.routes.api.shared.names')
   def test_browser_node(self, mock_names):
     dcid = 'geoId/06'
     mock_names.return_value = {dcid: 'California'}

--- a/server/tests/routes/dev_test.py
+++ b/server/tests/routes/dev_test.py
@@ -15,7 +15,7 @@
 import unittest
 from unittest.mock import patch
 
-from main import app
+from web_app import app
 
 
 class TestRoute(unittest.TestCase):
@@ -24,7 +24,7 @@ class TestRoute(unittest.TestCase):
     response = app.test_client().get('/dev/')
     assert response.status_code == 200
 
-  @patch('routes.dev.list_png')
+  @patch('server.routes.dev.list_png')
   def test_screenshot(self, mock_list_png):
     mock_list_png.side_effect = (lambda bucket, prefix: [])
     response = app.test_client().get('/dev/screenshot/folder')

--- a/server/tests/routes/factcheck_test.py
+++ b/server/tests/routes/factcheck_test.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import unittest
 from unittest.mock import patch
 
-from main import app
+from web_app import app
 
 
 class TestRoute(unittest.TestCase):
@@ -33,7 +32,7 @@ class TestRoute(unittest.TestCase):
     response = app.test_client().get('/factcheck/blog')
     assert response.status_code == 200
 
-  @patch('routes.factcheck.list_blobs')
+  @patch('server.routes.factcheck.list_blobs')
   def test_download(self, mock_list_blobs):
     mock_list_blobs.side_effect = (lambda bucket, max_blobs: [])
     response = app.test_client().get('/factcheck/download')

--- a/server/tests/routes/import_wizard_test.py
+++ b/server/tests/routes/import_wizard_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from main import app
+from web_app import app
 
 
 class TestStaticPage(unittest.TestCase):

--- a/server/tests/routes/place_test.py
+++ b/server/tests/routes/place_test.py
@@ -16,12 +16,13 @@ import unittest
 from unittest.mock import patch
 
 from flask import request
-from main import app
+
+from web_app import app
 
 
 class TestPlaceLandingPage(unittest.TestCase):
 
-  @patch('routes.api.place.get_display_name')
+  @patch('server.routes.api.place.get_display_name')
   def test_place_landing(self, mock_get_display_name):
     mock_get_display_name.return_value = {
         'geoId/1714000': 'Chicago, IL',
@@ -60,8 +61,8 @@ class TestPlaceLandingPage(unittest.TestCase):
 
 class TestPlacePage(unittest.TestCase):
 
-  @patch('routes.api.place.get_i18n_name')
-  @patch('routes.api.place.get_place_type')
+  @patch('server.routes.api.place.get_i18n_name')
+  @patch('server.routes.api.place.get_place_type')
   def test_place(self, mock_get_place_type, mock_get_i18n_name):
     mock_get_i18n_name.return_value = {'geoId/06': 'California'}
     mock_get_place_type.return_value = 'State'

--- a/server/tests/routes/placelist_test.py
+++ b/server/tests/routes/placelist_test.py
@@ -15,12 +15,12 @@
 import unittest
 from unittest.mock import patch
 
-from main import app
+from web_app import app
 
 
 class TestRoute(unittest.TestCase):
 
-  @patch('routes.placelist.fetch_data')
+  @patch('server.routes.placelist.fetch_data')
   def test_index(self, mock_fetch_data):
     mock_response = {
         'Country': {
@@ -39,7 +39,7 @@ class TestRoute(unittest.TestCase):
     assert response.status_code == 200
     assert b'United States' in response.data
 
-  @patch('routes.placelist.child_fetch')
+  @patch('server.routes.placelist.child_fetch')
   def test_node(self, mock_child_fetch):
     mock_response = {
         'County': [{
@@ -67,7 +67,7 @@ class TestRoute(unittest.TestCase):
     response = app.test_client().get('/placelist/geoId/06')
     self.assertTrue(mock_child_fetch.assert_called_once)
 
-  @patch('routes.placelist.child_fetch')
+  @patch('server.routes.placelist.child_fetch')
   def test_no_child(self, mock_child_fetch):
     mock_child_fetch.return_value = {}
     response = app.test_client().get('/placelist/geoId/07')

--- a/server/tests/routes/redirects_test.py
+++ b/server/tests/routes/redirects_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from main import app
+from web_app import app
 
 
 class TestRedirects(unittest.TestCase):

--- a/server/tests/routes/search_test.py
+++ b/server/tests/routes/search_test.py
@@ -15,7 +15,7 @@
 import unittest
 from unittest.mock import patch
 
-from main import app
+from web_app import app
 
 
 class TestSearchPages(unittest.TestCase):
@@ -35,7 +35,7 @@ class TestSearchPages(unittest.TestCase):
     assert response.status_code == 200
     assert b"Search the Data Commons Graph" in response.data
 
-  @patch('services.datacommons.search')
+  @patch('server.services.datacommons.search')
   def test_search_dc_query(self, mock_dc_search):
     mock_dc_search.return_value = {
         'section': [{

--- a/server/tests/routes/special_announcement_test.py
+++ b/server/tests/routes/special_announcement_test.py
@@ -15,12 +15,12 @@
 import unittest
 from unittest.mock import patch
 
-from main import app
+from web_app import app
 
 
 class TestSpecialAnnouncementPages(unittest.TestCase):
 
-  @patch('routes.special_announcement.list_blobs')
+  @patch('server.routes.special_announcement.list_blobs')
   def test_special_announcement(self, mock_list_blobs):
     mock_list_blobs.side_effect = (lambda bucket, max_blobs: [])
     response = app.test_client().get('/special_announcement')

--- a/server/tests/routes/static_test.py
+++ b/server/tests/routes/static_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from main import app
+from web_app import app
 
 
 class TestStaticPages(unittest.TestCase):

--- a/server/tests/routes/tools_test.py
+++ b/server/tests/routes/tools_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from main import app
+from web_app import app
 
 
 class TestStaticPage(unittest.TestCase):

--- a/server/tests/services/discovery_test.py
+++ b/server/tests/services/discovery_test.py
@@ -14,10 +14,10 @@
 
 import unittest
 
-from services.discovery import configure_endpoints_from_ingress
-from services.discovery import DEFAULT_INGRESS_RULES
-from services.discovery import get_all_endpoint_paths
-from services.discovery import get_service_url
+from server.services.discovery import configure_endpoints_from_ingress
+from server.services.discovery import DEFAULT_INGRESS_RULES
+from server.services.discovery import get_all_endpoint_paths
+from server.services.discovery import get_service_url
 
 
 class TestServiceDiscovery(unittest.TestCase):
@@ -31,7 +31,8 @@ class TestServiceDiscovery(unittest.TestCase):
 
   def test_configure_endpoints_from_ingress_1(self):
     """Tests simple ingress configuration."""
-    configure_endpoints_from_ingress('tests/test_data/ingress/test1.yaml')
+    configure_endpoints_from_ingress(
+        'server/tests/test_data/ingress/test1.yaml')
 
     assert get_service_url('/query') == 'http://query-host:8080/query'
     assert get_service_url(
@@ -50,7 +51,8 @@ class TestServiceDiscovery(unittest.TestCase):
 
   def test_configure_endpoints_from_ingress_2(self):
     """Tests ingress configuration."""
-    configure_endpoints_from_ingress('tests/test_data/ingress/test2.yaml')
+    configure_endpoints_from_ingress(
+        'server/tests/test_data/ingress/test2.yaml')
 
     assert get_service_url(
         '/v1/bulk/observation-dates/linked'

--- a/server/webdriver_tests/base_test.py
+++ b/server/webdriver_tests/base_test.py
@@ -16,9 +16,10 @@ import multiprocessing
 import sys
 
 from flask_testing import LiveServerTestCase
-from main import app
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+
+from web_app import app
 
 # Explicitly set multiprocessing start method to 'fork' so tests work with
 # python3.8+ on MacOS.

--- a/server/webdriver_tests/screenshot/screenshot_test.py
+++ b/server/webdriver_tests/screenshot/screenshot_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-
-from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait

--- a/server/webdriver_tests/tests/browser_test.py
+++ b/server/webdriver_tests/tests/browser_test.py
@@ -18,8 +18,9 @@ import urllib.request
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
-import webdriver_tests.shared as shared
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
+import server.webdriver_tests.shared as shared
 
 MTV_URL = '/browser/geoId/0649670'
 CA_POPULATION_URL = '/browser/geoId/06?statVar=Count_Person'

--- a/server/webdriver_tests/tests/download_test.py
+++ b/server/webdriver_tests/tests/download_test.py
@@ -21,8 +21,9 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
-import webdriver_tests.shared as shared
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
+import server.webdriver_tests.shared as shared
 
 DOWNLOAD_URL = '/tools/download'
 PLACE_SEARCH_CA = 'California'

--- a/server/webdriver_tests/tests/homepage_test.py
+++ b/server/webdriver_tests/tests/homepage_test.py
@@ -15,7 +15,8 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
 
 
 class TestPlaceLanding(WebdriverBaseTest):

--- a/server/webdriver_tests/tests/map_test.py
+++ b/server/webdriver_tests/tests/map_test.py
@@ -18,8 +18,9 @@ import urllib.request
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
-import webdriver_tests.shared as shared
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
+import server.webdriver_tests.shared as shared
 
 MAP_URL = '/tools/map'
 URL_HASH_1 = '#&sv=Median_Age_Person&pc=0&pd=geoId/06&pn=California&pt=State&ept=County'

--- a/server/webdriver_tests/tests/place_explorer_i18n_test.py
+++ b/server/webdriver_tests/tests/place_explorer_i18n_test.py
@@ -15,7 +15,8 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
 
 
 class TestPlaceI18nExplorer(WebdriverBaseTest):

--- a/server/webdriver_tests/tests/place_explorer_test.py
+++ b/server/webdriver_tests/tests/place_explorer_test.py
@@ -17,7 +17,8 @@ import urllib.request
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
 
 MTV_URL = '/place/geoId/0649670'
 USA_URL = '/place/country/USA'

--- a/server/webdriver_tests/tests/place_landing_test.py
+++ b/server/webdriver_tests/tests/place_landing_test.py
@@ -15,7 +15,8 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
 
 
 class TestPlaceLanding(WebdriverBaseTest):

--- a/server/webdriver_tests/tests/ranking_test.py
+++ b/server/webdriver_tests/tests/ranking_test.py
@@ -15,7 +15,8 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
 
 
 class TestRanking(WebdriverBaseTest):

--- a/server/webdriver_tests/tests/scatter_test.py
+++ b/server/webdriver_tests/tests/scatter_test.py
@@ -20,8 +20,9 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
-import webdriver_tests.shared as shared
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
+import server.webdriver_tests.shared as shared
 
 SCATTER_URL = '/tools/scatter'
 URL_HASH_1 = '#&svx=Median_Income_Person&svpx=0-3&svnx=Median_income&svy='\

--- a/server/webdriver_tests/tests/timeline_test.py
+++ b/server/webdriver_tests/tests/timeline_test.py
@@ -19,8 +19,9 @@ import urllib.request
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from webdriver_tests.base_test import WebdriverBaseTest
-import webdriver_tests.shared as shared
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
+import server.webdriver_tests.shared as shared
 
 TIMELINE_URL = '/tools/timeline'
 URL_HASH_1 = '#&statsVar=Median_Age_Person__Median_Income_Person__Count_Person_Upto5Years'\

--- a/web_app.py
+++ b/web_app.py
@@ -17,17 +17,13 @@ This module contains the request handler codes and the main app.
 """
 
 import logging
-import os
 import sys
 import threading
 import time
 
-from __init__ import create_app
-import flask
-from flask import request
 import requests
-import services.datacommons as dc
-from services.discovery import configure_endpoints_from_ingress
+
+from server.__init__ import create_app
 
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
This is a better practice for reusing packages across apps and allows to have both web and nl Flask apps in the same testing.

Repo module imports now are grouped together and much easier to navigate.