### PR TITLE
remove earth column from rankings

### DIFF
--- a/static/js/place/ranking.tsx
+++ b/static/js/place/ranking.tsx
@@ -63,6 +63,11 @@ class Ranking extends React.Component<RankingPropsType, RankingStateType> {
                     />
                   </th>
                   {data[data.label[0]].map((item, index: number) => {
+                    // Skip the "Earth" column, those rankings are incorrect.
+                    // TODO: Remove skip once Earth rankings are fixed.
+                    if (item.name == "Earth") {
+                      return <></>;
+                    }
                     return (
                       <th scope="col" key={index}>
                         {item.name}
@@ -77,6 +82,11 @@ class Ranking extends React.Component<RankingPropsType, RankingStateType> {
                     <tr key={index}>
                       <th scope="row">{item}</th>
                       {data[item].map((rankingInfo, index: number) => {
+                        // Skip the "Earth" column, those rankings are incorrect.
+                        // TODO: Remove skip once Earth rankings are fixed.
+                        if (rankingInfo.name == "Earth") {
+                          return <></>;
+                        }
                         const top = rankingInfo.data.rankFromTop;
                         const bottom = rankingInfo.data.rankFromBottom;
                         let text = "";


### PR DESCRIPTION
This PR is a quick fix for the incorrect "X of Y in Earth" rankings we currently show in place overview tiles (the ranking numbers are just a copy of the US rankings). The fix removes the Earth column in the ranking table. We should remove these changes once the Earth rankings are fixed.

Before:
<img width="1358" alt="Screenshot 2023-05-23 at 8 40 59 AM" src="https://github.com/datacommonsorg/website/assets/4034366/242f7e3d-8aba-48c8-b655-3d1fa5c2900e">

After:
<img width="1353" alt="Screenshot 2023-05-23 at 8 41 13 AM" src="https://github.com/datacommonsorg/website/assets/4034366/0d71ebab-7a73-4b31-ad54-f31aa9d4206c">
