### PR TITLE
[map] draw map points without data values

### DIFF
--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -589,10 +589,12 @@ export function addMapPoints(
       (point: MapPoint) => projection([point.longitude, point.latitude])[1]
     )
     .attr("r", (point: MapPoint) => {
-      if (_.isEmpty(pointSizeScale) || !mapPointValues[point.placeDcid]) {
+      if (_.isEmpty(pointSizeScale)) {
         return minDotSize * 2;
       }
-      return pointSizeScale(mapPointValues[point.placeDcid]);
+      return mapPointValues[point.placeDcid]
+        ? pointSizeScale(mapPointValues[point.placeDcid])
+        : minDotSize;
     });
   if (getTooltipHtml) {
     mapPointsLayer

--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -590,7 +590,7 @@ export function addMapPoints(
     )
     .attr("r", (point: MapPoint) => {
       if (_.isEmpty(pointSizeScale) || !mapPointValues[point.placeDcid]) {
-        return minDotSize;
+        return minDotSize * 2;
       }
       return pointSizeScale(mapPointValues[point.placeDcid]);
     });

--- a/static/js/tools/map/d3_map.tsx
+++ b/static/js/tools/map/d3_map.tsx
@@ -184,9 +184,14 @@ export function D3Map(props: D3MapProps): JSX.Element {
             ? statVar.value.info[statVar.value.mapPointSv].title
             : "";
       }
+      const filteredMapPoints = props.mapPointValues
+        ? props.mapPoints.filter((point) => {
+            return point.placeDcid in props.mapPointValues;
+          })
+        : props.mapPoints;
       addMapPoints(
         mapContainerRef.current,
-        props.mapPoints,
+        filteredMapPoints,
         props.mapPointValues || {},
         projection,
         props.mapPointValues
@@ -195,7 +200,7 @@ export function D3Map(props: D3MapProps): JSX.Element {
               "black" /* getPointColor: if there are mapPointValues, addMapPoints will color the points accordingly */,
         getTooltipHtml(
           props.metadata,
-          props.mapPointValues,
+          props.mapPointValues || {},
           false,
           mapPointSvTitle || statVar.value.mapPointSv
         )

--- a/static/js/tools/map/d3_map.tsx
+++ b/static/js/tools/map/d3_map.tsx
@@ -184,14 +184,9 @@ export function D3Map(props: D3MapProps): JSX.Element {
             ? statVar.value.info[statVar.value.mapPointSv].title
             : "";
       }
-      const filteredMapPoints = props.mapPointValues
-        ? props.mapPoints.filter((point) => {
-            return point.placeDcid in props.mapPointValues;
-          })
-        : props.mapPoints;
       addMapPoints(
         mapContainerRef.current,
-        filteredMapPoints,
+        props.mapPoints,
         props.mapPointValues || {},
         projection,
         props.mapPointValues

--- a/static/js/tools/map/d3_map.tsx
+++ b/static/js/tools/map/d3_map.tsx
@@ -176,7 +176,7 @@ export function D3Map(props: D3MapProps): JSX.Element {
       zoomDcid,
       zoomParams
     );
-    if (display.value.showMapPoints && props.mapPointValues) {
+    if (display.value.showMapPoints) {
       let mapPointSvTitle = "";
       if (statVar.value.mapPointSv !== statVar.value.dcid) {
         mapPointSvTitle =
@@ -184,15 +184,15 @@ export function D3Map(props: D3MapProps): JSX.Element {
             ? statVar.value.info[statVar.value.mapPointSv].title
             : "";
       }
-      const filteredMapPoints = props.mapPoints.filter((point) => {
-        return point.placeDcid in props.mapPointValues;
-      });
       addMapPoints(
         mapContainerRef.current,
-        filteredMapPoints,
-        props.mapPointValues,
+        props.mapPoints,
+        props.mapPointValues || {},
         projection,
-        null,
+        props.mapPointValues
+          ? null
+          : () =>
+              "black" /* getPointColor: if there are mapPointValues, addMapPoints will color the points accordingly */,
         getTooltipHtml(
           props.metadata,
           props.mapPointValues,


### PR DESCRIPTION
- allow drawing map points even if they don't have associated data values

e.g., map point place type is SuperfundSite, no map point sv, and there is no data on median income for superfund sites
<img width="1743" alt="Screenshot 2023-05-30 at 10 00 07 PM" src="https://github.com/datacommonsorg/website/assets/69875368/86478fbd-1bc5-4760-883d-d2821abc61f0">
