### PR TITLE
When model is enabled, should register stanford routes to get disaster config

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -212,9 +212,8 @@ def create_app():
   register_routes_common(app)
   if cfg.CUSTOM:
     register_routes_custom_dc(app)
-  if cfg.ENV_NAME == 'STANFORD' or os.environ.get('FLASK_ENV') in [
-      'autopush', 'dev'
-  ] or cfg.LOCAL and not cfg.LITE:
+  if (cfg.ENV_NAME == 'STANFORD' or os.environ.get('ENABLE_MODEL') == 'true' or
+      cfg.LOCAL and not cfg.LITE):
     register_routes_stanford_dc(app, cfg.LOCAL)
 
   if cfg.TEST or cfg.INTEGRATION:


### PR DESCRIPTION
The config should really be split out