### PR TITLE
More update on service group config

### DIFF
--- a/deploy/helm_charts/dc_website/templates/config_maps.yaml
+++ b/deploy/helm_charts/dc_website/templates/config_maps.yaml
@@ -61,8 +61,7 @@ metadata:
 data:
   rules: |
 {{- range $serviceName, $group := .Values.serviceGroups }}
-  {{- if eq $group nil }}
-  {{- else }}
+  {{- if $group }}
     dc-mixer-{{ $serviceName }}:
     {{- range $index, $urlPath := $group.urlPaths }}
       - {{ $urlPath }}

--- a/deploy/helm_charts/envs/autopush.yaml
+++ b/deploy/helm_charts/envs/autopush.yaml
@@ -53,6 +53,8 @@ nl:
   enabled: true
 
 serviceGroups:
+  recon: null
+  observation: null
   svg:
     replicas: 5
   default:

--- a/deploy/helm_charts/envs/custom.yaml
+++ b/deploy/helm_charts/envs/custom.yaml
@@ -40,6 +40,8 @@ serviceAccount:
   name: website-ksa
 
 serviceGroups:
+  recon: null
+  observation: null
   svg: null
   default:
     replicas: 1

--- a/deploy/helm_charts/envs/dev.yaml
+++ b/deploy/helm_charts/envs/dev.yaml
@@ -46,6 +46,8 @@ serviceAccount:
   name: website-ksa
 
 serviceGroups:
+  recon: null
+  observation: null
   svg:
     replicas: 2
   default:


### PR DESCRIPTION
When deploying mixer pods, the serviceGroup in deploy/helm_charts/envs/<ENV>.yaml is merged with the base values in mixer repo, hence "null" values should be added to prevent creating unwanted pods.