### PR TITLE
Fix diagonal x-axis labels being cut off

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -480,7 +480,7 @@ function addXAxis(
   }
 
   let axisHeight = axis.node().getBBox().height;
-  if (heightFromBottom > MARGIN.bottom) {
+  if (axisHeight > MARGIN.bottom) {
     axis.attr("transform", `translate(0, ${chartHeight - axisHeight})`);
   } else {
     axisHeight = MARGIN.bottom;


### PR DESCRIPTION
Fixes #2333 

Culprit was that the check to see if x-axis labels overflow the margins was not working as intended, so axis location wasn't updated as necessary.

Pair programmed with @chejennifer 

Before:
![Screenshot 2023-02-27 at 11 32 10 AM](https://user-images.githubusercontent.com/4034366/221665060-aaeb749b-e492-46b0-8992-a7b17a70245f.png)

After:
![Screenshot 2023-02-27 at 11 31 37 AM](https://user-images.githubusercontent.com/4034366/221665083-5a46082e-5541-417c-adfc-004d4d4d5a2f.png)
