### PR TITLE
Remove tmcf+csv mem cache support in website config

### DIFF
--- a/deploy/gke/feedingamerica.yaml
+++ b/deploy/gke/feedingamerica.yaml
@@ -21,5 +21,3 @@ region:
     -
 nodes: 1
 storage_project: datcom-store
-tmcf_csv_bucket: datcom-feedingamerica-resources
-tmcf_csv_folder: food

--- a/deploy/gke/stanford.yaml
+++ b/deploy/gke/stanford.yaml
@@ -24,5 +24,3 @@ region:
     -
 nodes: 1
 storage_project: datcom-store
-tmcf_csv_bucket: datcom-stanford-resources
-tmcf_csv_folder: stanford

--- a/deploy/gke/tidal.yaml
+++ b/deploy/gke/tidal.yaml
@@ -21,4 +21,3 @@ region:
     -
 nodes: 1
 storage_project: datcom-store
-tmcf_csv_bucket: poc-datasets

--- a/deploy/helm_charts/dc_website/values.yaml
+++ b/deploy/helm_charts/dc_website/values.yaml
@@ -57,10 +57,6 @@ mixer:
     pullPolicy: Always
     tag:
 
-    useTMCFCSVData: false
-    tmcfCSVBucket: ""
-    tmcfCSVFolder: ""
-
     hostProject:
     serviceName:
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -323,14 +323,6 @@ rm -rf ~/.datacommons/cache.*
 
 The GKE configuration is stored [here](../deploy/overlays).
 
-### Custom Instance
-
-Create a pub/sub topic for mixer to listen to data change.
-
-```bash
-gsutil notification create -t tmcf-csv-reload -f json gs://<BUCKET_NAME>
-```
-
 ### Redis memcache
 
 [Redis memcache](https://pantheon.corp.google.com/memorystore/redis/instances?project=datcom-website-prod)

--- a/gke/README.md
+++ b/gke/README.md
@@ -13,7 +13,6 @@ You should have owner/editor role to perform the following tasks.
   - `domain`: domain of the the website
   - `region.primary`: region for Kubernetes cluster
   - `storage-project`: base Data Commons project (set this to `datcom-store`)
-  - `tmcf_csv_bucket`: GCS bucket which contains the TMCF and CSV files for the instance
 
 - Install the following tools:
 

--- a/gke/add_policy_binding.sh
+++ b/gke/add_policy_binding.sh
@@ -17,7 +17,6 @@ set -e
 
 PROJECT_ID=$(yq eval '.project' config.yaml)
 STORE_PROJECT_ID=$(yq eval '.storage_project' config.yaml)
-TMCF_CSV_BUCKET=$(yq eval '.tmcf_csv_bucket' config.yaml)
 
 NAME="website-robot"
 SERVICE_ACCOUNT="$NAME@$PROJECT_ID.iam.gserviceaccount.com"
@@ -39,8 +38,3 @@ do
     --member serviceAccount:$SERVICE_ACCOUNT \
     --role $role
 done
-
-# Read CSV and TMCF from GCS
-if [[ $TMCF_CSV_BUCKET != '' ]]; then
-  gsutil iam ch serviceAccount:$SERVICE_ACCOUNT:roles/storage.objectViewer gs://$TMCF_CSV_BUCKET
-fi

--- a/gke/config.yaml.tpl
+++ b/gke/config.yaml.tpl
@@ -25,5 +25,3 @@ region:
     -
 nodes: 1
 storage_project:
-tmcf_csv_bucket:
-tmcf_csv_folder:

--- a/scripts/install_custom_dc.sh
+++ b/scripts/install_custom_dc.sh
@@ -199,11 +199,6 @@ terraform apply \
   -var="dc_resource_bucket=$RESOURCE_BUCKET" \
   -auto-approve
 
-# Copy over sample tmcfs/csvs from reference resource bucket.
-gsutil cp -r \
-  gs://datcom-public/reference/tmcf_csv \
-  gs://$RESOURCE_BUCKET/reference/tmcf_csv
-
 _success_msg="
 ###############################################################################
 # Status: Successfully launched the installer in $PROJECT_ID.


### PR DESCRIPTION
mem cache has been deprecated in mixer: https://github.com/datacommonsorg/mixer/pull/1155