### PR TITLE
[Custom DC] Fix helm/kustomize diff: remove kustomize config suffix

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -26,6 +26,9 @@ resources:
   - deployment.yaml
   - namespace.yaml
 
+generatorOptions:
+ disableNameSuffixHash: true
+
 configMapGenerator:
   - name: website-configmap
     behavior: create

--- a/deploy/git/kustomization.yaml
+++ b/deploy/git/kustomization.yaml
@@ -17,6 +17,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+generatorOptions:
+ disableNameSuffixHash: true
+
 configMapGenerator:
   - name: githash-configmap
     behavior: create

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -56,3 +56,6 @@ patchesStrategicMerge:
         rollingUpdate:
           maxSurge: 9
           maxUnavailable: 50%
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/climate_trace/kustomization.yaml
+++ b/deploy/overlays/climate_trace/kustomization.yaml
@@ -46,3 +46,6 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 6
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/custom/kustomization.yaml
+++ b/deploy/overlays/custom/kustomization.yaml
@@ -51,3 +51,6 @@ patchesJson6902:
     patch: |-
       - op: remove
         path: /spec/template/spec/containers/2
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -48,3 +48,6 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 6
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/feedingamerica/kustomization.yaml
+++ b/deploy/overlays/feedingamerica/kustomization.yaml
@@ -69,3 +69,6 @@ patchesJson6902:
       kind: Deployment
       name: website-app
       version: v1
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/iitm/kustomization.yaml
+++ b/deploy/overlays/iitm/kustomization.yaml
@@ -51,3 +51,6 @@ patchesJson6902:
     patch: |-
       - op: remove
         path: /spec/template/spec/containers/2
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/kustomization.yaml.tpl
+++ b/deploy/overlays/kustomization.yaml.tpl
@@ -22,6 +22,9 @@ namespace: website
 resources:
   - ../../base
 
+generatorOptions:
+ disableNameSuffixHash: true
+
 configMapGenerator:
   - name: website-configmap
     behavior: merge

--- a/deploy/overlays/magiceye/kustomization.yaml
+++ b/deploy/overlays/magiceye/kustomization.yaml
@@ -46,3 +46,6 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 18
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -47,3 +47,6 @@ configMapGenerator:
 
 patchesStrategicMerge:
   - patch_deployment.yaml
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/staging/kustomization.yaml
+++ b/deploy/overlays/staging/kustomization.yaml
@@ -47,3 +47,6 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 12
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/stanford-staging/kustomization.yaml
+++ b/deploy/overlays/stanford-staging/kustomization.yaml
@@ -45,3 +45,6 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 6
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/stanford/kustomization.yaml
+++ b/deploy/overlays/stanford/kustomization.yaml
@@ -45,3 +45,6 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 6
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/overlays/tidal/kustomization.yaml
+++ b/deploy/overlays/tidal/kustomization.yaml
@@ -52,3 +52,6 @@ patchesJson6902:
       kind: Deployment
       name: website-app
       version: v1
+
+generatorOptions:
+ disableNameSuffixHash: true


### PR DESCRIPTION
Kustomize currently adds a suffix to all config maps deployed. It seems like there are some rationales for doing this (link below) but so far I'm not sure if it helped us. Since it is difficult for helm to match this, let's get rid of the configmap suffix?

https://pauldally.medium.com/why-is-kustomize-adding-a-bunch-of-characters-to-my-secret-configmap-names-b1572741c846