### PR TITLE
[tiles] merge all svgs in chart tile container and export

### DIFF
--- a/static/js/chart/draw_bivariate.ts
+++ b/static/js/chart/draw_bivariate.ts
@@ -97,10 +97,9 @@ function drawMapLegend(
   xUnit?: string,
   yUnit?: string
 ): void {
-  const legendSvg = d3
-    .select(legendRef.current)
-    .append("svg")
-    .attr("width", svgWidth);
+  const container = d3.select(legendRef.current)
+  container.selectAll("*").remove();
+  const legendSvg = container.append("svg").attr("width", svgWidth);
   const legendContainer = legendSvg.append("g");
   const legendLabels = legendContainer
     .append("text")

--- a/static/js/chart/draw_bivariate.ts
+++ b/static/js/chart/draw_bivariate.ts
@@ -97,7 +97,7 @@ function drawMapLegend(
   xUnit?: string,
   yUnit?: string
 ): void {
-  const container = d3.select(legendRef.current)
+  const container = d3.select(legendRef.current);
   container.selectAll("*").remove();
   const legendSvg = container.append("svg").attr("width", svgWidth);
   const legendContainer = legendSvg.append("g");

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -81,16 +81,21 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
     const chartTitle = props.title
       ? formatString(props.title, props.replacementStrings)
       : "";
-    const svgElemList = containerRef.current.getElementsByTagName("svg") as SVGElement[];
+    const svgElemList = containerRef.current.getElementsByTagName(
+      "svg"
+    ) as SVGElement[];
     // Create new svg element to return which will hold all the svgs coming from
     // containerRef
-    const embedSvg = document.createElementNS("http://www.w3.org/2000/svg", 'svg');
+    const embedSvg = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "svg"
+    );
     let embedSvgWidth = 0;
     let embedSvgHeight = 0;
     // Set embedSvgHeight as the max height of all svgs
     Array.from(svgElemList).forEach((svg) => {
       embedSvgHeight = Math.max(svg.getBBox().height, embedSvgHeight);
-    })
+    });
     // Add each svg from svgElemList to embedSvg
     for (const svg of svgElemList) {
       const svgBBox = svg.getBBox();
@@ -100,13 +105,14 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
       const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
       // Move current svg to the right of svgs that have already been added to
       // embedSvg
-      g.setAttribute("transform", `translate(${embedSvgWidth})`)
+      g.setAttribute("transform", `translate(${embedSvgWidth})`);
       g.appendChild(clonedSvg);
       embedSvg.appendChild(g);
       // Update width of embedSvg to include current svg width
       embedSvgWidth += svgBBox.width + svgBBox.x;
     }
-    let svgXml = !_.isEmpty(svgElemList) && embedSvg ? embedSvg.outerHTML : "";
+    const svgXml =
+      !_.isEmpty(svgElemList) && embedSvg ? embedSvg.outerHTML : "";
     embedModalElement.current.show(
       svgXml,
       props.getDataCsv ? props.getDataCsv() : "",


### PR DESCRIPTION
- When a chart tile has mulitple svgs (e.g., map which has the map and the legend), in the export functionality, package the svgs together into 1 svg to be exported

![Screenshot 2023-05-05 at 2 52 33 PM](https://user-images.githubusercontent.com/69875368/236574827-76e7ff69-3b23-4eca-81e6-82a50829c1f6.jpg)


- also fix a bug in the bivariate tile where multiple legends were showing up