### PR TITLE
[disaster] small ui fixes

### DIFF
--- a/server/config/disaster_dashboard/Earth.textproto
+++ b/server/config/disaster_dashboard/Earth.textproto
@@ -440,7 +440,7 @@ categories {
       }
       tiles {
         type: HISTOGRAM
-        title: "Number of wet bulb events"
+        title: "Number of wet bulb temperature events"
         histogram_tile_spec {
           event_type_key: "wetbulb"
         }
@@ -454,7 +454,7 @@ categories {
     columns {
       tiles {
         type: TOP_EVENT
-        title: "Most severe wet bulb"
+        title: "Most severe wet bulb events"
         top_event_tile_spec {
           event_type_key: "wetbulb"
           show_start_date: true

--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -26,6 +26,7 @@ $chart-container-top-margin: 20px;
 $highlight-font-family: base.$headings-font-family;
 $border: 1px solid rgba(0, 0, 0, 0.125);
 $border-radius: 0.5rem;
+$box-shadow-8dp: 0 8px 10px 1px rgba(0, 0, 0, .14), 0 3px 14px 2px rgba(0, 0, 0, .12), 0 5px 5px -3px rgba(0, 0, 0, .4);
 
 .chart-container {
   margin-top: $chart-container-top-margin;
@@ -226,9 +227,10 @@ $border-radius: 0.5rem;
     position: absolute;
     border: $border;
     background-color: white;
-    max-width: 15rem;
+    max-width: 18rem;
     max-height: 15rem;
     overflow-y: auto;
+    box-shadow: $box-shadow-8dp;
   }
   
   .disaster-event-map-info-card-content {
@@ -236,12 +238,12 @@ $border-radius: 0.5rem;
     word-break: break-word;
     font-size: 0.9rem;
   }
- 
+
   .disaster-event-map-info-card-header {
     display: flex;
     justify-content: space-between;
     margin-bottom: 0.5rem;
-    font-size: 1rem;
+    font-size: 0.9rem;
   }
   
   .disaster-event-map-info-card-title {
@@ -256,6 +258,10 @@ $border-radius: 0.5rem;
   .disaster-event-map-info-card-header i {
     margin-left: 0.5rem;
     cursor: default;
+  }
+
+  .disaster-event-map-info-card-footer {
+    margin-top: .5rem;
   }
 
   svg {

--- a/static/js/components/tiles/disaster_event_map_info_card.tsx
+++ b/static/js/components/tiles/disaster_event_map_info_card.tsx
@@ -16,7 +16,7 @@
 
 /**
  * Component for the content of the info card.
- * TODO: Use display properties from spec.
+ * TODO: Use display properties & unit from spec.
  */
 import React from "react";
 

--- a/static/js/components/tiles/disaster_event_map_info_card.tsx
+++ b/static/js/components/tiles/disaster_event_map_info_card.tsx
@@ -33,7 +33,6 @@ interface DisasterEventMapInfoCardPropType {
 export function DisasterEventMapInfoCard(
   props: DisasterEventMapInfoCardPropType
 ): JSX.Element {
-  debugger;
   return (
     <div className="disaster-event-map-info-card-content">
       <div className="disaster-event-map-info-card-header">

--- a/static/js/components/tiles/disaster_event_map_info_card.tsx
+++ b/static/js/components/tiles/disaster_event_map_info_card.tsx
@@ -20,8 +20,8 @@
  */
 import React from "react";
 
-import { formatNumber } from "../../utils/string_utils";
 import { DisasterEventPoint } from "../../types/disaster_event_map_types";
+import { formatNumber } from "../../utils/string_utils";
 
 interface DisasterEventMapInfoCardPropType {
   // The event data to show info about

--- a/static/js/components/tiles/disaster_event_map_info_card.tsx
+++ b/static/js/components/tiles/disaster_event_map_info_card.tsx
@@ -16,9 +16,11 @@
 
 /**
  * Component for the content of the info card.
+ * TODO: Use display properties from spec.
  */
 import React from "react";
 
+import { formatNumber } from "../../utils/string_utils";
 import { DisasterEventPoint } from "../../types/disaster_event_map_types";
 
 interface DisasterEventMapInfoCardPropType {
@@ -31,6 +33,7 @@ interface DisasterEventMapInfoCardPropType {
 export function DisasterEventMapInfoCard(
   props: DisasterEventMapInfoCardPropType
 ): JSX.Element {
+  debugger;
   return (
     <div className="disaster-event-map-info-card-content">
       <div className="disaster-event-map-info-card-header">
@@ -47,16 +50,24 @@ export function DisasterEventMapInfoCard(
           <span>End Date: {props.eventData.endDate}</span>
         )}
         {props.eventData.severity &&
-          Object.keys(props.eventData.severity).map((prop) => {
+          Object.keys(props.eventData.displayProps).map((prop) => {
             return (
               <span key={prop}>
-                {prop}: {props.eventData.severity[prop]}
+                {prop}: {formatNumber(props.eventData.severity[prop])}
               </span>
             );
           })}
-        <span>
-          <a href={`/browser/${props.eventData.placeDcid}`}>More info</a>
-        </span>
+        {props.eventData.severity &&
+          Object.keys(props.eventData.severity).map((prop) => {
+            return (
+              <span key={prop}>
+                {prop}: {formatNumber(props.eventData.severity[prop])}
+              </span>
+            );
+          })}
+      </div>
+      <div className="disaster-event-map-info-card-footer">
+        <a href={`/browser/${props.eventData.placeDcid}`}>More info</a>
       </div>
     </div>
   );

--- a/static/js/components/tiles/disaster_event_map_info_card.tsx
+++ b/static/js/components/tiles/disaster_event_map_info_card.tsx
@@ -48,11 +48,11 @@ export function DisasterEventMapInfoCard(
         {props.eventData.endDate && (
           <span>End Date: {props.eventData.endDate}</span>
         )}
-        {props.eventData.severity &&
+        {props.eventData.displayProps &&
           Object.keys(props.eventData.displayProps).map((prop) => {
             return (
               <span key={prop}>
-                {prop}: {formatNumber(props.eventData.severity[prop])}
+                {prop}: {formatNumber(props.eventData.displayProps[prop])}
               </span>
             );
           })}

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -91,7 +91,6 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
     MIN_PERCENT_PLACE_NAMES;
   const showNameColumn =
     topEvents.filter((event) => !isUnnamedEvent(event.placeName)).length > 0;
-  const addLinkToDate = !showNameColumn && !showPlaceColumn;
 
   return (
     <div
@@ -137,18 +136,16 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
                       )}
                       {showPlaceColumn && (
                         <td>
-                          {showNameColumn ? (
-                            placeName
-                          ) : (
-                            addEventLink(event.placeDcid, placeName)
-                          )}
+                          {showNameColumn
+                            ? placeName
+                            : addEventLink(event.placeDcid, placeName)}
                         </td>
                       )}
                       {displayDate && (
                         <td>
-                          {(!showNameColumn && !showPlaceColumn) ?
-                          addEventLink(event.placeDcid, displayDate) :
-                          displayDate}
+                          {!showNameColumn && !showPlaceColumn
+                            ? addEventLink(event.placeDcid, displayDate)
+                            : displayDate}
                         </td>
                       )}
                       {props.topEventMetadata.displayProp &&
@@ -315,23 +312,19 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
   }
 
   function addEventLink(eventId: string, displayStr: string): JSX.Element {
-    return (
-      <a href={`/browser/${eventId}`}>
-        {displayStr}
-      </a>
-    );
+    return <a href={`/browser/${eventId}`}>{displayStr}</a>;
   }
 
   function getDisplayDate(event: DisasterEventPoint): string {
-    let ret = '';
+    let ret = "";
     if (props.topEventMetadata.showStartDate && event.startDate) {
       ret += formatDateString(event.startDate);
       if (props.topEventMetadata.showEndDate && event.endDate) {
-        ret += ' - ';
+        ret += " - ";
       }
     }
     if (props.topEventMetadata.showEndDate && event.endDate) {
-      ret += formatDateString(event.endDate)
+      ret += formatDateString(event.endDate);
     }
     return ret;
   }

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -91,6 +91,7 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
     MIN_PERCENT_PLACE_NAMES;
   const showNameColumn =
     topEvents.filter((event) => !isUnnamedEvent(event.placeName)).length > 0;
+  const addLinkToDate = !showNameColumn && !showPlaceColumn;
 
   return (
     <div
@@ -125,19 +126,13 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
                   const placeName = eventPlaces[event.placeDcid]
                     ? eventPlaces[event.placeDcid].name
                     : "N/A";
-                  const showDateRange =
-                    props.topEventMetadata.showStartDate &&
-                    props.topEventMetadata.showEndDate &&
-                    event.endDate &&
-                    event.startDate;
+                  const displayDate = getDisplayDate(event);
                   return (
                     <tr key={i}>
                       <td className="rank">{i + 1}</td>
                       {showNameColumn && (
                         <td>
-                          <a href={`/browser/${event.placeDcid}`}>
-                            {getEventName(event)}
-                          </a>
+                          {addEventLink(event.placeDcid, getEventName(event))}
                         </td>
                       )}
                       {showPlaceColumn && (
@@ -145,20 +140,15 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
                           {showNameColumn ? (
                             placeName
                           ) : (
-                            <a href={`/browser/${event.placeDcid}`}>
-                              {placeName}
-                            </a>
+                            addEventLink(event.placeDcid, placeName)
                           )}
                         </td>
                       )}
-                      {(props.topEventMetadata.showStartDate ||
-                        props.topEventMetadata.showEndDate) && (
+                      {displayDate && (
                         <td>
-                          {props.topEventMetadata.showStartDate &&
-                            formatDateString(event.startDate)}
-                          {showDateRange && " to "}
-                          {props.topEventMetadata.showEndDate &&
-                            formatDateString(event.endDate)}
+                          {(!showNameColumn && !showPlaceColumn) ?
+                          addEventLink(event.placeDcid, displayDate) :
+                          displayDate}
                         </td>
                       )}
                       {props.topEventMetadata.displayProp &&
@@ -322,5 +312,27 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
    */
   function formatDateString(dateString: string): string {
     return dateString.slice(0, "YYYY-MM-DD".length);
+  }
+
+  function addEventLink(eventId: string, displayStr: string): JSX.Element {
+    return (
+      <a href={`/browser/${eventId}`}>
+        {displayStr}
+      </a>
+    );
+  }
+
+  function getDisplayDate(event: DisasterEventPoint): string {
+    let ret = '';
+    if (props.topEventMetadata.showStartDate && event.startDate) {
+      ret += formatDateString(event.startDate);
+      if (props.topEventMetadata.showEndDate && event.endDate) {
+        ret += ' - ';
+      }
+    }
+    if (props.topEventMetadata.showEndDate && event.endDate) {
+      ret += formatDateString(event.endDate)
+    }
+    return ret;
   }
 }

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -320,7 +320,7 @@ export function TopEventTile(props: TopEventTilePropType): JSX.Element {
     if (props.topEventMetadata.showStartDate && event.startDate) {
       ret += formatDateString(event.startDate);
       if (props.topEventMetadata.showEndDate && event.endDate) {
-        ret += " - ";
+        ret += " — ";
       }
     }
     if (props.topEventMetadata.showEndDate && event.endDate) {

--- a/static/js/utils/disaster_event_map_utils.tsx
+++ b/static/js/utils/disaster_event_map_utils.tsx
@@ -47,7 +47,6 @@ import {
   MapPointsData,
 } from "../types/disaster_event_map_types";
 import {
-  EventDisplayProp,
   EventTypeSpec,
   SeverityFilter,
 } from "../types/subject_page_proto_types";

--- a/static/js/utils/string_utils.ts
+++ b/static/js/utils/string_utils.ts
@@ -105,6 +105,9 @@ export function formatNumber(
   useDefaultFormat?: boolean,
   numFractionDigits?: number
 ): string {
+  if (isNaN(value)) {
+    return "-";
+  }
   if (useDefaultFormat) {
     return Intl.NumberFormat("en-US").format(value);
   }


### PR DESCRIPTION
top event tile:
- add links to dates if place & name are not available
- don't show NaN

event map info card:
- add box shadow
- only show 3 significant digits
- don't show NaN
- TODO: bring in event spec so we can use display name & units

![image](https://user-images.githubusercontent.com/6052978/218563220-f352ed2c-104b-47fa-85a4-24395b63d945.png)
![image](https://user-images.githubusercontent.com/6052978/218563456-40ce1f69-b820-4b1d-ad06-cb49e8503d74.png)
