### PR TITLE
[Disaster Dashboard] Add units to info cards

### DIFF
--- a/static/js/apps/event/app.tsx
+++ b/static/js/apps/event/app.tsx
@@ -26,10 +26,16 @@ import { Container } from "reactstrap";
 import { ArcTableRow } from "../../browser/arc_table_row";
 import { GoogleMap } from "../../components/google_map";
 import { SubjectPageMainPane } from "../../components/subject_page/main_pane";
-import { formatNumber, intl } from "../../i18n/i18n";
-import { Node, PropertyValues } from "../../shared/api_response_types";
+import { intl } from "../../i18n/i18n";
+import { PropertyValues } from "../../shared/api_response_types";
 import { NamedTypedPlace } from "../../shared/types";
 import { SubjectPageConfig } from "../../types/subject_page_proto_types";
+import {
+  findProperty,
+  formatPropertyNodeValue,
+  getValue,
+  parseLatLong,
+} from "../../utils/property_value_utils";
 
 const _START_DATE_PROPERTIES = ["startDate", "discoveryDate"];
 const _END_DATE_PROPERTIES = ["endDate", "containmentDate", "controlledDate"];
@@ -158,7 +164,9 @@ export function App(props: AppPropsType): JSX.Element {
                       propertyLabel={_.startCase(property)}
                       values={[
                         {
-                          text: formatNumericValue(props.properties[property]),
+                          text: formatPropertyNodeValue(
+                            props.properties[property]
+                          ),
                         },
                       ]}
                       noPropLink={true}
@@ -183,52 +191,6 @@ export function App(props: AppPropsType): JSX.Element {
 }
 
 /**
- * Returns the first property in the list with any of the given dcids.
- */
-function findProperty(dcids: string[], properties: PropertyValues): Node[] {
-  for (const k of dcids) {
-    if (k in properties) {
-      return properties[k];
-    }
-  }
-  return undefined;
-}
-
-/**
- * Returns the first display value of the property.
- */
-function getValue(property: Node[]): string {
-  if (!property || !property.length) {
-    return "";
-  }
-  return property[0].dcid || property[0].value;
-}
-
-/**
- * Formats the first display value of the property as a number with unit.
- */
-function formatNumericValue(property: Node[]): string {
-  const val = getValue(property);
-  if (!val) {
-    return "";
-  }
-  // If value is a date, pass through without a unit.
-  if (!isNaN(Date.parse(val))) {
-    return val;
-  }
-  const numIndex = val.search(/-?[0-9]/);
-  if (numIndex < 0) {
-    return val;
-  }
-  let unit = val.substring(0, numIndex);
-  if (unit) {
-    unit = unit.trim();
-  }
-  const num = Number.parseFloat(val.substring(numIndex));
-  return formatNumber(num, unit);
-}
-
-/**
  * Formats the date range for the event.
  */
 function getDateDisplay(properties: PropertyValues): string {
@@ -246,18 +208,4 @@ function getDateDisplay(properties: PropertyValues): string {
     ret += endDate;
   }
   return ret;
-}
-
-/**
- * Parses a lat,long pair from the first value of the property.
- */
-function parseLatLong(property: Node[]): [number, number] {
-  if (!property || !property.length) return null;
-  const val = property[0];
-  if (val.name) {
-    const latLong = val.name.split(",").map((f) => parseFloat(f));
-    console.assert(latLong.length == 2);
-    return [latLong[0], latLong[1]];
-  }
-  return null;
 }

--- a/static/js/components/tiles/disaster_event_map_info_card.tsx
+++ b/static/js/components/tiles/disaster_event_map_info_card.tsx
@@ -22,6 +22,7 @@ import React from "react";
 
 import { formatNumber } from "../../i18n/i18n";
 import { DisasterEventPoint } from "../../types/disaster_event_map_types";
+import { formatPropertyValue } from "../../utils/property_value_utils";
 
 interface DisasterEventMapInfoCardPropType {
   // The event data to show info about
@@ -57,7 +58,8 @@ export function DisasterEventMapInfoCard(
             seenProps.add(prop);
             return (
               <span key={prop}>
-                {prop}: {formatNumber(props.eventData.displayProps[prop])}
+                {prop}:{" "}
+                {formatPropertyValue(props.eventData.displayProps[prop])}
               </span>
             );
           })}

--- a/static/js/components/tiles/histogram_tile.tsx
+++ b/static/js/components/tiles/histogram_tile.tsx
@@ -178,10 +178,12 @@ function binData(
 
     // Get value of property to aggregate
     let eventValue = 1;
-    if (property) {
+    if (property && event.displayProps) {
       // default to 0 if property can't be found in display props
-      eventValue =
-        stripUnitFromPropertyValue(event.displayProps[property]) || 0;
+      const propertyValueString = event.displayProps[property];
+      eventValue = propertyValueString
+        ? stripUnitFromPropertyValue(event.displayProps[property])
+        : 0;
     }
 
     // Increment value in corresponding bin if event has at least

--- a/static/js/components/tiles/histogram_tile.tsx
+++ b/static/js/components/tiles/histogram_tile.tsx
@@ -182,7 +182,7 @@ function binData(
       // Default to 0 if property can't be found in display props
       const propertyValueString = event.displayProps[property];
       eventValue = propertyValueString
-        ? stripUnitFromPropertyValue(event.displayProps[property])
+        ? stripUnitFromPropertyValue(propertyValueString)
         : 0;
     }
 

--- a/static/js/components/tiles/histogram_tile.tsx
+++ b/static/js/components/tiles/histogram_tile.tsx
@@ -19,7 +19,7 @@
  */
 
 import _ from "lodash";
-import React, { memo, useCallback, useEffect, useRef } from "react";
+import React, { memo, useCallback, useRef } from "react";
 
 import { DataPoint } from "../../chart/base";
 import { drawHistogram } from "../../chart/draw";
@@ -32,6 +32,7 @@ import {
 } from "../../types/disaster_event_map_types";
 import { EventTypeSpec } from "../../types/subject_page_proto_types";
 import { getDateRange } from "../../utils/disaster_event_map_utils";
+import { stripUnitFromPropertyValue } from "../../utils/property_value_utils";
 import { ReplacementStrings } from "../../utils/tile_utils";
 import { ChartTileContainer } from "./chart_tile";
 import { useDrawOnResize } from "./use_draw_on_resize";
@@ -179,7 +180,8 @@ function binData(
     let eventValue = 1;
     if (property) {
       // default to 0 if property can't be found in display props
-      eventValue = event.displayProps[property] || 0;
+      eventValue =
+        stripUnitFromPropertyValue(event.displayProps[property]) || 0;
     }
 
     // Increment value in corresponding bin if event has at least

--- a/static/js/components/tiles/histogram_tile.tsx
+++ b/static/js/components/tiles/histogram_tile.tsx
@@ -179,7 +179,7 @@ function binData(
     // Get value of property to aggregate
     let eventValue = 1;
     if (property && event.displayProps) {
-      // default to 0 if property can't be found in display props
+      // Default to 0 if property can't be found in display props
       const propertyValueString = event.displayProps[property];
       eventValue = propertyValueString
         ? stripUnitFromPropertyValue(event.displayProps[property])

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -38,6 +38,7 @@ import {
 import { stringifyFn } from "../../utils/axios";
 import { rankingPointsToCsv } from "../../utils/chart_csv_utils";
 import { getPlaceNames } from "../../utils/place_utils";
+import { formatPropertyValue } from "../../utils/property_value_utils";
 import { ChartFooter } from "./chart_footer";
 
 const DEFAULT_RANKING_COUNT = 10;
@@ -176,11 +177,7 @@ export const TopEventTile = memo(function TopEventTile(
                         props.topEventMetadata.displayProp.map((dp, i) => {
                           return (
                             <td key={i} className="stat">
-                              {formatNumber(
-                                event.displayProps[dp],
-                                displayPropUnits[dp],
-                                false
-                              )}
+                              {formatPropertyValue(event.displayProps[dp])}
                             </td>
                           );
                         })}

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -78,7 +78,6 @@ export const TopEventTile = memo(function TopEventTile(
   }, [props]);
 
   const displayPropNames = {};
-  const displayPropUnits = {};
   if (props.topEventMetadata.displayProp) {
     for (const dp of props.topEventMetadata.displayProp) {
       if (_.isEmpty(props.eventTypeSpec.displayProp)) {
@@ -87,7 +86,6 @@ export const TopEventTile = memo(function TopEventTile(
       for (const edp of props.eventTypeSpec.displayProp) {
         if (edp.prop == dp) {
           displayPropNames[dp] = edp.displayName;
-          displayPropUnits[dp] = edp.unit;
           break;
         }
       }

--- a/static/js/types/disaster_event_map_types.ts
+++ b/static/js/types/disaster_event_map_types.ts
@@ -68,7 +68,7 @@ export interface DisasterEventPoint extends MapPoint {
   disasterType: string;
   startDate: string;
   severity: { [prop: string]: number };
-  displayProps?: { [prop: string]: number };
+  displayProps?: { [prop: string]: string };
   affectedPlaces: string[];
   provenanceId: string;
   polygonGeoJson?: GeoJsonFeature;

--- a/static/js/utils/disaster_event_map_utils.tsx
+++ b/static/js/utils/disaster_event_map_utils.tsx
@@ -49,6 +49,7 @@ import {
   EventTypeSpec,
   SeverityFilter,
 } from "../types/subject_page_proto_types";
+import { getValue } from "./property_value_utils";
 import { isValidDate } from "./string_utils";
 
 const MAX_YEARS = 20;
@@ -262,9 +263,11 @@ function fetchEventPoints(
         if (eventTypeSpec.displayProp) {
           for (const dp of eventTypeSpec.displayProp) {
             if (dp.prop in eventData.propVals) {
-              const val = eventData.propVals[dp.prop].vals[0];
-              if (val) {
-                displayProps[dp.prop] = val;
+              if (!_.isEmpty(eventData.propVals[dp.prop].vals)) {
+                const val = eventData.propVals[dp.prop].vals[0];
+                if (val) {
+                  displayProps[dp.prop] = val;
+                }
               }
             }
           }

--- a/static/js/utils/disaster_event_map_utils.tsx
+++ b/static/js/utils/disaster_event_map_utils.tsx
@@ -49,7 +49,6 @@ import {
   EventTypeSpec,
   SeverityFilter,
 } from "../types/subject_page_proto_types";
-import { getValue } from "./property_value_utils";
 import { isValidDate } from "./string_utils";
 
 const MAX_YEARS = 20;

--- a/static/js/utils/disaster_event_map_utils.tsx
+++ b/static/js/utils/disaster_event_map_utils.tsx
@@ -262,12 +262,8 @@ function fetchEventPoints(
         if (eventTypeSpec.displayProp) {
           for (const dp of eventTypeSpec.displayProp) {
             if (dp.prop in eventData.propVals) {
-              const val = parseEventPropVal(
-                eventData.propVals[dp.prop].vals,
-                dp.unit || "",
-                reqParams
-              );
-              if (!isNaN(val)) {
+              const val = eventData.propVals[dp.prop].vals[0];
+              if (val) {
                 displayProps[dp.prop] = val;
               }
             }

--- a/static/js/utils/property_value_utils.tsx
+++ b/static/js/utils/property_value_utils.tsx
@@ -23,6 +23,8 @@ import { Node, PropertyValues } from "../shared/api_response_types";
 
 /**
  * Returns the first property in a list with any of the given dcids.
+ * @param dcids list of dcids of properties to look for
+ * @param properties mapping of property dcids to value nodes
  */
 export function findProperty(
   dcids: string[],
@@ -38,6 +40,7 @@ export function findProperty(
 
 /**
  * Returns the first display value of the property.
+ * @param property list of property value nodes for a property
  */
 export function getValue(property: Node[]): string {
   if (!property || !property.length) {
@@ -48,12 +51,12 @@ export function getValue(property: Node[]): string {
 
 /**
  * Formats the raw property value string from an API call as a number with unit.
+ * @param val property value string to format
  */
 export function formatPropertyValue(val: string): string {
   if (!val) {
     return "";
   }
-
   // If value is a date, pass through without a unit.
   if (!isNaN(Date.parse(val))) {
     return val;
@@ -72,6 +75,7 @@ export function formatPropertyValue(val: string): string {
 
 /**
  * Formats the first display value of a property value node as a number with unit.
+ * @param property list of property value nodes for a property
  */
 export function formatPropertyNodeValue(property: Node[]): string {
   const val = getValue(property);
@@ -83,6 +87,7 @@ export function formatPropertyNodeValue(property: Node[]): string {
 
 /**
  * Parses a lat,long pair from the first value of a property value node.
+ * @param property list of property value nodes for a property
  */
 export function parseLatLong(property: Node[]): [number, number] {
   if (!property || !property.length) return null;
@@ -98,6 +103,7 @@ export function parseLatLong(property: Node[]): [number, number] {
 /**
  * Strips the unit from a numeric property value, returning just the number.
  * Expects values formatted as "Unit 1.2345".
+ * @param value property value string to strip unit from
  */
 export function stripUnitFromPropertyValue(value: string): number {
   const numIndex = value.search(/-?[0-9]/);

--- a/static/js/utils/property_value_utils.tsx
+++ b/static/js/utils/property_value_utils.tsx
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utils for processing and formatting property values from API calls.
+ */
+
+import { formatNumber } from "../i18n/i18n";
+import { Node, PropertyValues } from "../shared/api_response_types";
+
+/**
+ * Returns the first property in a list with any of the given dcids.
+ */
+export function findProperty(
+  dcids: string[],
+  properties: PropertyValues
+): Node[] {
+  for (const k of dcids) {
+    if (k in properties) {
+      return properties[k];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Returns the first display value of the property.
+ */
+export function getValue(property: Node[]): string {
+  if (!property || !property.length) {
+    return "";
+  }
+  return property[0].dcid || property[0].value;
+}
+
+/**
+ * Formats the raw property value string from an API call as a number with unit.
+ */
+export function formatPropertyValue(val: string): string {
+  if (!val) {
+    return "";
+  }
+
+  // If value is a date, pass through without a unit.
+  if (!isNaN(Date.parse(val))) {
+    return val;
+  }
+  const numIndex = val.search(/-?[0-9]/);
+  if (numIndex < 0) {
+    return val;
+  }
+  let unit = val.substring(0, numIndex);
+  if (unit) {
+    unit = unit.trim();
+  }
+  const num = Number.parseFloat(val.substring(numIndex));
+  return formatNumber(num, unit);
+}
+
+/**
+ * Formats the first display value of a property value node as a number with unit.
+ */
+export function formatPropertyNodeValue(property: Node[]): string {
+  const val = getValue(property);
+  if (!val) {
+    return "";
+  }
+  return formatPropertyValue(val);
+}
+
+/**
+ * Parses a lat,long pair from the first value of a property value node.
+ */
+export function parseLatLong(property: Node[]): [number, number] {
+  if (!property || !property.length) return null;
+  const val = property[0];
+  if (val.name) {
+    const latLong = val.name.split(",").map((f) => parseFloat(f));
+    console.assert(latLong.length == 2);
+    return [latLong[0], latLong[1]];
+  }
+  return null;
+}
+
+/**
+ * Strips the unit from a numeric property value, returning just the number.
+ * Expects values formatted as "Unit 1.2345".
+ */
+export function stripUnitFromPropertyValue(value: string): number {
+  const numIndex = value.search(/-?[0-9]/);
+  if (numIndex < 0) {
+    return Number.NaN;
+  }
+  return Number.parseFloat(value.substring(numIndex));
+}

--- a/static/js/utils/tests/disaster_event_map_utils.test.ts
+++ b/static/js/utils/tests/disaster_event_map_utils.test.ts
@@ -95,7 +95,7 @@ const EARTHQUAKE_EVENT_1_PROCESSED = {
   disasterType: EARTHQUAKE_DISASTER_TYPE_ID,
   startDate: "2022-01-01",
   severity: { magnitude: 5 },
-  displayProps: { keep: 132 },
+  displayProps: { keep: "Unit 132" },
   endDate: "",
   provenanceId: "earthquakeProv",
   affectedPlaces: ["country/USA"],


### PR DESCRIPTION
This PR enables property value units to be displayed on the disaster dashboard.

More specifically, the following changes are made:
* Extract out the util functions in `event/app.tsx` to a dedicated utils file, that way these general functions can be reused.
* Edit `displayProps` interface to map to strings instead of numbers, to keep the unit stored.
* Remove stripping the unit in the main `disaster_event_map_utils`.
* Pass that unit to the info card so it can also be displayed.
* Update property value processing in `histogram_tile` and `top_event_tile` which expect numbers instead of a number with unit.
* Update `disaster_event_map_utils_test` to reflect changes

Before:
<img width="676" alt="Screenshot 2023-06-05 at 4 16 33 PM" src="https://github.com/datacommonsorg/website/assets/4034366/952ed62a-81e6-4740-b241-fe562a53c7c8">

After:
<img width="663" alt="Screenshot 2023-06-05 at 4 21 25 PM" src="https://github.com/datacommonsorg/website/assets/4034366/9f15529a-b361-4cec-8b05-2e297cdd0ee4">

Dashboard page itself remains unchanged:
<img width="949" alt="Screenshot 2023-06-05 at 4 25 19 PM" src="https://github.com/datacommonsorg/website/assets/4034366/ca5fe167-ffc5-4216-b9e0-e7ad062b95f1">
<img width="788" alt="Screenshot 2023-06-05 at 4 25 28 PM" src="https://github.com/datacommonsorg/website/assets/4034366/63b4640c-6ac5-4632-98f1-99e647d1b892">
<img width="781" alt="Screenshot 2023-06-05 at 4 25 37 PM" src="https://github.com/datacommonsorg/website/assets/4034366/99f89cc4-e680-4cf6-a10a-5e8372648f51">
<img width="773" alt="Screenshot 2023-06-05 at 4 29 31 PM" src="https://github.com/datacommonsorg/website/assets/4034366/b64d6799-b972-4e40-a89a-0be532f3df74">
<img width="772" alt="Screenshot 2023-06-05 at 4 29 40 PM" src="https://github.com/datacommonsorg/website/assets/4034366/91784261-a196-475e-ab31-4638b9415e49">
<img width="779" alt="Screenshot 2023-06-05 at 4 29 48 PM" src="https://github.com/datacommonsorg/website/assets/4034366/a045ec2c-77dc-44a3-befa-3127b3a07e58">
