### PR TITLE
[disaster] remove NA from top event tiles

### DIFF
--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -132,7 +132,13 @@ export const TopEventTile = memo(function TopEventTile(
                 <tr>
                   <td></td>
                   {showNameColumn && <td>Name</td>}
-                  {showPlaceColumn && <td>{props.enclosedPlaceType}</td>}
+                  {showPlaceColumn && (
+                    <td>
+                      {Object.keys(eventPlaces).length < topEvents.length
+                        ? "Location"
+                        : props.enclosedPlaceType}
+                    </td>
+                  )}
                   {(props.topEventMetadata.showStartDate ||
                     props.topEventMetadata.showEndDate) && <td>Date</td>}
                   {props.topEventMetadata.displayProp &&
@@ -148,7 +154,7 @@ export const TopEventTile = memo(function TopEventTile(
                 {topEvents.map((event, i) => {
                   const placeName = eventPlaces[event.placeDcid]
                     ? eventPlaces[event.placeDcid].name
-                    : "N/A";
+                    : props.place.name || props.place.dcid;
                   const displayDate = getDisplayDate(event);
                   return (
                     <tr key={i}>


### PR DESCRIPTION
<img width="1454" alt="Screenshot 2023-06-05 at 2 18 12 PM" src="https://github.com/datacommonsorg/website/assets/69875368/c2155a5e-aee4-4b32-840f-779aade0a2b5">
