### PR TITLE
[nl] fix small window size css

### DIFF
--- a/static/css/nl_interface.scss
+++ b/static/css/nl_interface.scss
@@ -35,10 +35,19 @@ $answer-min-height: 100vh;
 $text-color: inherit;
 $search-section-bottom-height: 7rem;
 
+#main {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  align-items: stretch;
+}
+
 #nl-interface {
   margin: 0;
   padding: 0;
   background: $page-background-color;
+  flex: 1 1 auto;
+  position: relative;
 }
 
 #dc-nl-interface {


### PR DESCRIPTION
fix nl interface layout on small window sizes (width < 992px). The problem was that nl interface css depends on the styling for the containing divs from here: https://github.com/datacommonsorg/website/blob/master/static/css/tools/base_tools.scss#L50-L66, but this styling is only applied when page size is lg which is when min-width = 992px

autopush:
![Screenshot 2023-02-27 at 3 17 35 PM](https://user-images.githubusercontent.com/69875368/221711213-00c76e09-b156-4219-8865-76775b48d9da.jpg)

with the change:
![Screenshot 2023-02-27 at 3 13 27 PM](https://user-images.githubusercontent.com/69875368/221711251-dcee0ffd-6029-444c-a290-f65add950ea4.jpg)
