### PR TITLE
[Disaster Dashboard] Add dates to storm top events

### DIFF
--- a/server/config/disaster_dashboard/Earth.textproto
+++ b/server/config/disaster_dashboard/Earth.textproto
@@ -400,6 +400,7 @@ categories {
         title: "Most severe cyclones"
         top_event_tile_spec {
           event_type_key: "storm"
+          show_start_date: true
         }
       }
     }

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -155,9 +155,10 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
                         props.topEventMetadata.showEndDate) && (
                         <td>
                           {props.topEventMetadata.showStartDate &&
-                            event.startDate}
+                            formatDateString(event.startDate)}
                           {showDateRange && " to "}
-                          {props.topEventMetadata.showEndDate && event.endDate}
+                          {props.topEventMetadata.showEndDate &&
+                            formatDateString(event.endDate)}
                         </td>
                       )}
                       {props.topEventMetadata.displayProp &&
@@ -312,5 +313,14 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
       }
     }
     return name;
+  }
+
+  /**
+   * Given a string containing a datetime in ISO 8601 format, return only the
+   * date portion, without the time portion.
+   * @param dateString date in ISO 8601 format
+   */
+  function formatDateString(dateString: string): string {
+    return dateString.slice(0, "YYYY-MM-DD".length);
   }
 }


### PR DESCRIPTION
Adds dates to the top event tile for storms

Screenshot:
<img width="1373" alt="Screenshot 2023-02-09 at 2 32 22 PM" src="https://user-images.githubusercontent.com/4034366/217954618-8d5b4bd6-3b53-49b9-bcda-9351b2a04cc0.png">


Also confirmed changes don't break any of the other top event tiles:
<img width="1381" alt="Screenshot 2023-02-09 at 2 31 10 PM" src="https://user-images.githubusercontent.com/4034366/217954663-cd95ceb9-8684-42f4-8c0f-5bc53d8e4898.png">
<img width="1363" alt="Screenshot 2023-02-09 at 2 31 21 PM" src="https://user-images.githubusercontent.com/4034366/217954673-accebd0f-f3e2-4f4b-82b3-bc2d6babb3ec.png">
<img width="1384" alt="Screenshot 2023-02-09 at 2 31 33 PM" src="https://user-images.githubusercontent.com/4034366/217954690-5c8b89fc-d078-48b5-bf8d-d8f873b49f20.png">
<img width="1369" alt="Screenshot 2023-02-09 at 2 31 43 PM" src="https://user-images.githubusercontent.com/4034366/217954697-5423e5cc-19fa-403f-86fc-edae45eea201.png">
<img width="1369" alt="Screenshot 2023-02-09 at 2 31 51 PM" src="https://user-images.githubusercontent.com/4034366/217954709-4754f0fc-506f-4094-8355-3e9be45cc1d8.png">
<img width="1366" alt="Screenshot 2023-02-09 at 2 31 59 PM" src="https://user-images.githubusercontent.com/4034366/217954726-1a6abc23-abb2-43be-9f2a-ba9cc555b6a0.png">
