### PR TITLE
NL: Fix a few bugs related to guessing place types and per-capita

### DIFF
--- a/server/integration_tests/test_data/place_detection_e2e/query_2/chart_config.json
+++ b/server/integration_tests/test_data/place_detection_e2e/query_2/chart_config.json
@@ -148,32 +148,6 @@
                       "showHighest": true
                     },
                     "statVarKey": [
-                      "Mean_Income_Household_pc"
-                    ],
-                    "title": "Per Capita Average Income for Households in States of United States of America",
-                    "type": "RANKING"
-                  },
-                  {
-                    "statVarKey": [
-                      "Mean_Income_Household_pc"
-                    ],
-                    "title": "Per Capita Average Income for Households in States of United States of America",
-                    "type": "MAP"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 10,
-                      "showHighest": true
-                    },
-                    "statVarKey": [
                       "dc/x3gghqtglpr59"
                     ],
                     "title": "Median Income for People Working in the Finance and Insurance Industry in States of United States of America",
@@ -247,11 +221,6 @@
         ],
         "statVarSpec": {
           "Mean_Income_Household": {
-            "name": "Average Income for Households",
-            "statVar": "Mean_Income_Household"
-          },
-          "Mean_Income_Household_pc": {
-            "denom": "Count_Person",
             "name": "Average Income for Households",
             "statVar": "Mean_Income_Household"
           },

--- a/server/integration_tests/test_data/place_detection_e2e/query_3/chart_config.json
+++ b/server/integration_tests/test_data/place_detection_e2e/query_3/chart_config.json
@@ -73,13 +73,6 @@
                     ],
                     "title": "Average Income for Households in Florida",
                     "type": "LINE"
-                  },
-                  {
-                    "statVarKey": [
-                      "Mean_Income_Household_pc"
-                    ],
-                    "title": "Per Capita Average Income for Households in Florida",
-                    "type": "LINE"
                   }
                 ]
               }
@@ -160,11 +153,6 @@
             "statVar": "Count_Worker_NAICSFinanceInsurance"
           },
           "Mean_Income_Household": {
-            "name": "Average Income for Households",
-            "statVar": "Mean_Income_Household"
-          },
-          "Mean_Income_Household_pc": {
-            "denom": "Count_Person",
             "name": "Average Income for Households",
             "statVar": "Mean_Income_Household"
           },

--- a/server/integration_tests/test_data/place_detection_e2e/query_4/chart_config.json
+++ b/server/integration_tests/test_data/place_detection_e2e/query_4/chart_config.json
@@ -98,18 +98,6 @@
                     ],
                     "title": "Average Income for Households",
                     "type": "BAR"
-                  },
-                  {
-                    "comparisonPlaces": [
-                      "geoId/06",
-                      "geoId/36",
-                      "geoId/53"
-                    ],
-                    "statVarKey": [
-                      "Mean_Income_Household_multiple_place_bar_block_pc"
-                    ],
-                    "title": "Per Capita Average Income for Households",
-                    "type": "BAR"
                   }
                 ]
               }
@@ -170,11 +158,6 @@
         ],
         "statVarSpec": {
           "Mean_Income_Household_multiple_place_bar_block": {
-            "name": "Average Income for Households",
-            "statVar": "Mean_Income_Household"
-          },
-          "Mean_Income_Household_multiple_place_bar_block_pc": {
-            "denom": "Count_Person",
             "name": "Average Income for Households",
             "statVar": "Mean_Income_Household"
           },

--- a/server/integration_tests/test_data/textbox_sample/query_1/chart_config.json
+++ b/server/integration_tests/test_data/textbox_sample/query_1/chart_config.json
@@ -13,13 +13,6 @@
                     ],
                     "title": "Average Income for Family Households in California",
                     "type": "LINE"
-                  },
-                  {
-                    "statVarKey": [
-                      "Mean_Income_Household_FamilyHousehold_pc"
-                    ],
-                    "title": "Per Capita Average Income for Family Households in California",
-                    "type": "LINE"
                   }
                 ]
               }
@@ -83,13 +76,6 @@
                     ],
                     "title": "Average Income for Married Couple Family Households in California",
                     "type": "LINE"
-                  },
-                  {
-                    "statVarKey": [
-                      "Mean_Income_Household_MarriedCoupleFamilyHousehold_pc"
-                    ],
-                    "title": "Per Capita Average Income for Married Couple Family Households in California",
-                    "type": "LINE"
                   }
                 ]
               }
@@ -131,17 +117,7 @@
             "name": "Average Income for Family Households",
             "statVar": "Mean_Income_Household_FamilyHousehold"
           },
-          "Mean_Income_Household_FamilyHousehold_pc": {
-            "denom": "Count_Person",
-            "name": "Average Income for Family Households",
-            "statVar": "Mean_Income_Household_FamilyHousehold"
-          },
           "Mean_Income_Household_MarriedCoupleFamilyHousehold": {
-            "name": "Average Income for Married Couple Family Households",
-            "statVar": "Mean_Income_Household_MarriedCoupleFamilyHousehold"
-          },
-          "Mean_Income_Household_MarriedCoupleFamilyHousehold_pc": {
-            "denom": "Count_Person",
             "name": "Average Income for Married Couple Family Households",
             "statVar": "Mean_Income_Household_MarriedCoupleFamilyHousehold"
           },

--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -17,6 +17,7 @@ from typing import Dict, FrozenSet, List, Set, Union
 
 from server.lib.nl.detection import ContainedInPlaceType
 from server.lib.nl.detection import EventType
+from server.lib.nl.detection import Place
 
 STOP_WORDS: Set[str] = {
     'ourselves',
@@ -451,6 +452,13 @@ CHILD_PLACES_TYPES = {
     "County": "City",
 }
 
+DEFAULT_PARENT_PLACES = {
+    ContainedInPlaceType.COUNTRY: Place('Earth', 'Earth', 'Place'),
+    ContainedInPlaceType.COUNTY: Place('country/USA', 'USA', 'Country'),
+    ContainedInPlaceType.STATE: Place('country/USA', 'USA', 'Country'),
+    ContainedInPlaceType.CITY: Place('country/USA', 'USA', 'Country'),
+}
+
 MAP_PLACE_TYPES = frozenset([
     ContainedInPlaceType.COUNTY, ContainedInPlaceType.STATE,
     ContainedInPlaceType.COUNTRY
@@ -466,6 +474,7 @@ QUERY_FAILED = 'failed'
 
 TEST_SESSION_ID = '007_999999999'
 
+EARTH_DCID = 'Earth'
 DEFAULT_DENOMINATOR = 'Count_Person'
 
 SV_DISPLAY_SHORT_NAME = {

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -37,13 +37,6 @@ from server.lib.nl.utterance import Utterance
 
 _EVENT_PREFIX = 'event/'
 
-DEFAULT_PARENT_PLACES = {
-    ContainedInPlaceType.COUNTRY: Place('Earth', 'Earth', 'Place'),
-    ContainedInPlaceType.COUNTY: Place('country/USA', 'USA', 'Country'),
-    ContainedInPlaceType.STATE: Place('country/USA', 'USA', 'Country'),
-    ContainedInPlaceType.CITY: Place('country/USA', 'USA', 'Country'),
-}
-
 
 # Data structure to store state for a single "populate" call.
 @dataclass
@@ -430,9 +423,8 @@ def maybe_handle_contained_in_fallback(state: PopulateState,
                                        places: List[Place]):
   if utils.get_contained_in_type(
       state.uttr) == ContainedInPlaceType.ACROSS and len(places) == 1:
-    ptype = places[0].place_type
     state.place_type = ContainedInPlaceType(
-        constants.CHILD_PLACES_TYPES.get(ptype, 'County'))
+        utils.get_default_child_place_type(places[0]))
     utils.update_counter(state.uttr.counters, 'contained_in_across_fallback',
                          state.place_type.value)
 
@@ -443,4 +435,4 @@ def get_default_contained_in_place(state: PopulateState) -> Place:
   ptype = state.place_type
   if isinstance(ptype, str):
     ptype = ContainedInPlaceType(ptype)
-  return DEFAULT_PARENT_PLACES.get(ptype, None)
+  return constants.DEFAULT_PARENT_PLACES.get(ptype, None)

--- a/server/lib/nl/fulfillment/containedin.py
+++ b/server/lib/nl/fulfillment/containedin.py
@@ -39,8 +39,6 @@ def populate(uttr: Utterance) -> bool:
         classification.attributes, ContainedInClassificationAttributes)):
       continue
     place_type = classification.attributes.contained_in_place_type
-    if not utils.has_map(place_type):
-      continue
     if populate_charts(
         PopulateState(uttr=uttr, main_cb=_populate_cb, place_type=place_type)):
       return True
@@ -62,6 +60,10 @@ def _populate_cb(state: PopulateState, chart_vars: ChartVars,
   if not state.place_type:
     utils.update_counter(state.uttr.counters,
                          'containedin_failed_cb_missing_type', 1)
+    return False
+  if not utils.has_map(state.place_type):
+    utils.update_counter(state.uttr.counters,
+                         'containedin_failed_cb_nonmap_type', state.place_type)
     return False
   if not chart_vars:
     utils.update_counter(state.uttr.counters,

--- a/server/lib/nl/page_config_builder.py
+++ b/server/lib/nl/page_config_builder.py
@@ -635,9 +635,9 @@ def _event_chart_block(metadata, block, column, place: Place,
     return
 
   if not place.place_type in metadata.contained_place_types:
-    metadata.contained_place_types[
-        place.place_type] = constants.CHILD_PLACES_TYPES.get(
-            place.place_type, "Place")
+    metadata.contained_place_types[place.place_type] = \
+      utils.get_default_child_place_type(place)
+
   event_name = metadata.event_type_spec[event_id].name
   if event_type in constants.EVENT_TYPE_TO_DISPLAY_NAME:
     event_name = constants.EVENT_TYPE_TO_DISPLAY_NAME[event_type]

--- a/server/lib/nl/utils.py
+++ b/server/lib/nl/utils.py
@@ -834,6 +834,8 @@ _SV_PARTIAL_DCID_NO_PC = [
     "AsFractionOf",
     "AsAFractionOfCount",
     "UnemploymentRate_",
+    "Mean_Income_",
+    "GenderIncomeInequality_",
 ]
 
 _SV_FULL_DCID_NO_PC = ["Count_Person"]
@@ -847,3 +849,9 @@ def is_percapita_relevant(sv_dcid: str) -> bool:
     if skip_sv == sv_dcid:
       return False
   return True
+
+
+def get_default_child_place_type(place: detection.Place) -> str:
+  if place.dcid == constants.EARTH_DCID:
+    return 'Country'
+  return constants.CHILD_PLACES_TYPES.get(place.place_type, 'County')

--- a/server/lib/nl/utils.py
+++ b/server/lib/nl/utils.py
@@ -854,4 +854,6 @@ def is_percapita_relevant(sv_dcid: str) -> bool:
 def get_default_child_place_type(place: detection.Place) -> str:
   if place.dcid == constants.EARTH_DCID:
     return 'Country'
+  # TODO: Since most queries/data tends to be US specific and we have
+  # maps for it, we pick County as default, but reconsider in future.
   return constants.CHILD_PLACES_TYPES.get(place.place_type, 'County')


### PR DESCRIPTION
1. Make default child types for "Earth" work right
2. Make contained-in ACROSS work right (regressed with map_type check)
3. Drop per-capita for a couple of more cases
 
![image](https://user-images.githubusercontent.com/4375037/223609191-4c90f0cf-410f-4d6d-8f5d-74ea18a15aef.png)

![image](https://user-images.githubusercontent.com/4375037/223609204-2f6005ec-4387-4bb4-8e0f-7432a944d79e.png)

![image](https://user-images.githubusercontent.com/4375037/223609243-3712d8fa-c78d-4340-908d-20dde463c70f.png)

