### PR TITLE
[Disaster Dashboard] Fix zoom buttons on disaster specific maps

### DIFF
--- a/static/js/components/tiles/disaster_event_map_tile.tsx
+++ b/static/js/components/tiles/disaster_event_map_tile.tsx
@@ -28,6 +28,7 @@ import {
   addPolygonLayer,
   drawD3Map,
   getProjection,
+  MapZoomParams,
 } from "../../chart/draw_d3_map";
 import {
   GeoJsonData,
@@ -66,12 +67,6 @@ const MAP_POINTS_MIN_RADIUS = 1.5;
 const MAP_POINTS_MIN_RADIUS_EARTH = 0.8;
 // Set of dcids of places that should use the selected place as the base geojson
 const PLACE_MAP_PLACES = new Set(["country/AUS", "country/BRA"]);
-
-// Stores IDs for the zoom buttons on the map
-interface ZoomParams {
-  zoomInButtonId: string;
-  zoomOutButtonId: string;
-}
 
 interface DisasterEventMapTilePropType {
   // Id for this tile
@@ -354,7 +349,7 @@ export const DisasterEventMapTile = memo(function DisasterEventMapTile(
     disasterEventData: Record<string, DisasterEventPointData>,
     polygonGeoJson: GeoJsonData,
     pathGeoJson: GeoJsonData,
-    zoomParams: ZoomParams
+    zoomParams: MapZoomParams
   ): void {
     const width = svgContainerRef.current.offsetWidth;
     const height = svgHeight;

--- a/static/js/components/tiles/disaster_event_map_tile.tsx
+++ b/static/js/components/tiles/disaster_event_map_tile.tsx
@@ -67,6 +67,12 @@ const MAP_POINTS_MIN_RADIUS_EARTH = 0.8;
 // Set of dcids of places that should use the selected place as the base geojson
 const PLACE_MAP_PLACES = new Set(["country/AUS", "country/BRA"]);
 
+// Stores IDs for the zoom buttons on the map
+interface ZoomParams {
+  zoomInButtonId: string;
+  zoomOutButtonId: string;
+}
+
 interface DisasterEventMapTilePropType {
   // Id for this tile
   id: string;
@@ -110,7 +116,10 @@ export const DisasterEventMapTile = memo(function DisasterEventMapTile(
     _.isNull(props.disasterEventData);
   const shouldShowMap =
     !isInitialLoading && !_.isEmpty(baseMapGeoJson.features);
-
+  const zoomParams = {
+    zoomInButtonId: `${ZOOM_IN_BUTTON_ID}-${props.id}`,
+    zoomOutButtonId: `${ZOOM_OUT_BUTTON_ID}-${props.id}`,
+  };
   useEffect(() => {
     if (_.isNull(props.disasterEventData)) {
       return;
@@ -143,7 +152,8 @@ export const DisasterEventMapTile = memo(function DisasterEventMapTile(
         baseMapGeoJson,
         props.disasterEventData,
         polygonGeoJson,
-        pathGeoJson
+        pathGeoJson,
+        zoomParams
       );
     }
   }, [
@@ -187,13 +197,13 @@ export const DisasterEventMapTile = memo(function DisasterEventMapTile(
           {shouldShowMap && (
             <div className={`${CSS_SELECTOR_PREFIX}-zoom-button-section`}>
               <div
-                id={ZOOM_IN_BUTTON_ID}
+                id={zoomParams.zoomInButtonId}
                 className={`${CSS_SELECTOR_PREFIX}-zoom-button`}
               >
                 <i className="material-icons">add</i>
               </div>
               <div
-                id={ZOOM_OUT_BUTTON_ID}
+                id={zoomParams.zoomOutButtonId}
                 className={`${CSS_SELECTOR_PREFIX}-zoom-button`}
               >
                 <i className="material-icons">remove</i>
@@ -343,14 +353,11 @@ export const DisasterEventMapTile = memo(function DisasterEventMapTile(
     geoJsonData: GeoJsonData,
     disasterEventData: Record<string, DisasterEventPointData>,
     polygonGeoJson: GeoJsonData,
-    pathGeoJson: GeoJsonData
+    pathGeoJson: GeoJsonData,
+    zoomParams: ZoomParams
   ): void {
     const width = svgContainerRef.current.offsetWidth;
     const height = svgHeight;
-    const zoomParams = {
-      zoomInButtonId: ZOOM_IN_BUTTON_ID,
-      zoomOutButtonId: ZOOM_OUT_BUTTON_ID,
-    };
     const isUsaPlace = isChildPlaceOf(
       props.place.dcid,
       USA_PLACE_DCID,


### PR DESCRIPTION
Fixes a bug where the (+)/(-) zoom buttons on the individual disaster maps don't do anything on click. This PR makes the ids of each button div unique, which fixes the issue.

https://github.com/datacommonsorg/website/assets/4034366/e9cc526f-29a8-4e98-b1e0-34a4a9244aea

