### PR TITLE
Only load bigtable module when LOG_QUERY is enabled

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -37,6 +37,7 @@ from server.lib.disaster_dashboard import get_disaster_dashboard_data
 import server.lib.i18n as i18n
 import server.lib.util as libutil
 import server.services.ai as ai
+import server.services.bigtable as bt
 from server.services.discovery import configure_endpoints_from_ingress
 from server.services.discovery import get_health_check_urls
 
@@ -303,6 +304,10 @@ def create_app():
     app.config['NL_MODEL'] = nl_model
     # This also requires disaster and event routes.
     app.config['NL_DISASTER_CONFIG'] = libutil.get_nl_disaster_config()
+    if app.config['LOG_QUERY']:
+      app.config['NL_TABLE'] = bt.get_nl_table()
+    else:
+      app.config['NL_TABLE'] = None
 
   if not cfg.TEST:
     urls = get_health_check_urls()


### PR DESCRIPTION
Now server/services/bigtable.py is always imported hence require bigtable client is always created. This gives GCP auth error for 3P developers that do not have corresponding access.