### PR TITLE
[NL Interface] Adding continent names to special cases

### DIFF
--- a/nl_server/tests/ner_place_model_test.py
+++ b/nl_server/tests/ner_place_model_test.py
@@ -50,6 +50,7 @@ class TestNERPlaces(unittest.TestCase):
   @parameterized.expand([
       # All these queries should detect places.
       # Starting with several special cases (continents, US etc).
+      ["GDP of Africa", ["africa"]],
       ["median income in africa", ["africa"]],
       ["GDP of countries in asia", ["asia"]],
       ["economy of Asia", ["asia"]],

--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -155,8 +155,10 @@ STOP_WORDS: Set[str] = {
 
 # TODO: remove this special casing when a better NER model is identified which
 # can always detect these.
-OVERRIDE_FOR_NER: FrozenSet[str] = frozenset(
-    ['palo alto', 'mountain view', 'world', 'earth', 'oceania'])
+OVERRIDE_FOR_NER: FrozenSet[str] = frozenset([
+    'palo alto', 'mountain view', 'world', 'earth', 'africa', 'antarctica',
+    'asia', 'europe', 'north america', 'south america', 'oceania'
+])
 
 SPECIAL_PLACE_REPLACEMENTS: Dict[str, str] = {'us': 'United States'}
 


### PR DESCRIPTION
NER does an Ok job in recognizing continent names. But to guard against any missed detection (for such important places like continents), adding continent names to special cases.