### PR TITLE
[V2 API] Migrate place stat var union/existence and place name related APIs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,14 +5,13 @@
             "name": "Jest Tests",
             "type": "node",
             "request": "launch",
-            "args": [
-            ],
+            "args": [],
             "cwd": "${workspaceFolder}/static",
             "console": "integratedTerminal",
             "program": "${workspaceFolder}/static/node_modules/jest/bin/jest",
         },
         {
-            "name": "Flask",
+            "name": "Flask (with NL)",
             "type": "python",
             "request": "launch",
             "stopOnEntry": false,
@@ -34,7 +33,7 @@
             "console": "internalConsole",
         },
         {
-            "name": "Flask - without NL",
+            "name": "Flask (without NL)",
             "type": "python",
             "request": "launch",
             "stopOnEntry": false,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,16 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Jest Tests",
+            "type": "node",
+            "request": "launch",
+            "args": [
+            ],
+            "cwd": "${workspaceFolder}/static",
+            "console": "integratedTerminal",
+            "program": "${workspaceFolder}/static/node_modules/jest/bin/jest",
+        },
+        {
             "name": "Flask",
             "type": "python",
             "request": "launch",

--- a/server/routes/place/api.py
+++ b/server/routes/place/api.py
@@ -373,8 +373,8 @@ def get_i18n_all_child_places(raw_page_data):
   for place_type in list(all_child_places.keys()):
     for place in all_child_places[place_type]['places']:
       all_dcids.append(place.get('dcid', ''))
-  i18n_names = place_api.get_i18n_name(all_dcids,
-                                       False)  # Don't resolve en-only names
+  # Don't resolve en-only names
+  i18n_names = place_api.get_i18n_name(all_dcids, False)
   for place_type in list(all_child_places.keys()):
     for place in all_child_places[place_type]['places']:
       dcid = place.get('dcid')
@@ -566,7 +566,7 @@ def data(dcid):
   all_places = [dcid]
   for t in BAR_CHART_TYPES:
     all_places.extend(raw_page_data.get(t + 'Places', []))
-  names = place_api.get_display_name('^'.join(sorted(all_places)), g.locale)
+  names = place_api.get_display_name(all_places)
 
   # Pick data to highlight - only population for now
   highlight = {}

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -91,7 +91,7 @@ def place_landing():
   with open(os.path.join(current_app.root_path, 'templates', dcid_json)) as f:
     landing_dcids = json.load(f)
     # Use display names (including state, if applicable) for the static page
-    place_names = place_api.get_display_name('^'.join(landing_dcids), g.locale)
+    place_names = place_api.get_display_name(landing_dcids)
     return flask.render_template(
         template_file,
         place_names=place_names,

--- a/server/routes/ranking/api.py
+++ b/server/routes/ranking/api.py
@@ -84,8 +84,7 @@ def ranking_api(stat_var, place_type, place=None):
         dcids.add(r['placeDcid'])
       data[stat_var][k]['info'] = info
       # payload[stat_var][k]['count'] = count
-  place_names = place_api.get_display_name('^'.join(sorted(list(dcids))),
-                                           flask.g.locale)
+  place_names = place_api.get_display_name(list(dcids))
   for k in rank_keys:
     if k in data[stat_var] and 'info' in data[stat_var][k]:
       for r in data[stat_var][k]['info']:

--- a/server/routes/shared_api/choropleth.py
+++ b/server/routes/shared_api/choropleth.py
@@ -223,7 +223,7 @@ def geojson():
   # too fragmented
   if place_dcid == 'geoId/72':
     geojson_prop = 'geoJsonCoordinatesDP1'
-  names_by_geo = place_api.get_display_name('^'.join(geos), g.locale)
+  names_by_geo = place_api.get_display_name(geos)
   features = []
   if geojson_prop:
     geojson_by_geo = lib_util.property_values(geos, geojson_prop)
@@ -466,7 +466,7 @@ def get_map_points():
   geos = dc.get_places_in([place_dcid], place_type).get(place_dcid, [])
   if not geos:
     return Response(json.dumps({}), 200, mimetype='application/json')
-  names_by_geo = place_api.get_display_name('^'.join(geos), g.locale)
+  names_by_geo = place_api.get_display_name(geos)
   # For some places, lat long is attached to the place node, but for other
   # places, the lat long is attached to the location value of the place node.
   # If a place has location, we will use the location value to find the lat

--- a/server/routes/shared_api/place.py
+++ b/server/routes/shared_api/place.py
@@ -750,7 +750,7 @@ def api_ranking_chart(dcid):
     parent_place_list = parent_places([dcid]).get(dcid, [])
     for parent in parent_place_list:
       parent_place_dcid = parent.get("dcid", "")
-      parent_type = parent.get('type', '')
+      parent_type = parent.get("type", "")
       # All wanted place types plus continent except CensusZipCodeTabulationArea.
       if parent_type == "Continent" or (
           parent_type in ALL_WANTED_PLACE_TYPES and

--- a/server/routes/shared_api/place.py
+++ b/server/routes/shared_api/place.py
@@ -156,34 +156,25 @@ def api_name():
     return 'error fetching names for the given places', 400
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def cached_i18n_name(dcids, locale, should_resolve_all):
+def get_i18n_name(dcids, should_resolve_all=True):
   """Returns localization names for set of dcids.
 
   Args:
-      dcids: ^ separated string of dcids. It must be a single string for the cache.
-      locale: the desired localization language code.
+      dcids: A list of dcids.
       should_resolve_all: True if every dcid should be returned with a
-                          name, False if only i18n names should be filled
+                          name, False if only i18n names should be filled.
 
   Returns:
       A dictionary of place names, keyed by dcid (potentially sparse if should_resolve_all=False)
   """
   if not dcids:
     return {}
-  dcids = dcids.split('^')
-  response = fetch_data('/node/property-values', {
-      'dcids': dcids,
-      'property': 'nameWithLanguage',
-      'direction': 'out'
-  },
-                        compress=False,
-                        post=True)
+  response = util.property_values(dcids, 'nameWithLanguage')
   result = {}
   dcids_default_name = []
-  locales = i18n.locale_choices(locale)
+  locales = i18n.locale_choices(g.locale)
   for dcid in dcids:
-    values = response[dcid].get('out')
+    values = response.get(dcid, [])
     # If there is no nameWithLanguage for this dcid, fall back to name.
     if not values:
       dcids_default_name.append(dcid)
@@ -207,30 +198,15 @@ def cached_i18n_name(dcids, locale, should_resolve_all):
 
 
 def has_locale_name(entry, locale):
-  return entry['value'].endswith('@' + locale.lower())
+  return entry.endswith('@' + locale.lower())
 
 
 def extract_locale_name(entry, locale):
-  if entry['value'].endswith('@' + locale.lower()):
-    locale_index = len(entry['value']) - len(locale) - 1
-    return entry['value'][:locale_index]
+  if entry.endswith('@' + locale.lower()):
+    locale_index = len(entry) - len(locale) - 1
+    return entry[:locale_index]
   else:
     return ''
-
-
-def get_i18n_name(dcids, should_resolve_all=True):
-  """Returns localization names for set of dcids.
-
-  Args:
-      dcids: A list of place dcids.
-      should_resolve_all: True if every dcid should be returned with a
-                          name, False if only i18n names should be filled
-
-  Returns:
-      A dictionary of place names, keyed by dcid (potentially sparse if should_resolve_all=False)
-  """
-  return cached_i18n_name('^'.join((sorted(dcids))), g.locale,
-                          should_resolve_all)
 
 
 @bp.route('/name/i18n')
@@ -258,55 +234,43 @@ def get_named_typed_place():
   return Response(json.dumps(ret), 200, mimetype='application/json')
 
 
-@bp.route('/statsvars/<path:dcid>')
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def statsvars_route(dcid):
-  """Get all the statistical variables that exist for a give place.
-  Args:
-    dcid: Place dcid.
-  Returns:
-    A list of statistical variable dcids.
-  """
-  return Response(json.dumps(dc.get_variables(dcid)),
-                  200,
-                  mimetype='application/json')
-
-
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def get_stat_vars_union(places, stat_vars):
-  """Get all the statistical variable dcids for some places.
-
-  Args:
-      places: Place DCIDs separated by "^" as a single string.
-      stat_vars: list of stat var dcids.
-
-  Returns:
-      List of unique statistical variable dcids each as a string.
-  """
-  places = places.split("^")
-  # The two indexings are due to how protobuf fields are converted to json
-  return fetch_data('/v1/place/stat-vars/union', {
-      'dcids': places,
-      'statVars': stat_vars,
-  },
-                    compress=False,
-                    post=True,
-                    has_payload=False).get('statVars', [])
-
-
 @bp.route('/stat-vars/union', methods=['POST'])
-def get_stat_vars_union_route():
+def get_stat_vars_union():
   """Get all the statistical variables that exist for some places.
 
   Returns:
       List of unique statistical variable dcids each as a string.
   """
-  dcids = sorted(request.json.get('dcids', []))
-  stat_vars = (request.json.get('statVars', []))
+  result = []
+  entities = sorted(request.json.get('dcids', []))
+  resp = dc.entity_variables(entities)
+  for var, entity_obs in resp['byVariable'].items():
+    if len(entity_obs.get('byEntity'), {}) == len(entities):
+      result.append(var)
+  return Response(json.dumps(result), 200, mimetype='application/json')
 
-  return Response(json.dumps(get_stat_vars_union("^".join(dcids), stat_vars)),
-                  200,
-                  mimetype='application/json')
+
+@bp.route('/stat-vars/existence', methods=['POST'])
+def get_stat_vars_existence():
+  """Check if statistical variables that exist for some places.
+
+  Returns:
+      Map from variable to place to a boolean of whether there is observation.
+  """
+  result = {}
+  variables = request.json.get('variables', [])
+  entities = request.json.get('entities', [])
+  # Populate result
+  for var in variables:
+    result[var] = {}
+    for e in entities:
+      result[var][e] = False
+  # Fetch existence check data
+  resp = dc.entity_variables_existence(variables, entities)
+  for var, entity_obs in resp.get('byVariable', {}).items():
+    for e in entity_obs.get('byEntity', {}):
+      result[var][e] = True
+  return Response(json.dumps(result), 200, mimetype='application/json')
 
 
 @bp.route('/child/<path:dcid>')
@@ -345,14 +309,11 @@ def child_fetch(parent_dcid):
 
   # Fetch population of child places
   pop = {}
-  obs = dc.obs_point(wanted_dcids, [POPULATION_DCID])
-  obs = obs.get('observationsByVariable', [])
-  if obs and obs[0]['variable'] == POPULATION_DCID:
-    obs = obs[0].get('observationsByEntity', [])
-    for p in obs:
-      v = p.get('pointsByFacet', [])
-      if v:
-        pop[p['entity']] = v[0]['value']
+  obs_response = util.point_core(wanted_dcids, [POPULATION_DCID],
+                                 date='LATEST',
+                                 all_facets=False)
+  for entity, points in obs_response['data'].get(POPULATION_DCID, {}).items():
+    pop[entity] = points[0]['value']
 
   # Build return object
   place_names = util.property_values(wanted_dcids, 'name', True)
@@ -383,90 +344,31 @@ def child_fetch(parent_dcid):
 
 
 @bp.route('/parent/<path:dcid>')
+@cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def api_parent_places(dcid):
-  result = parent_places(dcid)[dcid]
+  result = parent_places([dcid])[dcid]
   return Response(json.dumps(result), 200, mimetype='application/json')
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def parent_places(dcids):
   """ Get the parent place chain for a list of places.
 
   Args:
-      dcids: ^ separated string of dcids. It must be a single string for the cache.
-
-  Returns:
-      A dictionary of lists of parent places, keyed by dcid.
-  """
-  # In DataCommons knowledge graph, places has multiple containedInPlace
-  # relation with parent places, but it might not be comprehensive. For
-  # example, "Mountain View" is containedInPlace for "Santa Clara County" and
-  # "California" but not "United States":
-  # https://datacommons.org/browser/geoId/0649670
-  # Here calling get_parent_place twice to get to the top parents.
-  if not dcids:
-    return {}
-
-  result = {}
-  parents1 = get_parent_place(dcids)
-  dcids = dcids.split('^')
-  dcid_parents1_mapping = {}
-  for dcid in dcids:
-    first_parents = parents1[dcid]
-    result[dcid] = first_parents
-    if first_parents:
-      dcid_parents1_mapping[dcid] = first_parents[-1]['dcid']
-  if not dcid_parents1_mapping:
-    return result
-
-  parents2 = get_parent_place('^'.join(dcid_parents1_mapping.values()))
-  dcid_parents2_mapping = {}
-  for dcid in dcid_parents1_mapping.keys():
-    second_parents = parents2[dcid_parents1_mapping[dcid]]
-    result[dcid].extend(second_parents)
-    if second_parents:
-      dcid_parents2_mapping[dcid] = second_parents[-1]['dcid']
-  if not dcid_parents2_mapping:
-    return result
-
-  parents3 = get_parent_place('^'.join(dcid_parents2_mapping.values()))
-  for dcid in dcid_parents2_mapping.keys():
-    result[dcid].extend(parents3[dcid_parents2_mapping[dcid]])
-    result[dcid] = [x for x in result[dcid] if x['dcid'] != 'Earth']
-  return result
-
-
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def get_parent_place(dcids):
-  """ Get containedInPlace for each place in a list of places
-
-  Args:
-      dcids: ^ separated string of dcids. It must be a single string for the cache.
+      dcids: A list of place dids.
 
   Returns:
       A dictionary of lists of containedInPlace, keyed by dcid.
   """
-  if dcids:
-    dcids = dcids.split('^')
-  else:
-    dcids = []
-  response = fetch_data('/node/property-values', {
-      'dcids': dcids,
-      'property': 'containedInPlace',
-      'direction': 'out'
-  },
-                        compress=False,
-                        post=True)
-  result = {}
-  for dcid in dcids:
-    parents = response[dcid].get('out', [])
-    parents.sort(key=lambda x: x['dcid'], reverse=True)
-    for i in range(len(parents)):
-      if len(parents[i]['types']) > 1:
-        parents[i]['types'] = [
-            x for x in parents[i]['types']
-            if not x.startswith('AdministrativeArea')
-        ]
+  result = {dcid: {} for dcid in dcids}
+  place_info = dc.get_place_info(dcids)
+  for item in place_info.get('data', []):
+    if 'node' not in item or 'info' not in item:
+      continue
+    dcid = item['node']
+    parents = item['info'].get('parents', [])
+    parents = [
+        x for x in parents if not x['type'].startswith('AdministrativeArea')
+    ]
     result[dcid] = parents
   return result
 
@@ -554,15 +456,14 @@ def get_ranking_url(containing_dcid,
 def api_ranking(dcid):
   """Get the ranking information for a given place."""
   current_place_type = get_place_type(dcid)
-  parents = parent_places(dcid)[dcid]
-  parents_str = '^'.join(sorted(map(lambda x: x['dcid'], parents)))
-  parent_i18n_names = cached_i18n_name(parents_str, g.locale, False)
+  parents = parent_places([dcid])[dcid]
+  parent_i18n_names = get_i18n_name([x['dcid'] for x in parents], False)
 
   selected_parents = []
   parent_names = {}
   for parent in parents:
     parent_dcid = parent['dcid']
-    parent_type = parent['types'][0]
+    parent_type = parent['type']
     if parent_type not in WANTED_PLACE_TYPES:
       continue
     if parent_dcid.startswith('zip'):
@@ -635,12 +536,11 @@ def api_ranking(dcid):
   return Response(json.dumps(result), 200, mimetype='application/json')
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def get_state_code(dcids):
   """Get state codes for a list of places that are state equivalents
 
   Args:
-      dcids: ^ separated string of dcids of places that are state equivalents
+      dcids: A list of dcids.
 
   Returns:
       A dictionary of state codes, keyed by dcid
@@ -648,7 +548,6 @@ def get_state_code(dcids):
   result = {}
   if not dcids:
     return result
-  dcids = dcids.split('^')
   iso_codes = util.property_values(dcids, 'isoCode')
 
   for dcid in dcids:
@@ -663,22 +562,19 @@ def get_state_code(dcids):
   return result
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
-def get_display_name(dcids, locale="en"):
+def get_display_name(dcids):
   """ Get display names for a list of places.
 
   Display name is place name with state code if it has a parent place that is a state.
 
   Args:
-      dcids: ^ separated string of dcids. It must be a single string for the cache.
-      locale: the desired localization language code.
+      dcids: A list of dcids.
 
   Returns:
       A dictionary of display names, keyed by dcid.
   """
-  place_names = cached_i18n_name(dcids, locale, True)
+  place_names = get_i18n_name(dcids)
   parents = parent_places(dcids)
-  dcids = dcids.split('^')
   result = {}
   dcid_state_mapping = {}
   for dcid in dcids:
@@ -686,18 +582,16 @@ def get_display_name(dcids, locale="en"):
       continue
     for parent_place in parents[dcid]:
       parent_dcid = parent_place['dcid']
-      place_types = parent_place['types']
-      for place_type in place_types:
-        if place_type in STATE_EQUIVALENTS:
-          dcid_state_mapping[dcid] = parent_dcid
-          break
+      place_type = parent_place['type']
+      if place_type in STATE_EQUIVALENTS:
+        dcid_state_mapping[dcid] = parent_dcid
     result[dcid] = place_names[dcid]
 
-  states_lookup = '^'.join(sorted(set(dcid_state_mapping.values())))
-  if locale == "en":
+  states_lookup = set(dcid_state_mapping.values())
+  if g.locale == "en":
     state_codes = get_state_code(states_lookup)
   else:
-    state_codes = cached_i18n_name(states_lookup, locale, True)
+    state_codes = get_i18n_name(list(states_lookup), True)
   for dcid in dcid_state_mapping.keys():
     state_code = state_codes[dcid_state_mapping[dcid]]
     if state_code:
@@ -711,7 +605,7 @@ def api_display_name():
   dcids = request.args.getlist('dcids')
   if not dcids:
     dcids = request.json.get('dcids', [])
-  result = get_display_name('^'.join((sorted(dcids))), g.locale)
+  result = get_display_name(dcids)
   return Response(json.dumps(result), 200, mimetype='application/json')
 
 
@@ -744,7 +638,7 @@ def get_places_in_names():
   dcid = request.args.get("dcid")
   place_type = request.args.get("placeType")
   child_places = dc.get_places_in([dcid], place_type)[dcid]
-  return Response(json.dumps(get_display_name('^'.join(child_places))),
+  return Response(json.dumps(get_display_name(child_places)),
                   200,
                   mimetype='application/json')
 
@@ -853,17 +747,15 @@ def api_ranking_chart(dcid):
     place_type = "Country"
   else:
     place_type = get_place_type(dcid)
-    parent_place_list = parent_places(dcid).get(dcid, [])
+    parent_place_list = parent_places([dcid]).get(dcid, [])
     for parent in parent_place_list:
-      parent_type_list = parent.get("types", [])
       parent_place_dcid = parent.get("dcid", "")
-      if parent_type_list:
-        parent_type = parent_type_list[0]
-        # All wanted place types plus continent except CensusZipCodeTabulationArea.
-        if parent_type == "Continent" or (
-            parent_type in ALL_WANTED_PLACE_TYPES and
-            parent_type != "CensusZipCodeTabulationArea"):
-          break
+      parent_type = parent.get('type', '')
+      # All wanted place types plus continent except CensusZipCodeTabulationArea.
+      if parent_type == "Continent" or (
+          parent_type in ALL_WANTED_PLACE_TYPES and
+          parent_type != "CensusZipCodeTabulationArea"):
+        break
     # If break is not encountered, return empty result.
     else:
       return Response(json.dumps(result), 200, mimetype='application/json')

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -175,6 +175,41 @@ def obs_series_within(parent_entity, child_type, variables):
       })
 
 
+def entity_variables(entities):
+  """Gets the statistical variables that have obserations for given entities.
+
+  Args:
+      entities: List of entity dcids.
+  """
+  url = get_service_url('/v2/observation')
+  return post(url, {
+      'select': ['variable', 'entity'],
+      'entity': {
+          'dcids': entities,
+      },
+  })
+
+
+def entity_variables_existence(variables, entities):
+  """Check if statistical variables have observations for given entities.
+
+  Args:
+      variables: List of variable dcids.
+      entities: List of entity dcids.
+  """
+  url = get_service_url('/v2/observation')
+  return post(
+      url, {
+          'select': ['variable', 'entity'],
+          'entity': {
+              'dcids': entities,
+          },
+          'variable': {
+              'dcids': variables,
+          },
+      })
+
+
 def triples(node, direction):
   """Retrieves the triples for a node.
 

--- a/server/services/discovery.py
+++ b/server/services/discovery.py
@@ -147,7 +147,6 @@ endpoints = Endpoints([
     '/node/property-values',
     '/node/places-in',
     '/node/ranking-locations',
-    '/v1/place/stat-vars/union',
     # TODO(shifucun): switch back to /node/related-places after data switch.
     '/node/related-locations',
     '/stat-var/search',

--- a/server/tests/routes/api/landing_page_test.py
+++ b/server/tests/routes/api/landing_page_test.py
@@ -102,29 +102,16 @@ class TestI18n(unittest.TestCase):
         '/api/landingpage/data/geoId/06?hl=ru')
 
   @staticmethod
-  def side_effect(url, req, compress, post):
+  def side_effect(dcids, prop):
     return {
-        "geoId/0646870": {
-            "out": [{
-                "value": "门洛帕克@ru",
-                "provenance": "prov1"
-            }]
-        },
-        "geoId/0651840": {
-            "out": [{
-                "value": "北費爾奧克斯 (加利福尼亞州)@ru",
-                "provenance": "prov1"
-            }, {
-                "value": "North Fair Oaks@en",
-                "provenance": "prov1"
-            }]
-        },
-        "geoId/0684536": {}
+        "geoId/0646870": ["门洛帕克@ru"],
+        "geoId/0651840": ["北費爾奧克斯 (加利福尼亞州)@ru", "North Fair Oaks@en"],
+        "geoId/0684536": []
     }
 
-  @patch('server.routes.shared_api.place.fetch_data')
-  def test_child_places_i18n(self, mock_fetch_data):
-    mock_fetch_data.side_effect = self.side_effect
+  @patch('server.routes.shared_api.place.util.property_values')
+  def test_child_places_i18n(self, mock_property_values):
+    mock_property_values.side_effect = self.side_effect
 
     raw_page_data = {
         "allChildPlaces": {

--- a/static/js/shared/ga_events.test.tsx
+++ b/static/js/shared/ga_events.test.tsx
@@ -66,7 +66,7 @@ import {
 import { ScatterChartType } from "../tools/scatter/util";
 import { Chart as TimelineToolChart } from "../tools/timeline/chart";
 import * as dataFetcher from "../tools/timeline/data_fetcher";
-import { axios_mock } from "../tools/timeline/mock_functions";
+import { axiosMock } from "../tools/timeline/mock_functions";
 import {
   GA_EVENT_PLACE_CATEGORY_CLICK,
   GA_EVENT_PLACE_CHART_CLICK,
@@ -788,7 +788,7 @@ describe("test ga event tool stat var click", () => {
     const mockgtag = jest.fn();
     window.gtag = mockgtag;
     // Mock child stat var groups.
-    axios_mock();
+    axiosMock();
 
     // When the component is rendered.
     const statVarHierarchy = render(

--- a/static/js/tools/download/mock_functions.ts
+++ b/static/js/tools/download/mock_functions.ts
@@ -22,7 +22,7 @@ import { when } from "jest-when";
 
 import { stringifyFn } from "../../utils/axios";
 
-export function axios_mock(): void {
+export function axiosMock(): void {
   // Mock all the async axios call.
   axios.get = jest.fn();
   axios.post = jest.fn();
@@ -208,7 +208,7 @@ export function axios_mock(): void {
   when(axios.get)
     .calledWith("/api/place/parent/geoId/06")
     .mockResolvedValue({
-      data: ["country/USA"],
+      data: [{ dcid: "country/USA", type: "Country", name: "United States" }],
     });
 
   // get facets within place for Count_Person
@@ -275,21 +275,31 @@ export function axios_mock(): void {
 
   // get place stats vars for places in geoId/06
   when(axios.post)
-    .calledWith("/api/place/stat-vars/union", {
-      dcids: ["geoId/06001", "geoId/06002"],
-      statVars: ["Count_Person"],
+    .calledWith("/api/place/stat-vars/existence", {
+      entities: ["geoId/06001", "geoId/06002"],
+      variables: ["Count_Person"],
     })
     .mockResolvedValue({
-      data: ["Count_Person"],
+      data: {
+        Count_Person: {
+          "geoId/06001": true,
+          "geoId/06002": true,
+        },
+      },
     });
 
   when(axios.post)
-    .calledWith("/api/place/stat-vars/union", {
-      dcids: ["geoId/06002", "geoId/06001"],
-      statVars: ["Count_Person"],
+    .calledWith("/api/place/stat-vars/existence", {
+      entities: ["geoId/06002", "geoId/06001"],
+      variables: ["Count_Person"],
     })
     .mockResolvedValue({
-      data: ["Count_Person"],
+      data: {
+        Count_Person: {
+          "geoId/06001": true,
+          "geoId/06002": true,
+        },
+      },
     });
 
   // get csv

--- a/static/js/tools/download/page.test.tsx
+++ b/static/js/tools/download/page.test.tsx
@@ -26,7 +26,7 @@ import React from "react";
 
 import * as SharedUtil from "../../shared/util";
 import { InfoPlace } from "./info";
-import { axios_mock } from "./mock_functions";
+import { axiosMock } from "./mock_functions";
 import { Page } from "./page";
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -60,7 +60,7 @@ test("Loading options from URL", async () => {
     },
   });
   // Mock all the async axios calls
-  axios_mock();
+  axiosMock();
   // Render the component
   const wrapper = mount(<Page infoPlaces={INFO_PLACES} />);
   await waitForComponentUpdates(wrapper);
@@ -104,7 +104,7 @@ test("Manually updating options", async () => {
     },
   });
   // Mock all the async axios calls
-  axios_mock();
+  axiosMock();
   // Render the component
   const wrapper = mount(<Page infoPlaces={INFO_PLACES} />);
   await waitForComponentUpdates(wrapper);

--- a/static/js/tools/scatter/app.test.tsx
+++ b/static/js/tools/scatter/app.test.tsx
@@ -459,7 +459,7 @@ function mockAxios(): void {
   when(axios.get)
     .calledWith("/api/place/parent/geoId/10")
     .mockResolvedValue({
-      data: ["country/USA"],
+      data: [{ dcid: "country/USA", type: "Country", name: "United States" }],
     });
 
   when(axios.get).calledWith("/api/place/type/geoId/10").mockResolvedValue({

--- a/static/js/tools/shared/stat_var_widget.tsx
+++ b/static/js/tools/shared/stat_var_widget.tsx
@@ -82,16 +82,20 @@ export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
           const availableSVs = [];
           const unavailableSVs = [];
           for (const sv in props.selectedSVs) {
-            let available = true;
+            // sv is used if there is even one entity(place) has observations.
+            // This is apparently very loose and can be tightened by making this
+            // a percentage of all entities.
+            let available = false;
             for (const entity in resp.data[sv]) {
-              if (!resp.data[sv][entity]) {
-                unavailableSVs.push(sv);
-                available = false;
+              if (resp.data[sv][entity]) {
+                available = true;
                 break;
               }
             }
             if (available) {
               availableSVs.push(sv);
+            } else {
+              unavailableSVs.push(sv);
             }
           }
           if (!_.isEmpty(unavailableSVs)) {

--- a/static/js/tools/shared/stat_var_widget.tsx
+++ b/static/js/tools/shared/stat_var_widget.tsx
@@ -74,16 +74,24 @@ export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
   useEffect(() => {
     if (!_.isEmpty(props.sampleEntities) && !_.isEmpty(props.selectedSVs)) {
       axios
-        .post("/api/place/stat-vars/union", {
-          dcids: props.sampleEntities.map((place) => place.dcid),
-          statVars: Object.keys(props.selectedSVs),
+        .post("/api/place/stat-vars/existence", {
+          entities: props.sampleEntities.map((place) => place.dcid),
+          variables: Object.keys(props.selectedSVs),
         })
         .then((resp) => {
-          const availableSVs = resp.data;
+          const availableSVs = [];
           const unavailableSVs = [];
           for (const sv in props.selectedSVs) {
-            if (availableSVs.indexOf(sv) === -1) {
-              unavailableSVs.push(sv);
+            let available = true;
+            for (const entity in resp.data[sv]) {
+              if (!resp.data[sv][entity]) {
+                unavailableSVs.push(sv);
+                available = false;
+                break;
+              }
+            }
+            if (available) {
+              availableSVs.push(sv);
             }
           }
           if (!_.isEmpty(unavailableSVs)) {

--- a/static/js/tools/timeline/data_fetcher.test.ts
+++ b/static/js/tools/timeline/data_fetcher.test.ts
@@ -30,7 +30,7 @@ import {
   TimelineRawData,
 } from "./data_fetcher";
 
-function axios_mock(): void {
+function axiosMock(): void {
   axios.get = jest.fn();
   axios.post = jest.fn();
   when(axios.get)
@@ -236,7 +236,7 @@ beforeAll(() => {
 });
 
 test("fetch raw data", () => {
-  axios_mock();
+  axiosMock();
   return fetchRawData(
     ["geoId/05", "geoId/06"],
     ["Count_Person", "Count_Person_Male"],

--- a/static/js/tools/timeline/mock_functions.tsx
+++ b/static/js/tools/timeline/mock_functions.tsx
@@ -23,7 +23,7 @@ import { when } from "jest-when";
 import { drawGroupLineChart } from "../../chart/draw";
 import { stringifyFn } from "../../utils/axios";
 
-export function axios_mock(): void {
+export function axiosMock(): void {
   // Mock all the async axios call.
   axios.get = jest.fn();
   axios.post = jest.fn();
@@ -98,42 +98,61 @@ export function axios_mock(): void {
 
   // get place stats vars, geoId/05
   when(axios.post)
-    .calledWith("/api/place/stat-vars/union", {
-      dcids: ["geoId/05"],
-      statVars: ["Median_Age_Person"],
+    .calledWith("/api/place/stat-vars/existence", {
+      entities: ["geoId/05"],
+      variables: ["Median_Age_Person"],
     })
     .mockResolvedValue({
-      data: ["Median_Age_Person"],
+      data: {
+        Median_Age_Person: {
+          "geoId/05": true,
+        },
+      },
     });
 
   // get place stats vars, geoId/05
   when(axios.post)
-    .calledWith("/api/place/stat-vars/union", {
-      dcids: ["geoId/05"],
-      statVars: ["Median_Age_Person", "Count_Person"],
+    .calledWith("/api/place/stat-vars/existence", {
+      entities: ["geoId/05"],
+      variables: ["Median_Age_Person", "Count_Person"],
     })
     .mockResolvedValue({
-      data: ["Count_Person", "Median_Age_Person"],
+      data: {
+        Count_Person: {
+          "geoId/05": true,
+        },
+        Median_Age_Person: {
+          "geoId/05": true,
+        },
+      },
     });
 
   // get place stats vars, geoId/05
   when(axios.post)
-    .calledWith("/api/place/stat-vars/union", {
-      dcids: ["geoId/05"],
-      statVars: ["NotInTheTree"],
+    .calledWith("/api/place/stat-vars/existence", {
+      entities: ["geoId/05"],
+      variables: ["NotInTheTree"],
     })
     .mockResolvedValue({
-      data: ["NotInTheTree"],
+      data: {
+        NotInTheTree: {
+          "geoId/05": true,
+        },
+      },
     });
 
   // get place stats vars, geoId/05
   when(axios.post)
-    .calledWith("/api/place/stat-vars/union", {
-      dcids: ["geoId/05"],
-      statVars: ["Count_Person"],
+    .calledWith("/api/place/stat-vars/existence", {
+      entities: ["geoId/05"],
+      variables: ["Count_Person"],
     })
     .mockResolvedValue({
-      data: ["Count_Person"],
+      data: {
+        Count_Person: {
+          "geoId/05": true,
+        },
+      },
     });
 
   // get place names, geoId/05
@@ -475,7 +494,7 @@ export function axios_mock(): void {
 
 // Mock drawGroupLineChart() as getComputedTextLength can has issue with jest
 // and jsdom.
-export function drawGroupLineChart_mock(): void {
+export function drawGroupLineChartMock(): void {
   (drawGroupLineChart as jest.Mock).mockImplementation(
     (selector: string | HTMLDivElement) => {
       let container: d3.Selection<any, any, any, any>;

--- a/static/js/tools/timeline/page.test.tsx
+++ b/static/js/tools/timeline/page.test.tsx
@@ -23,7 +23,7 @@ import Adapter from "enzyme-adapter-react-16";
 import pretty from "pretty";
 import React from "react";
 
-import { axios_mock, drawGroupLineChart_mock } from "./mock_functions";
+import { axiosMock, drawGroupLineChartMock } from "./mock_functions";
 import { Page } from "./page";
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -60,9 +60,9 @@ test("Single place and single stat var", async () => {
   });
   // Mock drawGroupLineChart() as getComputedTextLength can has issue with jest
   // and jsdom.
-  drawGroupLineChart_mock();
+  drawGroupLineChartMock();
   // Mock all the async axios call
-  axios_mock();
+  axiosMock();
   // Do the actual render!
   const wrapper = mount(<Page />);
   await waitForComponentUpdates(wrapper);
@@ -136,9 +136,9 @@ test("statVar not in PV-tree", async () => {
   });
   // Mock drawGroupLineChart() as getComputedTextLength can has issue with jest
   // and jsdom.
-  drawGroupLineChart_mock();
+  drawGroupLineChartMock();
   // mock all the async axios call
-  axios_mock();
+  axiosMock();
   // Do the actual render!
   const wrapper = mount(<Page />);
   await waitForComponentUpdates(wrapper);
@@ -163,9 +163,9 @@ test("chart options", async () => {
 
   // Mock drawGroupLineChart() as getComputedTextLength can has issue with jest
   // and jsdom.
-  drawGroupLineChart_mock();
+  drawGroupLineChartMock();
   // mock all the async axios call
-  axios_mock();
+  axiosMock();
 
   // Do the actual render!
   const wrapper = mount(<Page />);

--- a/static/js/utils/place_utils.ts
+++ b/static/js/utils/place_utils.ts
@@ -77,15 +77,10 @@ export function getParentPlacesPromise(
     .then((resp) => {
       const parentsData = resp.data;
       const filteredParentsData = parentsData.filter((parent) => {
-        for (const type of parent.types) {
-          if (type in ALL_MAP_PLACE_TYPES) {
-            return true;
-          }
-        }
-        return false;
+        return parent.type in ALL_MAP_PLACE_TYPES;
       });
       const parentPlaces = filteredParentsData.map((parent) => {
-        return { dcid: parent.dcid, name: parent.name, types: parent.types };
+        return { dcid: parent.dcid, name: parent.name, types: [parent.type] };
       });
       if (placeDcid !== EARTH_NAMED_TYPED_PLACE.dcid) {
         parentPlaces.push(EARTH_NAMED_TYPED_PLACE);
@@ -253,8 +248,8 @@ export function getPlaceIdsFromNames(
   }
   return Promise.all(names.map(getPlaceId)).then((places) => {
     const result = {};
-    for (const [name, place_id] of places) {
-      result[name] = place_id;
+    for (const [name, placeId] of places) {
+      result[name] = placeId;
     }
     return result;
   });

--- a/static/js/utils/tests/disaster_event_map_utils.test.ts
+++ b/static/js/utils/tests/disaster_event_map_utils.test.ts
@@ -368,7 +368,7 @@ const DATE_RANGES = {
   },
 };
 
-function axios_mock(): void {
+function axiosMock(): void {
   axios.get = jest.fn();
 
   for (const eventList of Object.values(DISASTER_EVENT_TYPES)) {
@@ -422,7 +422,7 @@ function axios_mock(): void {
 }
 
 test("fetch date list for all disasters", () => {
-  axios_mock();
+  axiosMock();
   return fetchDateList(
     Object.values(DISASTER_EVENT_TYPES).flat(),
     EARTH_NAMED_TYPED_PLACE.dcid
@@ -466,7 +466,7 @@ test("fetch date list for all disasters", () => {
 });
 
 test("fetch date list for single disaster multiple event types", () => {
-  axios_mock();
+  axiosMock();
   return fetchDateList(
     DISASTER_EVENT_TYPES[STORM_DISASTER_TYPE_ID],
     EARTH_NAMED_TYPED_PLACE.dcid
@@ -502,7 +502,7 @@ test("fetch date list for single disaster multiple event types", () => {
 });
 
 test("fetch date list for single eventType", () => {
-  axios_mock();
+  axiosMock();
   return fetchDateList(
     DISASTER_EVENT_TYPES[EARTHQUAKE_DISASTER_TYPE_ID],
     EARTH_NAMED_TYPED_PLACE.dcid
@@ -545,7 +545,7 @@ test("fetch date list for single eventType", () => {
 });
 
 test("fetch data for single disaster multiple events with date as YYYY-MM", () => {
-  axios_mock();
+  axiosMock();
   const eventSpec = {
     id: STORM_DISASTER_TYPE_ID,
     name: "storm",
@@ -578,7 +578,7 @@ test("fetch data for single disaster multiple events with date as YYYY-MM", () =
 });
 
 test("fetch data for single disaster multiple events with date as YYYY", () => {
-  axios_mock();
+  axiosMock();
   const eventSpec = {
     id: STORM_DISASTER_TYPE_ID,
     name: "storm",
@@ -612,7 +612,7 @@ test("fetch data for single disaster multiple events with date as YYYY", () => {
 });
 
 test("fetch data for single event with date as YYYY-MM", () => {
-  axios_mock();
+  axiosMock();
   const eventSpec = {
     id: EARTHQUAKE_DISASTER_TYPE_ID,
     name: "earthquake",
@@ -644,7 +644,7 @@ test("fetch data for single event with date as YYYY-MM", () => {
 });
 
 test("fetch data for single event with date as YYYY", () => {
-  axios_mock();
+  axiosMock();
   const eventSpec = {
     id: EARTHQUAKE_DISASTER_TYPE_ID,
     name: "earthquake",


### PR DESCRIPTION
* Use /info/place API to get parent places instead of using get_prop_value a few times.
* Get rid of "cached" version of some data fetch functions. The dc.Fn() call result is already cached, and/or there is cache for flask endpoints response.