### PR TITLE
Implement place fallback and optimize existence checks

### DIFF
--- a/server/integration_tests/nlnext_test.py
+++ b/server/integration_tests/nlnext_test.py
@@ -166,10 +166,11 @@ class IntegrationTest(LiveServerTestCase):
             # We have no crime at county-level in CA, so we should fall back as:
             # RANKING_ACROSS_PLACES -> CONTAINED_IN -> SIMPLE
             'counties in California with highest crime',
-            # We have no obesity data at State-level.  And since an SV was
-            # provided, we would not fallback to previous query (past version
-            # of code would have again returned crime in california).
+            # We have no obesity data at State-level. Instead we should fallback to
+            # parent place USA.
             'obesity in California',
+            # Since an SV was provided, we would not fallback to previous query
+            # (past version of code would have again returned crime in california).
         ])
 
   def test_demo_climatetrace(self):

--- a/server/integration_tests/nlnext_test.py
+++ b/server/integration_tests/nlnext_test.py
@@ -169,8 +169,6 @@ class IntegrationTest(LiveServerTestCase):
             # We have no obesity data at State-level. Instead we should fallback to
             # parent place USA.
             'obesity in California',
-            # Since an SV was provided, we would not fallback to previous query
-            # (past version of code would have again returned crime in california).
         ])
 
   def test_demo_climatetrace(self):

--- a/server/integration_tests/test_data/demo_fallback/query_4/chart_config.json
+++ b/server/integration_tests/test_data/demo_fallback/query_4/chart_config.json
@@ -8,27 +8,82 @@
               {
                 "tiles": [
                   {
-                    "type": "PLACE_OVERVIEW"
+                    "comparisonPlaces": [
+                      "country/USA"
+                    ],
+                    "statVarKey": [
+                      "Percent_Person_Obesity_multiple_place_bar_block"
+                    ],
+                    "title": "Percentage of Population That Is Obese in United States",
+                    "type": "BAR"
                   }
                 ]
               }
-            ],
-            "title": "California"
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "comparisonPlaces": [
+                      "country/USA"
+                    ],
+                    "statVarKey": [
+                      "Percent_Person_BingeDrinking_multiple_place_bar_block",
+                      "Percent_Person_Obesity_multiple_place_bar_block",
+                      "Percent_Person_PhysicalInactivity_multiple_place_bar_block",
+                      "Percent_Person_SleepLessThan7Hours_multiple_place_bar_block",
+                      "Percent_Person_Smoking_multiple_place_bar_block"
+                    ],
+                    "title": "Compared with Other Variables in United States",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ]
           }
-        ]
+        ],
+        "statVarSpec": {
+          "Percent_Person_BingeDrinking_multiple_place_bar_block": {
+            "name": "Percentage of Population Who Engage in Binge Drinking",
+            "statVar": "Percent_Person_BingeDrinking",
+            "unit": "%"
+          },
+          "Percent_Person_Obesity_multiple_place_bar_block": {
+            "name": "Percentage of Population That Is Obese",
+            "statVar": "Percent_Person_Obesity",
+            "unit": "%"
+          },
+          "Percent_Person_PhysicalInactivity_multiple_place_bar_block": {
+            "name": "Percentage of Population Who Are Physically Inactive",
+            "statVar": "Percent_Person_PhysicalInactivity",
+            "unit": "%"
+          },
+          "Percent_Person_SleepLessThan7Hours_multiple_place_bar_block": {
+            "name": "Percentage of Population That Sleeps Less Than 7 Hours Per Night",
+            "statVar": "Percent_Person_SleepLessThan7Hours",
+            "unit": "%"
+          },
+          "Percent_Person_Smoking_multiple_place_bar_block": {
+            "name": "Percentage of Population That Smokes",
+            "statVar": "Percent_Person_Smoking",
+            "unit": "%"
+          }
+        }
       }
     ],
     "metadata": {
       "placeDcid": [
-        "geoId/06"
+        "country/USA"
       ]
     }
   },
   "context": {},
   "debug": {},
   "place": {
-    "dcid": "geoId/06",
-    "name": "California",
-    "place_type": "State"
+    "dcid": "country/USA",
+    "name": "United States",
+    "place_type": "Country"
   }
 }

--- a/server/integration_tests/test_data/demo_fallback/query_4/debug_info.json
+++ b/server/integration_tests/test_data/demo_fallback/query_4/debug_info.json
@@ -10,48 +10,38 @@
           "geoId/06"
         ],
         "svs": [
-          "Percent_Person_Obesity"
-        ]
-      }
-    ],
-    "failed_existence_check_extended_svs": [
-      {
-        "places": [
-          "geoId/06"
-        ],
-        "svs": [
           "Percent_Person_Obesity",
-          "Percent_Person_PhysicalInactivity",
-          "Percent_Person_BingeDrinking",
           "Percent_Person_SleepLessThan7Hours",
-          "Percent_Person_Smoking"
+          "Percent_Person_BingeDrinking",
+          "Percent_Person_Smoking",
+          "Percent_Person_PhysicalInactivity"
         ]
       }
-    ],
-    "failed_populate_main_places": [
-      [
-        {
-          "dcid": "geoId/06",
-          "name": "California",
-          "place_type": "State"
-        }
-      ]
-    ],
-    "failed_populate_main_svs": [
-      [
-        "Percent_Person_Obesity"
-      ]
     ],
     "filtered_svs": [
       "Percent_Person_Obesity"
     ],
-    "num_chart_candidates": 1,
-    "num_populate_fallbacks": 1,
-    "processed_fulfillment_types": [
-      "simple",
-      "overview"
+    "num_chart_candidates": 2,
+    "parent_place_fallback": [
+      {
+        "child": "geoId/06",
+        "parent": "country/USA"
+      }
     ],
+    "processed_fulfillment_types": [
+      "simple"
+    ],
+    "simple_timeline_to_bar_demotions": 2,
     "stat_var_extensions": [
+      {
+        "Percent_Person_Obesity": [
+          "Percent_Person_BingeDrinking",
+          "Percent_Person_Obesity",
+          "Percent_Person_PhysicalInactivity",
+          "Percent_Person_SleepLessThan7Hours",
+          "Percent_Person_Smoking"
+        ]
+      },
       {
         "Percent_Person_Obesity": [
           "Percent_Person_BingeDrinking",
@@ -78,30 +68,61 @@
         }
       ],
       "query": "obesity in California",
-      "query_type": 10,
+      "query_type": 1,
       "ranked_charts": [
         {
           "attr": {
-            "block_id": 1,
-            "chart_type": "",
+            "block_id": 2,
+            "chart_type": "bar chart",
             "class": 0,
             "description": "",
-            "include_percapita": false,
+            "include_percapita": true,
             "place_type": null,
             "ranking_types": [],
             "source_topic": "",
             "title": ""
           },
-          "chart_type": 4,
+          "chart_type": 3,
           "event": null,
           "places": [
             {
-              "dcid": "geoId/06",
-              "name": "California",
-              "place_type": "State"
+              "dcid": "country/USA",
+              "name": "United States",
+              "place_type": "Country"
             }
           ],
-          "svs": []
+          "svs": [
+            "Percent_Person_Obesity"
+          ]
+        },
+        {
+          "attr": {
+            "block_id": 3,
+            "chart_type": "bar chart",
+            "class": 1,
+            "description": "",
+            "include_percapita": true,
+            "place_type": null,
+            "ranking_types": [],
+            "source_topic": "",
+            "title": ""
+          },
+          "chart_type": 3,
+          "event": null,
+          "places": [
+            {
+              "dcid": "country/USA",
+              "name": "United States",
+              "place_type": "Country"
+            }
+          ],
+          "svs": [
+            "Percent_Person_BingeDrinking",
+            "Percent_Person_Obesity",
+            "Percent_Person_PhysicalInactivity",
+            "Percent_Person_SleepLessThan7Hours",
+            "Percent_Person_Smoking"
+          ]
         }
       ],
       "session_id": "007_999999999",
@@ -184,7 +205,7 @@
         },
         {
           "attr": {
-            "block_id": 3,
+            "block_id": 11,
             "chart_type": "bar chart",
             "class": 1,
             "description": "",
@@ -216,7 +237,7 @@
         },
         {
           "attr": {
-            "block_id": 4,
+            "block_id": 3,
             "chart_type": "timeline",
             "class": 0,
             "description": "",
@@ -241,7 +262,7 @@
         },
         {
           "attr": {
-            "block_id": 5,
+            "block_id": 4,
             "chart_type": "timeline",
             "class": 0,
             "description": "",
@@ -266,7 +287,7 @@
         },
         {
           "attr": {
-            "block_id": 6,
+            "block_id": 5,
             "chart_type": "timeline",
             "class": 0,
             "description": "",
@@ -291,7 +312,7 @@
         },
         {
           "attr": {
-            "block_id": 7,
+            "block_id": 6,
             "chart_type": "timeline",
             "class": 0,
             "description": "",
@@ -316,7 +337,7 @@
         },
         {
           "attr": {
-            "block_id": 8,
+            "block_id": 7,
             "chart_type": "timeline",
             "class": 0,
             "description": "",
@@ -341,7 +362,7 @@
         },
         {
           "attr": {
-            "block_id": 9,
+            "block_id": 8,
             "chart_type": "timeline",
             "class": 0,
             "description": "",
@@ -366,7 +387,7 @@
         },
         {
           "attr": {
-            "block_id": 10,
+            "block_id": 9,
             "chart_type": "timeline",
             "class": 0,
             "description": "",
@@ -768,6 +789,41 @@
     "california"
   ],
   "places_resolved": "(name: California, dcid: geoId/06); ",
+  "query_detection_debug_logs": {
+    "main_place_inferred": {
+      "dcid": "geoId/06",
+      "name": "California",
+      "place_type": "State"
+    },
+    "original_query": "obesity in California",
+    "place_dcid_inference": {
+      "dcid_not_found_for_place_ids": [],
+      "dcid_overrides_found": [],
+      "dcids_resolved": [
+        "geoId/06"
+      ],
+      "maps_api_failures": []
+    },
+    "place_resolution": {
+      "dc_resolution_failure": [],
+      "dc_resolved_places": [
+        {
+          "dcid": "geoId/06",
+          "name": "California",
+          "place_type": "State"
+        }
+      ]
+    },
+    "places_found_str": [
+      "california"
+    ],
+    "query_transformations": {
+      "place_detection_input": "obesity in california",
+      "place_detection_with_places_removed": "obesity",
+      "sv_detection_query_input": "obesity",
+      "sv_detection_query_stop_words_removal": "obesity"
+    }
+  },
   "query_with_places_removed": "obesity",
   "ranking_classification": "<None>",
   "size_type_classification": "<None>",

--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -446,18 +446,13 @@ EVENT_TYPE_TO_DC_TYPES = {
     EventType.WETBULB: ["WetBulbTemperatureEvent"],
 }
 
-# Given the original place type, this is the order of related place types.
-FALLBACK_CONTAINED_PLACE_TYPES = {
-    "City": ["County", "State", "Country"],
-    "County": ["State", "Country"],
-    "State": ["Country"],
+CHILD_PLACE_TYPES = {
+    ContainedInPlaceType.COUNTRY: ContainedInPlaceType.STATE,
+    ContainedInPlaceType.STATE: ContainedInPlaceType.COUNTY,
+    ContainedInPlaceType.COUNTY: ContainedInPlaceType.CITY,
 }
 
-CHILD_PLACES_TYPES = {
-    "Country": "State",
-    "State": "County",
-    "County": "City",
-}
+PARENT_PLACE_TYPES = {v: k for k, v in CHILD_PLACE_TYPES.items()}
 
 DEFAULT_PARENT_PLACES = {
     ContainedInPlaceType.COUNTRY: Place('Earth', 'Earth', 'Place'),

--- a/server/lib/nl/constants.py
+++ b/server/lib/nl/constants.py
@@ -445,6 +445,13 @@ EVENT_TYPE_TO_DC_TYPES = {
     EventType.WETBULB: ["WetBulbTemperatureEvent"],
 }
 
+# Given the original place type, this is the order of related place types.
+FALLBACK_CONTAINED_PLACE_TYPES = {
+    "City": ["County", "State", "Country"],
+    "County": ["State", "Country"],
+    "State": ["Country"],
+}
+
 CHILD_PLACES_TYPES = {
     "Country": "State",
     "State": "County",

--- a/server/lib/nl/detection.py
+++ b/server/lib/nl/detection.py
@@ -92,7 +92,9 @@ class BinaryClassificationResultType(IntEnum):
   SUCCESS = 1
 
 
-class ContainedInPlaceType(Enum):
+# Note: Inherit from `str` so that if the enum gets logged as json the serializer
+# will not complain.
+class ContainedInPlaceType(str, Enum):
   """ContainedInPlaceType indicates the type of places."""
   # PLACE is the most generic type.
   PLACE = "Place"

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -215,6 +215,9 @@ def _add_charts_with_place_fallback(state: PopulateState, places: List[Place],
   return False
 
 
+#
+# These are data classes to track state needed for batched existence-checks.
+#
 @dataclass
 class ChartVarsExistenceCheckState:
   chart_vars: ChartVars
@@ -234,6 +237,9 @@ class SVExistenceCheckState:
   extended_exist_svs: List[str]
 
 
+#
+# This class helps batch existence checks.
+#
 class ExistenceCheckStateTracker:
 
   def __init__(self, state: PopulateState, places: List[str], svs: List[str],

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -154,10 +154,10 @@ def populate_charts(state: PopulateState) -> bool:
 # Populate charts given a place.
 def populate_charts_for_places(state: PopulateState,
                                places: List[Place]) -> bool:
-  maybe_handle_contained_in_fallback(state, places)
+  handle_contained_in_across(state, places)
 
   if (len(state.uttr.svs) > 0):
-    if _add_charts(state, places, state.uttr.svs):
+    if _add_charts_with_place_fallback(state, places, state.uttr.svs):
       return True
     else:
       utils.update_counter(state.uttr.counters, 'failed_populate_main_svs',
@@ -166,7 +166,7 @@ def populate_charts_for_places(state: PopulateState,
     # If we have not found an SV, only then seek an SV from the context.
     # Otherwise the result seems unexpected to them.
     for svs in context.svs_from_context(state.uttr):
-      if _add_charts(state, places, svs):
+      if _add_charts_with_place_fallback(state, places, svs):
         return True
       else:
         utils.update_counter(state.uttr.counters, 'failed_populate_context_svs',
@@ -177,8 +177,149 @@ def populate_charts_for_places(state: PopulateState,
   return False
 
 
+def _add_charts_with_place_fallback(state: PopulateState, places: List[Place],
+                                    svs: List[str]) -> bool:
+  if _add_charts(state, places, svs):
+    return True
+  if len(places) > 1:
+    return False
+
+  pt = state.place_type if state.place_type else places[0].place_type
+  if isinstance(pt, ContainedInPlaceType):
+    pt = pt.value
+
+  place = places[0]
+  # Perform fallback
+  for parent_type in constants.FALLBACK_CONTAINED_PLACE_TYPES.get(pt, []):
+    if state.place_type:
+      utils.update_counter(state.uttr.counters, 'parent_place_type_fallback',
+                           parent_type)
+      state.place_type = ContainedInPlaceType(parent_type)
+    else:
+      # Pick next place.
+      parents = utils.get_parent_places(place.dcid, parent_type)
+      if not parents:
+        utils.update_counter(state.uttr.counters, 'failed_get_parent_places', {
+            'dcid': place.dcid,
+            'type': parent_type
+        })
+        return False
+      utils.update_counter(state.uttr.counters, 'parent_place_fallback', {
+          'child': place.dcid,
+          'parent': parents[0].dcid
+      })
+      place = parents[0]
+    if _add_charts(state, [place], svs):
+      return True
+
+  return False
+
+
+@dataclass
+class ChartVarsExistenceCheckState:
+  chart_vars: ChartVars
+  # Existing svs from among chart_vars.svs
+  exist_svs: List[str]
+  # Set only if chart_vars.event is set
+  exist_event: bool = False
+
+
+@dataclass
+class SVExistenceCheckState:
+  sv: str
+  chart_vars_list: List[ChartVarsExistenceCheckState]
+
+  extended_svs: List[str]
+  # Existence check result for extended SVs.
+  extended_exist_svs: List[str]
+
+
+class ExistenceCheckStateTracker:
+
+  def __init__(self, state: PopulateState, places: List[str], svs: List[str],
+               sv2extensions: Dict):
+    self.state = state
+    self.places = places
+    self.all_svs = set()
+    self.exist_sv_states: List[SVExistenceCheckState] = []
+
+    # Loop over all SVs, and construct existence check state.
+    for rank, sv in enumerate(svs):
+      exist_state = SVExistenceCheckState(sv=sv,
+                                          chart_vars_list=[],
+                                          extended_svs=[],
+                                          extended_exist_svs=[])
+
+      chart_vars_list = _build_chart_vars(state, sv, rank)
+      for chart_vars in chart_vars_list:
+        exist_cv = ChartVarsExistenceCheckState(chart_vars=chart_vars,
+                                                exist_svs=[])
+        if chart_vars.event:
+          exist_cv.exist_event = utils.event_existence_for_place(
+              places[0].dcid, chart_vars.event)
+          if not exist_cv.exist_event:
+            utils.update_counter(state.uttr.counters,
+                                 'failed_event_existence_check', {
+                                     'places': places,
+                                     'event': chart_vars.event
+                                 })
+        else:
+          self.all_svs.update(chart_vars.svs)
+        exist_state.chart_vars_list.append(exist_cv)
+
+      # Infer comparison charts with extended SVs.
+      extended_svs = sv2extensions.get(sv, [])
+      if extended_svs:
+        exist_state.extended_svs = extended_svs
+        self.all_svs.update(extended_svs)
+
+      self.exist_sv_states.append(exist_state)
+
+  def perform_existence_check(self):
+    # Perform batch existence check.
+    exist_svs = utils.sv_existence_for_places(self.places, list(self.all_svs))
+    exist_svs = set(exist_svs)
+    if exist_svs:
+      logging.info('Existence check succeeded for %s - %s',
+                   ', '.join(self.places), ', '.join(exist_svs))
+    else:
+      logging.info('Existence check failed for %s - %s', ', '.join(self.places),
+                   ', '.join(self.all_svs))
+      utils.update_counter(self.state.uttr.counters, 'failed_existence_check', {
+          'places': self.places,
+          'svs': list(self.all_svs),
+      })
+      return
+
+    # Set "exist_svs" and "extended_exist_svs" in the same order it was originally found.
+    for es in self.exist_sv_states:
+
+      for ecv in es.chart_vars_list:
+        for sv in ecv.chart_vars.svs:
+          if sv in exist_svs:
+            ecv.exist_svs.append(sv)
+        if len(ecv.exist_svs) < len(ecv.chart_vars.svs):
+          utils.update_counter(
+              self.state.uttr.counters, 'failed_partial_existence_check', {
+                  'places': self.places,
+                  'svs': list(set(ecv.chart_vars.svs) - set(exist_svs)),
+              })
+
+      for esv in es.extended_svs:
+        if esv in exist_svs:
+          es.extended_exist_svs.append(esv)
+
+      if len(es.extended_exist_svs) < len(es.extended_svs):
+        utils.update_counter(
+            self.state.uttr.counters, 'failed_existence_check_extended_svs', {
+                'places': self.places,
+                'svs': list(set(es.extended_svs) - set(es.extended_exist_svs))
+            })
+        logging.info('Existence check failed for %s - %s',
+                     ', '.join(self.places), ', '.join(es.extended_svs))
+
+
 # Add charts given a place and a list of stat-vars.
-# TODO: Batch existence check calls
 def _add_charts(state: PopulateState, places: List[Place],
                 svs: List[str]) -> bool:
   logging.info("Add chart %s %s" % (', '.join(_get_place_names(places)), svs))
@@ -206,44 +347,33 @@ def _add_charts(state: PopulateState, places: List[Place],
     utils.update_counter(state.uttr.counters, 'stat_var_extensions',
                          sv2extensions)
 
+  tracker = ExistenceCheckStateTracker(state, places_to_check, svs,
+                                       sv2extensions)
+  tracker.perform_existence_check()
+
   # A set used to ensure that a set of SVs are constructed into charts
   # only once. For example SV1 and SV2 may both be main SVs, and part of
   # the peer-group.  In that case, the peer-group is processed only once.
   printed_sv_extensions = set()
 
   found = False
-  for rank, sv in enumerate(svs):
+  for exist_state in tracker.exist_sv_states:
 
     # Infer charts for the main SV/Topic.
-    chart_vars_list = _build_chart_vars(state, sv, rank)
-    for chart_vars in chart_vars_list:
+    for exist_cv in exist_state.chart_vars_list:
+      chart_vars = exist_cv.chart_vars
       if chart_vars.event:
-        event = chart_vars.event
         # For this check the parent place.
-        if utils.event_existence_for_place(places[0].dcid, event):
+        if exist_cv.exist_event:
           if state.main_cb(state, chart_vars, places,
                            ChartOriginType.PRIMARY_CHART):
             found = True
           else:
             utils.update_counter(state.uttr.counters,
                                  'failed_populate_callback_primary_event', 1)
-        else:
-          utils.update_counter(state.uttr.counters, 'failed_existence_check', {
-              'places': places,
-              'event': event
-          })
       else:
-        exist_svs = utils.sv_existence_for_places(places_to_check,
-                                                  chart_vars.svs)
+        exist_svs = exist_cv.exist_svs
         if exist_svs:
-          if len(exist_svs) < len(chart_vars.svs):
-            utils.update_counter(
-                state.uttr.counters, 'failed_partial_existence_check', {
-                    'places': places_to_check,
-                    'svs': list(set(chart_vars.svs) - set(exist_svs)),
-                })
-          logging.info('Existence check succeeded for %s - %s',
-                       ', '.join(places_to_check), ', '.join(exist_svs))
           chart_vars.svs = exist_svs
           # Now that we've found existing vars, call the per-chart-type callback.
           if state.main_cb(state, chart_vars, places,
@@ -252,19 +382,12 @@ def _add_charts(state: PopulateState, places: List[Place],
           else:
             utils.update_counter(state.uttr.counters,
                                  'failed_populate_callback_primary', 1)
-        else:
-          utils.update_counter(state.uttr.counters, 'failed_existence_check', {
-              'places': places_to_check,
-              'svs': chart_vars.svs
-          })
-          logging.info('Existence check failed for %s - %s',
-                       ', '.join(places_to_check), ', '.join(chart_vars.svs))
 
     # Infer comparison charts with extended SVs.
-    extended_svs = sv2extensions.get(sv, [])
+    extended_svs = sv2extensions.get(exist_state.sv, [])
     if not extended_svs:
       continue
-    exist_svs = utils.sv_existence_for_places(places_to_check, extended_svs)
+    exist_svs = exist_state.extended_exist_svs
     if len(exist_svs) > 1:
       exist_svs_key = ''.join(sorted(exist_svs))
       if exist_svs_key in printed_sv_extensions:
@@ -282,14 +405,6 @@ def _add_charts(state: PopulateState, places: List[Place],
       else:
         utils.update_counter(state.uttr.counters,
                              'failed_populate_callback_secondary', 1)
-    elif len(exist_svs) < len(extended_svs):
-      utils.update_counter(
-          state.uttr.counters, 'failed_existence_check_extended_svs', {
-              'places': places_to_check,
-              'svs': list(set(extended_svs) - set(exist_svs))
-          })
-      logging.info('Existence check failed for %s - %s',
-                   ', '.join(places_to_check), ', '.join(extended_svs))
 
   logging.info("Add chart %s %s returning %r" %
                (', '.join(_get_place_names(places)), svs, found))
@@ -426,8 +541,7 @@ def _open_topic_in_var(sv: str, rank: int, counters: Dict) -> List[str]:
   return []
 
 
-def maybe_handle_contained_in_fallback(state: PopulateState,
-                                       places: List[Place]):
+def handle_contained_in_across(state: PopulateState, places: List[Place]):
   if utils.get_contained_in_type(
       state.uttr) == ContainedInPlaceType.ACROSS and len(places) == 1:
     ptype = places[0].place_type

--- a/server/lib/nl/fulfillment/correlation.py
+++ b/server/lib/nl/fulfillment/correlation.py
@@ -21,7 +21,7 @@ from server.lib.nl.detection import Place
 from server.lib.nl.fulfillment.base import add_chart_to_utterance
 from server.lib.nl.fulfillment.base import ChartVars
 from server.lib.nl.fulfillment.base import get_default_contained_in_place
-from server.lib.nl.fulfillment.base import maybe_handle_contained_in_fallback
+from server.lib.nl.fulfillment.base import handle_contained_in_across
 from server.lib.nl.fulfillment.base import open_top_topics_ordered
 from server.lib.nl.fulfillment.base import PopulateState
 from server.lib.nl.fulfillment.context import \
@@ -83,7 +83,7 @@ def _populate_correlation_for_place_type(state: PopulateState) -> bool:
 
 
 def _populate_correlation_for_place(state: PopulateState, place: Place) -> bool:
-  maybe_handle_contained_in_fallback(state, [place])
+  handle_contained_in_across(state, [place])
 
   # Get child place samples for existence check.
   places_to_check = utils.get_sample_child_places(place.dcid,

--- a/server/lib/nl/page_config_builder.py
+++ b/server/lib/nl/page_config_builder.py
@@ -636,7 +636,7 @@ def _event_chart_block(metadata, block, column, place: Place,
 
   if not place.place_type in metadata.contained_place_types:
     metadata.contained_place_types[place.place_type] = \
-      utils.get_default_child_place_type(place)
+      utils.get_default_child_place_type(place).value
 
   event_name = metadata.event_type_spec[event_id].name
   if event_type in constants.EVENT_TYPE_TO_DISPLAY_NAME:

--- a/server/lib/nl/utils.py
+++ b/server/lib/nl/utils.py
@@ -33,7 +33,7 @@ import server.services.datacommons as dc
 _CHART_TITLE_CONFIG_RELATIVE_PATH = "../../config/nl_page/chart_titles_by_sv.json"
 
 # TODO: Consider tweaking/reducing this
-_NUM_CHILD_PLACES_FOR_EXISTENCE = 20
+_NUM_CHILD_PLACES_FOR_EXISTENCE = 15
 
 # (growth_direction, rank_order) -> reverse
 _TIME_DELTA_SORT_MAP = {
@@ -448,8 +448,6 @@ def _get_sample_child_places(main_place_dcid: str,
                contained_place_type)
   if not contained_place_type:
     return []
-  if contained_place_type == "City":
-    return ["geoId/0667000"]
   child_places = dc.get_places_in([main_place_dcid], contained_place_type)
   if child_places.get(main_place_dcid):
     logging.info(
@@ -500,6 +498,25 @@ def get_all_child_places(main_place_dcid: str,
           detection.Place(dcid=value['dcid'],
                           name=value['name'],
                           place_type=contained_place_type))
+  return results
+
+
+def get_parent_places(main_place_dcid: str,
+                      parent_place_type: str) -> List[detection.Place]:
+  resp = dc.property_values_v1([main_place_dcid], 'containedInPlace')
+  results = []
+  for item in resp.get('data', []):
+    if item.get('node', '') != main_place_dcid:
+      continue
+    for value in item.get('values', []):
+      if 'dcid' not in value or 'name' not in value or 'types' not in value:
+        continue
+      if parent_place_type not in value['types']:
+        continue
+      results.append(
+          detection.Place(dcid=value['dcid'],
+                          name=value['name'],
+                          place_type=parent_place_type))
   return results
 
 

--- a/server/lib/nl/variable.py
+++ b/server/lib/nl/variable.py
@@ -118,6 +118,8 @@ def extend_svs(svs: Dict[str, List[str]]):
   sv2svgs = dc.property_values(svs, "memberOf", True)
   sv2svg = {sv: svg[0] for sv, svg in sv2svgs.items() if svg}
   svg2childsvs = {}
+  if not sv2svg:
+    return {}
   svginfo = dc.get_variable_group_info(list(sv2svg.values()), [])
   if 'data' not in svginfo:
     return {}

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -190,6 +190,16 @@ def properties(node, direction):
   return get(f'{url}/{direction}/{node}').get('properties', [])
 
 
+def property_values_v1(nodes, prop, out=True):
+  """Retrieves the property values with V1 response."""
+  direction = 'out' if out else 'in'
+  url = get_service_url('/v1/bulk/property/values')
+  return post(f'{url}/{direction}', {
+      'nodes': sorted(set(nodes)),
+      'property': prop,
+  })
+
+
 def property_values(nodes, prop, out=True):
   """Retrieves the property values for a list of nodes.
 
@@ -198,12 +208,7 @@ def property_values(nodes, prop, out=True):
       prop: The property label to query for.
       out: Whether the property direction is 'out'.
   """
-  direction = 'out' if out else 'in'
-  url = get_service_url('/v1/bulk/property/values')
-  resp = post(f'{url}/{direction}', {
-      'nodes': sorted(set(nodes)),
-      'property': prop,
-  })
+  resp = property_values_v1(nodes, prop, out)
   result = {}
   for item in resp.get('data', []):
     node, values = item['node'], item.get('values', [])

--- a/server/tests/lib/nl/fulfiller_test.py
+++ b/server/tests/lib/nl/fulfiller_test.py
@@ -87,8 +87,9 @@ class TestDataSpecNext(unittest.TestCase):
     mock_extend_svs.return_value = {}
     mock_single_datapoint.return_value = False
     # - Make SVs exist
-    mock_sv_existence.side_effect = [['Count_Person_Male'],
-                                     ['Count_Person_Female']]
+    mock_sv_existence.side_effect = [[
+        'Count_Person_Male', 'Count_Person_Female'
+    ]]
 
     got = _run(detection, [])
 
@@ -126,8 +127,9 @@ class TestDataSpecNext(unittest.TestCase):
     mock_extend_svs.return_value = {}
     mock_single_datapoint.return_value = True
     # - Make SVs exist
-    mock_sv_existence.side_effect = [['Count_Person_Male'],
-                                     ['Count_Person_Female']]
+    mock_sv_existence.side_effect = [[
+        'Count_Person_Male', 'Count_Person_Female'
+    ]]
 
     got = _run(detection, [])
 
@@ -151,7 +153,7 @@ class TestDataSpecNext(unittest.TestCase):
     # - Return santa clara as child place
     mock_child_places.return_value = ['geoId/06085']
     # - Make SVs exist
-    mock_sv_existence.side_effect = [['Count_Farm'], ['Income_Farm']]
+    mock_sv_existence.side_effect = [['Count_Farm', 'Income_Farm']]
 
     got = _run(detection, [SIMPLE_UTTR])
 
@@ -226,8 +228,9 @@ class TestDataSpecNext(unittest.TestCase):
     # - Do no SV extensions
     mock_extend_svs.return_value = {}
     # - Make SVs (from context) exist
-    mock_sv_existence.side_effect = [['Count_Person_Male'],
-                                     ['Count_Person_Female']]
+    mock_sv_existence.side_effect = [[
+        'Count_Person_Male', 'Count_Person_Female'
+    ]]
 
     # Pass in the simple SV utterance as context
     got = _run(detection, [SIMPLE_UTTR])
@@ -250,11 +253,9 @@ class TestDataSpecNext(unittest.TestCase):
         'Count_Person_Male': ['Count_Person_Male', 'Count_Person_Female']
     }
     # - Make SVs exist. Importantly, the second call is for both male + female.
-    mock_sv_existence.side_effect = [['Count_Person_Male'],
-                                     [
-                                         'Count_Person_Male',
-                                         'Count_Person_Female'
-                                     ]]
+    mock_sv_existence.side_effect = [[
+        'Count_Person_Male', 'Count_Person_Female'
+    ]]
     mock_single_datapoint.return_value = False
 
     got = _run(detection, [])
@@ -294,13 +295,11 @@ class TestDataSpecNext(unittest.TestCase):
                        is_topic_peer_group=True)
     ]
     mock_single_datapoint.return_value = False
-    # - Make SVs exist. Importantly, in the order in which the ChartVars were set.
+    # - Make SVs exist. The order doesn't matter.
     #   Make Wheat inventory fail existence check.
-    mock_sv_existence.side_effect = [['Count_Farm'], ['Area_Farm'],
-                                     [
-                                         'FarmInventory_Rice',
-                                         'FarmInventory_Barley'
-                                     ]]
+    mock_sv_existence.side_effect = [[
+        'Count_Farm', 'Area_Farm', 'FarmInventory_Rice', 'FarmInventory_Barley'
+    ]]
 
     got = _run(detection, [])
 
@@ -340,8 +339,9 @@ class TestDataSpecNext(unittest.TestCase):
     ]
     # - Make SVs exist
     mock_sv_existence.side_effect = [[
-        'Count_Farm'
-    ], ['FarmInventory_Rice', 'FarmInventory_Wheat', 'FarmInventory_Barley']]
+        'Count_Farm', 'FarmInventory_Rice', 'FarmInventory_Wheat',
+        'FarmInventory_Barley'
+    ]]
     # Differently order result
     mock_rank_svs.return_value = [
         'FarmInventory_Barley',
@@ -432,8 +432,9 @@ class TestDataSpecNext(unittest.TestCase):
     mock_extend_svs.return_value = {}
     mock_single_datapoint.return_value = False
     # - Make SVs exist
-    mock_sv_existence.side_effect = [['Count_Person_Male'],
-                                     ['Count_Person_Female']]
+    mock_sv_existence.side_effect = [[
+        'Count_Person_Male', 'Count_Person_Female'
+    ]]
 
     got = fulfiller.fulfill(detection, None, constants.TEST_SESSION_ID).counters
 


### PR DESCRIPTION
1. We may fallback to parent places... eg, jobs in sunnyvale -> SC county
2. We may fallback to parent contained-in types... eg, cities with highest agricultural production in california -> counties of CA
3. Collect SVs and batch existence check... this is done using a tracker class

Fallback is implemented in common code so it works for all query-types (except correlation and comparison, which is v custom rn).

TODO: Providing user feedback about the fallback

![image](https://user-images.githubusercontent.com/4375037/223683119-c1e4e650-6c8c-49d9-833d-be4006dde720.png)

![image](https://user-images.githubusercontent.com/4375037/223683737-0ba96e0e-0af1-4d0d-93e0-4f00d3447c2d.png)
