### PR TITLE
Revert "[Custom DC] Fix helm/kustomize diff: remove kustomize config suffix"

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -26,9 +26,6 @@ resources:
   - deployment.yaml
   - namespace.yaml
 
-generatorOptions:
- disableNameSuffixHash: true
-
 configMapGenerator:
   - name: website-configmap
     behavior: create

--- a/deploy/git/kustomization.yaml
+++ b/deploy/git/kustomization.yaml
@@ -17,9 +17,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-generatorOptions:
- disableNameSuffixHash: true
-
 configMapGenerator:
   - name: githash-configmap
     behavior: create

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -56,6 +56,3 @@ patchesStrategicMerge:
         rollingUpdate:
           maxSurge: 9
           maxUnavailable: 50%
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/climate_trace/kustomization.yaml
+++ b/deploy/overlays/climate_trace/kustomization.yaml
@@ -46,6 +46,3 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 6
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/custom/kustomization.yaml
+++ b/deploy/overlays/custom/kustomization.yaml
@@ -51,6 +51,3 @@ patchesJson6902:
     patch: |-
       - op: remove
         path: /spec/template/spec/containers/2
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -48,6 +48,3 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 6
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/feedingamerica/kustomization.yaml
+++ b/deploy/overlays/feedingamerica/kustomization.yaml
@@ -69,6 +69,3 @@ patchesJson6902:
       kind: Deployment
       name: website-app
       version: v1
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/iitm/kustomization.yaml
+++ b/deploy/overlays/iitm/kustomization.yaml
@@ -51,6 +51,3 @@ patchesJson6902:
     patch: |-
       - op: remove
         path: /spec/template/spec/containers/2
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/kustomization.yaml.tpl
+++ b/deploy/overlays/kustomization.yaml.tpl
@@ -22,9 +22,6 @@ namespace: website
 resources:
   - ../../base
 
-generatorOptions:
- disableNameSuffixHash: true
-
 configMapGenerator:
   - name: website-configmap
     behavior: merge

--- a/deploy/overlays/magiceye/kustomization.yaml
+++ b/deploy/overlays/magiceye/kustomization.yaml
@@ -46,6 +46,3 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 18
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -47,6 +47,3 @@ configMapGenerator:
 
 patchesStrategicMerge:
   - patch_deployment.yaml
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/staging/kustomization.yaml
+++ b/deploy/overlays/staging/kustomization.yaml
@@ -47,6 +47,3 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 12
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/stanford/kustomization.yaml
+++ b/deploy/overlays/stanford/kustomization.yaml
@@ -45,6 +45,3 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 6
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/stanford_staging/stanford-staging/kustomization.yaml
+++ b/deploy/overlays/stanford_staging/stanford-staging/kustomization.yaml
@@ -45,6 +45,3 @@ patchesStrategicMerge:
       name: website-app
     spec:
       replicas: 6
-
-generatorOptions:
- disableNameSuffixHash: true

--- a/deploy/overlays/tidal/kustomization.yaml
+++ b/deploy/overlays/tidal/kustomization.yaml
@@ -52,6 +52,3 @@ patchesJson6902:
       kind: Deployment
       name: website-app
       version: v1
-
-generatorOptions:
- disableNameSuffixHash: true


### PR DESCRIPTION
Reverts datacommonsorg/website#2335

Going to revert the removal of config map suffix. I don't have a deep enough understanding of the k8s resource chain to know what field triggers the recreation of what resources.  Configmap change  + deployment referencing the config map seems like it should obviously update the upstream deployment but it doesn't. For helm/kustomize divergence, config map naming shouldn't affect anything because the name changes everytime anyways.

This solution is also worth looking into, but for later.
https://blog.questionable.services/article/kubernetes-deployments-configmap-change/