### PR TITLE
Fix google maps scrolling issue

### DIFF
--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -342,7 +342,7 @@ $box-shadow-8dp: 0 8px 10px 1px rgba(0, 0, 0, .14), 0 3px 14px 2px rgba(0, 0, 0,
   }
 }
 
-#map-container {
+.map-container {
   height: 100%;
   min-height: 200px;
 }

--- a/static/js/components/google_map.tsx
+++ b/static/js/components/google_map.tsx
@@ -96,16 +96,10 @@ function drawKmlCoordinates(
   // Adjust map bounds
   const sw = new google.maps.LatLng(mapInfo.down, mapInfo.left);
   const ne = new google.maps.LatLng(mapInfo.up, mapInfo.right);
-  const bounds = new google.maps.LatLngBounds();
-  bounds.extend(sw);
-  bounds.extend(ne);
-
-  // add listener to set bounds after map finishes loading.
-  // fitting bounds needs to be called after map finishes loading
-  // otherwise, the map will zoom all the way out to earth.
-  map.addListener("idle", () => {
-    map.fitBounds(bounds, MAP_BOUNDS_PADDING);
-  });
+  let bounds = new google.maps.LatLngBounds();
+  bounds = bounds.extend(sw);
+  bounds = bounds.extend(ne);
+  map.fitBounds(bounds, MAP_BOUNDS_PADDING);
 
   // Add polygons
   if (mapInfo.coordinateSequenceSet) {


### PR DESCRIPTION
After PR #2189, google map tiles with KML coordinates drawn don't let the user scroll or pan.

This PR removes the listener added as a quick-fix, and instead fixes a CSS bug that caused map heights to sometimes be set to 0.

Before:

https://user-images.githubusercontent.com/4034366/219223889-0125501a-70d1-42c0-b91a-a4750ed525bb.mov


After:

https://user-images.githubusercontent.com/4034366/219223926-39c46b17-2ead-406e-a728-f0d7d05d4121.mov


Also tested the changes on the following pages:

Place pages:
* San Francisco City
* California
* USA (no maps expected)
* India (no maps expected)

Browser pages:
* Mountain View
* Santa Clara County
* Alaska
* India

NL interface:
* "Tell me about palo alto"
* "Tell me about Santa Clara County"
* "Tell me about Nebraska"
* "Tell me about USA"