### PR TITLE
Kustomize changes for making Argo auto deploy to stanford staging

### DIFF
--- a/deploy/overlays/stanford_staging/base_bigtable_info.yaml
+++ b/deploy/overlays/stanford_staging/base_bigtable_info.yaml
@@ -1,0 +1,8 @@
+project: datcom-store
+instance: prophet-cache
+tables:
+  - frequent_2023_03_07_19_58_29
+  - ipcc_2023_03_01_03_46_42
+  - disaster_2023_03_05_23_44_18
+  - infrequent_2023_03_06_09_05_14
+  - place_2023_03_06_15_27_01

--- a/deploy/overlays/stanford_staging/kustomization.yaml
+++ b/deploy/overlays/stanford_staging/kustomization.yaml
@@ -34,8 +34,14 @@ configMapGenerator:
     name: mixer-configmap
   - behavior: merge
     files:
+      - base_bigtable_info.yaml
       - custom_bigtable_info.yaml
     name: store-configmap
+  - name: githash-configmap
+    behavior: merge
+    literals:
+      - mixer_hash.txt=1aa6137
+      - website_hash.txt=61c29b2
 
 patchesStrategicMerge:
   - |-


### PR DESCRIPTION
I configured Argo to watch for stanford staging changes under deploy/overlay/stanford_staging. This PR contains some changes to support that.

Some noticeable changes 
- We're brining all BT versions into stanford_staging subdirectory. I think it make it clearer which cache versions stanford staging instance is using
- Git versions (hence image tags) are no longer tied to the PR. Meaning, just by looking at the kustomization files, we know exactly which versions of mixer and website is deployed. Also, each instance can have a different version of images. 

For a view of what is deployed, please see:
https://deploy.datacommons.dev/applications/website/stanford-staging?view=tree&resource=

Note that currently my repo is tracked, but will be switched to main repo once this PR is committed.