### PR TITLE
[NL Interface] Size type (big/small) attribution/classification

### DIFF
--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -311,6 +311,10 @@ QUERY_CLASSIFICATION_HEURISTICS: Dict[str, Union[List[str], Dict[
                 "loss",
             ],
         },
+        "SizeType": {
+            "Big": ["big",],
+            "Small": ["small",],
+        },
         "Overview": ["tell me (more )?about",],
     }
 

--- a/server/lib/nl/detection.py
+++ b/server/lib/nl/detection.py
@@ -140,6 +140,19 @@ class TimeDeltaType(IntEnum):
   DECREASE = 1
 
 
+class SizeType(IntEnum):
+  """SizeType indicates the type of size query specified."""
+  NONE = 0
+
+  # BIG is for queries like:
+  # "how big ..."
+  BIG = 1
+
+  # SMALL is for queries like:
+  # "how small ..."
+  SMALL = 2
+
+
 class ClassificationAttributes(ABC):
   """Abstract class to hold classification attributes."""
   pass
@@ -236,6 +249,16 @@ class TimeDeltaClassificationAttributes(ClassificationAttributes):
   time_delta_trigger_words: List[str]
 
 
+@dataclass
+class SizeTypeClassificationAttributes(ClassificationAttributes):
+  """Size classification attributes."""
+  size_types: List[SizeType]
+
+  # List of words which made this a size-type query:
+  # e.g. "big", "small" etc
+  size_types_trigger_words: List[str]
+
+
 class ClassificationType(IntEnum):
   OTHER = 0
   SIMPLE = 1
@@ -248,7 +271,8 @@ class ClassificationType(IntEnum):
   TIME_DELTA = 8
   EVENT = 9
   OVERVIEW = 10
-  UNKNOWN = 11
+  SIZE_TYPE = 11
+  UNKNOWN = 12
 
 
 @dataclass

--- a/server/routes/nl.py
+++ b/server/routes/nl.py
@@ -174,6 +174,7 @@ def _result_with_debug_info(data_dict: Dict, status: str,
   ranking_classification = "<None>"
   overview_classification = "<None>"
   temporal_classification = "<None>"
+  size_type_classification = "<None>"
   time_delta_classification = "<None>"
   comparison_classification = "<None>"
   contained_in_classification = "<None>"
@@ -188,6 +189,8 @@ def _result_with_debug_info(data_dict: Dict, status: str,
       overview_classification = str(classification.type)
     elif classification.type == ClassificationType.TEMPORAL:
       temporal_classification = str(classification.type)
+    elif classification.type == ClassificationType.SIZE_TYPE:
+      size_type_classification = str(classification.attributes.size_types)
     elif classification.type == ClassificationType.TIME_DELTA:
       time_delta_classification = str(
           classification.attributes.time_delta_types)
@@ -218,6 +221,7 @@ def _result_with_debug_info(data_dict: Dict, status: str,
       'ranking_classification': ranking_classification,
       'overview_classification': overview_classification,
       'temporal_classification': temporal_classification,
+      'size_type_classification': size_type_classification,
       'time_delta_classification': time_delta_classification,
       'contained_in_classification': contained_in_classification,
       'clustering_classification': clustering_classification,
@@ -306,6 +310,7 @@ def _detection(orig_query, cleaned_query) -> Detection:
   comparison_classification = model.heuristic_comparison_classification(query)
   overview_classification = model.heuristic_overview_classification(query)
   temporal_classification = model.query_classification("temporal", query)
+  size_type_classification = model.heuristic_size_type_classification(query)
   time_delta_classification = model.heuristic_time_delta_classification(query)
   contained_in_classification = model.query_classification(
       "contained_in", query)
@@ -313,6 +318,7 @@ def _detection(orig_query, cleaned_query) -> Detection:
   logging.info(f'Ranking classification: {ranking_classification}')
   logging.info(f'Comparison classification: {comparison_classification}')
   logging.info(f'Temporal classification: {temporal_classification}')
+  logging.info(f'SizeType classification: {size_type_classification}')
   logging.info(f'TimeDelta classification: {time_delta_classification}')
   logging.info(f'ContainedIn classification: {contained_in_classification}')
   logging.info(f'Event Classification: {event_classification}')
@@ -326,6 +332,8 @@ def _detection(orig_query, cleaned_query) -> Detection:
     classifications.append(comparison_classification)
   if contained_in_classification is not None:
     classifications.append(contained_in_classification)
+  if size_type_classification is not None:
+    classifications.append(size_type_classification)
   if time_delta_classification is not None:
     classifications.append(time_delta_classification)
   if event_classification is not None:

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -36,6 +36,8 @@ from server.lib.nl.detection import OverviewClassificationAttributes
 from server.lib.nl.detection import PeriodType
 from server.lib.nl.detection import RankingClassificationAttributes
 from server.lib.nl.detection import RankingType
+from server.lib.nl.detection import SizeType
+from server.lib.nl.detection import SizeTypeClassificationAttributes
 from server.lib.nl.detection import TemporalClassificationAttributes
 from server.lib.nl.detection import TimeDeltaClassificationAttributes
 from server.lib.nl.detection import TimeDeltaType
@@ -305,6 +307,50 @@ class Model:
         time_delta_types=subtypes_matched,
         time_delta_trigger_words=trigger_words)
     return NLClassifier(type=ClassificationType.TIME_DELTA,
+                        attributes=attributes)
+
+  # TODO: This code is similar to the ranking and time_delta classifiers.
+  # Ideally, refactor.
+  def heuristic_size_type_classification(
+      self, query: str) -> Union[NLClassifier, None]:
+    """Determine if query is a 'Size-Type' type.
+
+    Uses heuristics instead of ML-based classification.
+
+    Args:
+      query (str): the user's input
+
+    Returns:
+      NLClassifier with SizeTypeClassificationAttributes
+    """
+    subtype_map = {
+        "Big": SizeType.BIG,
+        "Small": SizeType.SMALL,
+    }
+    size_type_heuristics = constants.QUERY_CLASSIFICATION_HEURISTICS["SizeType"]
+    size_type_subtypes = size_type_heuristics.keys()
+    query = query.lower()
+    subtypes_matched = []
+    trigger_words = []
+    for subtype in size_type_subtypes:
+      type_trigger_words = []
+
+      for keyword in size_type_heuristics[subtype]:
+        # look for keyword surrounded by spaces or start/end delimiters
+        regex = r"(^|\W)" + keyword + r"($|\W)"
+        type_trigger_words += [w.group() for w in re.finditer(regex, query)]
+
+      if len(type_trigger_words) > 0:
+        subtypes_matched.append(subtype_map[subtype])
+      trigger_words += type_trigger_words
+
+    # If no matches, this query is not a size-type query
+    if len(trigger_words) == 0:
+      return None
+
+    attributes = SizeTypeClassificationAttributes(
+        size_types=subtypes_matched, size_types_trigger_words=trigger_words)
+    return NLClassifier(type=ClassificationType.SIZE_TYPE,
                         attributes=attributes)
 
   def heuristic_comparison_classification(self,

--- a/static/js/apps/nl_interface/debug_info.tsx
+++ b/static/js/apps/nl_interface/debug_info.tsx
@@ -109,6 +109,7 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
     rankingClassification: props.debugData["ranking_classification"],
     overviewClassification: props.debugData["overview_classification"],
     temporalClassification: props.debugData["temporal_classification"],
+    sizeTypeClassification: props.debugData["size_type_classification"],
     timeDeltaClassification: props.debugData["time_delta_classification"],
     comparisonClassification: props.debugData["comparison_classification"],
     containedInClassification: props.debugData["contained_in_classification"],
@@ -165,6 +166,12 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
           </Row>
           <Row>
             <Col>Ranking classification: {debugInfo.rankingClassification}</Col>
+          </Row>
+          <Row>
+            <Col>
+              Size Type (generic) classification:{" "}
+              {debugInfo.sizeTypeClassification}
+            </Col>
           </Row>
           <Row>
             <Col>

--- a/static/js/types/app/nl_interface_types.ts
+++ b/static/js/types/app/nl_interface_types.ts
@@ -41,7 +41,12 @@ export interface DebugInfo {
   svScores: SVScores;
   svSentences: Map<string, Array<string>>;
   rankingClassification: string;
+  overviewClassification: string;
   temporalClassification: string;
+  sizeTypeClassification: string;
+  timeDeltaClassification: string;
+  comparisonClassification: string;
   containedInClassification: string;
   correlationClassification: string;
+  eventClassification: string;
 }


### PR DESCRIPTION
Detects "big" and "small" query type. The generic name is called SizeType. Plumbs it all the the way to debugInfo and adds the right types to debugInfo javascript object too (some were missing even though it worked fine).

Tested locally + on the previous demo script. All work. Some screenshots of the latest changes are below (note this "big" and "small" do not automatically trigger the RANKING.HIGH and RANKING.LOW attributes which is good):

![Screenshot 2023-02-16 at 3 42 35 PM](https://user-images.githubusercontent.com/1021616/219513126-c67a1a15-03d8-4d43-b3ae-e684ec34b19d.png)
![Screenshot 2023-02-16 at 3 44 27 PM](https://user-images.githubusercontent.com/1021616/219513183-44a92e5d-d870-4bb8-88e1-5766ea09fa48.png)


