### PR TITLE
[NL Interface] Adding schools to contained in

### DIFF
--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -337,6 +337,16 @@ PLACE_TYPE_TO_PLURALS: Dict[str, str] = {
     "administrativearea5": "administrative area 5 places",
 }
 
+SCHOOL_TYPE_TO_PLURALS: Dict[str, str] = {
+    "high school": "high schools",
+    "middle school": "middle schools",
+    "elementary school": "elementary schools",
+    "primary school": "primary schools",
+    "public school": "public schools",
+    "private school": "private schools",
+    "school": "schools",
+}
+
 # TODO: Unify the different event maps by using a struct value.
 
 # Override the names from configs.  These have plurals, etc.

--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -335,9 +335,7 @@ PLACE_TYPE_TO_PLURALS: Dict[str, str] = {
     "administrativearea3": "administrative area 3 places",
     "administrativearea4": "administrative area 4 places",
     "administrativearea5": "administrative area 5 places",
-}
-
-SCHOOL_TYPE_TO_PLURALS: Dict[str, str] = {
+    # Schools
     "high school": "high schools",
     "middle school": "middle schools",
     "elementary school": "elementary schools",

--- a/server/lib/nl/detection.py
+++ b/server/lib/nl/detection.py
@@ -101,6 +101,14 @@ class ContainedInPlaceType(Enum):
   DISTRICT = "District"
   TOWN = "Town"
   ZIP = "CensusZipCodeTabulationArea"
+  SCHOOL = "School"
+  PUBLICSCHOOL = "PublicSchool"
+  PRIVATESCHOOL = "PrivateSchool"
+  PRIMARYSCHOOL = "PrimarySchool"
+  ELEMENTARYSCHOOL = "ElementarySchool"
+  MIDDLESCHOOL = "MiddleSchool"
+  HIGHSCHOOL = "HighSchool"
+
   # Across is a generic containedInPlaceType which determines if the
   # query is using the word "across".
   ACROSS = "Across"

--- a/server/lib/nl/detection.py
+++ b/server/lib/nl/detection.py
@@ -102,12 +102,12 @@ class ContainedInPlaceType(Enum):
   TOWN = "Town"
   ZIP = "CensusZipCodeTabulationArea"
   SCHOOL = "School"
-  PUBLICSCHOOL = "PublicSchool"
-  PRIVATESCHOOL = "PrivateSchool"
-  PRIMARYSCHOOL = "PrimarySchool"
-  ELEMENTARYSCHOOL = "ElementarySchool"
-  MIDDLESCHOOL = "MiddleSchool"
-  HIGHSCHOOL = "HighSchool"
+  PUBLIC_SCHOOL = "PublicSchool"
+  PRIVATE_SCHOOL = "PrivateSchool"
+  PRIMARY_SCHOOL = "PrimarySchool"
+  ELEMENTARY_SCHOOL = "ElementarySchool"
+  MIDDLE_SCHOOL = "MiddleSchool"
+  HIGH_SCHOOL = "HighSchool"
 
   # Across is a generic containedInPlaceType which determines if the
   # query is using the word "across".

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -46,6 +46,10 @@ from server.lib.nl.training import NLQueryClusteringDetectionModel
 import server.lib.nl.utils as utils
 from server.services import datacommons as dc
 
+# TODO: decouple words removal from detected attributes. Today, the removal
+# blanket removes anything that matches, including the various attribute/
+# classification triggers and contained_in place types (and their plurals).
+# This may not always be the best thing to do.
 ALL_STOP_WORDS = utils.combine_stop_words()
 
 
@@ -391,12 +395,6 @@ class Model:
         contained_in_place_type = place_enum
         break
 
-      # Check for school type plurals.
-      if place_type in constants.SCHOOL_TYPE_TO_PLURALS and \
-        constants.SCHOOL_TYPE_TO_PLURALS[place_type] in query:
-        contained_in_place_type = place_enum
-        break
-
     # If place_type is just PLACE, that means no actual type was detected.
     if contained_in_place_type == ContainedInPlaceType.PLACE:
       # Try to check if the special case of ACROSS can be found.
@@ -603,6 +601,10 @@ class Model:
 
   def detect_svs(self, query) -> Dict[str, Union[Dict, List]]:
     # Remove stop words.
+    # Check comment at the top of this file above `ALL_STOP_WORDS` to understand
+    # the potential areas for improvement. For now, this removal blanket removes
+    # any words in ALL_STOP_WORDS which includes contained_in places and their
+    # plurals and any other query attribution/classification trigger words.
     logging.info(f"SV Detection: Query provided to SV Detection: {query}")
     query = utils.remove_stop_words(query, ALL_STOP_WORDS)
     logging.info(f"SV Detection: Query used after removing stop words: {query}")

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -359,6 +359,7 @@ class Model:
       return None
 
     contained_in_place_type = ContainedInPlaceType.PLACE
+    # place_type_to_enum is an OrderedDict.
     place_type_to_enum = OrderedDict({
         "county": ContainedInPlaceType.COUNTY,
         "state": ContainedInPlaceType.STATE,
@@ -368,18 +369,18 @@ class Model:
         "province": ContainedInPlaceType.PROVINCE,
         "town": ContainedInPlaceType.TOWN,
         "zip": ContainedInPlaceType.ZIP,
-        # Schools (only plurals).
-        "high schools": ContainedInPlaceType.HIGHSCHOOL,
-        "middle schools": ContainedInPlaceType.MIDDLESCHOOL,
-        "elementary schools": ContainedInPlaceType.ELEMENTARYSCHOOL,
-        "primary schools": ContainedInPlaceType.PRIMARYSCHOOL,
-        "public schools": ContainedInPlaceType.PUBLICSCHOOL,
-        "private schools": ContainedInPlaceType.PRIVATESCHOOL,
-        "schools": ContainedInPlaceType.SCHOOL,
+        # Schools.
+        "high school": ContainedInPlaceType.HIGH_SCHOOL,
+        "middle school": ContainedInPlaceType.MIDDLE_SCHOOL,
+        "elementary school": ContainedInPlaceType.ELEMENTARY_SCHOOL,
+        "primary school": ContainedInPlaceType.PRIMARY_SCHOOL,
+        "public school": ContainedInPlaceType.PUBLIC_SCHOOL,
+        "private school": ContainedInPlaceType.PRIVATE_SCHOOL,
+        "school": ContainedInPlaceType.SCHOOL,
     })
 
     query = query.lower()
-    # Note that place_type_to_enum is an OrderedDict.
+    # Note again that place_type_to_enum is an OrderedDict.
     for place_type, place_enum in place_type_to_enum.items():
       if place_type in query:
         contained_in_place_type = place_enum
@@ -387,6 +388,12 @@ class Model:
 
       if place_type in constants.PLACE_TYPE_TO_PLURALS and \
         constants.PLACE_TYPE_TO_PLURALS[place_type] in query:
+        contained_in_place_type = place_enum
+        break
+
+      # Check for school type plurals.
+      if place_type in constants.SCHOOL_TYPE_TO_PLURALS and \
+        constants.SCHOOL_TYPE_TO_PLURALS[place_type] in query:
         contained_in_place_type = place_enum
         break
 

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -368,8 +368,18 @@ class Model:
         "province": ContainedInPlaceType.PROVINCE,
         "town": ContainedInPlaceType.TOWN,
         "zip": ContainedInPlaceType.ZIP,
+        # Schools (only plurals).
+        "high schools": ContainedInPlaceType.HIGHSCHOOL,
+        "middle schools": ContainedInPlaceType.MIDDLESCHOOL,
+        "elementary schools": ContainedInPlaceType.ELEMENTARYSCHOOL,
+        "primary schools": ContainedInPlaceType.PRIMARYSCHOOL,
+        "public schools": ContainedInPlaceType.PUBLICSCHOOL,
+        "private schools": ContainedInPlaceType.PRIVATESCHOOL,
+        "schools": ContainedInPlaceType.SCHOOL,
     })
+
     query = query.lower()
+    # Note that place_type_to_enum is an OrderedDict.
     for place_type, place_enum in place_type_to_enum.items():
       if place_type in query:
         contained_in_place_type = place_enum


### PR DESCRIPTION
This PR does the following:

1. Adds the following types to contained in detection (singular + plural):  

"School"
"PublicSchool"
"PrivateSchool"
"PrimarySchool"
"ElementarySchool"
"MiddleSchool"
"HighSchool"

Note: these all exist in the KG today and "pre school" does not (so that has not been added).

2. These are added in ranked order for contained in so all previous contained in attributes are given preference. For example, see the screenshot below for "what about private schools in counties in New York State" and the contained in classification says "COUNTY".

3. There are some cases where unintended consequences will also happen. For example "high schools" will also trigger the RANKING.HIGH attribution/classification. See example below of "what about high schools in San Mateo County" and notice that it gets **both** Ranking classification: [<RankingType.HIGH: 1>] and ContainedIn classification: ContainedInPlaceType.HIGHSCHOOL.

Tested on the previous demo url and all cases still work: http://127.0.0.1:8080/nl/#q=What%20are%20the%20projected%20temperature%20extremes%20across%20california;Where%20were%20the%20major%20fires%20in%20the%20last%20year;tell%20me%20more%20about%20Placer%20County;What%20were%20the%20most%20common%20jobs%20there;Which%20jobs%20have%20grown%20the%20most;What%20are%20the%20most%20common%20health%20issues%20there;Which%20counties%20in%20california%20have%20the%20highest%20levels%20of%20blood%20pressure;Which%20counties%20in%20the%20US%20have%20the%20highest%20levels%20of%20blood%20pressure;How%20does%20this%20correlate%20with%20income

Some screenshots of the new attribution below (they show plurals but singulars work too):

![Screenshot 2023-02-16 at 10 15 01 AM](https://user-images.githubusercontent.com/1021616/219454414-4ec47f67-024f-4ce1-85b9-491d25100f38.png)
![Screenshot 2023-02-16 at 10 14 27 AM](https://user-images.githubusercontent.com/1021616/219454418-6b6ef4cd-8a62-4697-96c3-c329e1e92145.png)
![Screenshot 2023-02-16 at 10 13 40 AM](https://user-images.githubusercontent.com/1021616/219454421-5b429650-f7b8-4718-af44-2041475d1c1c.png)
![Screenshot 2023-02-16 at 10 12 59 AM](https://user-images.githubusercontent.com/1021616/219454426-9372c67a-3f69-44de-8656-e74cfcecba95.png)

