### PR TITLE
[google map] handle when geojson is not a properly formatted json string

### DIFF
--- a/static/js/components/google_map.tsx
+++ b/static/js/components/google_map.tsx
@@ -165,12 +165,18 @@ function drawGeoJson(geoJson: any, map: google.maps.Map) {
 function geoJsonFromGeometry(
   geoJsonGeometry: string
 ): GeoJSON.FeatureCollection {
+  let geoJson;
+  try {
+    geoJson = JSON.parse(geoJsonGeometry);
+  } catch (e) {
+    return null;
+  }
   return {
     type: "FeatureCollection",
     features: [
       {
         type: "Feature",
-        geometry: JSON.parse(geoJsonGeometry),
+        geometry: geoJson,
         properties: {}, // TODO: Fill in with a name or dcid.
       },
     ],
@@ -211,7 +217,7 @@ export class GoogleMap extends React.Component<
     if (this.props.geoJsonGeometry) {
       const geoJson = geoJsonFromGeometry(this.props.geoJsonGeometry);
       this.setState({
-        shouldShowMap: true,
+        shouldShowMap: geoJson !== null,
         geoJson,
       });
     } else if (this.props.latLong) {


### PR DESCRIPTION
- instead of having the page break due to improperly formatted json string, just hide the map

autopush fire event page which has an improperly formatted json string as the geojson string:
<img width="1786" alt="Screenshot 2023-05-30 at 11 39 50 AM" src="https://github.com/datacommonsorg/website/assets/69875368/67e6ebae-de32-4188-8bc6-7894b0955fcb">

with the fix:
<img width="1761" alt="Screenshot 2023-05-30 at 11 39 33 AM" src="https://github.com/datacommonsorg/website/assets/69875368/3549542b-dfa4-4781-a8d0-21a6fb3f706e">
