### PR TITLE
Add a screenshot landing page

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -22,6 +22,7 @@ opencensus-ext-stackdriver==0.8.0
 parameterized==0.8.1
 pillow==9.5.0
 protobuf==3.20.2
+PyGithub==1.58.2
 pyOpenSSL==22.1.0
 pytest-rerunfailures==10.2
 pytest-xdist==3.2.1

--- a/server/routes/screenshot/html.py
+++ b/server/routes/screenshot/html.py
@@ -35,6 +35,10 @@ bp = flask.Blueprint("screenshot", __name__, url_prefix='/screenshot')
 
 @bp.route('/')
 def commit_list():
+  """List recent commits and diff url
+
+  Optional url argument "base" to set a base commit sha for comparison.
+  """
   base_sha = request.args.get('base', '')
   # Secret generated from Github account 'dc-org2018'
   secret_client = secretmanager.SecretManagerServiceClient()

--- a/server/routes/screenshot/html.py
+++ b/server/routes/screenshot/html.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 from base64 import b64encode
+from datetime import datetime
 import io
 import os
 
+from dateutil.relativedelta import relativedelta
 import flask
+from flask import request
+from github import Github
 from markupsafe import escape
 
 from server.lib.gcs import list_png
@@ -25,6 +29,48 @@ from server.routes.screenshot.diff import img_diff
 SCREENSHOT_BUCKET = 'datcom-website-screenshot'
 
 bp = flask.Blueprint("screenshot", __name__, url_prefix='/screenshot')
+
+
+@bp.route('/')
+def list():
+  base_sha = request.args.get('base', '')
+  g = Github("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")
+  # Then, get the repository:
+  repo = g.get_repo("datacommonsorg/website")
+  one_month_ago = datetime.now() - relativedelta(months=1)
+  # Get the most recent commits:
+  commits = repo.get_commits(since=one_month_ago)
+  data = []
+  prev_sha = ''
+  for c in commits.reversed:
+    item = {}
+    commit = c.commit
+    raw_message = commit.message
+    message = raw_message
+    ready = False
+    for i in range(0, len(raw_message) - 1):
+      if raw_message[i] == '(' and raw_message[i + 1] == '#':
+        ready = True
+      if ready and raw_message[i] == ')':
+        message = raw_message[0:i + 1]
+        break
+    sha = c.sha[0:7]
+    item = {
+        'message': message,
+        'url': c.html_url,
+        'sha': sha,
+        'base_sha': base_sha,
+        'compare_base': ''
+    }
+    if prev_sha:
+      item['compare'] = '{}...{}'.format(prev_sha, sha)
+    if base_sha:
+      item['compare_base'] = '{}...{}'.format(prev_sha, base_sha)
+    prev_sha = sha
+    data.append(item)
+  # Change back the item order from new to old
+  data.reverse()
+  return flask.render_template('screenshot_landing.html', data=data)
 
 
 @bp.route('/commit/<path:githash>')

--- a/server/templates/screenshot_landing.html
+++ b/server/templates/screenshot_landing.html
@@ -1,0 +1,52 @@
+{#
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+#}
+{%- extends BASE_HTML -%}
+
+{% set main_id = 'screenshot' %}
+{% set page_id = 'page-screenshot-landing' %}
+{% set title = 'Screenshot Page List' %}
+
+{% block head %}
+  <link rel="stylesheet" href={{url_for('static', filename='css/screenshot.min.css')}}>
+{% endblock %}
+
+{% block content %}
+  <div class="container">
+    <table>
+      {% for item in data %}
+        <tr>
+          <th>
+            <a href="{{item['url']}}">{{item['message']}}</a>
+          </th>
+          <th>
+            {{item['sha']}}
+          </th>
+          <th>
+            <a href="/screenshot/commit/{{item['sha']}}">current</a>
+          </th>
+          <th>
+            <a href="/screenshot/compare/{{item['compare']}}">diff (vs previoius)</a>
+          </th>
+          {% if item['compare_base'] %}
+            <th>
+              <a href="/screenshot/compare/{{item['compare_base']}}">diff (vs base)</a>
+            </th>
+          {% endif %}
+        </tr>
+      {% endfor %}
+    </table>
+  </div>
+{% endblock %}

--- a/static/css/screenshot.scss
+++ b/static/css/screenshot.scss
@@ -23,3 +23,7 @@
 img {
   border: 1px solid black;
 }
+
+th {
+  padding: 0 20px;
+}


### PR DESCRIPTION
This page pulls the github commits from the past month, list them with screenshot links, including current, diff with previous, and diff with a base commit. 