### PR TITLE
Store mixer-api-key in the website GCP project instead of in the mixer project

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -124,8 +124,9 @@ By default the NL server runs on port 6060.
 ### Use Local Mixer
 
 If local mixer is needed, can start it locally by following [this
-instruction](https://github.com/datacommonsorg/mixer/blob/master/docs/developer_guide.md#develop-mixer-locally-with-docker-and-kubernetes).
-This allows development with custom BigTable or mixer code change.
+instruction](https://github.com/datacommonsorg/mixer/blob/master/docs/developer_guide.md#running-esp-locally).
+This allows development with custom BigTable or mixer code change. Make sure to
+also [run ESP locally](https://github.com/datacommonsorg/mixer/blob/master/docs/developer_guide.md#running-esp-locally).
 
 Then start the Flask server with `-l` option to let it use the local mixer:
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -275,9 +275,9 @@ def create_app():
   if app.config['LOCAL']:
     os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 
-  if app.config['API_PROJECT']:
+  if cfg.SECRET_PROJECT:
     secret_client = secretmanager.SecretManagerServiceClient()
-    secret_name = secret_client.secret_version_path(cfg.API_PROJECT,
+    secret_name = secret_client.secret_version_path(cfg.SECRET_PROJECT,
                                                     'mixer-api-key', 'latest')
     secret_response = secret_client.access_secret_version(name=secret_name)
     app.config['DC_API_KEY'] = secret_response.payload.data.decode('UTF-8')

--- a/server/app_env/_base.py
+++ b/server/app_env/_base.py
@@ -61,7 +61,3 @@ class Config:
   # overrides in the default base template. Will not be compiled. Must be the
   # full serving path from /static folder.
   OVERRIDE_CSS_PATH = ''
-  # The GCP project of the mixer which Flask talks to. This only needs to
-  # be set for local development. Website deployed to GKE bundles the mixer
-  # as a custom service accessible via localhost.
-  API_PROJECT = ''

--- a/server/app_env/custom.py
+++ b/server/app_env/custom.py
@@ -25,3 +25,10 @@ class Config(_base.Config):
 
 class LocalConfig(Config, local.Config):
   LITE = True
+  API_ROOT = 'https://autopush.api.datacommons.org'
+  # NEED TO DO THE FOLLOWING CHANGES:
+  # 1. Get an API key from Data Commons team
+  # 2. In the custom GCP project, store the API key in secret manager
+  #    `printf "<API_KEY>" | gcloud secrets create mixer-api-key --data-file=-`
+  # 3. Update SECRET_PROJECT to be the custom GCP project id.
+  SECRET_PROJECT = ''

--- a/server/app_env/feedingamerica.py
+++ b/server/app_env/feedingamerica.py
@@ -25,7 +25,3 @@ class Config(_base.Config):
 class LocalConfig(local.Config):
   CUSTOM = True
   NAME = "Feeding America"
-  # This needs to talk to local mixer that is setup as a custom mixer, which
-  # loads csv + tmcf files from GCS
-  API_ROOT = 'https://mixer.endpoints.datcom-mixer-statvar.cloud.goog'
-  API_PROJECT = 'datcom-mixer-statvar'

--- a/server/app_env/integration_test.py
+++ b/server/app_env/integration_test.py
@@ -18,6 +18,5 @@ from server.app_env import _base
 class Config(_base.Config):
   INTEGRATION = True
   API_ROOT = 'https://autopush.api.datacommons.org'
-  API_PROJECT = 'datcom-mixer-autopush'
-  SCHEME = 'http'
   SECRET_PROJECT = 'datcom-website-dev'
+  SCHEME = 'http'

--- a/server/app_env/local.py
+++ b/server/app_env/local.py
@@ -20,10 +20,9 @@ from server.app_env import _base
 class Config(_base.Config):
   LOCAL = True
   API_ROOT = 'https://autopush.api.datacommons.org'
-  API_PROJECT = 'datcom-mixer-autopush'
+  SECRET_PROJECT = 'datcom-website-dev'
   AI_CONFIG_PATH = os.path.abspath(
       os.path.join(os.path.curdir, 'deploy/overlays/local/ai.yaml'))
   SCHEME = 'http'
   GCS_BUCKET = 'datcom-website-autopush-resources'
   LOG_QUERY = True
-  SECRET_PROJECT = 'datcom-website-dev'

--- a/server/app_env/stanford.py
+++ b/server/app_env/stanford.py
@@ -24,6 +24,4 @@ class Config(_base.Config):
 
 
 class LocalConfig(Config, local.Config):
-  API_ROOT = 'https://mixer.endpoints.datcom-mixer-statvar.cloud.goog'
-  API_PROJECT = 'datcom-mixer-statvar'
-  SECRET_PROJECT = 'datcom-stanford'
+  pass

--- a/server/app_env/stanford_staging.py
+++ b/server/app_env/stanford_staging.py
@@ -20,5 +20,3 @@ class Config(_base.Config):
   NAME = "Google Stanford Data Commons (Staging)"
   ENABLE_BLOCKLIST = True
   GCS_BUCKET = 'datcom-stanford-staging-resources'
-  API_PROJECT = 'datcom-mixer-statvar'
-  SECRET_PROJECT = 'datcom-stanford-staging'

--- a/server/app_env/webdriver.py
+++ b/server/app_env/webdriver.py
@@ -17,8 +17,7 @@ from server.app_env import _base
 
 class Config(_base.Config):
   WEBDRIVER = True
-  SECRET_PROJECT = 'datcom-website-dev'
   API_ROOT = 'https://autopush.api.datacommons.org'
-  API_PROJECT = 'datcom-mixer-autopush'
+  SECRET_PROJECT = 'datcom-website-dev'
   AI_CONFIG_PATH = None  # No models in this configuration.
   SCHEME = 'http'


### PR DESCRIPTION
This aligns with the regular practice that api key sits in a separate (client) project. With this, custom DC users can store the API key in the custom project.