### PR TITLE
Implement a size_across_entities fulfiller

### DIFF
--- a/server/integration_tests/nlnext_test.py
+++ b/server/integration_tests/nlnext_test.py
@@ -123,8 +123,10 @@ class IntegrationTest(LiveServerTestCase):
 
   def test_demo_cities_feb2023(self):
     self.run_sequence('demo2_cities_feb2023', [
-        'How do people commute in Sunnyvale?',
-        'How does that compare to Palo Alto',
+        'How big are the public schools in Sunnyvale',
+        'What is the prevalence of asthma there',
+        'What is the commute pattern there',
+        'How does that compare with San Bruno',
     ])
 
   def test_demo_fallback(self):

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_1/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_1/chart_config.json
@@ -8,112 +8,63 @@
               {
                 "tiles": [
                   {
-                    "comparisonPlaces": [
-                      "geoId/0677000"
-                    ],
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
                     "statVarKey": [
-                      "dc/6rltk4kf75612_multiple_place_bar_block",
-                      "dc/vp8cbt6k79t94_multiple_place_bar_block",
-                      "dc/hbkh95kc7pkb6_multiple_place_bar_block",
-                      "dc/wc8q05drd74bd_multiple_place_bar_block",
-                      "dc/0gettc3bc60cb_multiple_place_bar_block",
-                      "dc/vt2q292eme79f_multiple_place_bar_block"
+                      "Count_Student"
                     ],
-                    "title": "Modes of Commute in Sunnyvale",
-                    "type": "BAR"
+                    "title": "Number of Students in Public Schools of Sunnyvale",
+                    "type": "RANKING"
                   },
                   {
-                    "comparisonPlaces": [
-                      "geoId/0677000"
-                    ],
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
                     "statVarKey": [
-                      "dc/6rltk4kf75612_multiple_place_bar_block_pc",
-                      "dc/vp8cbt6k79t94_multiple_place_bar_block_pc",
-                      "dc/hbkh95kc7pkb6_multiple_place_bar_block_pc",
-                      "dc/wc8q05drd74bd_multiple_place_bar_block_pc",
-                      "dc/0gettc3bc60cb_multiple_place_bar_block_pc",
-                      "dc/vt2q292eme79f_multiple_place_bar_block_pc"
+                      "Count_Teacher"
                     ],
-                    "title": "Per Capita Modes of Commute in Sunnyvale",
-                    "type": "BAR"
+                    "title": "Number of Teachers in Public Schools of Sunnyvale",
+                    "type": "RANKING"
+                  },
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "Percent_Student_AsAFractionOf_Count_Teacher"
+                    ],
+                    "title": "Student-Teacher Ratio in Public Schools of Sunnyvale",
+                    "type": "RANKING"
                   }
                 ]
               }
-            ],
-            "title": "Modes of Commute"
+            ]
           }
         ],
         "statVarSpec": {
-          "dc/0gettc3bc60cb_multiple_place_bar_block": {
-            "name": "Drive alone",
-            "statVar": "dc/0gettc3bc60cb"
+          "Count_Student": {
+            "name": "Number of Students",
+            "statVar": "Count_Student"
           },
-          "dc/0gettc3bc60cb_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Drive alone",
-            "scaling": 100.0,
-            "statVar": "dc/0gettc3bc60cb",
-            "unit": "%"
+          "Count_Teacher": {
+            "name": "Number of Teachers",
+            "statVar": "Count_Teacher"
           },
-          "dc/6rltk4kf75612_multiple_place_bar_block": {
-            "name": "Work at home",
-            "statVar": "dc/6rltk4kf75612"
-          },
-          "dc/6rltk4kf75612_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Work at home",
-            "scaling": 100.0,
-            "statVar": "dc/6rltk4kf75612",
-            "unit": "%"
-          },
-          "dc/hbkh95kc7pkb6_multiple_place_bar_block": {
-            "name": "Public Transit",
-            "statVar": "dc/hbkh95kc7pkb6"
-          },
-          "dc/hbkh95kc7pkb6_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Public Transit",
-            "scaling": 100.0,
-            "statVar": "dc/hbkh95kc7pkb6",
-            "unit": "%"
-          },
-          "dc/vp8cbt6k79t94_multiple_place_bar_block": {
-            "name": "Walk to work",
-            "statVar": "dc/vp8cbt6k79t94"
-          },
-          "dc/vp8cbt6k79t94_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Walk to work",
-            "scaling": 100.0,
-            "statVar": "dc/vp8cbt6k79t94",
-            "unit": "%"
-          },
-          "dc/vt2q292eme79f_multiple_place_bar_block": {
-            "name": "Others (incl. Taxcab, Motorcyle, Bicycle)",
-            "statVar": "dc/vt2q292eme79f"
-          },
-          "dc/vt2q292eme79f_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Others (incl. Taxcab, Motorcyle, Bicycle)",
-            "scaling": 100.0,
-            "statVar": "dc/vt2q292eme79f",
-            "unit": "%"
-          },
-          "dc/wc8q05drd74bd_multiple_place_bar_block": {
-            "name": "Carpool",
-            "statVar": "dc/wc8q05drd74bd"
-          },
-          "dc/wc8q05drd74bd_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Carpool",
-            "scaling": 100.0,
-            "statVar": "dc/wc8q05drd74bd",
-            "unit": "%"
+          "Percent_Student_AsAFractionOf_Count_Teacher": {
+            "name": "Student-Teacher Ratio",
+            "statVar": "Percent_Student_AsAFractionOf_Count_Teacher"
           }
         }
       }
     ],
     "metadata": {
+      "containedPlaceTypes": {
+        "City": "PublicSchool"
+      },
       "placeDcid": [
         "geoId/0677000"
       ]

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_1/debug_info.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_1/debug_info.json
@@ -1,177 +1,63 @@
 {
   "clustering_classification": "<None>",
   "comparison_classification": "<None>",
-  "contained_in_classification": "<None>",
+  "contained_in_classification": "ContainedInPlaceType.PUBLIC_SCHOOL",
   "correlation_classification": "<None>",
   "counters": {
-    "failed_existence_check": [
+    "child_places_result": [
       {
-        "places": [
-          "geoId/0677000"
+        "place": "geoId/0677000",
+        "result": [
+          "nces/060134312546",
+          "nces/060216913485",
+          "nces/061029001127",
+          "nces/061029001146",
+          "nces/061029001153",
+          "nces/061029001154",
+          "nces/061443001696",
+          "nces/061443008353",
+          "nces/063543001588",
+          "nces/063543006049",
+          "nces/063543007867",
+          "nces/063846002796",
+          "nces/063846004088",
+          "nces/063846006456",
+          "nces/063846006458",
+          "nces/063846006459",
+          "nces/063846006460",
+          "nces/063846006463",
+          "nces/063846006464",
+          "nces/063846006465"
         ],
-        "svs": [
-          "dc/8p97n7l96lgg8"
-        ]
+        "type": "PublicSchool"
       }
     ],
-    "failed_existence_check_extended_svs": [
-      {
-        "places": [
-          "geoId/0677000"
-        ],
-        "svs": [
-          "dc/tqgf8zv96r5t8",
-          "dc/8j8w7pf73ekn",
-          "dc/dy2k68mmhenfd",
-          "Count_Worker_NAICSManagementOfCompaniesEnterprises",
-          "Count_Worker_NAICSTotalAllIndustries",
-          "dc/yn0h4nw4k23f1",
-          "dc/w1tfjz3h6138",
-          "Count_Worker_NAICSPublicAdministration",
-          "dc/eh7s78v8s14l9",
-          "dc/bb4peddkgmqe7",
-          "Count_Worker_NAICSEducationalServices",
-          "Count_Worker_NAICSAccommodationFoodServices",
-          "Count_Worker_NAICSAdministrativeSupportWasteManagementRemediationServices",
-          "dc/ndg1xk1e9frc2",
-          "dc/34t2kjrwbjd31",
-          "Count_Worker_NAICSProfessionalScientificTechnicalServices",
-          "dc/qnz3rlypmfvw6",
-          "dc/n87t9dkckzxc8",
-          "Count_Worker_NAICSNonclassifiable",
-          "dc/k3hehk50ch012",
-          "dc/8b3gpw1zyr7bf",
-          "Count_Worker_NAICSAgricultureForestryFishingHunting",
-          "dc/6n6l2wrzv7473",
-          "dc/c0wxmt45gffxc",
-          "Count_Worker_NAICSHealthCareSocialAssistance",
-          "dc/e2zdnwjjhyj36",
-          "dc/8p97n7l96lgg8",
-          "Count_Worker_NAICSInformation",
-          "Count_Worker_NAICSUtilities",
-          "Count_Worker_NAICSConstruction",
-          "dc/3kwcvm428wpq4",
-          "Count_Worker_NAICSArtsEntertainmentRecreation",
-          "dc/4mm2p1rxr5wz4",
-          "dc/vp4cplffwv86g",
-          "dc/63gkdt13bmsv8",
-          "dc/bwr1l8y9we9k7",
-          "dc/7bck6xpkc205c",
-          "dc/z27q5dymqyrnf",
-          "dc/rlk1yxmkk1qqg",
-          "dc/ws19bm1hl105b",
-          "Count_Worker_NAICSWholesaleTrade",
-          "dc/107jnwnsh17xb",
-          "Count_Worker_NAICSFinanceInsurance",
-          "dc/h1jy2glt2m7e6",
-          "dc/90nswpkp8wlw5",
-          "Count_Worker_NAICSOtherServices",
-          "dc/v3qgyhwx13m44",
-          "dc/p69tpsldf99h7",
-          "Count_Worker_NAICSRealEstateRentalLeasing",
-          "Count_Worker_NAICSMiningQuarryingOilGasExtraction",
-          "dc/hlxvn1t8b9bhh",
-          "dc/2etwgx6vecreh"
-        ]
-      }
-    ],
-    "filtered_svs": [
-      "dc/topic/WorkCommute",
-      "dc/g/Person_Industry-NAICS/488",
-      "dc/g/Person_Industry-NAICS/3133",
-      "dc/g/Person_Industry-NAICS/481",
-      "dc/g/Person_Industry-NAICS/4849",
-      "dc/g/Person_Industry-NAICS/485",
-      "dc/8p97n7l96lgg8",
-      "dc/g/Person_Industry-NAICS/484922"
-    ],
-    "num_chart_candidates": 1,
+    "filtered_svs": [],
+    "num_chart_candidates": 3,
     "processed_fulfillment_types": [
-      "simple"
+      "size_across_entities"
     ],
     "stat_var_extensions": [
       {
-        "dc/8p97n7l96lgg8": [
-          "Count_Worker_NAICSTotalAllIndustries",
-          "Count_Worker_NAICSAgricultureForestryFishingHunting",
-          "dc/hlxvn1t8b9bhh",
-          "Count_Worker_NAICSMiningQuarryingOilGasExtraction",
-          "Count_Worker_NAICSUtilities",
-          "Count_Worker_NAICSConstruction",
-          "dc/107jnwnsh17xb",
-          "dc/rlk1yxmkk1qqg",
-          "dc/8b3gpw1zyr7bf",
-          "dc/ndg1xk1e9frc2",
-          "dc/tqgf8zv96r5t8",
-          "dc/dy2k68mmhenfd",
-          "dc/z27q5dymqyrnf",
-          "dc/7bck6xpkc205c",
-          "dc/ws19bm1hl105b",
-          "dc/6n6l2wrzv7473",
-          "dc/vp4cplffwv86g",
-          "dc/34t2kjrwbjd31",
-          "dc/eh7s78v8s14l9",
-          "dc/qnz3rlypmfvw6",
-          "dc/90nswpkp8wlw5",
-          "Count_Worker_NAICSWholesaleTrade",
-          "dc/p69tpsldf99h7",
-          "dc/e2zdnwjjhyj36",
-          "dc/c0wxmt45gffxc",
-          "dc/4mm2p1rxr5wz4",
-          "dc/2etwgx6vecreh",
-          "dc/63gkdt13bmsv8",
-          "dc/3kwcvm428wpq4",
-          "dc/h1jy2glt2m7e6",
-          "dc/k3hehk50ch012",
-          "dc/8p97n7l96lgg8",
-          "dc/bwr1l8y9we9k7",
-          "dc/yn0h4nw4k23f1",
-          "dc/v3qgyhwx13m44",
-          "dc/bb4peddkgmqe7",
-          "dc/8j8w7pf73ekn",
-          "dc/n87t9dkckzxc8",
-          "dc/w1tfjz3h6138",
-          "Count_Worker_NAICSInformation",
-          "Count_Worker_NAICSFinanceInsurance",
-          "Count_Worker_NAICSRealEstateRentalLeasing",
-          "Count_Worker_NAICSProfessionalScientificTechnicalServices",
-          "Count_Worker_NAICSManagementOfCompaniesEnterprises",
-          "Count_Worker_NAICSAdministrativeSupportWasteManagementRemediationServices",
-          "Count_Worker_NAICSEducationalServices",
-          "Count_Worker_NAICSHealthCareSocialAssistance",
-          "Count_Worker_NAICSArtsEntertainmentRecreation",
-          "Count_Worker_NAICSAccommodationFoodServices",
-          "Count_Worker_NAICSOtherServices",
-          "Count_Worker_NAICSPublicAdministration",
-          "Count_Worker_NAICSNonclassifiable"
+        "Count_Student": [
+          "Count_Student"
+        ],
+        "Count_Teacher": [
+          "Count_Teacher"
+        ],
+        "Percent_Student_AsAFractionOf_Count_Teacher": [
+          "Percent_Student_AsAFractionOf_Count_Teacher"
         ]
-      }
-    ],
-    "topics_processed": [
-      {
-        "dc/topic/WorkCommute": {
-          "peer_groups": [
-            [
-              "Modes of Commute",
-              "",
-              [
-                "dc/6rltk4kf75612",
-                "dc/vp8cbt6k79t94",
-                "dc/hbkh95kc7pkb6",
-                "dc/wc8q05drd74bd",
-                "dc/0gettc3bc60cb",
-                "dc/vt2q292eme79f"
-              ]
-            ]
-          ],
-          "svs": []
-        }
       }
     ]
   },
   "data_spec": [
     {
       "classifications": [
+        {
+          "contained_in_place_type": "PublicSchool",
+          "type": 4
+        },
         {
           "type": 11
         }
@@ -183,22 +69,25 @@
           "place_type": "City"
         }
       ],
-      "query": "How do people commute in Sunnyvale?",
-      "query_type": 1,
+      "query": "How big are the public schools in Sunnyvale",
+      "query_type": 10,
       "ranked_charts": [
         {
           "attr": {
-            "block_id": 2,
-            "chart_type": "bar chart",
+            "block_id": 1,
+            "chart_type": "ranking table",
             "class": 0,
             "description": "",
-            "include_percapita": true,
-            "place_type": null,
-            "ranking_types": [],
-            "source_topic": "dc/topic/WorkCommute",
-            "title": "Modes of Commute"
+            "include_percapita": false,
+            "place_type": "PublicSchool",
+            "ranking_types": [
+              1
+            ],
+            "skip_map_for_ranking": true,
+            "source_topic": "",
+            "title": ""
           },
-          "chart_type": 3,
+          "chart_type": 2,
           "event": null,
           "places": [
             {
@@ -208,176 +97,199 @@
             }
           ],
           "svs": [
-            "dc/6rltk4kf75612",
-            "dc/vp8cbt6k79t94",
-            "dc/hbkh95kc7pkb6",
-            "dc/wc8q05drd74bd",
-            "dc/0gettc3bc60cb",
-            "dc/vt2q292eme79f"
+            "Count_Student"
+          ]
+        },
+        {
+          "attr": {
+            "block_id": 1,
+            "chart_type": "ranking table",
+            "class": 0,
+            "description": "",
+            "include_percapita": false,
+            "place_type": "PublicSchool",
+            "ranking_types": [
+              1
+            ],
+            "skip_map_for_ranking": true,
+            "source_topic": "",
+            "title": ""
+          },
+          "chart_type": 2,
+          "event": null,
+          "places": [
+            {
+              "dcid": "geoId/0677000",
+              "name": "Sunnyvale",
+              "place_type": "City"
+            }
+          ],
+          "svs": [
+            "Count_Teacher"
+          ]
+        },
+        {
+          "attr": {
+            "block_id": 1,
+            "chart_type": "ranking table",
+            "class": 0,
+            "description": "",
+            "include_percapita": false,
+            "place_type": "PublicSchool",
+            "ranking_types": [
+              1
+            ],
+            "skip_map_for_ranking": true,
+            "source_topic": "",
+            "title": ""
+          },
+          "chart_type": 2,
+          "event": null,
+          "places": [
+            {
+              "dcid": "geoId/0677000",
+              "name": "Sunnyvale",
+              "place_type": "City"
+            }
+          ],
+          "svs": [
+            "Percent_Student_AsAFractionOf_Count_Teacher"
           ]
         }
       ],
       "svs": [
-        "dc/topic/WorkCommute",
-        "dc/g/Person_Industry-NAICS/488",
-        "dc/g/Person_Industry-NAICS/3133",
-        "dc/g/Person_Industry-NAICS/481",
-        "dc/g/Person_Industry-NAICS/4849",
-        "dc/g/Person_Industry-NAICS/485",
-        "dc/8p97n7l96lgg8",
-        "dc/g/Person_Industry-NAICS/484922"
+        "Count_Student",
+        "Count_Teacher",
+        "Percent_Student_AsAFractionOf_Count_Teacher"
       ]
     }
   ],
   "event_classification": "<None>",
   "main_place_dcid": "geoId/0677000",
   "main_place_name": "Sunnyvale",
-  "original_query": "How do people commute in Sunnyvale?",
+  "original_query": "How big are the public schools in Sunnyvale",
   "overview_classification": "<None>",
   "places_detected": [
     "sunnyvale"
   ],
-  "query_with_places_removed": "how do people commute",
+  "query_with_places_removed": "how big are the public schools",
   "ranking_classification": "<None>",
+  "size_type_classification": "[<SizeType.BIG: 1>]",
   "status": "",
   "sv_matching": {
     "CosineScore": [
-      0.7448244094848633,
-      0.5310036540031433,
-      0.5310036540031433,
-      0.5215447545051575,
-      0.5151081085205078,
-      0.5151081085205078,
-      0.5098081827163696,
-      0.500896692276001,
-      0.4969985783100128,
-      0.4969985783100128,
-      0.4889006018638611,
-      0.4889006018638611,
-      0.4867348372936249,
-      0.4867348372936249,
-      0.48278555274009705
+      0.3702762722969055,
+      0.3159871995449066,
+      0.2831984758377075,
+      0.27669644355773926,
+      0.2557689845561981,
+      0.237177774310112,
+      0.22020845115184784,
+      0.21446263790130615,
+      0.2134648710489273,
+      0.20017607510089874,
+      0.1957034021615982
     ],
     "SV": [
+      "dc/topic/Income",
+      "dc/topic/Economy",
+      "dc/topic/Jobs",
+      "dc/topic/MedicalConditions",
+      "dc/hlxvn1t8b9bhh",
+      "dc/g/Person_MedicalCondition-Wasting",
+      "AirQualityIndex_AirPollutant",
       "dc/topic/WorkCommute",
-      "dc/g/Person_Industry-NAICS/488",
-      "dc/g/Person_Industry-NAICS/3133",
-      "dc/g/Person_Industry-NAICS/481",
-      "dc/g/Person_Industry-NAICS/4849",
-      "dc/g/Person_Industry-NAICS/485",
-      "dc/8p97n7l96lgg8",
-      "dc/g/Person_Industry-NAICS/484922",
-      "dc/g/Person_Industry-NAICS/99",
-      "dc/g/Person_Industry-NAICS/484",
-      "dc/g/Person_Industry-NAICS/483",
-      "dc/g/Person_Industry-NAICS/42",
-      "dc/g/Person_Industry-NAICS/487",
-      "dc/g/Person_Industry-NAICS/451",
-      "dc/g/Person_Industry-NAICS/JOLTS480099"
+      "dc/topic/Agriculture",
+      "dc/g/Farm_FarmInventoryType-Forage",
+      "dc/g/Farm_FarmInventoryType-HogsAndPigs"
     ],
     "SV_to_Sentences": {
-      "dc/8p97n7l96lgg8": [
-        "People working in the transportation and warehousing field (0.5098081827163696)"
+      "AirQualityIndex_AirPollutant": [
+        "AQI (0.22020845115184784)"
       ],
-      "dc/g/Person_Industry-NAICS/3133": [
-        "Number of people working in support activities for transportation (0.5310036540031433)"
+      "dc/g/Farm_FarmInventoryType-Forage": [
+        "Forage Farms (0.20017607510089874)",
+        "forage farms (0.20017607510089874)"
       ],
-      "dc/g/Person_Industry-NAICS/42": [
-        "Number of people working in water transportation (0.4889006018638611)"
+      "dc/g/Farm_FarmInventoryType-HogsAndPigs": [
+        "pig farm (0.1957034021615982)",
+        "Pig Farm (0.1957034021615982)"
       ],
-      "dc/g/Person_Industry-NAICS/451": [
-        "Number of people working in scenic and sightseeing transportation (0.4867348372936249)"
+      "dc/g/Person_MedicalCondition-Wasting": [
+        "people with wasting (0.237177774310112)"
       ],
-      "dc/g/Person_Industry-NAICS/481": [
-        "People Working in the Air Transportation Industry (0.5215447545051575)",
-        "People working in the air transportation industry (0.5215447545051575)"
+      "dc/hlxvn1t8b9bhh": [
+        "cattle ranchers (0.2557689845561981)",
+        "farmers (0.22553962469100952)"
       ],
-      "dc/g/Person_Industry-NAICS/483": [
-        "Number of People Working in Water Transportation (0.4889006018638611)"
+      "dc/topic/Agriculture": [
+        "Agriculture (0.2134648710489273)"
       ],
-      "dc/g/Person_Industry-NAICS/484": [
-        "Number of People Working in Truck Transportation (0.4969985783100128)"
+      "dc/topic/Economy": [
+        "Economy (0.3159871995449066)"
       ],
-      "dc/g/Person_Industry-NAICS/4849": [
-        "Number of people working in transit and ground passenger transportation (0.5151081085205078)",
-        "Number of People Working in Transportation and Warehousing (0.500896692276001)"
+      "dc/topic/Income": [
+        "pay (0.3702762722969055)",
+        "compensation (0.22850871086120605)",
+        "Earnings (0.2226836234331131)",
+        "Income (0.20594438910484314)"
       ],
-      "dc/g/Person_Industry-NAICS/484922": [
-        "Number of people working in transportation and warehousing (0.500896692276001)",
-        "Number of People Working in Transportation and Warehousing, and Utilities (0.48278555274009705)"
+      "dc/topic/Jobs": [
+        "Jobs (0.2831984758377075)",
+        "Careers (0.24140897393226624)",
+        "Professions (0.20911738276481628)"
       ],
-      "dc/g/Person_Industry-NAICS/485": [
-        "Number of People Working in Transit and Ground Passenger Transportation (0.5151081085205078)"
-      ],
-      "dc/g/Person_Industry-NAICS/487": [
-        "Number of People Working in Scenic and Sightseeing Transportation (0.4867348372936249)"
-      ],
-      "dc/g/Person_Industry-NAICS/488": [
-        "Number of People Working in Support Activities for Transportation (0.5310036540031433)"
-      ],
-      "dc/g/Person_Industry-NAICS/99": [
-        "Number of people working in truck transportation (0.4969985783100128)"
-      ],
-      "dc/g/Person_Industry-NAICS/JOLTS480099": [
-        "Number of people working in transportation and warehousing, and utilities (0.48278555274009705)"
+      "dc/topic/MedicalConditions": [
+        "Maladies (0.27669644355773926)",
+        "Medical infirmities (0.2347508668899536)"
       ],
       "dc/topic/WorkCommute": [
-        "Work commute (0.7448244094848633)",
-        "Work Commute (0.7448244094848633)",
-        "commute mode (0.5773593187332153)"
+        "journey to work (0.21446263790130615)"
       ]
     }
   },
   "svs_to_sentences": {
-    "dc/8p97n7l96lgg8": [
-      "People working in the transportation and warehousing field (0.5098081827163696)"
+    "AirQualityIndex_AirPollutant": [
+      "AQI (0.22020845115184784)"
     ],
-    "dc/g/Person_Industry-NAICS/3133": [
-      "Number of people working in support activities for transportation (0.5310036540031433)"
+    "dc/g/Farm_FarmInventoryType-Forage": [
+      "Forage Farms (0.20017607510089874)",
+      "forage farms (0.20017607510089874)"
     ],
-    "dc/g/Person_Industry-NAICS/42": [
-      "Number of people working in water transportation (0.4889006018638611)"
+    "dc/g/Farm_FarmInventoryType-HogsAndPigs": [
+      "pig farm (0.1957034021615982)",
+      "Pig Farm (0.1957034021615982)"
     ],
-    "dc/g/Person_Industry-NAICS/451": [
-      "Number of people working in scenic and sightseeing transportation (0.4867348372936249)"
+    "dc/g/Person_MedicalCondition-Wasting": [
+      "people with wasting (0.237177774310112)"
     ],
-    "dc/g/Person_Industry-NAICS/481": [
-      "People Working in the Air Transportation Industry (0.5215447545051575)",
-      "People working in the air transportation industry (0.5215447545051575)"
+    "dc/hlxvn1t8b9bhh": [
+      "cattle ranchers (0.2557689845561981)",
+      "farmers (0.22553962469100952)"
     ],
-    "dc/g/Person_Industry-NAICS/483": [
-      "Number of People Working in Water Transportation (0.4889006018638611)"
+    "dc/topic/Agriculture": [
+      "Agriculture (0.2134648710489273)"
     ],
-    "dc/g/Person_Industry-NAICS/484": [
-      "Number of People Working in Truck Transportation (0.4969985783100128)"
+    "dc/topic/Economy": [
+      "Economy (0.3159871995449066)"
     ],
-    "dc/g/Person_Industry-NAICS/4849": [
-      "Number of people working in transit and ground passenger transportation (0.5151081085205078)",
-      "Number of People Working in Transportation and Warehousing (0.500896692276001)"
+    "dc/topic/Income": [
+      "pay (0.3702762722969055)",
+      "compensation (0.22850871086120605)",
+      "Earnings (0.2226836234331131)",
+      "Income (0.20594438910484314)"
     ],
-    "dc/g/Person_Industry-NAICS/484922": [
-      "Number of people working in transportation and warehousing (0.500896692276001)",
-      "Number of People Working in Transportation and Warehousing, and Utilities (0.48278555274009705)"
+    "dc/topic/Jobs": [
+      "Jobs (0.2831984758377075)",
+      "Careers (0.24140897393226624)",
+      "Professions (0.20911738276481628)"
     ],
-    "dc/g/Person_Industry-NAICS/485": [
-      "Number of People Working in Transit and Ground Passenger Transportation (0.5151081085205078)"
-    ],
-    "dc/g/Person_Industry-NAICS/487": [
-      "Number of People Working in Scenic and Sightseeing Transportation (0.4867348372936249)"
-    ],
-    "dc/g/Person_Industry-NAICS/488": [
-      "Number of People Working in Support Activities for Transportation (0.5310036540031433)"
-    ],
-    "dc/g/Person_Industry-NAICS/99": [
-      "Number of people working in truck transportation (0.4969985783100128)"
-    ],
-    "dc/g/Person_Industry-NAICS/JOLTS480099": [
-      "Number of people working in transportation and warehousing, and utilities (0.48278555274009705)"
+    "dc/topic/MedicalConditions": [
+      "Maladies (0.27669644355773926)",
+      "Medical infirmities (0.2347508668899536)"
     ],
     "dc/topic/WorkCommute": [
-      "Work commute (0.7448244094848633)",
-      "Work Commute (0.7448244094848633)",
-      "commute mode (0.5773593187332153)"
+      "journey to work (0.21446263790130615)"
     ]
   },
   "temporal_classification": "<None>",

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_2/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_2/chart_config.json
@@ -8,109 +8,195 @@
               {
                 "tiles": [
                   {
-                    "comparisonPlaces": [
-                      "geoId/0677000",
-                      "geoId/0655282"
-                    ],
                     "statVarKey": [
-                      "dc/6rltk4kf75612_multiple_place_bar_block",
-                      "dc/vp8cbt6k79t94_multiple_place_bar_block",
-                      "dc/hbkh95kc7pkb6_multiple_place_bar_block",
-                      "dc/wc8q05drd74bd_multiple_place_bar_block",
-                      "dc/0gettc3bc60cb_multiple_place_bar_block",
-                      "dc/vt2q292eme79f_multiple_place_bar_block"
+                      "Percent_Person_WithAsthma"
                     ],
-                    "title": "Modes of Commute",
-                    "type": "BAR"
-                  },
+                    "title": "Asthma in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
                   {
                     "comparisonPlaces": [
-                      "geoId/0677000",
-                      "geoId/0655282"
+                      "geoId/0677000"
                     ],
                     "statVarKey": [
-                      "dc/6rltk4kf75612_multiple_place_bar_block_pc",
-                      "dc/vp8cbt6k79t94_multiple_place_bar_block_pc",
-                      "dc/hbkh95kc7pkb6_multiple_place_bar_block_pc",
-                      "dc/wc8q05drd74bd_multiple_place_bar_block_pc",
-                      "dc/0gettc3bc60cb_multiple_place_bar_block_pc",
-                      "dc/vt2q292eme79f_multiple_place_bar_block_pc"
+                      "Percent_Person_WithAllTeethLoss_multiple_place_bar_block",
+                      "Percent_Person_WithArthritis_multiple_place_bar_block",
+                      "Percent_Person_WithAsthma_multiple_place_bar_block",
+                      "Percent_Person_WithCancerExcludingSkinCancer_multiple_place_bar_block",
+                      "Percent_Person_WithChronicKidneyDisease_multiple_place_bar_block",
+                      "Percent_Person_WithChronicObstructivePulmonaryDisease_multiple_place_bar_block",
+                      "Percent_Person_WithCoronaryHeartDisease_multiple_place_bar_block",
+                      "Percent_Person_WithDiabetes_multiple_place_bar_block",
+                      "Percent_Person_WithHighBloodPressure_multiple_place_bar_block",
+                      "Percent_Person_WithHighCholesterol_multiple_place_bar_block",
+                      "Percent_Person_WithMentalHealthNotGood_multiple_place_bar_block",
+                      "Percent_Person_WithPhysicalHealthNotGood_multiple_place_bar_block",
+                      "Percent_Person_WithStroke_multiple_place_bar_block"
                     ],
-                    "title": "Per Capita Modes of Commute",
+                    "title": "Compared with Other Variables in Sunnyvale",
                     "type": "BAR"
                   }
                 ]
               }
-            ],
-            "title": "Modes of Commute"
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_Smoking"
+                    ],
+                    "title": "Percentage of Population That Smokes in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_BingeDrinking",
+                      "Percent_Person_Obesity",
+                      "Percent_Person_PhysicalInactivity",
+                      "Percent_Person_SleepLessThan7Hours",
+                      "Percent_Person_Smoking"
+                    ],
+                    "title": "Compared with Other Variables in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_WithArthritis"
+                    ],
+                    "title": "Arthritis in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_WithChronicObstructivePulmonaryDisease"
+                    ],
+                    "title": "Chronic Obstructive Pulmonary Disease in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
           }
         ],
         "statVarSpec": {
-          "dc/0gettc3bc60cb_multiple_place_bar_block": {
-            "name": "Drive alone",
-            "statVar": "dc/0gettc3bc60cb"
+          "Percent_Person_BingeDrinking": {
+            "name": "Percentage of Population Who Engage in Binge Drinking",
+            "statVar": "Percent_Person_BingeDrinking"
           },
-          "dc/0gettc3bc60cb_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Drive alone",
-            "scaling": 100.0,
-            "statVar": "dc/0gettc3bc60cb",
-            "unit": "%"
+          "Percent_Person_Obesity": {
+            "name": "Percentage of Population That Is Obese",
+            "statVar": "Percent_Person_Obesity"
           },
-          "dc/6rltk4kf75612_multiple_place_bar_block": {
-            "name": "Work at home",
-            "statVar": "dc/6rltk4kf75612"
+          "Percent_Person_PhysicalInactivity": {
+            "name": "Percentage of Population Who Are Physically Inactive",
+            "statVar": "Percent_Person_PhysicalInactivity"
           },
-          "dc/6rltk4kf75612_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Work at home",
-            "scaling": 100.0,
-            "statVar": "dc/6rltk4kf75612",
-            "unit": "%"
+          "Percent_Person_SleepLessThan7Hours": {
+            "name": "Percentage of Population That Sleeps Less Than 7 Hours Per Night",
+            "statVar": "Percent_Person_SleepLessThan7Hours"
           },
-          "dc/hbkh95kc7pkb6_multiple_place_bar_block": {
-            "name": "Public Transit",
-            "statVar": "dc/hbkh95kc7pkb6"
+          "Percent_Person_Smoking": {
+            "name": "Percentage of Population That Smokes",
+            "statVar": "Percent_Person_Smoking"
           },
-          "dc/hbkh95kc7pkb6_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Public Transit",
-            "scaling": 100.0,
-            "statVar": "dc/hbkh95kc7pkb6",
-            "unit": "%"
+          "Percent_Person_WithAllTeethLoss_multiple_place_bar_block": {
+            "name": "Prevalance of Complete Tooth Loss in the Population",
+            "statVar": "Percent_Person_WithAllTeethLoss"
           },
-          "dc/vp8cbt6k79t94_multiple_place_bar_block": {
-            "name": "Walk to work",
-            "statVar": "dc/vp8cbt6k79t94"
+          "Percent_Person_WithArthritis": {
+            "name": "Arthritis",
+            "statVar": "Percent_Person_WithArthritis"
           },
-          "dc/vp8cbt6k79t94_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Walk to work",
-            "scaling": 100.0,
-            "statVar": "dc/vp8cbt6k79t94",
-            "unit": "%"
+          "Percent_Person_WithArthritis_multiple_place_bar_block": {
+            "name": "Arthritis",
+            "statVar": "Percent_Person_WithArthritis"
           },
-          "dc/vt2q292eme79f_multiple_place_bar_block": {
-            "name": "Others (incl. Taxcab, Motorcyle, Bicycle)",
-            "statVar": "dc/vt2q292eme79f"
+          "Percent_Person_WithAsthma": {
+            "name": "Asthma",
+            "statVar": "Percent_Person_WithAsthma"
           },
-          "dc/vt2q292eme79f_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Others (incl. Taxcab, Motorcyle, Bicycle)",
-            "scaling": 100.0,
-            "statVar": "dc/vt2q292eme79f",
-            "unit": "%"
+          "Percent_Person_WithAsthma_multiple_place_bar_block": {
+            "name": "Asthma",
+            "statVar": "Percent_Person_WithAsthma"
           },
-          "dc/wc8q05drd74bd_multiple_place_bar_block": {
-            "name": "Carpool",
-            "statVar": "dc/wc8q05drd74bd"
+          "Percent_Person_WithCancerExcludingSkinCancer_multiple_place_bar_block": {
+            "name": "Cancer (excluding skin cancer)",
+            "statVar": "Percent_Person_WithCancerExcludingSkinCancer"
           },
-          "dc/wc8q05drd74bd_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
-            "name": "Carpool",
-            "scaling": 100.0,
-            "statVar": "dc/wc8q05drd74bd",
-            "unit": "%"
+          "Percent_Person_WithChronicKidneyDisease_multiple_place_bar_block": {
+            "name": "Chronic Kidney Disease",
+            "statVar": "Percent_Person_WithChronicKidneyDisease"
+          },
+          "Percent_Person_WithChronicObstructivePulmonaryDisease": {
+            "name": "Chronic Obstructive Pulmonary Disease",
+            "statVar": "Percent_Person_WithChronicObstructivePulmonaryDisease"
+          },
+          "Percent_Person_WithChronicObstructivePulmonaryDisease_multiple_place_bar_block": {
+            "name": "Chronic Obstructive Pulmonary Disease",
+            "statVar": "Percent_Person_WithChronicObstructivePulmonaryDisease"
+          },
+          "Percent_Person_WithCoronaryHeartDisease_multiple_place_bar_block": {
+            "name": "Coronary Heart Disease",
+            "statVar": "Percent_Person_WithCoronaryHeartDisease"
+          },
+          "Percent_Person_WithDiabetes_multiple_place_bar_block": {
+            "name": "Diabetes",
+            "statVar": "Percent_Person_WithDiabetes"
+          },
+          "Percent_Person_WithHighBloodPressure_multiple_place_bar_block": {
+            "name": "High Bood Pressure",
+            "statVar": "Percent_Person_WithHighBloodPressure"
+          },
+          "Percent_Person_WithHighCholesterol_multiple_place_bar_block": {
+            "name": "High Cholesterol",
+            "statVar": "Percent_Person_WithHighCholesterol"
+          },
+          "Percent_Person_WithMentalHealthNotGood_multiple_place_bar_block": {
+            "name": "Mental Health Issues",
+            "statVar": "Percent_Person_WithMentalHealthNotGood"
+          },
+          "Percent_Person_WithPhysicalHealthNotGood_multiple_place_bar_block": {
+            "name": "Physical Health Issues",
+            "statVar": "Percent_Person_WithPhysicalHealthNotGood"
+          },
+          "Percent_Person_WithStroke_multiple_place_bar_block": {
+            "name": "Stroke",
+            "statVar": "Percent_Person_WithStroke"
           }
         }
       }

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_3/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_3/chart_config.json
@@ -1,0 +1,129 @@
+{
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "comparisonPlaces": [
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "dc/6rltk4kf75612_multiple_place_bar_block",
+                      "dc/vp8cbt6k79t94_multiple_place_bar_block",
+                      "dc/hbkh95kc7pkb6_multiple_place_bar_block",
+                      "dc/wc8q05drd74bd_multiple_place_bar_block",
+                      "dc/0gettc3bc60cb_multiple_place_bar_block",
+                      "dc/vt2q292eme79f_multiple_place_bar_block"
+                    ],
+                    "title": "Modes of Commute in Sunnyvale",
+                    "type": "BAR"
+                  },
+                  {
+                    "comparisonPlaces": [
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "dc/6rltk4kf75612_multiple_place_bar_block_pc",
+                      "dc/vp8cbt6k79t94_multiple_place_bar_block_pc",
+                      "dc/hbkh95kc7pkb6_multiple_place_bar_block_pc",
+                      "dc/wc8q05drd74bd_multiple_place_bar_block_pc",
+                      "dc/0gettc3bc60cb_multiple_place_bar_block_pc",
+                      "dc/vt2q292eme79f_multiple_place_bar_block_pc"
+                    ],
+                    "title": "Per Capita Modes of Commute in Sunnyvale",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "title": "Modes of Commute"
+          }
+        ],
+        "statVarSpec": {
+          "dc/0gettc3bc60cb_multiple_place_bar_block": {
+            "name": "Drive alone",
+            "statVar": "dc/0gettc3bc60cb"
+          },
+          "dc/0gettc3bc60cb_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Drive alone",
+            "scaling": 100.0,
+            "statVar": "dc/0gettc3bc60cb",
+            "unit": "%"
+          },
+          "dc/6rltk4kf75612_multiple_place_bar_block": {
+            "name": "Work at home",
+            "statVar": "dc/6rltk4kf75612"
+          },
+          "dc/6rltk4kf75612_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Work at home",
+            "scaling": 100.0,
+            "statVar": "dc/6rltk4kf75612",
+            "unit": "%"
+          },
+          "dc/hbkh95kc7pkb6_multiple_place_bar_block": {
+            "name": "Public Transit",
+            "statVar": "dc/hbkh95kc7pkb6"
+          },
+          "dc/hbkh95kc7pkb6_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Public Transit",
+            "scaling": 100.0,
+            "statVar": "dc/hbkh95kc7pkb6",
+            "unit": "%"
+          },
+          "dc/vp8cbt6k79t94_multiple_place_bar_block": {
+            "name": "Walk to work",
+            "statVar": "dc/vp8cbt6k79t94"
+          },
+          "dc/vp8cbt6k79t94_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Walk to work",
+            "scaling": 100.0,
+            "statVar": "dc/vp8cbt6k79t94",
+            "unit": "%"
+          },
+          "dc/vt2q292eme79f_multiple_place_bar_block": {
+            "name": "Others (incl. Taxcab, Motorcyle, Bicycle)",
+            "statVar": "dc/vt2q292eme79f"
+          },
+          "dc/vt2q292eme79f_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Others (incl. Taxcab, Motorcyle, Bicycle)",
+            "scaling": 100.0,
+            "statVar": "dc/vt2q292eme79f",
+            "unit": "%"
+          },
+          "dc/wc8q05drd74bd_multiple_place_bar_block": {
+            "name": "Carpool",
+            "statVar": "dc/wc8q05drd74bd"
+          },
+          "dc/wc8q05drd74bd_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Carpool",
+            "scaling": 100.0,
+            "statVar": "dc/wc8q05drd74bd",
+            "unit": "%"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "placeDcid": [
+        "geoId/0677000"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "place": {
+    "dcid": "geoId/0677000",
+    "name": "Sunnyvale",
+    "place_type": "City"
+  }
+}

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_3/debug_info.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_3/debug_info.json
@@ -4,101 +4,84 @@
   "contained_in_classification": "<None>",
   "correlation_classification": "<None>",
   "counters": {
-    "failed_existence_check": [
-      {
-        "places": [
-          "geoId/0677000"
-        ],
-        "svs": [
-          "Percent_Person_Children_WithAsthma"
-        ]
-      }
-    ],
-    "failed_existence_check_extended_svs": [
-      {
-        "places": [
-          "geoId/0677000"
-        ],
-        "svs": [
-          "Count_Person_Upto18Years",
-          "Percent_Person_Children_WithAsthma"
-        ]
-      }
-    ],
     "filtered_svs": [
-      "Percent_Person_WithAsthma",
-      "Percent_Person_Children_WithAsthma",
-      "dc/g/Person_MedicalCondition-Asthma",
-      "Percent_Person_Smoking",
-      "Percent_Person_WithArthritis",
-      "Percent_Person_WithChronicObstructivePulmonaryDisease"
+      "dc/topic/WorkCommute"
     ],
-    "num_chart_candidates": 6,
+    "num_chart_candidates": 1,
     "processed_fulfillment_types": [
       "simple"
     ],
     "stat_var_extensions": [
+      {}
+    ],
+    "topics_processed": [
       {
-        "Percent_Person_Children_WithAsthma": [
-          "Count_Person_Upto18Years",
-          "Percent_Person_Children_WithAsthma"
-        ],
-        "Percent_Person_Smoking": [
-          "Percent_Person_BingeDrinking",
-          "Percent_Person_Obesity",
-          "Percent_Person_PhysicalInactivity",
-          "Percent_Person_SleepLessThan7Hours",
-          "Percent_Person_Smoking"
-        ],
-        "Percent_Person_WithArthritis": [
-          "Percent_Person_WithAllTeethLoss",
-          "Percent_Person_WithArthritis",
-          "Percent_Person_WithAsthma",
-          "Percent_Person_WithCancerExcludingSkinCancer",
-          "Percent_Person_WithChronicKidneyDisease",
-          "Percent_Person_WithChronicObstructivePulmonaryDisease",
-          "Percent_Person_WithCoronaryHeartDisease",
-          "Percent_Person_WithDiabetes",
-          "Percent_Person_WithHighBloodPressure",
-          "Percent_Person_WithHighCholesterol",
-          "Percent_Person_WithMentalHealthNotGood",
-          "Percent_Person_WithPhysicalHealthNotGood",
-          "Percent_Person_WithStroke"
-        ],
-        "Percent_Person_WithAsthma": [
-          "Percent_Person_WithAllTeethLoss",
-          "Percent_Person_WithArthritis",
-          "Percent_Person_WithAsthma",
-          "Percent_Person_WithCancerExcludingSkinCancer",
-          "Percent_Person_WithChronicKidneyDisease",
-          "Percent_Person_WithChronicObstructivePulmonaryDisease",
-          "Percent_Person_WithCoronaryHeartDisease",
-          "Percent_Person_WithDiabetes",
-          "Percent_Person_WithHighBloodPressure",
-          "Percent_Person_WithHighCholesterol",
-          "Percent_Person_WithMentalHealthNotGood",
-          "Percent_Person_WithPhysicalHealthNotGood",
-          "Percent_Person_WithStroke"
-        ],
-        "Percent_Person_WithChronicObstructivePulmonaryDisease": [
-          "Percent_Person_WithAllTeethLoss",
-          "Percent_Person_WithArthritis",
-          "Percent_Person_WithAsthma",
-          "Percent_Person_WithCancerExcludingSkinCancer",
-          "Percent_Person_WithChronicKidneyDisease",
-          "Percent_Person_WithChronicObstructivePulmonaryDisease",
-          "Percent_Person_WithCoronaryHeartDisease",
-          "Percent_Person_WithDiabetes",
-          "Percent_Person_WithHighBloodPressure",
-          "Percent_Person_WithHighCholesterol",
-          "Percent_Person_WithMentalHealthNotGood",
-          "Percent_Person_WithPhysicalHealthNotGood",
-          "Percent_Person_WithStroke"
-        ]
+        "dc/topic/WorkCommute": {
+          "peer_groups": [
+            [
+              "Modes of Commute",
+              "",
+              [
+                "dc/6rltk4kf75612",
+                "dc/vp8cbt6k79t94",
+                "dc/hbkh95kc7pkb6",
+                "dc/wc8q05drd74bd",
+                "dc/0gettc3bc60cb",
+                "dc/vt2q292eme79f"
+              ]
+            ]
+          ],
+          "svs": []
+        }
       }
     ]
   },
   "data_spec": [
+    {
+      "classifications": [
+        {
+          "type": 12
+        }
+      ],
+      "places": [],
+      "query": "What is the commute pattern there",
+      "query_type": 1,
+      "ranked_charts": [
+        {
+          "attr": {
+            "block_id": 2,
+            "chart_type": "bar chart",
+            "class": 0,
+            "description": "",
+            "include_percapita": true,
+            "place_type": null,
+            "ranking_types": [],
+            "source_topic": "dc/topic/WorkCommute",
+            "title": "Modes of Commute"
+          },
+          "chart_type": 3,
+          "event": null,
+          "places": [
+            {
+              "dcid": "geoId/0677000",
+              "name": "Sunnyvale",
+              "place_type": "City"
+            }
+          ],
+          "svs": [
+            "dc/6rltk4kf75612",
+            "dc/vp8cbt6k79t94",
+            "dc/hbkh95kc7pkb6",
+            "dc/wc8q05drd74bd",
+            "dc/0gettc3bc60cb",
+            "dc/vt2q292eme79f"
+          ]
+        }
+      ],
+      "svs": [
+        "dc/topic/WorkCommute"
+      ]
+    },
     {
       "classifications": [
         {
@@ -400,123 +383,111 @@
   "event_classification": "<None>",
   "main_place_dcid": "<None>",
   "main_place_name": "<None>",
-  "original_query": "What is the prevalence of asthma there",
+  "original_query": "What is the commute pattern there",
   "overview_classification": "<None>",
   "places_detected": [
     "<None>"
   ],
-  "query_with_places_removed": "What is the prevalence of asthma there",
+  "query_with_places_removed": "What is the commute pattern there",
   "ranking_classification": "<None>",
   "size_type_classification": "<None>",
   "status": "",
   "sv_matching": {
     "CosineScore": [
-      0.9887783527374268,
-      0.8786565065383911,
-      0.8242027163505554,
-      0.5711094737052917,
-      0.5687739253044128,
-      0.5341616868972778,
-      0.4882679879665375,
-      0.48637840151786804,
-      0.4809362292289734,
-      0.4783497452735901
+      0.672934353351593,
+      0.21922606229782104,
+      0.21280181407928467,
+      0.21179991960525513,
+      0.2049480527639389,
+      0.19941174983978271,
+      0.1981937438249588,
+      0.184875026345253
     ],
     "SV": [
-      "Percent_Person_WithAsthma",
-      "Percent_Person_Children_WithAsthma",
-      "dc/g/Person_MedicalCondition-Asthma",
-      "Percent_Person_Smoking",
-      "Percent_Person_WithArthritis",
-      "Percent_Person_WithChronicObstructivePulmonaryDisease",
-      "Percent_Person_WithHighCholesterol",
-      "Percent_Person_18To64Years_ReceivedNoHealthInsurance",
-      "Count_Death_DiseasesOfTheRespiratorySystem",
-      "Percent_Person_WithCoronaryHeartDisease"
+      "dc/topic/WorkCommute",
+      "dc/topic/Jobs",
+      "dc/g/Person_Industry-NAICS/492",
+      "dc/g/Person_MedicalCondition-ChronicObstructivePulmonaryDisease",
+      "Count_CriminalActivities_MotorVehicleTheft",
+      "Count_CriminalActivities_PropertyCrime",
+      "Count_CriminalIncidents_IsHateCrime",
+      "dc/n87t9dkckzxc8"
     ],
     "SV_to_Sentences": {
-      "Count_Death_DiseasesOfTheRespiratorySystem": [
-        "Number of Deaths Due to Diseases of the Respiratory System (0.4809362292289734)",
-        "Number of deaths due to diseases of the respiratory system (0.4809362292289734)"
+      "Count_CriminalActivities_MotorVehicleTheft": [
+        "Number of vehicles stolen (0.2049480527639389)",
+        "Count of Criminal Activities: Motor Vehicle Theft (0.20094163715839386)",
+        "Number of motor vehicles taken (0.19183626770973206)",
+        "Number of thefts of motor vehicles (0.18853498995304108)",
+        "Total number of vehicles stolen (0.18824565410614014)",
+        "Number of motor vehicle heists (0.18401506543159485)",
+        "Total number of motor vehicle theft cases (0.18093903362751007)"
       ],
-      "Percent_Person_18To64Years_ReceivedNoHealthInsurance": [
-        "Prevalence: 18 - 64 Years, No Health Insurance (0.48637840151786804)"
+      "Count_CriminalActivities_PropertyCrime": [
+        "Number of property cases (0.19941174983978271)"
       ],
-      "Percent_Person_Children_WithAsthma": [
-        "Prevalence: Asthma in Children (0.8786565065383911)",
-        "percent of children that have asthma (0.7320816516876221)",
-        "Percent of Children That Have Asthma (0.7320816516876221)"
+      "Count_CriminalIncidents_IsHateCrime": [
+        "Number of discriminatory crimes (0.1981937438249588)"
       ],
-      "Percent_Person_Smoking": [
-        "Prevalence: Smoking (0.5711094737052917)"
+      "dc/g/Person_Industry-NAICS/492": [
+        "People Working as Couriers and Messengers (0.21280181407928467)",
+        "People working as couriers and messengers (0.21280181407928467)",
+        "Person With Industry = Couriers And Messengers (NAICS/492) (0.1928308606147766)"
       ],
-      "Percent_Person_WithArthritis": [
-        "Prevalence: Arthritis (0.5687739253044128)",
-        "Percentage of Population With Arthritis (0.47449490427970886)"
+      "dc/g/Person_MedicalCondition-ChronicObstructivePulmonaryDisease": [
+        "Person With Medical Condition = Chronic Obstructive Pulmonary Disease (0.21179991960525513)"
       ],
-      "Percent_Person_WithAsthma": [
-        "Prevalence: Asthma (0.9887783527374268)",
-        "Percent of People That Have Asthma (0.8041638731956482)",
-        "percent of people that have asthma (0.8041638731956482)"
+      "dc/n87t9dkckzxc8": [
+        "number of couriers and messengers workers (0.184875026345253)",
+        "Population of Person: Couriers And Messengers (NAICS/492) (0.18129093945026398)"
       ],
-      "Percent_Person_WithChronicObstructivePulmonaryDisease": [
-        "Prevalence: Chronic Obstructive Pulmonary Disease (0.5341616868972778)",
-        "Percent of People That Have Chronic Obstructive Pulmonary Disease (0.48919302225112915)",
-        "percent of people that have chronic obstructive pulmonary disease (0.48919302225112915)"
+      "dc/topic/Jobs": [
+        "Work Occupations (0.21922606229782104)"
       ],
-      "Percent_Person_WithCoronaryHeartDisease": [
-        "Prevalence: Coronary Heart Disease (0.4783497452735901)"
-      ],
-      "Percent_Person_WithHighCholesterol": [
-        "Prevalence: High Cholesterol (0.4882679879665375)"
-      ],
-      "dc/g/Person_MedicalCondition-Asthma": [
-        "Number of People With Asthma (0.8242027163505554)",
-        "people with asthma (0.7225263714790344)",
-        "Person With Medical Condition = Asthma (0.6960465908050537)"
+      "dc/topic/WorkCommute": [
+        "commute mode (0.672934353351593)",
+        "Work Commute (0.5764998197555542)",
+        "Work commute (0.5764998197555542)",
+        "travel to work (0.1901087909936905)"
       ]
     }
   },
   "svs_to_sentences": {
-    "Count_Death_DiseasesOfTheRespiratorySystem": [
-      "Number of Deaths Due to Diseases of the Respiratory System (0.4809362292289734)",
-      "Number of deaths due to diseases of the respiratory system (0.4809362292289734)"
+    "Count_CriminalActivities_MotorVehicleTheft": [
+      "Number of vehicles stolen (0.2049480527639389)",
+      "Count of Criminal Activities: Motor Vehicle Theft (0.20094163715839386)",
+      "Number of motor vehicles taken (0.19183626770973206)",
+      "Number of thefts of motor vehicles (0.18853498995304108)",
+      "Total number of vehicles stolen (0.18824565410614014)",
+      "Number of motor vehicle heists (0.18401506543159485)",
+      "Total number of motor vehicle theft cases (0.18093903362751007)"
     ],
-    "Percent_Person_18To64Years_ReceivedNoHealthInsurance": [
-      "Prevalence: 18 - 64 Years, No Health Insurance (0.48637840151786804)"
+    "Count_CriminalActivities_PropertyCrime": [
+      "Number of property cases (0.19941174983978271)"
     ],
-    "Percent_Person_Children_WithAsthma": [
-      "Prevalence: Asthma in Children (0.8786565065383911)",
-      "percent of children that have asthma (0.7320816516876221)",
-      "Percent of Children That Have Asthma (0.7320816516876221)"
+    "Count_CriminalIncidents_IsHateCrime": [
+      "Number of discriminatory crimes (0.1981937438249588)"
     ],
-    "Percent_Person_Smoking": [
-      "Prevalence: Smoking (0.5711094737052917)"
+    "dc/g/Person_Industry-NAICS/492": [
+      "People Working as Couriers and Messengers (0.21280181407928467)",
+      "People working as couriers and messengers (0.21280181407928467)",
+      "Person With Industry = Couriers And Messengers (NAICS/492) (0.1928308606147766)"
     ],
-    "Percent_Person_WithArthritis": [
-      "Prevalence: Arthritis (0.5687739253044128)",
-      "Percentage of Population With Arthritis (0.47449490427970886)"
+    "dc/g/Person_MedicalCondition-ChronicObstructivePulmonaryDisease": [
+      "Person With Medical Condition = Chronic Obstructive Pulmonary Disease (0.21179991960525513)"
     ],
-    "Percent_Person_WithAsthma": [
-      "Prevalence: Asthma (0.9887783527374268)",
-      "Percent of People That Have Asthma (0.8041638731956482)",
-      "percent of people that have asthma (0.8041638731956482)"
+    "dc/n87t9dkckzxc8": [
+      "number of couriers and messengers workers (0.184875026345253)",
+      "Population of Person: Couriers And Messengers (NAICS/492) (0.18129093945026398)"
     ],
-    "Percent_Person_WithChronicObstructivePulmonaryDisease": [
-      "Prevalence: Chronic Obstructive Pulmonary Disease (0.5341616868972778)",
-      "Percent of People That Have Chronic Obstructive Pulmonary Disease (0.48919302225112915)",
-      "percent of people that have chronic obstructive pulmonary disease (0.48919302225112915)"
+    "dc/topic/Jobs": [
+      "Work Occupations (0.21922606229782104)"
     ],
-    "Percent_Person_WithCoronaryHeartDisease": [
-      "Prevalence: Coronary Heart Disease (0.4783497452735901)"
-    ],
-    "Percent_Person_WithHighCholesterol": [
-      "Prevalence: High Cholesterol (0.4882679879665375)"
-    ],
-    "dc/g/Person_MedicalCondition-Asthma": [
-      "Number of People With Asthma (0.8242027163505554)",
-      "people with asthma (0.7225263714790344)",
-      "Person With Medical Condition = Asthma (0.6960465908050537)"
+    "dc/topic/WorkCommute": [
+      "commute mode (0.672934353351593)",
+      "Work Commute (0.5764998197555542)",
+      "Work commute (0.5764998197555542)",
+      "travel to work (0.1901087909936905)"
     ]
   },
   "temporal_classification": "<None>",

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_4/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_4/chart_config.json
@@ -1,0 +1,131 @@
+{
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "comparisonPlaces": [
+                      "geoId/0677000",
+                      "geoId/0665028"
+                    ],
+                    "statVarKey": [
+                      "dc/6rltk4kf75612_multiple_place_bar_block",
+                      "dc/vp8cbt6k79t94_multiple_place_bar_block",
+                      "dc/hbkh95kc7pkb6_multiple_place_bar_block",
+                      "dc/wc8q05drd74bd_multiple_place_bar_block",
+                      "dc/0gettc3bc60cb_multiple_place_bar_block",
+                      "dc/vt2q292eme79f_multiple_place_bar_block"
+                    ],
+                    "title": "Modes of Commute",
+                    "type": "BAR"
+                  },
+                  {
+                    "comparisonPlaces": [
+                      "geoId/0677000",
+                      "geoId/0665028"
+                    ],
+                    "statVarKey": [
+                      "dc/6rltk4kf75612_multiple_place_bar_block_pc",
+                      "dc/vp8cbt6k79t94_multiple_place_bar_block_pc",
+                      "dc/hbkh95kc7pkb6_multiple_place_bar_block_pc",
+                      "dc/wc8q05drd74bd_multiple_place_bar_block_pc",
+                      "dc/0gettc3bc60cb_multiple_place_bar_block_pc",
+                      "dc/vt2q292eme79f_multiple_place_bar_block_pc"
+                    ],
+                    "title": "Per Capita Modes of Commute",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "title": "Modes of Commute"
+          }
+        ],
+        "statVarSpec": {
+          "dc/0gettc3bc60cb_multiple_place_bar_block": {
+            "name": "Drive alone",
+            "statVar": "dc/0gettc3bc60cb"
+          },
+          "dc/0gettc3bc60cb_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Drive alone",
+            "scaling": 100.0,
+            "statVar": "dc/0gettc3bc60cb",
+            "unit": "%"
+          },
+          "dc/6rltk4kf75612_multiple_place_bar_block": {
+            "name": "Work at home",
+            "statVar": "dc/6rltk4kf75612"
+          },
+          "dc/6rltk4kf75612_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Work at home",
+            "scaling": 100.0,
+            "statVar": "dc/6rltk4kf75612",
+            "unit": "%"
+          },
+          "dc/hbkh95kc7pkb6_multiple_place_bar_block": {
+            "name": "Public Transit",
+            "statVar": "dc/hbkh95kc7pkb6"
+          },
+          "dc/hbkh95kc7pkb6_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Public Transit",
+            "scaling": 100.0,
+            "statVar": "dc/hbkh95kc7pkb6",
+            "unit": "%"
+          },
+          "dc/vp8cbt6k79t94_multiple_place_bar_block": {
+            "name": "Walk to work",
+            "statVar": "dc/vp8cbt6k79t94"
+          },
+          "dc/vp8cbt6k79t94_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Walk to work",
+            "scaling": 100.0,
+            "statVar": "dc/vp8cbt6k79t94",
+            "unit": "%"
+          },
+          "dc/vt2q292eme79f_multiple_place_bar_block": {
+            "name": "Others (incl. Taxcab, Motorcyle, Bicycle)",
+            "statVar": "dc/vt2q292eme79f"
+          },
+          "dc/vt2q292eme79f_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Others (incl. Taxcab, Motorcyle, Bicycle)",
+            "scaling": 100.0,
+            "statVar": "dc/vt2q292eme79f",
+            "unit": "%"
+          },
+          "dc/wc8q05drd74bd_multiple_place_bar_block": {
+            "name": "Carpool",
+            "statVar": "dc/wc8q05drd74bd"
+          },
+          "dc/wc8q05drd74bd_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Carpool",
+            "scaling": 100.0,
+            "statVar": "dc/wc8q05drd74bd",
+            "unit": "%"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "placeDcid": [
+        "geoId/0677000"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "place": {
+    "dcid": "geoId/0677000",
+    "name": "Sunnyvale",
+    "place_type": "City"
+  }
+}

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_4/debug_info.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_4/debug_info.json
@@ -1,104 +1,145 @@
 {
   "clustering_classification": "<None>",
-  "comparison_classification": "<None>",
+  "comparison_classification": "ClassificationType.COMPARISON",
   "contained_in_classification": "<None>",
   "correlation_classification": "<None>",
   "counters": {
-    "failed_existence_check": [
-      {
-        "places": [
-          "geoId/0677000"
-        ],
-        "svs": [
-          "Percent_Person_Children_WithAsthma"
-        ]
-      }
+    "comparison_place_candidates": [
+      [
+        "geoId/0677000",
+        "geoId/0665028"
+      ]
     ],
-    "failed_existence_check_extended_svs": [
-      {
-        "places": [
-          "geoId/0677000"
-        ],
-        "svs": [
-          "Count_Person_Upto18Years",
-          "Percent_Person_Children_WithAsthma"
-        ]
-      }
-    ],
-    "filtered_svs": [
-      "Percent_Person_WithAsthma",
-      "Percent_Person_Children_WithAsthma",
-      "dc/g/Person_MedicalCondition-Asthma",
-      "Percent_Person_Smoking",
-      "Percent_Person_WithArthritis",
-      "Percent_Person_WithChronicObstructivePulmonaryDisease"
-    ],
-    "num_chart_candidates": 6,
+    "filtered_svs": [],
+    "num_chart_candidates": 1,
     "processed_fulfillment_types": [
-      "simple"
+      "comparison"
     ],
     "stat_var_extensions": [
+      {}
+    ],
+    "topics_processed": [
       {
-        "Percent_Person_Children_WithAsthma": [
-          "Count_Person_Upto18Years",
-          "Percent_Person_Children_WithAsthma"
-        ],
-        "Percent_Person_Smoking": [
-          "Percent_Person_BingeDrinking",
-          "Percent_Person_Obesity",
-          "Percent_Person_PhysicalInactivity",
-          "Percent_Person_SleepLessThan7Hours",
-          "Percent_Person_Smoking"
-        ],
-        "Percent_Person_WithArthritis": [
-          "Percent_Person_WithAllTeethLoss",
-          "Percent_Person_WithArthritis",
-          "Percent_Person_WithAsthma",
-          "Percent_Person_WithCancerExcludingSkinCancer",
-          "Percent_Person_WithChronicKidneyDisease",
-          "Percent_Person_WithChronicObstructivePulmonaryDisease",
-          "Percent_Person_WithCoronaryHeartDisease",
-          "Percent_Person_WithDiabetes",
-          "Percent_Person_WithHighBloodPressure",
-          "Percent_Person_WithHighCholesterol",
-          "Percent_Person_WithMentalHealthNotGood",
-          "Percent_Person_WithPhysicalHealthNotGood",
-          "Percent_Person_WithStroke"
-        ],
-        "Percent_Person_WithAsthma": [
-          "Percent_Person_WithAllTeethLoss",
-          "Percent_Person_WithArthritis",
-          "Percent_Person_WithAsthma",
-          "Percent_Person_WithCancerExcludingSkinCancer",
-          "Percent_Person_WithChronicKidneyDisease",
-          "Percent_Person_WithChronicObstructivePulmonaryDisease",
-          "Percent_Person_WithCoronaryHeartDisease",
-          "Percent_Person_WithDiabetes",
-          "Percent_Person_WithHighBloodPressure",
-          "Percent_Person_WithHighCholesterol",
-          "Percent_Person_WithMentalHealthNotGood",
-          "Percent_Person_WithPhysicalHealthNotGood",
-          "Percent_Person_WithStroke"
-        ],
-        "Percent_Person_WithChronicObstructivePulmonaryDisease": [
-          "Percent_Person_WithAllTeethLoss",
-          "Percent_Person_WithArthritis",
-          "Percent_Person_WithAsthma",
-          "Percent_Person_WithCancerExcludingSkinCancer",
-          "Percent_Person_WithChronicKidneyDisease",
-          "Percent_Person_WithChronicObstructivePulmonaryDisease",
-          "Percent_Person_WithCoronaryHeartDisease",
-          "Percent_Person_WithDiabetes",
-          "Percent_Person_WithHighBloodPressure",
-          "Percent_Person_WithHighCholesterol",
-          "Percent_Person_WithMentalHealthNotGood",
-          "Percent_Person_WithPhysicalHealthNotGood",
-          "Percent_Person_WithStroke"
-        ]
+        "dc/topic/WorkCommute": {
+          "peer_groups": [
+            [
+              "Modes of Commute",
+              "",
+              [
+                "dc/6rltk4kf75612",
+                "dc/vp8cbt6k79t94",
+                "dc/hbkh95kc7pkb6",
+                "dc/wc8q05drd74bd",
+                "dc/0gettc3bc60cb",
+                "dc/vt2q292eme79f"
+              ]
+            ]
+          ],
+          "svs": []
+        }
       }
     ]
   },
   "data_spec": [
+    {
+      "classifications": [
+        {
+          "type": 7
+        }
+      ],
+      "places": [
+        {
+          "dcid": "geoId/0665028",
+          "name": "San Bruno",
+          "place_type": "City"
+        }
+      ],
+      "query": "How does that compare with San Bruno",
+      "query_type": 6,
+      "ranked_charts": [
+        {
+          "attr": {
+            "block_id": 2,
+            "chart_type": "comparison chart",
+            "class": 0,
+            "description": "",
+            "include_percapita": true,
+            "place_type": null,
+            "ranking_types": [],
+            "source_topic": "dc/topic/WorkCommute",
+            "title": "Modes of Commute"
+          },
+          "chart_type": 3,
+          "event": null,
+          "places": [
+            {
+              "dcid": "geoId/0677000",
+              "name": "Sunnyvale",
+              "place_type": "City"
+            },
+            {
+              "dcid": "geoId/0665028",
+              "name": "San Bruno",
+              "place_type": "City"
+            }
+          ],
+          "svs": [
+            "dc/6rltk4kf75612",
+            "dc/vp8cbt6k79t94",
+            "dc/hbkh95kc7pkb6",
+            "dc/wc8q05drd74bd",
+            "dc/0gettc3bc60cb",
+            "dc/vt2q292eme79f"
+          ]
+        }
+      ],
+      "svs": []
+    },
+    {
+      "classifications": [
+        {
+          "type": 12
+        }
+      ],
+      "places": [],
+      "query": "What is the commute pattern there",
+      "query_type": 1,
+      "ranked_charts": [
+        {
+          "attr": {
+            "block_id": 2,
+            "chart_type": "bar chart",
+            "class": 0,
+            "description": "",
+            "include_percapita": true,
+            "place_type": null,
+            "ranking_types": [],
+            "source_topic": "dc/topic/WorkCommute",
+            "title": "Modes of Commute"
+          },
+          "chart_type": 3,
+          "event": null,
+          "places": [
+            {
+              "dcid": "geoId/0677000",
+              "name": "Sunnyvale",
+              "place_type": "City"
+            }
+          ],
+          "svs": [
+            "dc/6rltk4kf75612",
+            "dc/vp8cbt6k79t94",
+            "dc/hbkh95kc7pkb6",
+            "dc/wc8q05drd74bd",
+            "dc/0gettc3bc60cb",
+            "dc/vt2q292eme79f"
+          ]
+        }
+      ],
+      "svs": [
+        "dc/topic/WorkCommute"
+      ]
+    },
     {
       "classifications": [
         {
@@ -398,125 +439,137 @@
     }
   ],
   "event_classification": "<None>",
-  "main_place_dcid": "<None>",
-  "main_place_name": "<None>",
-  "original_query": "What is the prevalence of asthma there",
+  "main_place_dcid": "geoId/0665028",
+  "main_place_name": "San Bruno",
+  "original_query": "How does that compare with San Bruno",
   "overview_classification": "<None>",
   "places_detected": [
-    "<None>"
+    "san bruno"
   ],
-  "query_with_places_removed": "What is the prevalence of asthma there",
+  "query_with_places_removed": "how does that compare with",
   "ranking_classification": "<None>",
   "size_type_classification": "<None>",
   "status": "",
   "sv_matching": {
     "CosineScore": [
-      0.9887783527374268,
-      0.8786565065383911,
-      0.8242027163505554,
-      0.5711094737052917,
-      0.5687739253044128,
-      0.5341616868972778,
-      0.4882679879665375,
-      0.48637840151786804,
-      0.4809362292289734,
-      0.4783497452735901
+      0.3138737976551056,
+      0.2785080075263977,
+      0.27663561701774597,
+      0.2477339506149292,
+      0.2361648827791214,
+      0.2359907180070877,
+      0.23327934741973877,
+      0.20929011702537537,
+      0.19067034125328064,
+      0.18910424411296844,
+      0.18715006113052368,
+      0.1836508810520172
     ],
     "SV": [
-      "Percent_Person_WithAsthma",
-      "Percent_Person_Children_WithAsthma",
-      "dc/g/Person_MedicalCondition-Asthma",
-      "Percent_Person_Smoking",
-      "Percent_Person_WithArthritis",
-      "Percent_Person_WithChronicObstructivePulmonaryDisease",
-      "Percent_Person_WithHighCholesterol",
-      "Percent_Person_18To64Years_ReceivedNoHealthInsurance",
-      "Count_Death_DiseasesOfTheRespiratorySystem",
-      "Percent_Person_WithCoronaryHeartDisease"
+      "GiniIndex_EconomicActivity",
+      "dc/topic/MedicalConditions",
+      "dc/topic/Economy",
+      "AirQualityIndex_AirPollutant",
+      "dc/topic/Income",
+      "dc/topic/Jobs",
+      "Amount_FarmInventory_PeanutsForNuts",
+      "Count_Person",
+      "dc/g/Person_MedicalCondition-Wasting",
+      "Count_CriminalIncidents_IsHateCrime",
+      "dc/g/Farm_FarmInventoryType-PeanutsForNuts",
+      "dc/g/Farm_FarmInventoryType-HogsAndPigs"
     ],
     "SV_to_Sentences": {
-      "Count_Death_DiseasesOfTheRespiratorySystem": [
-        "Number of Deaths Due to Diseases of the Respiratory System (0.4809362292289734)",
-        "Number of deaths due to diseases of the respiratory system (0.4809362292289734)"
+      "AirQualityIndex_AirPollutant": [
+        "AQI (0.2477339506149292)"
       ],
-      "Percent_Person_18To64Years_ReceivedNoHealthInsurance": [
-        "Prevalence: 18 - 64 Years, No Health Insurance (0.48637840151786804)"
+      "Amount_FarmInventory_PeanutsForNuts": [
+        "Peanut output (0.23327934741973877)"
       ],
-      "Percent_Person_Children_WithAsthma": [
-        "Prevalence: Asthma in Children (0.8786565065383911)",
-        "percent of children that have asthma (0.7320816516876221)",
-        "Percent of Children That Have Asthma (0.7320816516876221)"
+      "Count_CriminalIncidents_IsHateCrime": [
+        "Number of hate crimes (0.18910424411296844)",
+        "Hate crime incidents (0.1843578815460205)"
       ],
-      "Percent_Person_Smoking": [
-        "Prevalence: Smoking (0.5711094737052917)"
+      "Count_Person": [
+        "Population (0.20929011702537537)"
       ],
-      "Percent_Person_WithArthritis": [
-        "Prevalence: Arthritis (0.5687739253044128)",
-        "Percentage of Population With Arthritis (0.47449490427970886)"
+      "GiniIndex_EconomicActivity": [
+        "Inequality (0.3138737976551056)",
+        "Gini index (0.2066114842891693)"
       ],
-      "Percent_Person_WithAsthma": [
-        "Prevalence: Asthma (0.9887783527374268)",
-        "Percent of People That Have Asthma (0.8041638731956482)",
-        "percent of people that have asthma (0.8041638731956482)"
+      "dc/g/Farm_FarmInventoryType-HogsAndPigs": [
+        "pig farm (0.1836508810520172)",
+        "Pig Farm (0.1836508810520172)"
       ],
-      "Percent_Person_WithChronicObstructivePulmonaryDisease": [
-        "Prevalence: Chronic Obstructive Pulmonary Disease (0.5341616868972778)",
-        "Percent of People That Have Chronic Obstructive Pulmonary Disease (0.48919302225112915)",
-        "percent of people that have chronic obstructive pulmonary disease (0.48919302225112915)"
+      "dc/g/Farm_FarmInventoryType-PeanutsForNuts": [
+        "peanut farms (0.18715006113052368)",
+        "Peanut Farms (0.18715006113052368)"
       ],
-      "Percent_Person_WithCoronaryHeartDisease": [
-        "Prevalence: Coronary Heart Disease (0.4783497452735901)"
+      "dc/g/Person_MedicalCondition-Wasting": [
+        "people with wasting (0.19067034125328064)"
       ],
-      "Percent_Person_WithHighCholesterol": [
-        "Prevalence: High Cholesterol (0.4882679879665375)"
+      "dc/topic/Economy": [
+        "Economy (0.27663561701774597)"
       ],
-      "dc/g/Person_MedicalCondition-Asthma": [
-        "Number of People With Asthma (0.8242027163505554)",
-        "people with asthma (0.7225263714790344)",
-        "Person With Medical Condition = Asthma (0.6960465908050537)"
+      "dc/topic/Income": [
+        "pay (0.2361648827791214)"
+      ],
+      "dc/topic/Jobs": [
+        "Jobs (0.2359907180070877)",
+        "Careers (0.20936834812164307)",
+        "Professions (0.2041512280702591)"
+      ],
+      "dc/topic/MedicalConditions": [
+        "Maladies (0.2785080075263977)",
+        "Health problems (0.2000654637813568)",
+        "health issues (0.19044229388237)"
       ]
     }
   },
   "svs_to_sentences": {
-    "Count_Death_DiseasesOfTheRespiratorySystem": [
-      "Number of Deaths Due to Diseases of the Respiratory System (0.4809362292289734)",
-      "Number of deaths due to diseases of the respiratory system (0.4809362292289734)"
+    "AirQualityIndex_AirPollutant": [
+      "AQI (0.2477339506149292)"
     ],
-    "Percent_Person_18To64Years_ReceivedNoHealthInsurance": [
-      "Prevalence: 18 - 64 Years, No Health Insurance (0.48637840151786804)"
+    "Amount_FarmInventory_PeanutsForNuts": [
+      "Peanut output (0.23327934741973877)"
     ],
-    "Percent_Person_Children_WithAsthma": [
-      "Prevalence: Asthma in Children (0.8786565065383911)",
-      "percent of children that have asthma (0.7320816516876221)",
-      "Percent of Children That Have Asthma (0.7320816516876221)"
+    "Count_CriminalIncidents_IsHateCrime": [
+      "Number of hate crimes (0.18910424411296844)",
+      "Hate crime incidents (0.1843578815460205)"
     ],
-    "Percent_Person_Smoking": [
-      "Prevalence: Smoking (0.5711094737052917)"
+    "Count_Person": [
+      "Population (0.20929011702537537)"
     ],
-    "Percent_Person_WithArthritis": [
-      "Prevalence: Arthritis (0.5687739253044128)",
-      "Percentage of Population With Arthritis (0.47449490427970886)"
+    "GiniIndex_EconomicActivity": [
+      "Inequality (0.3138737976551056)",
+      "Gini index (0.2066114842891693)"
     ],
-    "Percent_Person_WithAsthma": [
-      "Prevalence: Asthma (0.9887783527374268)",
-      "Percent of People That Have Asthma (0.8041638731956482)",
-      "percent of people that have asthma (0.8041638731956482)"
+    "dc/g/Farm_FarmInventoryType-HogsAndPigs": [
+      "pig farm (0.1836508810520172)",
+      "Pig Farm (0.1836508810520172)"
     ],
-    "Percent_Person_WithChronicObstructivePulmonaryDisease": [
-      "Prevalence: Chronic Obstructive Pulmonary Disease (0.5341616868972778)",
-      "Percent of People That Have Chronic Obstructive Pulmonary Disease (0.48919302225112915)",
-      "percent of people that have chronic obstructive pulmonary disease (0.48919302225112915)"
+    "dc/g/Farm_FarmInventoryType-PeanutsForNuts": [
+      "peanut farms (0.18715006113052368)",
+      "Peanut Farms (0.18715006113052368)"
     ],
-    "Percent_Person_WithCoronaryHeartDisease": [
-      "Prevalence: Coronary Heart Disease (0.4783497452735901)"
+    "dc/g/Person_MedicalCondition-Wasting": [
+      "people with wasting (0.19067034125328064)"
     ],
-    "Percent_Person_WithHighCholesterol": [
-      "Prevalence: High Cholesterol (0.4882679879665375)"
+    "dc/topic/Economy": [
+      "Economy (0.27663561701774597)"
     ],
-    "dc/g/Person_MedicalCondition-Asthma": [
-      "Number of People With Asthma (0.8242027163505554)",
-      "people with asthma (0.7225263714790344)",
-      "Person With Medical Condition = Asthma (0.6960465908050537)"
+    "dc/topic/Income": [
+      "pay (0.2361648827791214)"
+    ],
+    "dc/topic/Jobs": [
+      "Jobs (0.2359907180070877)",
+      "Careers (0.20936834812164307)",
+      "Professions (0.2041512280702591)"
+    ],
+    "dc/topic/MedicalConditions": [
+      "Maladies (0.2785080075263977)",
+      "Health problems (0.2000654637813568)",
+      "health issues (0.19044229388237)"
     ]
   },
   "temporal_classification": "<None>",

--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -340,12 +340,12 @@ PLACE_TYPE_TO_PLURALS: Dict[str, str] = {
     "administrativearea4": "administrative area 4 places",
     "administrativearea5": "administrative area 5 places",
     # Schools
-    "high school": "high schools",
-    "middle school": "middle schools",
-    "elementary school": "elementary schools",
-    "primary school": "primary schools",
-    "public school": "public schools",
-    "private school": "private schools",
+    "highschool": "high schools",
+    "middleschool": "middle schools",
+    "elementaryschool": "elementary schools",
+    "primaryschool": "primary schools",
+    "publicschool": "public schools",
+    "privateschool": "private schools",
     "school": "schools",
 }
 

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -66,6 +66,7 @@ class ChartVars:
   # If svs came from a topic, the topic dcid.
   source_topic: str = ""
   event: EventType = None
+  skip_map_for_ranking: bool = False
 
 
 #
@@ -89,6 +90,8 @@ def add_chart_to_utterance(chart_type: ChartType, state: PopulateState,
       "chart_type": chart_vars.response_type,
       "source_topic": chart_vars.source_topic
   }
+  if chart_vars.skip_map_for_ranking:
+    attr['skip_map_for_ranking'] = True
   ch = ChartSpec(chart_type=chart_type,
                  svs=chart_vars.svs,
                  event=chart_vars.event,

--- a/server/lib/nl/fulfillment/size_across_entities.py
+++ b/server/lib/nl/fulfillment/size_across_entities.py
@@ -1,0 +1,127 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import List
+
+from server.lib.nl import utils
+from server.lib.nl.detection import ContainedInPlaceType
+from server.lib.nl.detection import Place
+from server.lib.nl.detection import RankingType
+from server.lib.nl.detection import SizeType
+from server.lib.nl.fulfillment.base import add_chart_to_utterance
+from server.lib.nl.fulfillment.base import ChartVars
+from server.lib.nl.fulfillment.base import populate_charts
+from server.lib.nl.fulfillment.base import PopulateState
+from server.lib.nl.utterance import ChartOriginType
+from server.lib.nl.utterance import ChartType
+from server.lib.nl.utterance import Utterance
+
+# TODO: Add area
+_PLACE_SIZE_VARS = [
+    'Count_Person', 'Count_Household',
+    'Amount_EconomicActivity_GrossDomesticProduction_RealValue',
+    'Amount_EconomicActivity_GrossDomesticProduction_Nominal'
+]
+
+_SCHOOL_SIZE_VARS = [
+    'Count_Student',
+    'Count_Teacher',
+    'Percent_Student_AsAFractionOf_Count_Teacher',
+]
+
+_SCHOOL_TYPES = frozenset([
+    ContainedInPlaceType.SCHOOL,
+    ContainedInPlaceType.ELEMENTARY_SCHOOL,
+    ContainedInPlaceType.MIDDLE_SCHOOL,
+    ContainedInPlaceType.HIGH_SCHOOL,
+    ContainedInPlaceType.PRIMARY_SCHOOL,
+    ContainedInPlaceType.PRIVATE_SCHOOL,
+    ContainedInPlaceType.PUBLIC_SCHOOL,
+])
+
+
+def _get_vars(pt: ContainedInPlaceType):
+  if pt in _SCHOOL_TYPES:
+    return _SCHOOL_SIZE_VARS
+  return _PLACE_SIZE_VARS
+
+
+#
+# For big/small entities in a parent entity (big schools in sunnyvale),
+# we infer the SVs from the contained-in entity-type and then rely on BIG/SMALL
+# to infer the ranking.
+#
+def populate(uttr: Utterance):
+  # Only if there are no SVs detected and contained-in is detected, do we consider
+  # the SIZE_TYPE classification.
+  if uttr.svs:
+    utils.update_counter(uttr.counters, 'size-across-entities_failed_foundvars',
+                         uttr.svs)
+    return False
+  place_type = utils.get_contained_in_type(uttr)
+  size_types = utils.get_size_types(uttr)
+  if not place_type or not size_types:
+    utils.update_counter(uttr.counters,
+                         'size-across-entities_failed_noplaceorsizetype', '-')
+    return False
+
+  uttr.svs = _get_vars(place_type)
+
+  # Map size_types[0] to ranking_types.
+  size_type = size_types[0]
+  if size_type == SizeType.BIG:
+    ranking_type = RankingType.HIGH
+  else:
+    ranking_type = RankingType.LOW
+
+  return populate_charts(
+      PopulateState(uttr=uttr,
+                    main_cb=_populate_cb,
+                    place_type=place_type,
+                    ranking_types=[ranking_type]))
+
+
+def _populate_cb(state: PopulateState, chart_vars: ChartVars,
+                 places: List[Place], chart_origin: ChartOriginType) -> bool:
+  logging.info('populate_cb for size_across_entities')
+  if not state.ranking_types:
+    utils.update_counter(state.uttr.counters,
+                         'size-across-entities_failed_cb_norankingtypes', 1)
+    return False
+  if len(places) > 1:
+    utils.update_counter(state.uttr.counters,
+                         'size-across-entities_failed_cb_toomanyplaces',
+                         [p.dcid for p in places])
+    return False
+  if not state.place_type:
+    utils.update_counter(state.uttr.counters,
+                         'size-across-entities_failed_cb_noplacetype', 1)
+    return False
+  if not chart_vars.svs:
+    utils.update_counter(state.uttr.counters,
+                         'size-across-entities_failed_cb_emptyvars',
+                         chart_vars.svs)
+    return False
+
+  chart_vars.response_type = "ranking table"
+  # NO Per-capita for these.
+  chart_vars.include_percapita = False
+  # No map chart for these.
+  chart_vars.skip_map_for_ranking = True
+  # We exactly control the Vars in this case,
+  # so line them all up in a single block.
+  chart_vars.block_id = 1
+  return add_chart_to_utterance(ChartType.RANKING_CHART, state, chart_vars,
+                                places, chart_origin)

--- a/server/lib/nl/page_config_builder.py
+++ b/server/lib/nl/page_config_builder.py
@@ -29,7 +29,7 @@ from server.lib.nl.detection import RankingType
 from server.lib.nl.utterance import ChartOriginType
 from server.lib.nl.utterance import ChartSpec
 from server.lib.nl.utterance import ChartType
-from server.lib.nl.utterance import ClassificationType
+from server.lib.nl.utterance import QueryType
 from server.lib.nl.utterance import Utterance
 
 
@@ -55,8 +55,7 @@ class PageConfigBuilder:
     self.prev_block_id = -1
 
     self.ignore_block_id_check = False
-    if (uttr.query_type == ClassificationType.RANKING and
-        utils.get_contained_in_type(uttr)):
+    if uttr.query_type == QueryType.RANKING_ACROSS_PLACES:
       self.ignore_block_id_check = True
 
   # Returns a Block and a Column
@@ -162,7 +161,7 @@ def build_page_config(
           # For a peer-group of SVs, set the title and description only once.
           builder.block.title = ''
           builder.block.description = ''
-        elif not builder.block.title:
+        elif not builder.block.title and builder.ignore_block_id_check:
           # For the first SV, if title weren't already set, set it to
           # the SV name.
           builder.block.title = sv2name[sv]
@@ -414,9 +413,10 @@ def _ranking_chart_block_nopc(column, pri_place: Place, pri_sv: str,
   stat_var_spec_map = {}
   stat_var_spec_map[pri_sv] = StatVarSpec(stat_var=pri_sv, name=sv2name[pri_sv])
 
-  # Also add a map chart.
-  stat_var_spec_map.update(
-      _map_chart_block_nopc(column, pri_place, pri_sv, sv2name, attr))
+  if not 'skip_map_for_ranking' in attr:
+    # Also add a map chart.
+    stat_var_spec_map.update(
+        _map_chart_block_nopc(column, pri_place, pri_sv, sv2name, attr))
 
   return stat_var_spec_map
 
@@ -441,9 +441,10 @@ def _ranking_chart_block_pc(column, pri_place: Place, pri_sv: str,
                                           scaling=100,
                                           unit="%")
 
-  # Also add a map chart.
-  stat_var_spec_map.update(
-      _map_chart_block_pc(column, pri_place, pri_sv, sv2name, attr))
+  if not 'skip_map_for_ranking' in attr:
+    # Also add a map chart.
+    stat_var_spec_map.update(
+        _map_chart_block_pc(column, pri_place, pri_sv, sv2name, attr))
 
   return stat_var_spec_map
 

--- a/server/lib/nl/utils.py
+++ b/server/lib/nl/utils.py
@@ -88,6 +88,18 @@ _SV_DISPLAY_NAME_OVERRIDE = {
         "Drive alone",
     "dc/vt2q292eme79f":
         "Others (incl. Taxcab, Motorcyle, Bicycle)",
+    "Count_Student":
+        "Number of Students",
+    "Count_Teacher":
+        "Number of Teachers",
+    "Percent_Student_AsAFractionOf_Count_Teacher":
+        "Student-Teacher Ratio",
+    "Count_Person":
+        "Population",
+    "Amount_EconomicActivity_GrossDomesticProduction_RealValue":
+        "GDP (Real Value)",
+    "Amount_EconomicActivity_GrossDomesticProduction_Nominal":
+        "GDP (Nominal Value)"
 }
 
 _SV_DISPLAY_FOOTNOTE_OVERRIDE = {
@@ -645,6 +657,18 @@ def get_contained_in_type(
     # Ranking among places.
     place_type = classification[0].attributes.contained_in_place_type
   return place_type
+
+
+def get_size_types(uttr: nl_uttr.Utterance) -> List[detection.SizeType]:
+  classification = ctx.classifications_of_type_from_utterance(
+      uttr, detection.ClassificationType.SIZE_TYPE)
+  size_types = []
+  if (classification and
+      isinstance(classification[0].attributes,
+                 detection.SizeTypeClassificationAttributes)):
+    # Ranking among places.
+    size_types = classification[0].attributes.size_types
+  return size_types
 
 
 def get_ranking_types(uttr: nl_uttr.Utterance) -> List[detection.RankingType]:

--- a/server/lib/nl/utterance.py
+++ b/server/lib/nl/utterance.py
@@ -66,6 +66,7 @@ class QueryType(IntEnum):
   TIME_DELTA = 7
   EVENT = 8
   OVERVIEW = 9
+  SIZE_ACROSS_ENTITIES = 10
   UNKNOWN = 11
 
 

--- a/server/services/nl.py
+++ b/server/services/nl.py
@@ -436,8 +436,9 @@ class Model:
         contained_in_place_type = place_enum
         break
 
-      if place_type in constants.PLACE_TYPE_TO_PLURALS and \
-        constants.PLACE_TYPE_TO_PLURALS[place_type] in query:
+      nospace_place_type = place_type.replace(' ', '')
+      if nospace_place_type in constants.PLACE_TYPE_TO_PLURALS and \
+        constants.PLACE_TYPE_TO_PLURALS[nospace_place_type] in query:
         contained_in_place_type = place_enum
         break
 


### PR DESCRIPTION
The new SIZE_ACROSS_ENTITIES fulfiller just maps "size" to set of SVs depending on the ContainedInPlaceType, and thereon pretends like a RANKING_ACROSS_PLACES fulfiller.

There is some page_config_builder tweaks needed to put all the charts in a single block and avoid showing map charts.

Also, extend the integration tests to include the working demo script.

![image](https://user-images.githubusercontent.com/4375037/219553651-8a0e43a1-c9c9-4f9d-9726-eb55d5456caf.png)
