### PR TITLE
[Event Pages] Fix negative numbers bug

### DIFF
--- a/static/js/apps/event/app.tsx
+++ b/static/js/apps/event/app.tsx
@@ -216,7 +216,7 @@ function formatNumericValue(property: Node[]): string {
   if (!isNaN(Date.parse(val))) {
     return val;
   }
-  const numIndex = val.search(/[0-9]/);
+  const numIndex = val.search(/-?[0-9]/);
   if (numIndex < 0) {
     return val;
   }


### PR DESCRIPTION
Fixes a bug where the negative sign in a property value shows up as a unit instead of being in front of the digits.

Before (see SPI value in table):
![Screenshot 2023-06-05 at 10 28 23 AM](https://github.com/datacommonsorg/website/assets/4034366/8372e68d-d6de-45b7-83f4-dae1684c7a1f)

After:
![Screenshot 2023-06-05 at 10 28 39 AM](https://github.com/datacommonsorg/website/assets/4034366/47b124cb-8524-4c42-b96f-d12190456c5c)
