### PR TITLE
[V2 API] Migrate and clean up usage of observation existence API

### DIFF
--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -232,7 +232,7 @@ def series_within_core(ancestor_entity, descendent_type, variables, all_facets):
 
 
 def observation_existence(variables, entities):
-  """Check if observation exist for variable, entity paris.
+  """Check if observation exist for variable, entity pairs.
 
   Returns:
       {

--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -231,6 +231,33 @@ def series_within_core(ancestor_entity, descendent_type, variables, all_facets):
   return _compact_series(resp, all_facets)
 
 
+def observation_existence(variables, entities):
+  """Check if observation exist for variable, entity paris.
+
+  Returns:
+      {
+        <variable_did>: {
+          <entity_dcid>: boolean
+        }
+      }
+
+  """
+  result = {}
+  # Populate result
+  for var in variables:
+    result[var] = {}
+    for e in entities:
+      result[var][e] = False
+  # Fetch existence check data
+  resp = dc.v2observation(['variable', 'entity'], {'dcids': entities}, {
+      'dcids': variables,
+  })
+  for var, entity_obs in resp.get('byVariable', {}).items():
+    for e in entity_obs.get('byEntity', {}):
+      result[var][e] = True
+  return result
+
+
 def properties(nodes, out=True):
   """Returns the properties for a list of nodes.
 

--- a/server/lib/nl/utils.py
+++ b/server/lib/nl/utils.py
@@ -104,7 +104,7 @@ def sv_existence_for_places(places: List[str], svs: List[str],
     return []
 
   start = time.time()
-  sv_existence = dc.observation_existence(svs, places)
+  sv_existence = fetch.observation_existence(svs, places)
   counters.timeit('sv_existence_for_places', start)
   if not sv_existence:
     logging.error("Existence checks for SVs failed.")
@@ -113,7 +113,7 @@ def sv_existence_for_places(places: List[str], svs: List[str],
   existing_svs = []
   for sv in svs:
     exists = False
-    for _, exist_bit in sv_existence['variable'][sv]['entity'].items():
+    for _, exist_bit in sv_existence.get(sv, {}).items():
       if not exist_bit:
         continue
       exists = True

--- a/server/lib/subject_page_config.py
+++ b/server/lib/subject_page_config.py
@@ -104,7 +104,7 @@ def _sv_places_exist(places, stat_var, stat_vars_existence, place_dcid):
   Returns true if stat_var exists for all places in stat_vars_existence. Also
   supports "self" placeholder replacement.
   """
-  sv_entity = stat_vars_existence['variable'][stat_var]['entity']
+  sv_entity = stat_vars_existence.get(stat_var, {})
   for p in places:
     if p == SELF_PLACE_DCID_PLACEHOLDER:
       p = place_dcid
@@ -178,7 +178,7 @@ def remove_empty_charts(page_config, place_dcid, contained_place_type=None):
       place_dcid, contained_place_type, ctr)[::SAMPLE_PLACE_STEP]
   bar_comparison_places = _bar_comparison_places(page_config, place_dcid)
   all_places = sample_child_places + bar_comparison_places + [place_dcid]
-  stat_vars_existence = dc.observation_existence(all_stat_vars, all_places)
+  stat_vars_existence = fetch.observation_existence(all_stat_vars, all_places)
 
   child_places_geojson = _places_with_geojson(sample_child_places)
 

--- a/server/routes/shared_api/observation/existence.py
+++ b/server/routes/shared_api/observation/existence.py
@@ -16,22 +16,23 @@ import json
 
 from flask import Blueprint
 from flask import request
+from flask import Response
 
-import server.services.datacommons as dc
+from server.lib import fetch
 
 # Define blueprint
 bp = Blueprint("observation_existence", __name__)
 
 
-@bp.route('/api/observation-existence')
+@bp.route('/api/observation/existence', methods=['POST'])
 def observation_existence():
-  """Given a list of stat vars and entities, check whether observation exist for
-  all the (variable,entity) pairs.
+  """Check if statistical variables that exist for some places.
+
+  Returns:
+      Map from variable to place to a boolean of whether there is observation.
   """
-  entities = request.args.getlist('entities')
-  if not entities:
-    return 'error: must provide entities field', 400
-  variables = request.args.getlist('variables')
-  if not variables:
-    return 'error: must provide variables field', 400
-  return json.dumps(dc.observation_existence(variables, entities))
+  variables = request.json.get('variables', [])
+  entities = request.json.get('entities', [])
+  return Response(json.dumps(fetch.observation_existene(variables, entities)),
+                  200,
+                  mimetype='application/json')

--- a/server/routes/shared_api/observation/existence.py
+++ b/server/routes/shared_api/observation/existence.py
@@ -33,6 +33,6 @@ def observation_existence():
   """
   variables = request.json.get('variables', [])
   entities = request.json.get('entities', [])
-  return Response(json.dumps(fetch.observation_existene(variables, entities)),
+  return Response(json.dumps(fetch.observation_existence(variables, entities)),
                   200,
                   mimetype='application/json')

--- a/server/routes/shared_api/place.py
+++ b/server/routes/shared_api/place.py
@@ -249,29 +249,6 @@ def get_stat_vars_union():
   return Response(json.dumps(result), 200, mimetype='application/json')
 
 
-@bp.route('/stat-vars/existence', methods=['POST'])
-def get_stat_vars_existence():
-  """Check if statistical variables that exist for some places.
-
-  Returns:
-      Map from variable to place to a boolean of whether there is observation.
-  """
-  result = {}
-  variables = request.json.get('variables', [])
-  entities = request.json.get('entities', [])
-  # Populate result
-  for var in variables:
-    result[var] = {}
-    for e in entities:
-      result[var][e] = False
-  # Fetch existence check data
-  resp = dc.entity_variables_existence(variables, entities)
-  for var, entity_obs in resp.get('byVariable', {}).items():
-    for e in entity_obs.get('byEntity', {}):
-      result[var][e] = True
-  return Response(json.dumps(result), 200, mimetype='application/json')
-
-
 @bp.route('/child/<path:dcid>')
 @cache.memoize(timeout=3600 * 24)  # Cache for one day.
 def child(dcid):

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -191,8 +191,8 @@ def v2observation(select, entity, variable):
   """
   Args:
     select: A list of select props.
-    entity: A dict in the form of {'dcis':, 'expression':}
-    variable: A dict in the form of {'dcis':, 'expression':}
+    entity: A dict in the form of {'dcids':, 'expression':}
+    variable: A dict in the form of {'dcids':, 'expression':}
 
   """
   url = get_service_url('/v2/observation')

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -187,24 +187,20 @@ def entity_variables(entities):
   })
 
 
-def entity_variables_existence(variables, entities):
-  """Check if statistical variables have observations for given entities.
-
+def v2observation(select, entity, variable):
+  """
   Args:
-      variables: List of variable dcids.
-      entities: List of entity dcids.
+    select: A list of select props.
+    entity: A dict in the form of {'dcis':, 'expression':}
+    variable: A dict in the form of {'dcis':, 'expression':}
+
   """
   url = get_service_url('/v2/observation')
-  return post(
-      url, {
-          'select': ['variable', 'entity'],
-          'entity': {
-              'dcids': entities,
-          },
-          'variable': {
-              'dcids': variables,
-          },
-      })
+  return post(url, {
+      'select': select,
+      'entity': entity,
+      'variable': variable,
+  })
 
 
 def v2node(nodes, prop):
@@ -273,15 +269,6 @@ def get_series_dates(parent_entity, child_type, variables):
           'entity_type': child_type,
           'variables': variables,
       })
-
-
-def observation_existence(variables, entities):
-  """Check if observation exist for <entity, variable> pairs"""
-  url = get_service_url('/v1/bulk/observation-existence')
-  return post(url, {
-      'entities': entities,
-      'variables': variables,
-  })
 
 
 def bio(entity):

--- a/server/services/discovery.py
+++ b/server/services/discovery.py
@@ -137,7 +137,6 @@ endpoints = Endpoints([
     '/v1/bulk/info/variable',
     '/v1/bulk/info/variable-group',
     '/v1/bulk/observation-dates/linked',
-    '/v1/bulk/observation-existence',
     '/v1/variables',
     '/v1/variable/ancestors',
     '/v1/place/ranking',

--- a/server/tests/lib/subject_page_config_test.py
+++ b/server/tests/lib/subject_page_config_test.py
@@ -77,28 +77,18 @@ class TestRemoveEmptyCharts(unittest.TestCase):
             }
             """, category)
     stat_vars_existence = {
-        'variable': {
-            'Count_fireEvent': {
-                'entity': {
-                    'place_id': False
-                }
-            },
-            'Area_fireEvent': {
-                'entity': {
-                    'place_id': True
-                }
-            },
-            'TotalArea': {
-                'entity': {
-                    'place_id': True
-                }
-            },
-            'Nonexistent': {
-                'entity': {
-                    'place_id': False
-                }
-            },
-        }
+        'Count_fireEvent': {
+            'place_id': False
+        },
+        'Area_fireEvent': {
+            'place_id': True
+        },
+        'TotalArea': {
+            'place_id': True
+        },
+        'Nonexistent': {
+            'place_id': False
+        },
     }
     result = lib_subject_page_config._exist_keys_category(['place_id'],
                                                           category,
@@ -114,7 +104,7 @@ class TestRemoveEmptyCharts(unittest.TestCase):
 
   @mock.patch('server.lib.fetch.properties')
   @mock.patch('server.lib.nl.utils.get_sample_child_places')
-  @mock.patch('server.services.datacommons.observation_existence')
+  @mock.patch('server.lib.fetch.observation_existence')
   def test_remove_empty_charts(self, mock_observation_existence,
                                mock_sample_child_places,
                                mock_geojson_properties):
@@ -127,62 +117,42 @@ class TestRemoveEmptyCharts(unittest.TestCase):
 
     def obs_side_effect(all_svs, place_dcids):
       return {
-          'variable': {
-              "sv_exists_1": {
-                  'entity': {
-                      'place_id': True,
-                      'child_id': False
-                  }
-              },
-              "sv_exists_3": {
-                  'entity': {
-                      'place_id': True,
-                      'child_id': False
-                  }
-              },
-              "sv_filtered_1": {
-                  'entity': {
-                      'place_id': False,
-                      'child_id': False
-                  }
-              },
-              "sv_filtered_2": {
-                  'entity': {
-                      'place_id': False,
-                      'child_id': False
-                  }
-              },
-              "sv_filtered_3": {
-                  'entity': {
-                      'place_id': False,
-                      'child_id': False
-                  }
-              },
-              "sv_child_exists_1": {
-                  'entity': {
-                      'place_id': False,
-                      'child_id': True
-                  }
-              },
-              "sv_child_filtered_1": {
-                  'entity': {
-                      'place_id': False,
-                      'child_id': False
-                  }
-              },
-              "sv_parent_exists_1": {
-                  'entity': {
-                      'place_id': True,
-                      'child_id': False
-                  }
-              },
-              "sv_parent_filtered_1": {
-                  'entity': {
-                      'place_id': False,
-                      'child_id': False
-                  }
-              },
-          }
+          "sv_exists_1": {
+              'place_id': True,
+              'child_id': False
+          },
+          "sv_exists_3": {
+              'place_id': True,
+              'child_id': False
+          },
+          "sv_filtered_1": {
+              'place_id': False,
+              'child_id': False
+          },
+          "sv_filtered_2": {
+              'place_id': False,
+              'child_id': False
+          },
+          "sv_filtered_3": {
+              'place_id': False,
+              'child_id': False
+          },
+          "sv_child_exists_1": {
+              'place_id': False,
+              'child_id': True
+          },
+          "sv_child_filtered_1": {
+              'place_id': False,
+              'child_id': False
+          },
+          "sv_parent_exists_1": {
+              'place_id': True,
+              'child_id': False
+          },
+          "sv_parent_filtered_1": {
+              'place_id': False,
+              'child_id': False
+          },
       }
 
     mock_observation_existence.side_effect = obs_side_effect

--- a/server/webdriver_tests/tests/stat_var_hierarchy_test.py
+++ b/server/webdriver_tests/tests/stat_var_hierarchy_test.py
@@ -1,0 +1,68 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from server.webdriver_tests.base_test import WebdriverBaseTest
+import server.webdriver_tests.shared as shared
+
+MAP_URL = '/tools/map'
+
+
+# Class to test stat var hierarchy component.
+class TestMap(WebdriverBaseTest):
+
+  def test_filter(self):
+    """Test the stat var filtering based on place selection."""
+    self.driver.get(self.url_ + MAP_URL)
+
+    # Wait until stat var hierarchy is present
+    element_present = EC.presence_of_element_located(
+        (By.ID, 'hierarchy-section'))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
+
+    # Get the count of the first category
+    first_category = self.driver.find_element(By.CLASS_NAME, 'sv-count')
+    count_text = first_category.text
+    count_initial = int(count_text.replace('(', '').replace(')', ''))
+
+    # Wait until search box is present.
+    element_present = EC.presence_of_element_located((By.ID, 'ac'))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
+    search_box_input = self.driver.find_element(By.ID, 'ac')
+
+    # Type california into the search box.
+    search_box_input.send_keys('California')
+
+    # Wait until there is at least one result in autocomplete results.
+    element_present = EC.presence_of_element_located(
+        (By.CLASS_NAME, 'pac-item'))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
+
+    # Click on the first result.
+    first_result = self.driver.find_element(By.CSS_SELECTOR,
+                                            '.pac-item:nth-child(1)')
+    first_result.click()
+    element_present = EC.presence_of_element_located((By.CLASS_NAME, 'chip'))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
+
+    # Get the count after filtering
+    shared.wait_for_loading(self.driver)
+    first_category = self.driver.find_element(By.CLASS_NAME, 'sv-count')
+    count_text = first_category.text
+    count_filter = int(count_text.replace('(', '').replace(')', ''))
+
+    self.assertGreater(count_initial, count_filter)

--- a/static/js/tools/download/mock_functions.ts
+++ b/static/js/tools/download/mock_functions.ts
@@ -275,7 +275,7 @@ export function axiosMock(): void {
 
   // get place stats vars for places in geoId/06
   when(axios.post)
-    .calledWith("/api/place/stat-vars/existence", {
+    .calledWith("/api/observation/existence", {
       entities: ["geoId/06001", "geoId/06002"],
       variables: ["Count_Person"],
     })
@@ -289,7 +289,7 @@ export function axiosMock(): void {
     });
 
   when(axios.post)
-    .calledWith("/api/place/stat-vars/existence", {
+    .calledWith("/api/observation/existence", {
       entities: ["geoId/06002", "geoId/06001"],
       variables: ["Count_Person"],
     })

--- a/static/js/tools/shared/stat_var_widget.tsx
+++ b/static/js/tools/shared/stat_var_widget.tsx
@@ -74,7 +74,7 @@ export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
   useEffect(() => {
     if (!_.isEmpty(props.sampleEntities) && !_.isEmpty(props.selectedSVs)) {
       axios
-        .post("/api/place/stat-vars/existence", {
+        .post("/api/observation/existence", {
           entities: props.sampleEntities.map((place) => place.dcid),
           variables: Object.keys(props.selectedSVs),
         })

--- a/static/js/tools/timeline/mock_functions.tsx
+++ b/static/js/tools/timeline/mock_functions.tsx
@@ -98,7 +98,7 @@ export function axiosMock(): void {
 
   // get place stats vars, geoId/05
   when(axios.post)
-    .calledWith("/api/place/stat-vars/existence", {
+    .calledWith("/api/observation/existence", {
       entities: ["geoId/05"],
       variables: ["Median_Age_Person"],
     })
@@ -112,7 +112,7 @@ export function axiosMock(): void {
 
   // get place stats vars, geoId/05
   when(axios.post)
-    .calledWith("/api/place/stat-vars/existence", {
+    .calledWith("/api/observation/existence", {
       entities: ["geoId/05"],
       variables: ["Median_Age_Person", "Count_Person"],
     })
@@ -129,7 +129,7 @@ export function axiosMock(): void {
 
   // get place stats vars, geoId/05
   when(axios.post)
-    .calledWith("/api/place/stat-vars/existence", {
+    .calledWith("/api/observation/existence", {
       entities: ["geoId/05"],
       variables: ["NotInTheTree"],
     })
@@ -143,7 +143,7 @@ export function axiosMock(): void {
 
   // get place stats vars, geoId/05
   when(axios.post)
-    .calledWith("/api/place/stat-vars/existence", {
+    .calledWith("/api/observation/existence", {
       entities: ["geoId/05"],
       variables: ["Count_Person"],
     })


### PR DESCRIPTION
Follow the new file layout pattern:

* Create data fetch function in fetch.py, with response simplification
* Remove v1/v2 observation existence REST call wrapper in datacommons.py