### PR TITLE
Bumped datasets to 2.11

### DIFF
--- a/nl_server/requirements.txt
+++ b/nl_server/requirements.txt
@@ -1,4 +1,4 @@
-datasets==2.8.0
+datasets==2.11
 diskcache==5.4.0
 Flask==2.0.0
 google-cloud-language==2.5.1


### PR DESCRIPTION
Old datasets version was causing the error:

```
    return pd.read_csv(xopen(filepath_or_buffer, "rb", use_auth_token=use_auth_token), **kwargs)
TypeError: read_csv() got an unexpected keyword argument 'mangle_dupe_cols'
```

Reference: https://github.com/huggingface/datasets/issues/5744