### PR TITLE
[Event Pages] Fix "observation date" value rendering.

### DIFF
--- a/static/js/apps/event/app.tsx
+++ b/static/js/apps/event/app.tsx
@@ -212,6 +212,10 @@ function formatNumericValue(property: Node[]): string {
   if (!val) {
     return "";
   }
+  // If value is a date, pass through without a unit.
+  if (!isNaN(Date.parse(val))) {
+    return val;
+  }
   const numIndex = val.search(/[0-9]/);
   if (numIndex < 0) {
     return val;


### PR DESCRIPTION
Fix a bug where the "observation date" entry on the property table in the event pages has an incorrectly formatted value. 

Before:
<img width="953" alt="Screenshot 2023-06-02 at 5 08 24 PM" src="https://github.com/datacommonsorg/website/assets/4034366/06358710-0149-4d17-84ec-52022f3e7ed8">

After:
<img width="957" alt="Screenshot 2023-06-02 at 5 07 56 PM" src="https://github.com/datacommonsorg/website/assets/4034366/41567a20-0561-4e06-b517-429703984166">
