### PR TITLE
Added ranking tile chart export from html to svg/image

### DIFF
--- a/static/js/components/ranking_unit.tsx
+++ b/static/js/components/ranking_unit.tsx
@@ -19,7 +19,7 @@
  */
 
 import _ from "lodash";
-import React from "react";
+import React, { RefObject } from "react";
 
 import { LocalizedLink } from "../i18n/i18n";
 import { RankingPoint } from "../types/ranking_unit_types";
@@ -42,6 +42,10 @@ interface RankingUnitPropType {
     numFractionDigits?: number
   ) => string;
   unit?: string[];
+  /**
+   * React ref for outermost div of this element
+   */
+  forwardRef?: RefObject<HTMLDivElement>;
   scaling?: number[];
   /**
    * Total number of points. This is used for calculating ranks if isHighest is false
@@ -80,7 +84,7 @@ export function RankingUnit(props: RankingUnitPropType): JSX.Element {
   }
 
   return (
-    <div className="ranking-list">
+    <div className="ranking-list" ref={props.forwardRef}>
       <h4>{props.title}</h4>
       <table>
         {props.svNames && !props.hideValue && (

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -97,6 +97,7 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
       props.getDataCsv ? props.getDataCsv() : "",
       svgWidth || containerRef.current.offsetWidth,
       svgHeight,
+      "",
       chartTitle,
       "",
       Array.from(props.sources)

--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -20,7 +20,13 @@
 
 import axios from "axios";
 import _ from "lodash";
-import React, { useEffect, useRef, useState } from "react";
+import React, {
+  MutableRefObject,
+  RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { formatNumber } from "../../i18n/i18n";
@@ -71,6 +77,8 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
   const [rankingData, setRankingData] = useState<RankingData | undefined>(null);
   const embedModalElement = useRef<ChartEmbed>(null);
   const chartContainer = useRef(null);
+  const rankingUnitHighestContainer = useRef<HTMLDivElement>(null);
+  const rankingUnitLowestContainer = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     fetchData(props, setRankingData);
@@ -123,6 +131,7 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
                   <RankingUnit
                     key={`${statVar}-highest`}
                     unit={unit}
+                    forwardRef={rankingUnitHighestContainer}
                     scaling={scaling}
                     title={formatString(
                       props.title ||
@@ -142,7 +151,7 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
                   />
                   <ChartFooter
                     sources={sources}
-                    handleEmbed={() => handleEmbed(points.reverse())}
+                    handleEmbed={() => handleEmbed(points.reverse(), sources)}
                   />
                 </div>
               )}
@@ -151,6 +160,7 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
                   <RankingUnit
                     key={`${statVar}-lowest`}
                     unit={unit}
+                    forwardRef={rankingUnitLowestContainer}
                     scaling={scaling}
                     title={formatString(
                       props.title ||
@@ -171,7 +181,7 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
                   />
                   <ChartFooter
                     sources={sources}
-                    handleEmbed={() => handleEmbed(points)}
+                    handleEmbed={() => handleEmbed(points, sources)}
                   />
                 </div>
               )}
@@ -182,15 +192,28 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
     </div>
   );
 
-  function handleEmbed(rankingPoints: RankingPoint[]): void {
+  function handleEmbed(
+    rankingPoints: RankingPoint[],
+    sources: Set<string>
+  ): void {
+    let chartHtml = "";
+    let chartHeight = 0;
+    if (rankingUnitHighestContainer.current) {
+      chartHtml = rankingUnitHighestContainer.current.outerHTML;
+      chartHeight = rankingUnitHighestContainer.current.offsetHeight;
+    } else if (rankingUnitLowestContainer.current) {
+      chartHtml = rankingUnitLowestContainer.current.outerHTML;
+      chartHeight = rankingUnitHighestContainer.current.offsetHeight;
+    }
     embedModalElement.current.show(
       "",
       rankingPointsToCsv(rankingPoints),
       chartContainer.current.offsetWidth,
-      0,
+      chartHeight,
+      chartHtml,
       "",
       "",
-      []
+      Array.from(sources)
     );
   }
 }

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -370,6 +370,7 @@ export const TopEventTile = memo(function TopEventTile(
       0,
       "",
       "",
+      "",
       []
     );
   }

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -452,6 +452,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       this.dataCsv(),
       this.svgContainerElement.current.offsetWidth,
       CHART_HEIGHT,
+      "",
       this.props.title,
       this.getDateString(),
       this.getSources()

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -36,6 +36,7 @@ interface ChartEmbedStateType {
   dataCsv: string;
   chartWidth: number;
   chartHeight: number;
+  chartHtml: string;
   chartTitle: string;
   chartDate: string;
   sources: string[];
@@ -59,6 +60,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
       dataCsv: "",
       chartWidth: 0,
       chartHeight: 0,
+      chartHtml: "",
       chartTitle: "",
       chartDate: "",
       sources: [],
@@ -92,20 +94,108 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
     dataCsv: string,
     chartWidth: number,
     chartHeight: number,
+    chartHtml: string,
     chartTitle: string,
     chartDate: string,
     sources: string[]
   ): void {
     this.setState({
       modal: true,
-      svgXml: svgXml,
-      dataCsv: dataCsv,
-      chartWidth: chartWidth,
-      chartHeight: chartHeight,
-      chartTitle: chartTitle,
-      chartDate: chartDate,
-      sources: sources,
+      svgXml,
+      dataCsv,
+      chartWidth,
+      chartHeight,
+      chartHtml,
+      chartTitle,
+      chartDate,
+      sources,
     });
+  }
+
+  /**
+   * Decorates chartHtml with title and provenance information embeded in an enclosing
+   * SVG node. Returns the SVG contents as a string.
+   */
+  private decorateChartHtml(): string {
+    const container = this.svgContainerElement.current;
+    container.innerHTML = "";
+    const chartWidth = this.state.chartWidth + 2 * CHART_PADDING;
+
+    // Decorate a hidden chart svg with title and provenance
+    const svg = d3
+      .select(container)
+      .append("svg")
+      .attr("xmlns", SVGNS)
+      .attr("xmlns:xlink", XLINKNS)
+      .attr("width", chartWidth);
+
+    const title = svg
+      .append("g")
+      .append("text")
+      .style("font-family", "sans-serif")
+      .style("fill", "#3b3b3b")
+      .style("font-size", ".85rem")
+      .style("font-weight", "bold")
+      .style("text-anchor", "middle")
+      .text(`${this.state.chartTitle} ${this.state.chartDate}`)
+      .call(wrap, this.state.chartWidth);
+    const titleHeight = title.node().getBBox().height;
+    title.attr("transform", `translate(${chartWidth / 2}, ${TITLE_Y})`);
+
+    svg
+      .append("g")
+      .attr(
+        "transform",
+        `translate(${CHART_PADDING}, ${titleHeight + TITLE_MARGIN})`
+      )
+      .append("svg")
+      .append("foreignObject")
+      .attr("width", chartWidth)
+      .attr("height", 500)
+      .append("xhtml:div")
+      .style("font", "14px 'Helvetica Neue'")
+      .html(this.state.chartHtml);
+
+    const sources = svg
+      .append("g")
+      .attr(
+        "transform",
+        `translate(${CHART_PADDING}, ${
+          titleHeight + TITLE_MARGIN + this.state.chartHeight + SOURCES_MARGIN
+        })`
+      )
+      .append("text")
+      .style("fill", "#3b3b3b")
+      .style("font-family", "sans-serif")
+      .style("font-size", ".7rem")
+      .text(
+        intl.formatMessage(
+          {
+            id: "embed_citation",
+            defaultMessage: "Data from {sources} via Data Commons",
+            description:
+              'Used to cite where the data is from, but that it was provided through Data Commons. For example, "Data from {nytimes.com} via Data Commons" or "Data from {census.gov, nytimes.com} via Data Commons". Please keep the name "Data Commons".',
+          },
+          { sources: this.state.sources.map((s) => urlToDomain(s)).join(", ") }
+        )
+      )
+      .call(wrap, this.state.chartWidth);
+
+    const sourcesHeight = sources.node().getBBox().height;
+    svg.attr(
+      "height",
+      this.state.chartHeight +
+        titleHeight +
+        TITLE_MARGIN +
+        sourcesHeight +
+        SOURCES_MARGIN
+    );
+
+    const s = new XMLSerializer();
+    const svgXml = s.serializeToString(svg.node());
+    container.innerHTML = "";
+
+    return svgXml;
   }
 
   /**
@@ -199,6 +289,16 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
     if (this.textareaElement.current) {
       this.textareaElement.current.style.width =
         this.state.chartWidth + CHART_PADDING * 2 + "px";
+    }
+
+    if (this.state.chartHtml) {
+      const chartDownloadXml = this.decorateChartHtml();
+      const imageElement = document.createElement("img");
+      const chartBase64 =
+        "data:image/svg+xml," + encodeURIComponent(chartDownloadXml);
+      imageElement.src = chartBase64;
+      this.svgContainerElement.current.append(imageElement);
+      this.setState({ chartDownloadXml });
     }
 
     if (this.state.svgXml) {


### PR DESCRIPTION
Pulls html table and puts it in an svg `<foreignObject>` tag.

Styling on the final SVG download needs work

![dc-export-html-table](https://user-images.githubusercontent.com/13766/236271981-b9333fcd-9331-4665-8ddc-a844dc86ee82.gif)
