### PR TITLE
Use Flask 2.1.3 and Werkzeug 2.1.2 to fix trailing slash issue

### DIFF
--- a/nl_server/requirements.txt
+++ b/nl_server/requirements.txt
@@ -1,17 +1,18 @@
 datasets==2.8.0
 diskcache==5.4.0
-Flask==1.1.4
+Flask==2.1.3
 google-cloud-language==2.5.1
 google-cloud-pubsub==2.14.0
 google-cloud-storage==2.4.0
 gunicorn==20.1.0
-markupsafe==2.0.1
+markupsafe==2.1.2
 pandas==1.3.5
 sentence_transformers==2.2.2
 spacy==3.5.0
 pydantic==1.9.2
-torch==1.12.1 # torch 1.13 or higher brings in nvidia lib, which  is 1.5GB.
 scikit-learn==1.0.2
+torch==1.12.1 # torch 1.13 or higher brings in nvidia lib, which  is 1.5GB.
+Werkzeug==2.1.2
 # Downloading the named-entity recognition (NER) library spacy and the large EN model
 # using the guidelines here: https://spacy.io/usage/models#production
 en_core_web_lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.5.0/en_core_web_lg-3.5.0-py3-none-any.whl

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,7 +1,7 @@
 CacheControl==0.12.11
 datasets==2.8.0
 diskcache==5.4.0
-Flask==2.2.3
+Flask==2.1.3
 Flask-Babel==2.0.0
 Flask-Caching==2.0.1
 flask_testing==0.8.1
@@ -33,7 +33,7 @@ sentence_transformers==2.2.2
 six==1.16.0
 typing_extensions==3.10.0.0
 torch==1.12.1 # torch 1.13 or higher brings in nvidia lib, which  is 1.5GB.
-Werkzeug==2.2.3
+Werkzeug==2.1.2
 wheel==0.38.1
 yapf==0.31.0
 geojson_rewind==1.0.1


### PR DESCRIPTION
Latest Flask (2.2.3) does not handle /path/ as /path well https://github.com/pallets/werkzeug/issues/2533. Use an older version before a good fix is available.