### PR TITLE
[nl] update determining if sv is per capita

### DIFF
--- a/server/integration_tests/test_data/demo_feb2023/query_9/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_9/chart_config.json
@@ -15,7 +15,7 @@
                       "Count_Person_15OrMoreYears_NoIncome_scatter",
                       "Percent_Person_WithHighBloodPressure_scatter"
                     ],
-                    "title": "Population of Working Age With No Income (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
+                    "title": "Population of Working Age With No Income Per Capita (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
                     "type": "SCATTER"
                   }
                 ]
@@ -34,7 +34,7 @@
                       "Income_Farm_scatter",
                       "Percent_Person_WithHighBloodPressure_scatter"
                     ],
-                    "title": "Total Farm Income (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
+                    "title": "Total Farm Income Per Capita (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
                     "type": "SCATTER"
                   }
                 ]
@@ -53,7 +53,7 @@
                       "Mean_Income_Household_scatter",
                       "Percent_Person_WithHighBloodPressure_scatter"
                     ],
-                    "title": "Average Income for Households (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
+                    "title": "Average Income for Households Per Capita (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
                     "type": "SCATTER"
                   }
                 ]
@@ -72,7 +72,7 @@
                       "Mean_Income_Household_FamilyHousehold_scatter",
                       "Percent_Person_WithHighBloodPressure_scatter"
                     ],
-                    "title": "Average Income for Family Households (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
+                    "title": "Average Income for Family Households Per Capita (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
                     "type": "SCATTER"
                   }
                 ]
@@ -91,7 +91,7 @@
                       "Mean_Income_Household_MarriedCoupleFamilyHousehold_scatter",
                       "Percent_Person_WithHighBloodPressure_scatter"
                     ],
-                    "title": "Average Income for Married Couple Family Households (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
+                    "title": "Average Income for Married Couple Family Households Per Capita (${yDate}) vs. High Bood Pressure (${xDate}) in Counties of United States",
                     "type": "SCATTER"
                   }
                 ]
@@ -101,24 +101,34 @@
         ],
         "statVarSpec": {
           "Count_Person_15OrMoreYears_NoIncome_scatter": {
-            "name": "Population of Working Age With No Income",
-            "statVar": "Count_Person_15OrMoreYears_NoIncome"
+            "denom": "Count_Person",
+            "name": "Population of Working Age With No Income Per Capita",
+            "statVar": "Count_Person_15OrMoreYears_NoIncome",
+            "unit": "%"
           },
           "Income_Farm_scatter": {
-            "name": "Total Farm Income",
-            "statVar": "Income_Farm"
+            "denom": "Count_Person",
+            "name": "Total Farm Income Per Capita",
+            "statVar": "Income_Farm",
+            "unit": "%"
           },
           "Mean_Income_Household_FamilyHousehold_scatter": {
-            "name": "Average Income for Family Households",
-            "statVar": "Mean_Income_Household_FamilyHousehold"
+            "denom": "Count_Person",
+            "name": "Average Income for Family Households Per Capita",
+            "statVar": "Mean_Income_Household_FamilyHousehold",
+            "unit": "%"
           },
           "Mean_Income_Household_MarriedCoupleFamilyHousehold_scatter": {
-            "name": "Average Income for Married Couple Family Households",
-            "statVar": "Mean_Income_Household_MarriedCoupleFamilyHousehold"
+            "denom": "Count_Person",
+            "name": "Average Income for Married Couple Family Households Per Capita",
+            "statVar": "Mean_Income_Household_MarriedCoupleFamilyHousehold",
+            "unit": "%"
           },
           "Mean_Income_Household_scatter": {
-            "name": "Average Income for Households",
-            "statVar": "Mean_Income_Household"
+            "denom": "Count_Person",
+            "name": "Average Income for Households Per Capita",
+            "statVar": "Mean_Income_Household",
+            "unit": "%"
           },
           "Percent_Person_WithHighBloodPressure_scatter": {
             "name": "High Bood Pressure",

--- a/server/lib/nl/page_config_builder.py
+++ b/server/lib/nl/page_config_builder.py
@@ -607,12 +607,16 @@ def _scatter_chart_block(column, pri_place: Place, sv_pair: List[str],
   sv_key_pair = [sv_pair[0] + '_scatter', sv_pair[1] + '_scatter']
 
   change_to_pc = [False, False]
-  if _is_sv_percapita(sv_names[0]):
-    if not _is_sv_percapita(sv_names[1]):
+  is_sv_pc = [
+      _is_sv_percapita(sv_names[0], sv_pair[0]),
+      _is_sv_percapita(sv_names[1], sv_pair[1])
+  ]
+  if is_sv_pc[0]:
+    if not is_sv_pc[1]:
       change_to_pc[1] = True
       sv_names[1] += " Per Capita"
-  if _is_sv_percapita(sv_names[1]):
-    if not _is_sv_percapita(sv_names[0]):
+  if is_sv_pc[1]:
+    if not is_sv_pc[0]:
       change_to_pc[0] = True
       sv_names[0] += " Per Capita"
 
@@ -786,8 +790,11 @@ def _decorate_chart_title(title: str,
   return title
 
 
-def _is_sv_percapita(sv_name: str) -> bool:
-  # Use names for these since some old prevalence dcid's do not use the new naming scheme.
-  if "Percentage" in sv_name or "Prevalence" in sv_name:
-    return True
+def _is_sv_percapita(sv_name: str, sv_dcid: str) -> bool:
+  # Check both names and dcids because per capita indicating word may be in one
+  # or the other.
+  for per_capita_indicator in ["Percent", "Prevalence"]:
+    for sv_string in [sv_name, sv_dcid]:
+      if per_capita_indicator in sv_string:
+        return True
   return False


### PR DESCRIPTION
- some stat var names no longer contain key words that indicate per capita, so should also check the dcid to tell if a stat var is per capita or not. 

e.g.,
sv dcid: Percent_Person_WithHighBloodPressure
sv name: High Blood Pressure