### PR TITLE
Format the count of SVs in the sidebar

### DIFF
--- a/static/js/stat_var_hierarchy/node_header.tsx
+++ b/static/js/stat_var_hierarchy/node_header.tsx
@@ -82,7 +82,7 @@ export class StatVarHierarchyNodeHeader extends React.Component<StatVarHierarchy
           {this.props.childrenStatVarCount > 0 &&
             this.props.nodeType !== StatVarHierarchyNodeType.STAT_VAR && (
               <span className="sv-count">
-                ({this.props.childrenStatVarCount})
+                ({this.props.childrenStatVarCount.toLocaleString()})
               </span>
             )}
         </span>


### PR DESCRIPTION
Format the count of stat vars in the sidebar of our explorer tools to the user's locale. In the US, this adds commas to numbers larger than 1k. This improves readability of the sidebar.

Before:
![Screenshot 2023-05-22 at 9 31 32 AM](https://github.com/datacommonsorg/website/assets/4034366/348566df-ff68-46f0-bdd5-04f49a089943)

After:
![Screenshot 2023-05-22 at 9 31 46 AM](https://github.com/datacommonsorg/website/assets/4034366/d19d3981-109b-4b32-af8a-84e44696784c)
