### PR TITLE
[disasters] use own place geojson if children are missing

### DIFF
--- a/server/routes/api/choropleth.py
+++ b/server/routes/api/choropleth.py
@@ -244,19 +244,19 @@ def geojson():
   return lib_util.gzip_compress_response(result, is_json=True)
 
 
-@bp.route('/entity-geojson', methods=['POST'])
-def entity_geojson():
-  """Gets geoJson data for a list of entities and a specified property to use to
+@bp.route('/node-geojson', methods=['POST'])
+def node_geojson():
+  """Gets geoJson data for a list of nodes and a specified property to use to
      get the geoJson data"""
-  entities = request.json.get("entities", [])
+  nodes = request.json.get("nodes", [])
   geojson_prop = request.json.get("geoJsonProp")
   if not geojson_prop:
     return "error: must provide a geoJsonProp field", 400
   features = []
-  geojson_by_entity = dc.property_values(entities, geojson_prop)
-  for entity_id, json_text in geojson_by_entity.items():
+  geojson_by_node = dc.property_values(nodes, geojson_prop)
+  for node_id, json_text in geojson_by_node.items():
     if json_text:
-      geo_feature = get_geojson_feature(entity_id, entity_id, json_text)
+      geo_feature = get_geojson_feature(node_id, node_id, json_text)
       if geo_feature:
         features.append(geo_feature)
   result = {

--- a/server/tests/routes/api/choropleth_test.py
+++ b/server/tests/routes/api/choropleth_test.py
@@ -556,7 +556,7 @@ class TestChoroplethData(unittest.TestCase):
     assert response_data == expected_data
 
 
-class TestGetEntityGeoJson(unittest.TestCase):
+class TestGetNodeGeoJson(unittest.TestCase):
 
   @patch('server.routes.api.choropleth.rewind')
   @patch('server.routes.api.choropleth.dc.property_values')
@@ -571,9 +571,8 @@ class TestGetEntityGeoJson(unittest.TestCase):
     test_geojson_2 = json.dumps(GEOJSON_MULTIPOLYGON_GEOMETRY)
     test_geojson_3 = json.dumps(GEOJSON_MULTILINE_GEOMETRY)
 
-    def geojson_side_effect(entities, prop):
-      if entities == [dcid1, dcid2, dcid3, dcid4, dcid5
-                     ] and prop == geojson_prop:
+    def geojson_side_effect(nodes, prop):
+      if nodes == [dcid1, dcid2, dcid3, dcid4, dcid5] and prop == geojson_prop:
         return {
             dcid1: [test_geojson_1, test_geojson_2],
             dcid2: [test_geojson_1],
@@ -592,9 +591,9 @@ class TestGetEntityGeoJson(unittest.TestCase):
     mock_geojson_rewind.side_effect = geojson_rewind_side_effect
 
     response = app.test_client().post(
-        '/api/choropleth/entity-geojson',
+        '/api/choropleth/node-geojson',
         json={
-            "entities": [dcid1, dcid2, dcid3, dcid4, dcid5],
+            "nodes": [dcid1, dcid2, dcid3, dcid4, dcid5],
             "geoJsonProp": geojson_prop
         })
     assert response.status_code == 200

--- a/static/js/components/subject_page/data_context.ts
+++ b/static/js/components/subject_page/data_context.ts
@@ -25,7 +25,12 @@ import { GeoJsonData } from "../../chart/types";
 
 export interface DataContextType {
   // TODO (chejennifer): use this in map tile
-  geoJsonData: GeoJsonData;
+  geoJsonData: {
+    // geojson data for children places
+    childrenGeoJson: GeoJsonData;
+    // geojson data for the selected place
+    placeGeoJson: GeoJsonData;
+  };
 }
 
 export const DataContext = createContext({} as DataContextType);

--- a/static/js/components/subject_page/main_pane.tsx
+++ b/static/js/components/subject_page/main_pane.tsx
@@ -25,7 +25,7 @@ import { CATEGORY_ID_PREFIX } from "../../constants/subject_page_constants";
 import { SVG_CHART_HEIGHT } from "../../constants/tile_constants";
 import { NamedPlace, NamedTypedPlace } from "../../shared/types";
 import { SubjectPageConfig } from "../../types/subject_page_proto_types";
-import { fetchEntityGeoJson } from "../../utils/geojson_utils";
+import { fetchNodeGeoJson } from "../../utils/geojson_utils";
 import { fetchGeoJsonData, getId } from "../../utils/subject_page_utils";
 import { ErrorBoundary } from "../error_boundary";
 import { Category } from "./category";
@@ -88,7 +88,7 @@ export const SubjectPageMainPane = memo(function SubjectPageMainPane(
         break;
       }
     }
-    const placeGeoJsonPromise = fetchEntityGeoJson(
+    const placeGeoJsonPromise = fetchNodeGeoJson(
       [props.place.dcid],
       placeGeoJsonProp
     );

--- a/static/js/components/subject_page/main_pane.tsx
+++ b/static/js/components/subject_page/main_pane.tsx
@@ -25,6 +25,7 @@ import { CATEGORY_ID_PREFIX } from "../../constants/subject_page_constants";
 import { SVG_CHART_HEIGHT } from "../../constants/tile_constants";
 import { NamedPlace, NamedTypedPlace } from "../../shared/types";
 import { SubjectPageConfig } from "../../types/subject_page_proto_types";
+import { fetchEntityGeoJson } from "../../utils/geojson_utils";
 import { fetchGeoJsonData, getId } from "../../utils/subject_page_utils";
 import { ErrorBoundary } from "../error_boundary";
 import { Category } from "./category";
@@ -42,6 +43,18 @@ interface SubjectPageMainPanePropType {
   // parent places of the place to show the page for.
   parentPlaces?: NamedPlace[];
 }
+
+const PLACE_TYPE_GEOJSON_PROP = {
+  Country: "geoJsonCoordinatesDP3",
+  State: "geoJsonCoordinatesDP3",
+  AdministrativeArea1: "geoJsonCoordinatesDP3",
+  County: "geoJsonCoordinatesDP1",
+  AdministrativeArea2: "geoJsonCoordinatesDP1",
+  AdministrativeArea3: "geoJsonCoordinatesDP1",
+  EurostatNUTS1: "geoJsonCoordinatesDP2",
+  EurostatNUTS2: "geoJsonCoordinatesDP2",
+  EurostatNUTS3: "geoJsonCoordinatesDP1",
+};
 
 export const SubjectPageMainPane = memo(function SubjectPageMainPane(
   props: SubjectPageMainPanePropType
@@ -63,9 +76,25 @@ export const SubjectPageMainPane = memo(function SubjectPageMainPane(
 
   useEffect(() => {
     // re-fetch geojson data if props change
-    fetchGeoJsonData(props.place, enclosedPlaceType, props.parentPlaces).then(
-      (geoJsonData) => {
-        setGeoJsonData(geoJsonData);
+    const childrenGeoJsonPromise = fetchGeoJsonData(
+      props.place,
+      enclosedPlaceType,
+      props.parentPlaces
+    );
+    let placeGeoJsonProp = "";
+    for (const type of props.place.types) {
+      if (type in PLACE_TYPE_GEOJSON_PROP) {
+        placeGeoJsonProp = PLACE_TYPE_GEOJSON_PROP[type];
+        break;
+      }
+    }
+    const placeGeoJsonPromise = fetchEntityGeoJson(
+      [props.place.dcid],
+      placeGeoJsonProp
+    );
+    Promise.all([childrenGeoJsonPromise, placeGeoJsonPromise]).then(
+      ([childrenGeoJson, placeGeoJson]) => {
+        setGeoJsonData({ placeGeoJson, childrenGeoJson });
       }
     );
   }, [props]);

--- a/static/js/components/tiles/disaster_event_map_tile.tsx
+++ b/static/js/components/tiles/disaster_event_map_tile.tsx
@@ -55,7 +55,7 @@ import {
   getMapPointsData,
   onPointClicked,
 } from "../../utils/disaster_event_map_utils";
-import { fetchEntityGeoJson } from "../../utils/geojson_utils";
+import { fetchNodeGeoJson } from "../../utils/geojson_utils";
 import {
   getEnclosedPlacesPromise,
   getParentPlacesPromise,
@@ -72,7 +72,7 @@ const REDIRECT_URL_PREFIX = "/disasters/";
 const MAP_POINTS_MIN_RADIUS = 1.5;
 const MAP_POINTS_MIN_RADIUS_EARTH = 0.8;
 // Set of dcids of places that should use the selected place as the base geojson
-const PLACE_MAP_PLACES = new Set(["country/AUS"]);
+const PLACE_MAP_PLACES = new Set(["country/AUS", "country/BRA"]);
 
 interface DisasterEventMapTilePropType {
   // Id for this tile
@@ -286,7 +286,7 @@ export function DisasterEventMapTile(
         const eventDcids = props.disasterEventData[eventType].eventPoints.map(
           (point) => point.placeDcid
         );
-        return fetchEntityGeoJson(
+        return fetchNodeGeoJson(
           eventDcids,
           props.eventTypeSpec[eventType][geoJsonPropKey]
         );
@@ -348,11 +348,13 @@ export function DisasterEventMapTile(
       width,
       {} /* dataValues: no data values to show on the base map */,
       null /* colorScale: no color scale since no data shown on the base map */,
-      (geoDcid: GeoJsonFeatureProperties) =>
-        redirectAction(geoDcid.geoDcid) /* redirectAction */,
+      (geoFeature: GeoJsonFeatureProperties) =>
+        redirectAction(geoFeature.geoDcid) /* redirectAction */,
       (place: NamedPlace) => place.name || place.dcid /* getTooltipHtml */,
-      () =>
-        !isPlaceBaseMap /* canClickRegion: allow all regions to be clickable if not using place base map */,
+      (placeDcid: string) =>
+        placeDcid !==
+        placeInfo.selectedPlace
+          .dcid /* canClickRegion: don't allow clicking region that will redirect to current page */,
       true /* shouldShowBoundaryLines */,
       projection,
       isPlaceBaseMap

--- a/static/js/components/tiles/disaster_event_map_tile.tsx
+++ b/static/js/components/tiles/disaster_event_map_tile.tsx
@@ -19,6 +19,7 @@
  */
 
 import * as d3 from "d3";
+import { geoJson } from "leaflet";
 import _ from "lodash";
 import React, { useContext, useEffect, useRef, useState } from "react";
 
@@ -51,10 +52,10 @@ import {
   EventTypeSpec,
 } from "../../types/subject_page_proto_types";
 import {
-  fetchEventGeoJson,
   getMapPointsData,
   onPointClicked,
 } from "../../utils/disaster_event_map_utils";
+import { fetchEntityGeoJson } from "../../utils/geojson_utils";
 import {
   getEnclosedPlacesPromise,
   getParentPlacesPromise,
@@ -70,6 +71,8 @@ const CSS_SELECTOR_PREFIX = "disaster-event-map";
 const REDIRECT_URL_PREFIX = "/disasters/";
 const MAP_POINTS_MIN_RADIUS = 1.5;
 const MAP_POINTS_MIN_RADIUS_EARTH = 0.8;
+// Set of dcids of places that should use the selected place as the base geojson
+const PLACE_MAP_PLACES = new Set(["country/AUS"]);
 
 interface DisasterEventMapTilePropType {
   // Id for this tile
@@ -98,10 +101,16 @@ export function DisasterEventMapTile(
   const { geoJsonData } = useContext(DataContext);
   const [polygonGeoJson, setPolygonGeoJson] = useState(null);
   const [pathGeoJson, setPathGeoJson] = useState(null);
+  let baseMapGeoJson = null;
+  if (geoJsonData) {
+    baseMapGeoJson = shouldUsePlaceGeoJson()
+      ? geoJsonData.placeGeoJson
+      : geoJsonData.childrenGeoJson;
+  }
   const shouldShowMap =
     placeInfo &&
-    !_.isEmpty(geoJsonData) &&
-    !_.isEmpty(geoJsonData.features) &&
+    !_.isEmpty(baseMapGeoJson) &&
+    !_.isEmpty(baseMapGeoJson.features) &&
     !_.isNull(polygonGeoJson) &&
     !_.isNull(pathGeoJson);
 
@@ -144,7 +153,7 @@ export function DisasterEventMapTile(
     if (shouldShowMap) {
       draw(
         placeInfo,
-        geoJsonData,
+        baseMapGeoJson,
         props.disasterEventData,
         polygonGeoJson,
         pathGeoJson
@@ -152,7 +161,7 @@ export function DisasterEventMapTile(
     }
   }, [
     placeInfo,
-    geoJsonData,
+    baseMapGeoJson,
     props.disasterEventData,
     polygonGeoJson,
     pathGeoJson,
@@ -277,7 +286,7 @@ export function DisasterEventMapTile(
         const eventDcids = props.disasterEventData[eventType].eventPoints.map(
           (point) => point.placeDcid
         );
-        return fetchEventGeoJson(
+        return fetchEntityGeoJson(
           eventDcids,
           props.eventTypeSpec[eventType][geoJsonPropKey]
         );
@@ -323,6 +332,7 @@ export function DisasterEventMapTile(
       USA_PLACE_DCID,
       placeInfo.parentPlaces
     );
+    const isPlaceBaseMap = shouldUsePlaceGeoJson();
     const projection = getProjection(
       isUsaPlace,
       placeInfo.selectedPlace.dcid,
@@ -341,10 +351,14 @@ export function DisasterEventMapTile(
       (geoDcid: GeoJsonFeatureProperties) =>
         redirectAction(geoDcid.geoDcid) /* redirectAction */,
       (place: NamedPlace) => place.name || place.dcid /* getTooltipHtml */,
-      () => true /* canClickRegion: allow all regions to be clickable */,
+      () =>
+        !isPlaceBaseMap /* canClickRegion: allow all regions to be clickable if not using place base map */,
       true /* shouldShowBoundaryLines */,
       projection,
-      placeInfo.selectedPlace.dcid,
+      isPlaceBaseMap
+        ? ""
+        : placeInfo.selectedPlace
+            .dcid /** zoomDcid: don't want special zoom handling of the selected place if usiing place base map */,
       zoomParams
     );
     // map of disaster event point id to the disaster event point
@@ -424,5 +438,23 @@ export function DisasterEventMapTile(
    */
   function redirectAction(placeDcid: string): void {
     window.open(`${REDIRECT_URL_PREFIX}${placeDcid}`, "_self");
+  }
+
+  // Gets whether the geojson for the selected place should be used for the base
+  // map.
+  function shouldUsePlaceGeoJson(): boolean {
+    if (!geoJsonData) {
+      // When geojson data hasn't been fetched yet, default to not using place
+      // geojson.
+      return false;
+    }
+    if (PLACE_MAP_PLACES.has(props.place.dcid)) {
+      return true;
+    }
+    // Should use place geojson if children geojson are not available.
+    return (
+      _.isEmpty(geoJsonData.childrenGeoJson) ||
+      _.isEmpty(geoJsonData.childrenGeoJson.features)
+    );
   }
 }

--- a/static/js/utils/disaster_event_map_utils.tsx
+++ b/static/js/utils/disaster_event_map_utils.tsx
@@ -24,7 +24,6 @@ import _ from "lodash";
 import React from "react";
 import ReactDOM from "react-dom";
 
-import { GeoJsonData } from "../chart/types";
 import { DisasterEventMapInfoCard } from "../components/tiles/disaster_event_map_info_card";
 import {
   DATE_OPTION_1Y_KEY,
@@ -41,7 +40,6 @@ import { getAllChildPlaceTypes, getParentPlaces } from "../tools/map/util";
 import {
   DisasterDataOptions,
   DisasterEventDataApiResponse,
-  DisasterEventMapPlaceInfo,
   DisasterEventPoint,
   DisasterEventPointData,
   MapPointsData,
@@ -55,76 +53,6 @@ import { isValidDate } from "./string_utils";
 const MAX_YEARS = 20;
 const INFO_CARD_OFFSET = 5;
 const DATE_SUBSTRING_IDX = 10;
-
-/**
- * Get promise for geojson data
- * @param selectedPlace the enclosing place to get geojson data for
- * @param placeType the place type to get geojson data for
- */
-export function fetchGeoJsonData(
-  placeInfo: DisasterEventMapPlaceInfo
-): Promise<GeoJsonData> {
-  let enclosingPlace = placeInfo.selectedPlace.dcid;
-  let enclosedPlaceType = placeInfo.enclosedPlaceType;
-  if (!enclosedPlaceType) {
-    if (
-      _.isEmpty(placeInfo.parentPlaces) ||
-      _.isEmpty(placeInfo.selectedPlace.types)
-    ) {
-      return Promise.resolve({
-        type: "FeatureCollection",
-        features: [],
-        properties: {
-          current_geo: enclosingPlace,
-        },
-      });
-    }
-    // set enclosing place to be the parent place and the enclosed place type to
-    // be the place type of the selected place.
-    enclosingPlace = placeInfo.parentPlaces[0].dcid;
-    enclosedPlaceType = placeInfo.selectedPlace.types[0];
-  }
-
-  return axios
-    .get<GeoJsonData>("/api/choropleth/geojson", {
-      params: {
-        placeDcid: enclosingPlace,
-        placeType: enclosedPlaceType,
-      },
-    })
-    .then((resp) => resp.data as GeoJsonData)
-    .catch(() => {
-      return {
-        type: "FeatureCollection",
-        features: [],
-        properties: {
-          current_geo: enclosingPlace,
-        },
-      };
-    });
-}
-
-/**
- * Get promise for geojson data for a list of events and a geojson prop
- * @param eventDcids events to get geojson for
- * @param geoJsonProp prop to use to get the geojson
- */
-export function fetchEventGeoJson(
-  eventDcids: string[],
-  geoJsonProp: string
-): Promise<GeoJsonData> {
-  return axios
-    .post<GeoJsonData>("/api/choropleth/entity-geojson", {
-      entities: eventDcids,
-      geoJsonProp,
-    })
-    .then((resp) => {
-      return resp.data as GeoJsonData;
-    })
-    .catch(() => {
-      return null;
-    });
-}
 
 /**
  * Get a list of dates that encompass all events for a place and a given list of event types

--- a/static/js/utils/geojson_utils.ts
+++ b/static/js/utils/geojson_utils.ts
@@ -24,16 +24,16 @@ import { GeoJsonData } from "../chart/types";
 
 /**
  * Get promise for geojson data for a list of events and a geojson prop
- * @param entities dcids of entities to get geojson for
+ * @param nodes dcids of nodes to get geojson for
  * @param geoJsonProp prop to use to get the geojson
  */
-export function fetchEntityGeoJson(
-  entities: string[],
+export function fetchNodeGeoJson(
+  nodes: string[],
   geoJsonProp: string
 ): Promise<GeoJsonData> {
   return axios
-    .post<GeoJsonData>("/api/choropleth/entity-geojson", {
-      entities,
+    .post<GeoJsonData>("/api/choropleth/node-geojson", {
+      nodes,
       geoJsonProp,
     })
     .then((resp) => {

--- a/static/js/utils/geojson_utils.ts
+++ b/static/js/utils/geojson_utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Util functions used for getting geojson data.
+ */
+
+import axios from "axios";
+
+import { GeoJsonData } from "../chart/types";
+
+/**
+ * Get promise for geojson data for a list of events and a geojson prop
+ * @param entities dcids of entities to get geojson for
+ * @param geoJsonProp prop to use to get the geojson
+ */
+export function fetchEntityGeoJson(
+  entities: string[],
+  geoJsonProp: string
+): Promise<GeoJsonData> {
+  return axios
+    .post<GeoJsonData>("/api/choropleth/entity-geojson", {
+      entities,
+      geoJsonProp,
+    })
+    .then((resp) => {
+      return resp.data as GeoJsonData;
+    })
+    .catch(() => {
+      return null;
+    });
+}


### PR DESCRIPTION
- If a place doesn't have geojson for its children, use its own geojson as the base map

autopush: 

![australiaAutopush](https://user-images.githubusercontent.com/69875368/219424363-7eeefa71-098c-421a-a569-b6dc267418fe.jpg)

with the change:

![austrailaLocal](https://user-images.githubusercontent.com/69875368/219424420-8a40ea2b-aa5d-49b8-bc24-856216d5f07d.jpg)
