### PR TITLE
[Maps] Add support for zip codes

### DIFF
--- a/server/routes/shared_api/choropleth.py
+++ b/server/routes/shared_api/choropleth.py
@@ -72,6 +72,8 @@ CHOROPLETH_GEOJSON_PROPERTY_MAP = {
     "EurostatNUTS2": "geoJsonCoordinatesDP2",
     "EurostatNUTS3": "geoJsonCoordinatesDP1",
     "IPCCPlace_50": "geoJsonCoordinates",
+    "City": "geoJsonCoordinates",
+    "CensusBlockGroup": "geoJsonCoordinates",
     "CensusTract": "geoJsonCoordinates",
     "CensusZipCodeTabulationArea": "geoJsonCoordinates",
 }

--- a/server/webdriver_tests/tests/map_test.py
+++ b/server/webdriver_tests/tests/map_test.py
@@ -143,6 +143,16 @@ class TestMap(WebdriverBaseTest):
     element_present = EC.presence_of_element_located((By.CLASS_NAME, 'chip'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
 
+    # Wait until place type selector populates with options
+    element_present = EC.presence_of_element_located(
+        (By.CSS_SELECTOR, "option[value='County']"))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
+
+    # Click on 'County' place type option
+    place_type = self.driver.find_element(By.CSS_SELECTOR,
+                                          "option[value='County']")
+    place_type.click()
+
     # Choose stat var
     shared.wait_for_loading(self.driver)
     shared.click_sv_group(self.driver, "Demographics")

--- a/server/webdriver_tests/tests/stat_var_hierarchy_test.py
+++ b/server/webdriver_tests/tests/stat_var_hierarchy_test.py
@@ -59,6 +59,16 @@ class TestMap(WebdriverBaseTest):
     element_present = EC.presence_of_element_located((By.CLASS_NAME, 'chip'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
 
+    # Wait until the place type selector populates with options
+    element_present = EC.presence_of_element_located(
+        (By.CSS_SELECTOR, "option[value='County']"))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
+
+    # Select the 'County' place type option
+    place_type = self.driver.find_element(By.CSS_SELECTOR,
+                                          "option[value='County']")
+    place_type.click()
+
     # Get the count after filtering
     shared.wait_for_loading(self.driver)
     first_category = self.driver.find_element(By.CLASS_NAME, 'sv-count')

--- a/static/js/tools/map/util.ts
+++ b/static/js/tools/map/util.ts
@@ -106,7 +106,7 @@ export const ALL_PLACE_CHILD_TYPES = {
 
 export const USA_CHILD_PLACE_TYPES = {
   Country: ["State", "County"],
-  State: ["County"],
+  State: ["County", "CensusZipCodeTabulationArea"],
   County: ["County", "CensusTract", "CensusZipCodeTabulationArea"],
   CensusRegion: ["State", "County"],
   CensusDivision: ["State", "County"],


### PR DESCRIPTION
This PR:
* Adds support for selecting zip codes (ZCTAs) as a place type in the map tool
* Allows for map tiles to use ZCTAs as an enclosed place type
* Allows for map tiles to use cities as an enclosed place type.

Sample map tool screenshots:
<img width="1309" alt="Screenshot 2023-05-24 at 10 30 20 AM" src="https://github.com/datacommonsorg/website/assets/4034366/e7a94926-ba72-48fe-8d9c-416bfef8b5c2">
<img width="1292" alt="Screenshot 2023-05-24 at 10 30 51 AM" src="https://github.com/datacommonsorg/website/assets/4034366/647539c2-4a6e-42d2-96b0-6ec016403c54">

Sample map tiles:
<img width="1322" alt="Screenshot 2023-05-24 at 11 11 01 AM" src="https://github.com/datacommonsorg/website/assets/4034366/daf78c19-5b79-4153-9a68-34cc5f532935">

<img width="1308" alt="Screenshot 2023-05-24 at 11 12 00 AM" src="https://github.com/datacommonsorg/website/assets/4034366/703f9f55-61f5-4226-bf5a-83e8cc8c14ec">


Note that ZCTAs and cities currently render poorly -- borders and some rescaling would improve readability. These improvements will come in future PRs.

Testing:
Confirmed these changes don't break the NL interface, place pages, disaster dashboard, and sustainability explorer.