### PR TITLE
Show full date range in histogram tile

### DIFF
--- a/static/js/components/tiles/histogram_tile.tsx
+++ b/static/js/components/tiles/histogram_tile.tsx
@@ -67,10 +67,7 @@ function getLastDayOfMonth(dateString: string): string {
  * Helper function for getting all months along x-axis to display.
  * Used for initializing bins when binning monthly.
  */
-function getMonthsArray(
-  dateSetting: string,
-  disasterEventPoints: DisasterEventPoint[]
-): string[] {
+function getMonthsArray(dateSetting: string): string[] {
   // get start and end of dates to show data for
   let [startDate, endDate] = getDateRange(dateSetting);
 
@@ -86,20 +83,6 @@ function getMonthsArray(
     endDate = `${getLastDayOfMonth(endDate)}`;
   }
 
-  // Update end date to the latest date we have data for, if our data ends
-  // before the end of the date range. This prevents us from incorrectly
-  // imputing 0s for dates the source(s) may not yet have data for.
-  if (!_.isEmpty(disasterEventPoints)) {
-    // Sort events into chronological order
-    disasterEventPoints.sort((a, b) =>
-      a.startDate < b.startDate ? -1 : a.startDate > b.startDate ? 1 : 0
-    );
-    const lastDate =
-      disasterEventPoints[disasterEventPoints.length - 1].startDate;
-    if (lastDate < endDate) {
-      endDate = lastDate;
-    }
-  }
   // Fill in months between start and end dates
   const months = new Array<string>();
   for (
@@ -127,7 +110,7 @@ function binDataByMonth(
   const bins = new Map<string, number>();
 
   // Initialize all bins at zero
-  const monthsToPlot = getMonthsArray(dateSetting, disasterEventPoints);
+  const monthsToPlot = getMonthsArray(dateSetting);
   for (const month of monthsToPlot) {
     bins.set(month, 0);
   }


### PR DESCRIPTION
Removes logic that truncates histogram to the last date we have data for. This makes the histograms show bars for every month in the range. As a nice side effect, all histogram bars will have the same width if the same time setting is used.

Before ("last year" setting):
![Screenshot 2023-02-13 at 10 22 30 AM](https://user-images.githubusercontent.com/4034366/218542560-4c18cb9b-a70f-44e3-8a44-f57b5220171f.png)
![Screenshot 2023-02-13 at 10 22 39 AM](https://user-images.githubusercontent.com/4034366/218542568-cc738fe4-7f83-419d-882b-f35a2b51a622.png)

After ("last year" setting):
![Screenshot 2023-02-13 at 10 23 40 AM](https://user-images.githubusercontent.com/4034366/218542729-2fef004c-ca7b-47d3-a7e4-18ce4579681c.png)
![Screenshot 2023-02-13 at 10 23 49 AM](https://user-images.githubusercontent.com/4034366/218542735-4e2be8a4-d817-478b-98f1-3bf74af0a750.png)
