### PR TITLE
[map] fix dot size

### DIFF
--- a/server/routes/shared_api/choropleth.py
+++ b/server/routes/shared_api/choropleth.py
@@ -450,7 +450,7 @@ def get_map_points():
   geos = []
   geos = fetch.descendent_places([place_dcid], place_type).get(place_dcid, [])
   if not geos:
-    return Response(json.dumps({}), 200, mimetype='application/json')
+    return Response(json.dumps([]), 200, mimetype='application/json')
   names_by_geo = place_api.get_display_name(geos)
   # For some places, lat long is attached to the place node, but for other
   # places, the lat long is attached to the location value of the place node.

--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -69,6 +69,7 @@ const MAP_PATH_LAYER_CLASS = "map-path-layer";
 const MAP_PATH_HIGHLIGHT_CLASS = "map-path-highlight";
 const MAP_PATH_STROKE_WIDTH = "1.5px";
 const MAP_PATH_OPACITY = "0.5";
+const DEFAULT_MIN_DOT_SIZE = 1.25;
 
 /**
  * From https://bl.ocks.org/HarryStevens/0e440b73fbd88df7c6538417481c9065
@@ -540,11 +541,12 @@ export function addMapPoints(
         const pathClientRect = (
           paths[idx] as SVGPathElement
         ).getBoundingClientRect();
-        minRegionDiagonal = Math.sqrt(
+        const regionDiagonal = Math.sqrt(
           Math.pow(pathClientRect.height, 2) + Math.pow(pathClientRect.width, 2)
         );
+        minRegionDiagonal = Math.min(regionDiagonal, minRegionDiagonal);
       });
-    minDotSize = Math.max(minRegionDiagonal * 0.02, 1.1);
+    minDotSize = Math.max(minRegionDiagonal * 0.02, DEFAULT_MIN_DOT_SIZE);
   }
   const filteredMapPoints = mapPoints.filter((point) => {
     const projectedPoint = projection([point.longitude, point.latitude]);
@@ -588,10 +590,12 @@ export function addMapPoints(
       (point: MapPoint) => projection([point.longitude, point.latitude])[1]
     )
     .attr("r", (point: MapPoint) => {
-      if (_.isEmpty(pointSizeScale) || !mapPointValues[point.placeDcid]) {
-        return minDotSize;
+      if (_.isEmpty(pointSizeScale)) {
+        return minDotSize * 2;
       }
-      return pointSizeScale(mapPointValues[point.placeDcid]);
+      return mapPointValues[point.placeDcid]
+        ? pointSizeScale(mapPointValues[point.placeDcid])
+        : minDotSize;
     });
   if (getTooltipHtml) {
     mapPointsLayer

--- a/static/js/tools/map/d3_map.tsx
+++ b/static/js/tools/map/d3_map.tsx
@@ -245,7 +245,10 @@ export function D3Map(props: D3MapProps): JSX.Element {
 
   // Replot when data changes.
   useEffect(() => {
-    if (display.value.showMapPoints && !props.mapPoints) {
+    if (
+      display.value.showMapPoints &&
+      (_.isNull(props.mapPoints) || _.isUndefined(props.mapPoints))
+    ) {
       loadSpinner(SECTION_CONTAINER_ID);
       return;
     } else {

--- a/static/js/tools/map/fetcher/map_point_coordinate.ts
+++ b/static/js/tools/map/fetcher/map_point_coordinate.ts
@@ -59,7 +59,7 @@ export function useFetchMapPointCoordinate(
         paramsSerializer: stringifyFn,
       })
       .then((resp) => {
-        if (_.isEmpty(resp.data)) {
+        if (resp.status !== 200) {
           action.error = "error fetching map point coordinate data";
         } else {
           action.payload = resp.data as Array<MapPoint>;


### PR DESCRIPTION
- Fixed a bug where map points size kept changing. This was because we were trying to get the min region diagonal without actually calling Math.min
- Reverted the dot size logic to use minDotSize * 2 when there is no dot size scale & increased minimum dot size from 1.1 to 1.25
- Additional bug fixed: infinite loading when there are no map points. This is because of a check for non empty map points data even though there just may not be map points for the chosen place type

<img width="1357" alt="Screenshot 2023-06-02 at 11 02 17 AM" src="https://github.com/datacommonsorg/website/assets/69875368/c39a8cb5-6f39-478b-96a0-28b287b54274">
