### PR TITLE
[map] make dots smaller

### DIFF
--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -588,12 +588,10 @@ export function addMapPoints(
       (point: MapPoint) => projection([point.longitude, point.latitude])[1]
     )
     .attr("r", (point: MapPoint) => {
-      if (_.isEmpty(pointSizeScale)) {
-        return minDotSize * 2;
+      if (_.isEmpty(pointSizeScale) || !mapPointValues[point.placeDcid]) {
+        return minDotSize;
       }
-      return mapPointValues[point.placeDcid]
-        ? pointSizeScale(mapPointValues[point.placeDcid])
-        : minDotSize;
+      return pointSizeScale(mapPointValues[point.placeDcid]);
     });
   if (getTooltipHtml) {
     mapPointsLayer


### PR DESCRIPTION
currently on autopush:
<img width="1345" alt="Screenshot 2023-06-02 at 8 27 02 AM" src="https://github.com/datacommonsorg/website/assets/69875368/f8efccb9-4362-4c5d-88d9-ed6d48b3adc0">

with this change:
<img width="1340" alt="Screenshot 2023-06-02 at 8 27 20 AM" src="https://github.com/datacommonsorg/website/assets/69875368/1ea746b7-ea30-4101-b2ec-79f124cdd857">

