### PR TITLE
[Disaster Dashboard] Increase default max severity filter for floods

### DIFF
--- a/server/config/subject_page/disaster_event_spec.textproto
+++ b/server/config/subject_page/disaster_event_spec.textproto
@@ -25,7 +25,7 @@ event_type_spec {
       prop: "area"
       display_name: "Area"
       unit: "SquareKilometer"
-      upper_limit: 1000
+      upper_limit: 10000
       lower_limit: 50
     }
     place_type_severity_filter {


### PR DESCRIPTION
Increases the default value for the severity filter's upper limit for floods from 1,000 sq km to 10,000 sq km. This change allows for the 2022 large (>1k sq km) floods in Pakistan to display using default settings.

Before:
![Screenshot 2023-06-05 at 1 10 26 PM](https://github.com/datacommonsorg/website/assets/4034366/764223ed-ed1f-4b4f-80b3-d07c059959aa)

After:
![Screenshot 2023-06-05 at 1 09 10 PM](https://github.com/datacommonsorg/website/assets/4034366/2352423a-be53-440f-be18-d4101cbd7718)
