### PR TITLE
Trim extra spaces around links in FAQ

### DIFF
--- a/server/templates/static/faq.html
+++ b/server/templates/static/faq.html
@@ -25,7 +25,7 @@
 
 {% block content %}
 <div class="container">
-  <h1>Frequently Asked Questions </h1>
+  <h1>Frequently Asked Questions</h1>
 
   <p>
   <b>Q: What is Data Commons?</b><br>
@@ -88,7 +88,7 @@
   <p>
     <b>Q: How can we access data in Data Commons?</b><br>
     The data in knowledge graph can be accessed through the <a
-      href="{{ url_for('browser.browser_main') }}">Data Commons Graph Browser </a> and APIs for <a
+      href="{{ url_for('browser.browser_main') }}">Data Commons Graph Browser</a> and APIs for <a
       href="https://docs.datacommons.org/api/python">Python</a>, <a
       href="https://docs.datacommons.org/api/rest">REST</a> and <a
       href="https://docs.datacommons.org/api/sheets">Google Sheets</a>.
@@ -98,7 +98,7 @@
     <b>Q: How can we add our own data to knowledge graph?</b><br>
     Data Commons is intended to be a community project and seeks your involvement.
     To know more about publishing data that can be included into Data Commons, check out our <a
-      href="https://docs.datacommons.org/contributing/">Contributing</a> page. You can also contact <a href="mailto:support@datacommons.org">support@datacommons.org </a>
+      href="https://docs.datacommons.org/contributing/">Contributing</a> page. You can also contact <a href="mailto:support@datacommons.org">support@datacommons.org</a>
     if you have an interesting dataset that you think should be included in Data Commons and would
     like to help.
     In the future we plan to allow users to ingest data into the Data Commons Graph using
@@ -132,7 +132,7 @@
     Given the size and evolving nature of the Data Commons Graph, we prefer you access
     it via the APIs.
     If your project needs local access to a large fraction of the Data Commons Graph, please contact <a
-      href="mailto:support@DataCommons.org">support@datacommons.org </a>.
+      href="mailto:support@DataCommons.org">support@datacommons.org</a>.
   </p>
 
   <p>


### PR DESCRIPTION
Links are styled with an underline (on hover, anyway), and there's extra spill-over

![image](https://user-images.githubusercontent.com/6527489/235630371-91424dd3-0227-413b-888b-e1aa52c30c2b.png)
