### PR TITLE
[subject page] allow place groups for a topic page config

### DIFF
--- a/server/config/subject_page.proto
+++ b/server/config/subject_page.proto
@@ -72,6 +72,14 @@ message PageMetadata {
   // Event type information to be used by this config. The key is the event
   // type id and the value is the spec for that event type.
   map<string, EventTypeSpec> event_type_spec = 5;
+
+  // A group of places characterized by place type and parent place
+  message PlaceGroup {
+    string parent_place = 1;
+    string place_type = 2;
+  }
+  // List of place groups supported by this config.
+  repeated PlaceGroup place_group = 6;
 }
 
 message StatVarSpec {

--- a/server/config/subject_page_pb2.py
+++ b/server/config/subject_page_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12subject_page.proto\x12\x0b\x64\x61tacommons\"l\n\x0eSeverityFilter\x12\x0c\n\x04prop\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x05 \x01(\t\x12\x0c\n\x04unit\x18\x02 \x01(\t\x12\x13\n\x0blower_limit\x18\x03 \x01(\x01\x12\x13\n\x0bupper_limit\x18\x04 \x01(\x01\"\x9b\x04\n\rEventTypeSpec\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x18\n\x10\x65vent_type_dcids\x18\x03 \x03(\t\x12\r\n\x05\x63olor\x18\x04 \x01(\t\x12<\n\x17\x64\x65\x66\x61ult_severity_filter\x18\x05 \x01(\x0b\x32\x1b.datacommons.SeverityFilter\x12[\n\x1aplace_type_severity_filter\x18\n \x03(\x0b\x32\x37.datacommons.EventTypeSpec.PlaceTypeSeverityFilterEntry\x12<\n\x0c\x64isplay_prop\x18\x06 \x03(\x0b\x32&.datacommons.EventTypeSpec.DisplayProp\x12\x15\n\rend_date_prop\x18\x07 \x03(\t\x12\x1d\n\x15polygon_geo_json_prop\x18\x08 \x01(\t\x12\x1a\n\x12path_geo_json_prop\x18\t \x01(\t\x1a[\n\x1cPlaceTypeSeverityFilterEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12*\n\x05value\x18\x02 \x01(\x0b\x32\x1b.datacommons.SeverityFilter:\x02\x38\x01\x1a?\n\x0b\x44isplayProp\x12\x0c\n\x04prop\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12\x0c\n\x04unit\x18\x03 \x01(\t\"\xf0\x02\n\x0cPageMetadata\x12\x10\n\x08topic_id\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x01(\t\x12\x12\n\nplace_dcid\x18\x03 \x03(\t\x12Q\n\x15\x63ontained_place_types\x18\x04 \x03(\x0b\x32\x32.datacommons.PageMetadata.ContainedPlaceTypesEntry\x12\x45\n\x0f\x65vent_type_spec\x18\x05 \x03(\x0b\x32,.datacommons.PageMetadata.EventTypeSpecEntry\x1a:\n\x18\x43ontainedPlaceTypesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1aP\n\x12\x45ventTypeSpecEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12)\n\x05value\x18\x02 \x01(\x0b\x32\x1a.datacommons.EventTypeSpec:\x02\x38\x01\"h\n\x0bStatVarSpec\x12\x10\n\x08stat_var\x18\x01 \x01(\t\x12\r\n\x05\x64\x65nom\x18\x02 \x01(\t\x12\x0c\n\x04unit\x18\x03 \x01(\t\x12\x0f\n\x07scaling\x18\x04 \x01(\x01\x12\x0b\n\x03log\x18\x05 \x01(\x08\x12\x0c\n\x04name\x18\x06 \x01(\t\"\xb3\x01\n\x0fRankingTileSpec\x12\x14\n\x0cshow_highest\x18\x01 \x01(\x08\x12\x13\n\x0bshow_lowest\x18\x02 \x01(\x08\x12\x16\n\x0e\x64iff_base_date\x18\x05 \x01(\t\x12\x15\n\rhighest_title\x18\x06 \x01(\t\x12\x14\n\x0clowest_title\x18\x07 \x01(\t\x12\x15\n\rranking_count\x18\n \x01(\x05\x12\x19\n\x11show_multi_column\x18\x0b \x01(\x08\"u\n\x18\x44isasterEventMapTileSpec\x12\x1c\n\x14point_event_type_key\x18\x01 \x03(\t\x12\x1e\n\x16polygon_event_type_key\x18\x02 \x03(\t\x12\x1b\n\x13path_event_type_key\x18\x03 \x03(\t\"9\n\x11HistogramTileSpec\x12\x16\n\x0e\x65vent_type_key\x18\x01 \x01(\t\x12\x0c\n\x04prop\x18\x02 \x01(\t\"\x9d\x01\n\x10TopEventTileSpec\x12\x16\n\x0e\x65vent_type_key\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_prop\x18\x02 \x03(\t\x12\x17\n\x0fshow_start_date\x18\x03 \x01(\x08\x12\x15\n\rshow_end_date\x18\x04 \x01(\x08\x12\x14\n\x0creverse_sort\x18\x05 \x01(\x08\x12\x15\n\rranking_count\x18\x06 \x01(\x05\"\x89\x01\n\x0fScatterTileSpec\x12\x1b\n\x13highlight_top_right\x18\x01 \x01(\x08\x12\x1a\n\x12highlight_top_left\x18\x02 \x01(\x08\x12\x1e\n\x16highlight_bottom_right\x18\x03 \x01(\x08\x12\x1d\n\x15highlight_bottom_left\x18\x04 \x01(\x08\"(\n\x0b\x42\x61rTileSpec\x12\x19\n\x11x_label_link_root\x18\x01 \x01(\t\"\xf4\x05\n\x04Tile\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12(\n\x04type\x18\x03 \x01(\x0e\x32\x1a.datacommons.Tile.TileType\x12\x14\n\x0cstat_var_key\x18\x04 \x03(\t\x12\x19\n\x11\x63omparison_places\x18\x07 \x03(\t\x12\x1b\n\x13place_dcid_override\x18\x0b \x01(\t\x12\x39\n\x11ranking_tile_spec\x18\x05 \x01(\x0b\x32\x1c.datacommons.RankingTileSpecH\x00\x12M\n\x1c\x64isaster_event_map_tile_spec\x18\x06 \x01(\x0b\x32%.datacommons.DisasterEventMapTileSpecH\x00\x12<\n\x13top_event_tile_spec\x18\x08 \x01(\x0b\x32\x1d.datacommons.TopEventTileSpecH\x00\x12\x39\n\x11scatter_tile_spec\x18\t \x01(\x0b\x32\x1c.datacommons.ScatterTileSpecH\x00\x12=\n\x13histogram_tile_spec\x18\n \x01(\x0b\x32\x1e.datacommons.HistogramTileSpecH\x00\x12\x31\n\rbar_tile_spec\x18\x0c \x01(\x0b\x32\x18.datacommons.BarTileSpecH\x00\"\xc8\x01\n\x08TileType\x12\r\n\tTYPE_NONE\x10\x00\x12\x08\n\x04LINE\x10\x01\x12\x07\n\x03\x42\x41R\x10\x02\x12\x07\n\x03MAP\x10\x03\x12\x0b\n\x07SCATTER\x10\x04\x12\r\n\tBIVARIATE\x10\x05\x12\x0b\n\x07RANKING\x10\x06\x12\r\n\tHIGHLIGHT\x10\x07\x12\x0f\n\x0b\x44\x45SCRIPTION\x10\x08\x12\r\n\tHISTOGRAM\x10\n\x12\x12\n\x0ePLACE_OVERVIEW\x10\x0b\x12\r\n\tTOP_EVENT\x10\x0c\x12\x16\n\x12\x44ISASTER_EVENT_MAP\x10\tB\x10\n\x0etile_type_spec\"\xf1\x01\n\x05\x42lock\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x10\n\x08\x66ootnote\x18\x05 \x01(\t\x12*\n\x07\x63olumns\x18\x03 \x03(\x0b\x32\x19.datacommons.Block.Column\x12*\n\x04type\x18\x04 \x01(\x0e\x32\x1c.datacommons.Block.BlockType\x1a*\n\x06\x43olumn\x12 \n\x05tiles\x18\x01 \x03(\x0b\x32\x11.datacommons.Tile\".\n\tBlockType\x12\r\n\tTYPE_NONE\x10\x00\x12\x12\n\x0e\x44ISASTER_EVENT\x10\x01\"\xdf\x01\n\x08\x43\x61tegory\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12=\n\rstat_var_spec\x18\x04 \x03(\x0b\x32&.datacommons.Category.StatVarSpecEntry\x12\"\n\x06\x62locks\x18\x03 \x03(\x0b\x32\x12.datacommons.Block\x1aL\n\x10StatVarSpecEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.datacommons.StatVarSpec:\x02\x38\x01\"k\n\x11SubjectPageConfig\x12+\n\x08metadata\x18\x01 \x01(\x0b\x32\x19.datacommons.PageMetadata\x12)\n\ncategories\x18\x02 \x03(\x0b\x32\x15.datacommons.Categoryb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12subject_page.proto\x12\x0b\x64\x61tacommons\"l\n\x0eSeverityFilter\x12\x0c\n\x04prop\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x05 \x01(\t\x12\x0c\n\x04unit\x18\x02 \x01(\t\x12\x13\n\x0blower_limit\x18\x03 \x01(\x01\x12\x13\n\x0bupper_limit\x18\x04 \x01(\x01\"\x9b\x04\n\rEventTypeSpec\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x18\n\x10\x65vent_type_dcids\x18\x03 \x03(\t\x12\r\n\x05\x63olor\x18\x04 \x01(\t\x12<\n\x17\x64\x65\x66\x61ult_severity_filter\x18\x05 \x01(\x0b\x32\x1b.datacommons.SeverityFilter\x12[\n\x1aplace_type_severity_filter\x18\n \x03(\x0b\x32\x37.datacommons.EventTypeSpec.PlaceTypeSeverityFilterEntry\x12<\n\x0c\x64isplay_prop\x18\x06 \x03(\x0b\x32&.datacommons.EventTypeSpec.DisplayProp\x12\x15\n\rend_date_prop\x18\x07 \x03(\t\x12\x1d\n\x15polygon_geo_json_prop\x18\x08 \x01(\t\x12\x1a\n\x12path_geo_json_prop\x18\t \x01(\t\x1a[\n\x1cPlaceTypeSeverityFilterEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12*\n\x05value\x18\x02 \x01(\x0b\x32\x1b.datacommons.SeverityFilter:\x02\x38\x01\x1a?\n\x0b\x44isplayProp\x12\x0c\n\x04prop\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12\x0c\n\x04unit\x18\x03 \x01(\t\"\xe3\x03\n\x0cPageMetadata\x12\x10\n\x08topic_id\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x01(\t\x12\x12\n\nplace_dcid\x18\x03 \x03(\t\x12Q\n\x15\x63ontained_place_types\x18\x04 \x03(\x0b\x32\x32.datacommons.PageMetadata.ContainedPlaceTypesEntry\x12\x45\n\x0f\x65vent_type_spec\x18\x05 \x03(\x0b\x32,.datacommons.PageMetadata.EventTypeSpecEntry\x12\x39\n\x0bplace_group\x18\x06 \x03(\x0b\x32$.datacommons.PageMetadata.PlaceGroup\x1a:\n\x18\x43ontainedPlaceTypesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1aP\n\x12\x45ventTypeSpecEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12)\n\x05value\x18\x02 \x01(\x0b\x32\x1a.datacommons.EventTypeSpec:\x02\x38\x01\x1a\x36\n\nPlaceGroup\x12\x14\n\x0cparent_place\x18\x01 \x01(\t\x12\x12\n\nplace_type\x18\x02 \x01(\t\"h\n\x0bStatVarSpec\x12\x10\n\x08stat_var\x18\x01 \x01(\t\x12\r\n\x05\x64\x65nom\x18\x02 \x01(\t\x12\x0c\n\x04unit\x18\x03 \x01(\t\x12\x0f\n\x07scaling\x18\x04 \x01(\x01\x12\x0b\n\x03log\x18\x05 \x01(\x08\x12\x0c\n\x04name\x18\x06 \x01(\t\"\xb3\x01\n\x0fRankingTileSpec\x12\x14\n\x0cshow_highest\x18\x01 \x01(\x08\x12\x13\n\x0bshow_lowest\x18\x02 \x01(\x08\x12\x16\n\x0e\x64iff_base_date\x18\x05 \x01(\t\x12\x15\n\rhighest_title\x18\x06 \x01(\t\x12\x14\n\x0clowest_title\x18\x07 \x01(\t\x12\x15\n\rranking_count\x18\n \x01(\x05\x12\x19\n\x11show_multi_column\x18\x0b \x01(\x08\"u\n\x18\x44isasterEventMapTileSpec\x12\x1c\n\x14point_event_type_key\x18\x01 \x03(\t\x12\x1e\n\x16polygon_event_type_key\x18\x02 \x03(\t\x12\x1b\n\x13path_event_type_key\x18\x03 \x03(\t\"9\n\x11HistogramTileSpec\x12\x16\n\x0e\x65vent_type_key\x18\x01 \x01(\t\x12\x0c\n\x04prop\x18\x02 \x01(\t\"\x9d\x01\n\x10TopEventTileSpec\x12\x16\n\x0e\x65vent_type_key\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_prop\x18\x02 \x03(\t\x12\x17\n\x0fshow_start_date\x18\x03 \x01(\x08\x12\x15\n\rshow_end_date\x18\x04 \x01(\x08\x12\x14\n\x0creverse_sort\x18\x05 \x01(\x08\x12\x15\n\rranking_count\x18\x06 \x01(\x05\"\x89\x01\n\x0fScatterTileSpec\x12\x1b\n\x13highlight_top_right\x18\x01 \x01(\x08\x12\x1a\n\x12highlight_top_left\x18\x02 \x01(\x08\x12\x1e\n\x16highlight_bottom_right\x18\x03 \x01(\x08\x12\x1d\n\x15highlight_bottom_left\x18\x04 \x01(\x08\"(\n\x0b\x42\x61rTileSpec\x12\x19\n\x11x_label_link_root\x18\x01 \x01(\t\"\xf4\x05\n\x04Tile\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12(\n\x04type\x18\x03 \x01(\x0e\x32\x1a.datacommons.Tile.TileType\x12\x14\n\x0cstat_var_key\x18\x04 \x03(\t\x12\x19\n\x11\x63omparison_places\x18\x07 \x03(\t\x12\x1b\n\x13place_dcid_override\x18\x0b \x01(\t\x12\x39\n\x11ranking_tile_spec\x18\x05 \x01(\x0b\x32\x1c.datacommons.RankingTileSpecH\x00\x12M\n\x1c\x64isaster_event_map_tile_spec\x18\x06 \x01(\x0b\x32%.datacommons.DisasterEventMapTileSpecH\x00\x12<\n\x13top_event_tile_spec\x18\x08 \x01(\x0b\x32\x1d.datacommons.TopEventTileSpecH\x00\x12\x39\n\x11scatter_tile_spec\x18\t \x01(\x0b\x32\x1c.datacommons.ScatterTileSpecH\x00\x12=\n\x13histogram_tile_spec\x18\n \x01(\x0b\x32\x1e.datacommons.HistogramTileSpecH\x00\x12\x31\n\rbar_tile_spec\x18\x0c \x01(\x0b\x32\x18.datacommons.BarTileSpecH\x00\"\xc8\x01\n\x08TileType\x12\r\n\tTYPE_NONE\x10\x00\x12\x08\n\x04LINE\x10\x01\x12\x07\n\x03\x42\x41R\x10\x02\x12\x07\n\x03MAP\x10\x03\x12\x0b\n\x07SCATTER\x10\x04\x12\r\n\tBIVARIATE\x10\x05\x12\x0b\n\x07RANKING\x10\x06\x12\r\n\tHIGHLIGHT\x10\x07\x12\x0f\n\x0b\x44\x45SCRIPTION\x10\x08\x12\r\n\tHISTOGRAM\x10\n\x12\x12\n\x0ePLACE_OVERVIEW\x10\x0b\x12\r\n\tTOP_EVENT\x10\x0c\x12\x16\n\x12\x44ISASTER_EVENT_MAP\x10\tB\x10\n\x0etile_type_spec\"\xf1\x01\n\x05\x42lock\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x10\n\x08\x66ootnote\x18\x05 \x01(\t\x12*\n\x07\x63olumns\x18\x03 \x03(\x0b\x32\x19.datacommons.Block.Column\x12*\n\x04type\x18\x04 \x01(\x0e\x32\x1c.datacommons.Block.BlockType\x1a*\n\x06\x43olumn\x12 \n\x05tiles\x18\x01 \x03(\x0b\x32\x11.datacommons.Tile\".\n\tBlockType\x12\r\n\tTYPE_NONE\x10\x00\x12\x12\n\x0e\x44ISASTER_EVENT\x10\x01\"\xdf\x01\n\x08\x43\x61tegory\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12=\n\rstat_var_spec\x18\x04 \x03(\x0b\x32&.datacommons.Category.StatVarSpecEntry\x12\"\n\x06\x62locks\x18\x03 \x03(\x0b\x32\x12.datacommons.Block\x1aL\n\x10StatVarSpecEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.datacommons.StatVarSpec:\x02\x38\x01\"k\n\x11SubjectPageConfig\x12+\n\x08metadata\x18\x01 \x01(\x0b\x32\x19.datacommons.PageMetadata\x12)\n\ncategories\x18\x02 \x03(\x0b\x32\x15.datacommons.Categoryb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'subject_page_pb2', globals())
@@ -37,39 +37,41 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _EVENTTYPESPEC_DISPLAYPROP._serialized_start=622
   _EVENTTYPESPEC_DISPLAYPROP._serialized_end=685
   _PAGEMETADATA._serialized_start=688
-  _PAGEMETADATA._serialized_end=1056
-  _PAGEMETADATA_CONTAINEDPLACETYPESENTRY._serialized_start=916
-  _PAGEMETADATA_CONTAINEDPLACETYPESENTRY._serialized_end=974
-  _PAGEMETADATA_EVENTTYPESPECENTRY._serialized_start=976
-  _PAGEMETADATA_EVENTTYPESPECENTRY._serialized_end=1056
-  _STATVARSPEC._serialized_start=1058
-  _STATVARSPEC._serialized_end=1162
-  _RANKINGTILESPEC._serialized_start=1165
-  _RANKINGTILESPEC._serialized_end=1344
-  _DISASTEREVENTMAPTILESPEC._serialized_start=1346
-  _DISASTEREVENTMAPTILESPEC._serialized_end=1463
-  _HISTOGRAMTILESPEC._serialized_start=1465
-  _HISTOGRAMTILESPEC._serialized_end=1522
-  _TOPEVENTTILESPEC._serialized_start=1525
-  _TOPEVENTTILESPEC._serialized_end=1682
-  _SCATTERTILESPEC._serialized_start=1685
-  _SCATTERTILESPEC._serialized_end=1822
-  _BARTILESPEC._serialized_start=1824
-  _BARTILESPEC._serialized_end=1864
-  _TILE._serialized_start=1867
-  _TILE._serialized_end=2623
-  _TILE_TILETYPE._serialized_start=2405
-  _TILE_TILETYPE._serialized_end=2605
-  _BLOCK._serialized_start=2626
-  _BLOCK._serialized_end=2867
-  _BLOCK_COLUMN._serialized_start=2777
-  _BLOCK_COLUMN._serialized_end=2819
-  _BLOCK_BLOCKTYPE._serialized_start=2821
-  _BLOCK_BLOCKTYPE._serialized_end=2867
-  _CATEGORY._serialized_start=2870
-  _CATEGORY._serialized_end=3093
-  _CATEGORY_STATVARSPECENTRY._serialized_start=3017
-  _CATEGORY_STATVARSPECENTRY._serialized_end=3093
-  _SUBJECTPAGECONFIG._serialized_start=3095
-  _SUBJECTPAGECONFIG._serialized_end=3202
+  _PAGEMETADATA._serialized_end=1171
+  _PAGEMETADATA_CONTAINEDPLACETYPESENTRY._serialized_start=975
+  _PAGEMETADATA_CONTAINEDPLACETYPESENTRY._serialized_end=1033
+  _PAGEMETADATA_EVENTTYPESPECENTRY._serialized_start=1035
+  _PAGEMETADATA_EVENTTYPESPECENTRY._serialized_end=1115
+  _PAGEMETADATA_PLACEGROUP._serialized_start=1117
+  _PAGEMETADATA_PLACEGROUP._serialized_end=1171
+  _STATVARSPEC._serialized_start=1173
+  _STATVARSPEC._serialized_end=1277
+  _RANKINGTILESPEC._serialized_start=1280
+  _RANKINGTILESPEC._serialized_end=1459
+  _DISASTEREVENTMAPTILESPEC._serialized_start=1461
+  _DISASTEREVENTMAPTILESPEC._serialized_end=1578
+  _HISTOGRAMTILESPEC._serialized_start=1580
+  _HISTOGRAMTILESPEC._serialized_end=1637
+  _TOPEVENTTILESPEC._serialized_start=1640
+  _TOPEVENTTILESPEC._serialized_end=1797
+  _SCATTERTILESPEC._serialized_start=1800
+  _SCATTERTILESPEC._serialized_end=1937
+  _BARTILESPEC._serialized_start=1939
+  _BARTILESPEC._serialized_end=1979
+  _TILE._serialized_start=1982
+  _TILE._serialized_end=2738
+  _TILE_TILETYPE._serialized_start=2520
+  _TILE_TILETYPE._serialized_end=2720
+  _BLOCK._serialized_start=2741
+  _BLOCK._serialized_end=2982
+  _BLOCK_COLUMN._serialized_start=2892
+  _BLOCK_COLUMN._serialized_end=2934
+  _BLOCK_BLOCKTYPE._serialized_start=2936
+  _BLOCK_BLOCKTYPE._serialized_end=2982
+  _CATEGORY._serialized_start=2985
+  _CATEGORY._serialized_end=3208
+  _CATEGORY_STATVARSPECENTRY._serialized_start=3132
+  _CATEGORY_STATVARSPECENTRY._serialized_end=3208
+  _SUBJECTPAGECONFIG._serialized_start=3210
+  _SUBJECTPAGECONFIG._serialized_end=3317
 # @@protoc_insertion_point(module_scope)

--- a/server/config/topic_page/equity/US_States.textproto
+++ b/server/config/topic_page/equity/US_States.textproto
@@ -17,7 +17,10 @@
 metadata {
   topic_id: "equity"
   topic_name: "Equity"
-  place_dcid: "geoId/06"
+  place_group {
+    parent_place: "country/USA"
+    place_type: "State"
+  }
   contained_place_types {
     key: "State"
     value: "County"

--- a/server/lib/subject_page_config.py
+++ b/server/lib/subject_page_config.py
@@ -254,7 +254,12 @@ def place_metadata(place_dcid, get_child_places=True) -> PlaceMetadata:
       return PlaceMetadata(place_dcid=escape(place_dcid), is_error=True)
     place_types = wanted_place_types
 
-    parent_places = place_api.parent_places(place_dcid).get(place_dcid, [])
+    for place in place_api.parent_places([place_dcid]).get(place_dcid, []):
+      parent_places.append({
+          'dcid': place.get('dcid', ''),
+          'name': place.get('name', ''),
+          'types': [place.get('type', '')]
+      })
 
   place_name = place_api.get_i18n_name([place_dcid
                                        ]).get(place_dcid, escape(place_dcid))

--- a/server/lib/util.py
+++ b/server/lib/util.py
@@ -46,7 +46,7 @@ PLACE_EXPLORER_CATEGORIES = [
 # key is topic_id, which should match the folder name under config/topic_page
 # property is the list of filenames in that folder to load.
 TOPIC_PAGE_CONFIGS = {
-    'equity': ['USA', 'CA'],
+    'equity': ['USA', 'US_States'],
     'poverty': ['USA', 'India'],
     'dev': ['CA'],
     'sdg': ['sdg']

--- a/server/routes/shared_api/choropleth.py
+++ b/server/routes/shared_api/choropleth.py
@@ -113,7 +113,7 @@ def get_choropleth_display_level(geoDcid):
     return None, None
 
   if place_type == display_level:
-    parents_places = place_api.parent_places(geoDcid)
+    parents_places = place_api.parent_places([geoDcid])
     # Multiple place types can be equivalent (eg. County and AA2) and we
     # want to find the parent who's display level is equivalent to the
     # geoDcid display_level
@@ -124,15 +124,14 @@ def get_choropleth_display_level(geoDcid):
       parent_dcid = parent.get('dcid', None)
       if not parent_dcid:
         continue
-      parent_place_types = parent.get('types', [])
-      for parent_place_type in parent_place_types:
+      parent_place_type = parent.get('type', '')
+      parent_display_level = CHOROPLETH_DISPLAY_LEVEL_MAP.get(
+          parent_place_type, None)
+      if not parent_display_level:
         parent_display_level = CHOROPLETH_DISPLAY_LEVEL_MAP.get(
-            parent_place_type, None)
-        if not parent_display_level:
-          parent_display_level = CHOROPLETH_DISPLAY_LEVEL_MAP.get(
-              EQUIVALENT_PLACE_TYPES.get(parent_place_type, ''))
-        if parent_display_level in target_display_levels:
-          return parent_dcid, display_level
+            EQUIVALENT_PLACE_TYPES.get(parent_place_type, ''))
+      if parent_display_level in target_display_levels:
+        return parent_dcid, display_level
     return None, None
   else:
     return geoDcid, display_level

--- a/server/routes/topic_page/html.py
+++ b/server/routes/topic_page/html.py
@@ -24,6 +24,7 @@ from google.protobuf.json_format import MessageToJson
 import server.lib.subject_page_config as lib_subject_page_config
 import server.lib.util as libutil
 import server.routes.shared_api.place as place_api
+import server.services.datacommons as dc
 
 _NL_DISASTER_TOPIC = 'nl_disasters'
 _SDG_TOPIC = 'sdg'
@@ -96,10 +97,17 @@ def topic_page(topic_id=None, place_dcid=None):
 
   more_places = request.args.getlist('places')
 
-  # TODO: should use place metadata API to fetch these data in one call.
-  place_type = place_api.get_place_type(place_dcid)
-  parent_places = place_api.parent_places([place_dcid]).get(place_dcid, [])
-  parent_dcids = list(map(lambda x: x.get('dcid', ''), parent_places))
+  place_name = ''
+  place_type = ''
+  parent_dcids = set()
+  place_info = dc.get_place_info([place_dcid])
+  for item in place_info.get('data', []):
+    if 'node' not in item or item['node'] != place_dcid or 'info' not in item:
+      continue
+    place_name = item['info'].get('self', {}).get('name', '')
+    place_type = item['info'].get('self', {}).get('type', '')
+    for parent in item['info'].get('parents', []):
+      parent_dcids.add(parent.get('dcid'))
 
   # Find the config for the topic & place.
   topic_place_config = None

--- a/server/tests/lib/subject_page_config_content_test.py
+++ b/server/tests/lib/subject_page_config_content_test.py
@@ -114,7 +114,9 @@ class TestSubjectPageConfigs(unittest.TestCase):
         page_msg = f"{id}[config={page_i}]"
         self.assertNotEqual(page.metadata.topic_id, '', page_msg)
         self.assertNotEqual(page.metadata.topic_name, '', page_msg)
-        self.assertGreater(len(page.metadata.place_dcid), 0, page_msg)
+        self.assertGreater(
+            len(page.metadata.place_dcid) + len(page.metadata.place_group), 0,
+            page_msg)
         self.assertGreater(len(page.metadata.contained_place_types), 0,
                            page_msg)
         event_type_specs = self.verify_event_type_specs(page, page_msg)

--- a/server/tests/routes/api/choropleth_test.py
+++ b/server/tests/routes/api/choropleth_test.py
@@ -73,7 +73,7 @@ class TestChoroplethPlaces(unittest.TestCase):
     mock_parents.return_value = mock_parents.return_value = {
         dcid: [{
             'dcid': parent_dcid,
-            'types': ['Country']
+            'type': 'Country'
         }]
     }
     result = choropleth_api.get_choropleth_display_level(dcid)
@@ -90,7 +90,7 @@ class TestChoroplethPlaces(unittest.TestCase):
     mock_parents.return_value = {
         dcid: [{
             'dcid': parent_dcid,
-            'types': ['AdministrativeArea1']
+            'type': 'AdministrativeArea1'
         }]
     }
     result = choropleth_api.get_choropleth_display_level(dcid)
@@ -104,12 +104,7 @@ class TestChoroplethPlaces(unittest.TestCase):
     parent_dcid = "parent_dcid"
 
     mock_place_type.return_value = "County"
-    mock_parents.return_value = {
-        dcid: [{
-            'dcid': parent_dcid,
-            'types': ['State']
-        }]
-    }
+    mock_parents.return_value = {dcid: [{'dcid': parent_dcid, 'type': 'State'}]}
     result = choropleth_api.get_choropleth_display_level(dcid)
     assert result == (parent_dcid, "County")
 

--- a/server/webdriver_tests/tests/event_page_test.py
+++ b/server/webdriver_tests/tests/event_page_test.py
@@ -53,8 +53,10 @@ class TestEventPage(WebdriverBaseTest):
     self.assertEqual(title.text, 'Nicole')
     dcid_subtitle = self.driver.find_element(
         By.XPATH, '//*[@id="main-pane"]/div[1]/div[1]/h3')
-    self.assertEqual(dcid_subtitle.text,
-                     'Cyclone Event in Indian River County, Earth')
+    self.assertEqual(
+        dcid_subtitle.text,
+        'Cyclone Event in Indian River County, Florida, United States, North America, Earth'
+    )
 
     # Check google map section
     element_present = EC.presence_of_element_located(
@@ -116,8 +118,10 @@ class TestEventPage(WebdriverBaseTest):
     self.assertEqual(title.text, 'Double Creek Fire')
     dcid_subtitle = self.driver.find_element(
         By.XPATH, '//*[@id="main-pane"]/div[1]/div[1]/h3')
-    self.assertEqual(dcid_subtitle.text,
-                     'Wildland Fire Event in Wallowa County, Earth')
+    self.assertEqual(
+        dcid_subtitle.text,
+        'Wildland Fire Event in Wallowa County, Oregon, United States, North America, Earth'
+    )
 
     # Check google map section
     element_present = EC.presence_of_element_located(
@@ -181,7 +185,8 @@ class TestEventPage(WebdriverBaseTest):
         title.text, 'DroughtEvent at LatLong(52.00000:-81.00000) on 2020-04-01')
     dcid_subtitle = self.driver.find_element(
         By.XPATH, '//*[@id="main-pane"]/div[1]/div[1]/h3')
-    self.assertEqual(dcid_subtitle.text, 'Drought Event in Canada, Earth')
+    self.assertEqual(dcid_subtitle.text,
+                     'Drought Event in Canada, North America, Earth')
 
     # Check google map section
     element_present = EC.presence_of_element_located(


### PR DESCRIPTION
- add list of allowed place groups in the subject page config
- allow equity page for all states in USA

<img width="1760" alt="Screenshot 2023-06-06 at 1 37 11 PM" src="https://github.com/datacommonsorg/website/assets/69875368/0beca796-c35f-43de-8d43-15afe69a9698">

bug fixes along the way (caused by updates in accepted parameter type and return value of parent_places):
- fix bug in getting parent place type in choropleth API
- fix bug in returned parent place list from subject page config place metadata
