### PR TITLE
Add a framework to get stable screenshot result

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -202,7 +202,7 @@ sudo chmod +x /usr/bin/chromedriver
 
 ```bash
 cd static
-npm test testfilename -- -u
+npm test testfilename -- -u .
 ```
 
 ## Other Developing Tips

--- a/run_test.sh
+++ b/run_test.sh
@@ -125,7 +125,7 @@ function run_webdriver_test {
   fi
   export FLASK_ENV=webdriver
   export GOOGLE_CLOUD_PROJECT=datcom-website-dev
-  python3 -m pytest -n 10 --reruns 2 server/webdriver_tests/tests/timeline_test.py
+  python3 -m pytest -n 10 --reruns 2 server/webdriver_tests/tests/
 }
 
 # Run test for screenshot test codes.

--- a/run_test.sh
+++ b/run_test.sh
@@ -125,7 +125,7 @@ function run_webdriver_test {
   fi
   export FLASK_ENV=webdriver
   export GOOGLE_CLOUD_PROJECT=datcom-website-dev
-  python3 -m pytest -n 10 --reruns 2 server/webdriver_tests/tests/
+  python3 -m pytest -n 10 --reruns 2 server/webdriver_tests/tests/timeline_test.py
 }
 
 # Run test for screenshot test codes.

--- a/server/routes/event/html.py
+++ b/server/routes/event/html.py
@@ -180,7 +180,7 @@ def event_node(dcid=DEFAULT_EVENT_DCID):
 
       # TODO: If not enough charts from the current place, add from the next place up and so on.
       subject_page_args = {
-          "place_types": [place_metadata.place_type],
+          "place_types": json.dumps([place_metadata.place_type]),
           "place_name": place_metadata.place_name,
           "place_dcid": place_dcid,
           "parent_places": json.dumps(place_metadata.parent_places),

--- a/server/routes/event/html.py
+++ b/server/routes/event/html.py
@@ -16,10 +16,8 @@
 import copy
 import json
 import logging
-import os
 from typing import Dict, List
 
-from flask import abort
 from flask import Blueprint
 from flask import current_app
 from flask import render_template
@@ -31,7 +29,6 @@ from server.lib import fetch
 import server.lib.shared as shared_api
 import server.lib.subject_page_config as lib_subject_page_config
 import server.lib.util as lib_util
-import server.services.datacommons as dc
 
 DEFAULT_EVENT_DCID = ""
 
@@ -44,11 +41,11 @@ DEFAULT_CONTAINED_PLACE_TYPES = {
 }
 
 EMPTY_SUBJECT_PAGE_ARGS = {
-    "place_type": "{}",
+    "place_types": "[]",
     "place_name": "",
     "place_dcid": "",
     "parent_places": "[]",
-    "config": "{}",
+    "subject_config": "{}",
 }
 
 LOCATION_PROPERTIES = ['location', 'startLocation']
@@ -183,7 +180,7 @@ def event_node(dcid=DEFAULT_EVENT_DCID):
 
       # TODO: If not enough charts from the current place, add from the next place up and so on.
       subject_page_args = {
-          "place_type": place_metadata.place_type,
+          "place_types": [place_metadata.place_type],
           "place_name": place_metadata.place_name,
           "place_dcid": place_dcid,
           "parent_places": json.dumps(place_metadata.parent_places),

--- a/server/templates/event.html
+++ b/server/templates/event.html
@@ -31,7 +31,7 @@
   <div id="main-pane"></div>
   <div id="metadata" class="d-none">
     <div id="node" data-dcid="{{dcid}}" data-nn="{{node_name}}" data-pv="{{properties}}" data-provenance="{{ provenance }}"></div>
-    <div id="place" data-dcid="{{ place_dcid }}" data-name="{{ place_name }}" data-type="{{ place_type }}" data-parents="{{ parent_places }}"></div>
+    <div id="place" data-dcid="{{ place_dcid }}" data-name="{{ place_name }}" data-types="{{ place_types }}" data-parents="{{ parent_places }}"></div>
     <div id="subject-config" data-config="{{ subject_config }}"></div>
   </div>
 {% endblock %}

--- a/server/webdriver_tests/base_test.py
+++ b/server/webdriver_tests/base_test.py
@@ -18,8 +18,8 @@ import sys
 from flask_testing import LiveServerTestCase
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
-from server.webdriver_tests import shared
 
+from server.webdriver_tests import shared
 from web_app import app
 
 # Explicitly set multiprocessing start method to 'fork' so tests work with

--- a/server/webdriver_tests/base_test.py
+++ b/server/webdriver_tests/base_test.py
@@ -18,6 +18,7 @@ import sys
 from flask_testing import LiveServerTestCase
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from server.webdriver_tests import shared
 
 from web_app import app
 
@@ -57,7 +58,7 @@ class WebdriverBaseTest(LiveServerTestCase):
       chrome_options.add_experimental_option("prefs", preferences)
 
     # Maximum time, in seconds, before throwing a TimeoutException.
-    self.TIMEOUT_SEC = 60
+    self.TIMEOUT_SEC = shared.TIMEOUT
     self.driver = webdriver.Chrome(options=chrome_options)
 
     # Set a reliable window size for all tests (can be overwritten though)

--- a/server/webdriver_tests/screenshot/screenshot_test.py
+++ b/server/webdriver_tests/screenshot/screenshot_test.py
@@ -16,7 +16,7 @@ import json
 import os
 import urllib.parse
 
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -38,12 +38,12 @@ def wait_for_charts(driver):
   for c in chart_containers:
     try:
       c.find_element(By.CLASS_NAME, CHART_EXIST_CLASS)
-    except TimeoutException:
+    except NoSuchElementException:
       return False
   return True
 
 
-# Class to test timeline tool.
+# Class to test screenshot capture.
 class TestScreenShot(WebdriverBaseTest):
 
   def test_pages_and_sreenshot(self):

--- a/server/webdriver_tests/screenshot/screenshot_test.py
+++ b/server/webdriver_tests/screenshot/screenshot_test.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
+import json
+import os
 import urllib.parse
 
 from selenium.webdriver.common.by import By
@@ -23,43 +24,22 @@ from server.webdriver_tests.base_test import WebdriverBaseTest
 
 # TODO(shifucun): add test for narrow width for mobile testing
 WIDTH = 1280
-
 SCREENSHOTS_FOLDER = 'screenshots'
-# TODO: Can add more urls and tests if necessary.
-TEST_URLS = [
-    {
-        'url': '/place/country/USA?topic=Demographics',
-        'selector': By.CLASS_NAME,
-        'name': 'chart-container',
-        'height': 4400
-    },
-    {
-        'url':
-            '/tools/timeline#&place=geoId/0606000,geoId/2511000&statsVar=Median_Age_Person',
-        'selector':
-            By.CLASS_NAME,
-        'name':
-            'chart-area',
-        'height':
-            1000
-    },
-    {
-        'url': '/ranking/Median_Income_Person/County/country/USA',
-        'selector': By.CLASS_NAME,
-        'name': 'chart-container',
-        'height': 1080
-    },
-    {
-        'url':
-            '/tools/map#%26sv%3DAnnual_Emissions_CarbonDioxide_NonBiogenic%26pc%3D0%26denom%3DCount_Person%26pd%3Dcountry%2FUSA%26ept%3DState%26ppt%3DEpaReportingFacility',
-        'selector':
-            By.ID,
-        'name':
-            'map-items',
-        'height':
-            1080
-    },
-]
+CHART_HOLDER_CLASS = 'dc-chart-holder'
+CHART_EXIST_CLASS = 'dc-chart-exist'
+
+
+def wait_for_charts(driver):
+  element_present = EC.presence_of_element_located(
+      (By.CLASS_NAME, CHART_HOLDER_CLASS))
+  WebDriverWait(driver, 30).until(element_present)
+  chart_containers = driver.find_elements(By.CLASS_NAME, CHART_HOLDER_CLASS)
+  for c in chart_containers:
+    try:
+      c.find_element(By.CLASS_NAME, CHART_EXIST_CLASS)
+    except:
+      return False
+  return True
 
 
 # Class to test timeline tool.
@@ -67,33 +47,19 @@ class TestScreenShot(WebdriverBaseTest):
 
   def test_pages_and_sreenshot(self):
     """Test these page can show correctly and do screenshot."""
-    for _, test_info in enumerate(TEST_URLS):
-      self.driver.get(self.url_ + test_info['url'])
+    with open(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     'test_page.json')) as f:
+      data = json.load(f)
+      for test_info in data:
+        self.driver.get(self.url_ + test_info['url'])
 
-      name = urllib.parse.quote_plus(test_info['url'].removeprefix('/'))
-
-      # Wait until the test_class_name has loaded.
-      element_present = EC.presence_of_element_located(
-          (test_info['selector'], test_info['name']))
-
-      try:
-        WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
-      except Exception as e:
-        logging.error(test_info['url'])
-        raise e
-
-      # Set the window size. Testing different sizes.
-      self.driver.set_window_size(width=WIDTH,
-                                  height=test_info['height'],
-                                  windowHandle='current')
-
-      # Get the element to test.
-      charts = self.driver.find_elements(test_info['selector'],
-                                         test_info['name'])
-
-      # Assert there is at least one chart.
-      self.assertGreater(len(charts), 0, test_info['url'])
-
-      # Take a screenshot of the page and save it.
-      file_name = '{}/{}.png'.format(SCREENSHOTS_FOLDER, name)
-      self.assertTrue(self.driver.save_screenshot(file_name))
+        name = urllib.parse.quote_plus(test_info['url'].removeprefix('/'))
+        # Set the window size. Testing different sizes.
+        self.driver.set_window_size(width=WIDTH,
+                                    height=test_info['height'],
+                                    windowHandle='current')
+        WebDriverWait(self.driver, self.TIMEOUT_SEC).until(wait_for_charts)
+        # Take a screenshot of the page and save it.
+        file_name = '{}/{}.png'.format(SCREENSHOTS_FOLDER, name)
+        self.assertTrue(self.driver.save_screenshot(file_name))

--- a/server/webdriver_tests/screenshot/screenshot_test.py
+++ b/server/webdriver_tests/screenshot/screenshot_test.py
@@ -19,7 +19,7 @@ import urllib.parse
 from selenium.webdriver.support.ui import WebDriverWait
 
 from server.webdriver_tests.base_test import WebdriverBaseTest
-from server.webdriver_tests.shared import wait_for_charts
+from server.webdriver_tests.shared import charts_rendered
 
 # TODO(shifucun): add test for narrow width for mobile testing
 WIDTH = 1280
@@ -43,7 +43,7 @@ class TestScreenShot(WebdriverBaseTest):
         self.driver.set_window_size(width=WIDTH,
                                     height=test_info['height'],
                                     windowHandle='current')
-        WebDriverWait(self.driver, self.TIMEOUT_SEC).until(wait_for_charts)
+        WebDriverWait(self.driver, self.TIMEOUT_SEC).until(charts_rendered)
         # Take a screenshot of the page and save it.
         file_name = '{}/{}.png'.format(SCREENSHOTS_FOLDER, name)
         self.assertTrue(self.driver.save_screenshot(file_name))

--- a/server/webdriver_tests/screenshot/screenshot_test.py
+++ b/server/webdriver_tests/screenshot/screenshot_test.py
@@ -16,6 +16,7 @@ import json
 import os
 import urllib.parse
 
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -37,7 +38,7 @@ def wait_for_charts(driver):
   for c in chart_containers:
     try:
       c.find_element(By.CLASS_NAME, CHART_EXIST_CLASS)
-    except:
+    except TimeoutException:
       return False
   return True
 

--- a/server/webdriver_tests/screenshot/screenshot_test.py
+++ b/server/webdriver_tests/screenshot/screenshot_test.py
@@ -16,31 +16,14 @@ import json
 import os
 import urllib.parse
 
-from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 from server.webdriver_tests.base_test import WebdriverBaseTest
+from server.webdriver_tests.shared import wait_for_charts
 
 # TODO(shifucun): add test for narrow width for mobile testing
 WIDTH = 1280
 SCREENSHOTS_FOLDER = 'screenshots'
-CHART_HOLDER_CLASS = 'dc-chart-holder'
-CHART_EXIST_CLASS = 'dc-chart-exist'
-
-
-def wait_for_charts(driver):
-  element_present = EC.presence_of_element_located(
-      (By.CLASS_NAME, CHART_HOLDER_CLASS))
-  WebDriverWait(driver, 30).until(element_present)
-  chart_containers = driver.find_elements(By.CLASS_NAME, CHART_HOLDER_CLASS)
-  for c in chart_containers:
-    try:
-      c.find_element(By.CLASS_NAME, CHART_EXIST_CLASS)
-    except NoSuchElementException:
-      return False
-  return True
 
 
 # Class to test screenshot capture.

--- a/server/webdriver_tests/screenshot/test_page.json
+++ b/server/webdriver_tests/screenshot/test_page.json
@@ -1,0 +1,18 @@
+[
+  {
+    "url": "/place/country/USA?topic=Demographics",
+    "height": 4400
+  },
+  {
+    "url": "/tools/timeline#&place=geoId/0606000,geoId/2511000&statsVar=Median_Age_Person",
+    "height": 1000
+  },
+  {
+    "url": "/ranking/Median_Income_Person/County/country/USA",
+    "height": 1080
+  },
+  {
+    "url": "/tools/map#%26sv%3DAnnual_Emissions_CarbonDioxide_NonBiogenic%26pc%3D0%26denom%3DCount_Person%26pd%3Dcountry%2FUSA%26ept%3DState%26ppt%3DEpaReportingFacility",
+    "height": 1080
+  }
+]

--- a/server/webdriver_tests/shared.py
+++ b/server/webdriver_tests/shared.py
@@ -22,6 +22,7 @@ LOADING_WAIT_TIME_SEC = 3
 MAX_NUM_SPINNERS = 3
 CHART_HOLDER_CLASS = 'dc-chart-holder'
 CHART_EXIST_CLASS = 'dc-chart-exist'
+TIMEOUT = 60
 
 
 def wait_for_loading(driver):
@@ -52,12 +53,12 @@ def click_sv_group(driver, svg_name):
       break
 
 
-def wait_for_charts(driver):
+def charts_rendered(driver):
   """Wait for asyncronously charts to show up.
   """
   element_present = EC.presence_of_element_located(
       (By.CLASS_NAME, CHART_HOLDER_CLASS))
-  WebDriverWait(driver, 30).until(element_present)
+  WebDriverWait(driver, TIMEOUT).until(element_present)
   chart_containers = driver.find_elements(By.CLASS_NAME, CHART_HOLDER_CLASS)
   for c in chart_containers:
     try:

--- a/server/webdriver_tests/shared.py
+++ b/server/webdriver_tests/shared.py
@@ -11,14 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Common library for functions used by multiple webdriver tests"""
 
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 LOADING_WAIT_TIME_SEC = 3
 MAX_NUM_SPINNERS = 3
-"""Common library for functions used by multiple webdriver tests"""
+CHART_HOLDER_CLASS = 'dc-chart-holder'
+CHART_EXIST_CLASS = 'dc-chart-exist'
 
 
 def wait_for_loading(driver):
@@ -47,3 +50,18 @@ def click_sv_group(driver, svg_name):
     if svg_name in group.text:
       group.click()
       break
+
+
+def wait_for_charts(driver):
+  """Wait for asyncronously charts to show up.
+  """
+  element_present = EC.presence_of_element_located(
+      (By.CLASS_NAME, CHART_HOLDER_CLASS))
+  WebDriverWait(driver, 30).until(element_present)
+  chart_containers = driver.find_elements(By.CLASS_NAME, CHART_HOLDER_CLASS)
+  for c in chart_containers:
+    try:
+      c.find_element(By.CLASS_NAME, CHART_EXIST_CLASS)
+    except NoSuchElementException:
+      return False
+  return True

--- a/server/webdriver_tests/tests/timeline_test.py
+++ b/server/webdriver_tests/tests/timeline_test.py
@@ -80,7 +80,7 @@ class TestCharts(WebdriverBaseTest):
     self.driver.get(self.url_ + TIMELINE_URL + URL_HASH_1)
 
     # Wait until the group of charts has loaded.
-    shared.wait_for_charts(self.driver)
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(shared.charts_rendered)
 
     # Store a list of all the charts.
     charts = self.driver.find_elements(By.CLASS_NAME, 'dc-chart-exist')

--- a/server/webdriver_tests/tests/timeline_test.py
+++ b/server/webdriver_tests/tests/timeline_test.py
@@ -80,9 +80,7 @@ class TestCharts(WebdriverBaseTest):
     self.driver.get(self.url_ + TIMELINE_URL + URL_HASH_1)
 
     # Wait until the group of charts has loaded.
-    element_present = EC.presence_of_element_located(
-        (By.CLASS_NAME, 'dc-chart-exist'))
-    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
+    shared.wait_for_charts(self.driver)
 
     # Store a list of all the charts.
     charts = self.driver.find_elements(By.CLASS_NAME, 'dc-chart-exist')

--- a/server/webdriver_tests/tests/timeline_test.py
+++ b/server/webdriver_tests/tests/timeline_test.py
@@ -80,12 +80,12 @@ class TestCharts(WebdriverBaseTest):
     self.driver.get(self.url_ + TIMELINE_URL + URL_HASH_1)
 
     # Wait until the group of charts has loaded.
-    element_present = EC.presence_of_element_located((By.ID, 'chart-region'))
+    element_present = EC.presence_of_element_located(
+        (By.CLASS_NAME, 'dc-chart-exist'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
 
     # Store a list of all the charts.
-    chart_region = self.driver.find_element(By.XPATH, '//*[@id="chart-region"]')
-    charts = chart_region.find_elements(By.CLASS_NAME, 'card')
+    charts = self.driver.find_elements(By.CLASS_NAME, 'dc-chart-exist')
     # Assert there are three charts.
     self.assertEqual(len(charts), 3)
     # Wait until the charts are drawn.
@@ -116,7 +116,7 @@ class TestCharts(WebdriverBaseTest):
     time.sleep(2)
 
     # Re-store a list of all the charts.
-    charts = chart_region.find_elements(By.CLASS_NAME, 'card')
+    charts = self.driver.find_elements(By.CLASS_NAME, 'dc-chart-exist')
     # Assert there are two charts.
     self.assertEqual(len(charts), 2)
 
@@ -149,12 +149,11 @@ class TestCharts(WebdriverBaseTest):
     # Wait until there is a card present.
     shared.wait_for_loading(self.driver)
     element_present = EC.presence_of_element_located(
-        (By.XPATH, '//*[@id="chart-region"]/div'))
+        (By.CLASS_NAME, 'dc-chart-exist'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
 
     # Assert there is one chart.
-    charts = self.driver.find_elements(
-        By.XPATH, '//*[@id="chart-region"]/div[@class="chart-container"]')
+    charts = self.driver.find_elements(By.CLASS_NAME, 'dc-chart-exist')
     self.assertEqual(len(charts), 1)
 
     # Uncheck the checked stat var.

--- a/static/js/apps/event/main.ts
+++ b/static/js/apps/event/main.ts
@@ -49,7 +49,7 @@ function renderPage(): void {
   // Event place
   const placeDcid = document.getElementById("place").dataset.dcid;
   const placeName = document.getElementById("place").dataset.name || placeDcid;
-  const placeTypes = [document.getElementById("place").dataset.type] || [];
+  const placeTypes = [document.getElementById("place").dataset.types] || [];
   const place = { dcid: placeDcid, name: placeName, types: placeTypes };
   const parentPlaces = JSON.parse(
     document.getElementById("place").dataset.parents || "[]"

--- a/static/js/apps/event/main.ts
+++ b/static/js/apps/event/main.ts
@@ -49,7 +49,9 @@ function renderPage(): void {
   // Event place
   const placeDcid = document.getElementById("place").dataset.dcid;
   const placeName = document.getElementById("place").dataset.name || placeDcid;
-  const placeTypes = [document.getElementById("place").dataset.types] || [];
+  const placeTypes =
+    JSON.parse(document.getElementById("place").dataset.types) || [];
+  console.log(placeTypes);
   const place = { dcid: placeDcid, name: placeName, types: placeTypes };
   const parentPlaces = JSON.parse(
     document.getElementById("place").dataset.parents || "[]"

--- a/static/js/apps/event/main.ts
+++ b/static/js/apps/event/main.ts
@@ -51,7 +51,6 @@ function renderPage(): void {
   const placeName = document.getElementById("place").dataset.name || placeDcid;
   const placeTypes =
     JSON.parse(document.getElementById("place").dataset.types) || [];
-  console.log(placeTypes);
   const place = { dcid: placeDcid, name: placeName, types: placeTypes };
   const parentPlaces = JSON.parse(
     document.getElementById("place").dataset.parents || "[]"

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -637,6 +637,7 @@ function drawHistogram(
   const svg = d3
     .select("#" + id)
     .append("svg")
+    .attr("class", "dc-chart-exist")
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
@@ -743,6 +744,7 @@ function drawStackBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
+    .attr("class", "dc-chart-exist")
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
@@ -852,6 +854,7 @@ function drawGroupBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
+    .attr("class", "dc-chart-exist")
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
@@ -968,6 +971,7 @@ function drawLineChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
+    .attr("class", "dc-chart-exist")
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", width)
@@ -1191,6 +1195,7 @@ function drawGroupLineChart(
 
   const svg = container
     .append("svg")
+    .attr("class", "dc-chart-exist")
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", width)

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -17,6 +17,7 @@
 import * as d3 from "d3";
 import _ from "lodash";
 
+import { CLASS_DC_CHART_EXIST } from "../constants/css_constants";
 import {
   GA_EVENT_PLACE_CHART_CLICK,
   GA_PARAM_PLACE_CHART_CLICK,
@@ -637,7 +638,6 @@ function drawHistogram(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("class", "dc-chart-exist")
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
@@ -698,6 +698,7 @@ function drawHistogram(
         (x.bandwidth() - Math.min(x.bandwidth(), MAX_HISTOGRAM_BAR_WIDTH)) / 2
       );
     })
+    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("y", (d) => y(Math.max(0, d.value)))
     .attr("width", Math.min(x.bandwidth(), MAX_HISTOGRAM_BAR_WIDTH))
     .attr("height", (d) => Math.abs(y(0) - y(d.value)))
@@ -744,7 +745,7 @@ function drawStackBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("class", "dc-chart-exist")
+    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
@@ -854,7 +855,7 @@ function drawGroupBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("class", "dc-chart-exist")
+    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
@@ -971,7 +972,7 @@ function drawLineChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("class", "dc-chart-exist")
+    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", width)
@@ -1195,7 +1196,7 @@ function drawGroupLineChart(
 
   const svg = container
     .append("svg")
-    .attr("class", "dc-chart-exist")
+    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", width)

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -745,7 +745,6 @@ function drawStackBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
@@ -815,6 +814,7 @@ function drawStackBarChart(
       link: dp.link,
     }))
   );
+  svg.attr("class", CLASS_DC_CHART_EXIST);
 }
 
 /**
@@ -855,7 +855,6 @@ function drawGroupBarChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", chartWidth)
@@ -930,6 +929,7 @@ function drawGroupBarChart(
       link: dp.link,
     }))
   );
+  svg.attr("class", CLASS_DC_CHART_EXIST);
 }
 
 /**
@@ -972,7 +972,6 @@ function drawLineChart(
   const svg = d3
     .select("#" + id)
     .append("svg")
-    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", width)
@@ -1126,6 +1125,7 @@ function drawLineChart(
       link: dg.link,
     }))
   );
+  svg.attr("class", CLASS_DC_CHART_EXIST);
   return !hasFilledInValues;
 }
 
@@ -1196,7 +1196,6 @@ function drawGroupLineChart(
 
   const svg = container
     .append("svg")
-    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
     .attr("width", width)
@@ -1413,6 +1412,7 @@ function drawGroupLineChart(
     unit,
     statVarInfos
   );
+  svg.attr("class", CLASS_DC_CHART_EXIST);
 }
 
 /**

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -698,11 +698,12 @@ function drawHistogram(
         (x.bandwidth() - Math.min(x.bandwidth(), MAX_HISTOGRAM_BAR_WIDTH)) / 2
       );
     })
-    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("y", (d) => y(Math.max(0, d.value)))
     .attr("width", Math.min(x.bandwidth(), MAX_HISTOGRAM_BAR_WIDTH))
     .attr("height", (d) => Math.abs(y(0) - y(d.value)))
     .attr("fill", color);
+
+  svg.attr("class", CLASS_DC_CHART_EXIST);
 }
 
 /**

--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -22,6 +22,7 @@ import * as d3 from "d3";
 import * as geo from "geo-albers-usa-territories";
 import _ from "lodash";
 
+import { CLASS_DC_CHART_EXIST } from "../constants/css_constants";
 import {
   ASIA_NAMED_TYPED_PLACE,
   EUROPE_NAMED_TYPED_PLACE,
@@ -507,7 +508,7 @@ export function drawD3Map(
       });
     }
   }
-  svg.attr("class", "dc-chart-exist");
+  svg.attr("class", CLASS_DC_CHART_EXIST);
 }
 
 /**

--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -507,6 +507,7 @@ export function drawD3Map(
       });
     }
   }
+  svg.attr("class", "dc-chart-exist");
 }
 
 /**

--- a/static/js/chart/draw_scatter.ts
+++ b/static/js/chart/draw_scatter.ts
@@ -844,7 +844,6 @@ export function drawScatter(
   const svg = container
     .append("svg")
     .attr("id", "scatterplot")
-    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("width", properties.width)
     .attr("height", properties.height)
     .attr("transform", `translate(${svgXTranslation},0)`);
@@ -975,4 +974,5 @@ export function drawScatter(
     options.xPerCapita,
     options.yPerCapita
   );
+  svg.attr("class", CLASS_DC_CHART_EXIST);
 }

--- a/static/js/chart/draw_scatter.ts
+++ b/static/js/chart/draw_scatter.ts
@@ -843,6 +843,7 @@ export function drawScatter(
   const svg = container
     .append("svg")
     .attr("id", "scatterplot")
+    .attr("class", "dc-chart-exist")
     .attr("width", properties.width)
     .attr("height", properties.height)
     .attr("transform", `translate(${svgXTranslation},0)`);

--- a/static/js/chart/draw_scatter.ts
+++ b/static/js/chart/draw_scatter.ts
@@ -22,6 +22,7 @@ import * as d3 from "d3";
 import * as d3Regression from "d3-regression";
 import ReactDOM from "react-dom";
 
+import { CLASS_DC_CHART_EXIST } from "../constants/css_constants";
 import { ChartQuadrant } from "../constants/scatter_chart_constants";
 import { formatNumber } from "../i18n/i18n";
 import { NamedPlace } from "../shared/types";
@@ -843,7 +844,7 @@ export function drawScatter(
   const svg = container
     .append("svg")
     .attr("id", "scatterplot")
-    .attr("class", "dc-chart-exist")
+    .attr("class", CLASS_DC_CHART_EXIST)
     .attr("width", properties.width)
     .attr("height", properties.height)
     .attr("transform", `translate(${svgXTranslation},0)`);

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -20,6 +20,7 @@
 
 import React, { useRef } from "react";
 
+import { CLASS_DC_CHART_HOLDER } from "../../constants/css_constants";
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { ChartEmbed } from "../../place/chart_embed";
 import {
@@ -56,7 +57,7 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
   const showEmbed = props.allowEmbed && !props.isInitialLoading;
   return (
     <div
-      className={`chart-container dc-chart-holder ${
+      className={`chart-container ${CLASS_DC_CHART_HOLDER} ${
         props.className ? props.className : ""
       }`}
       ref={containerRef}

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -18,7 +18,6 @@
  * A container for any tile containing a chart.
  */
 
-import _ from "lodash";
 import React, { useRef } from "react";
 
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
@@ -57,7 +56,9 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
   const showEmbed = props.allowEmbed && !props.isInitialLoading;
   return (
     <div
-      className={`chart-container ${props.className ? props.className : ""}`}
+      className={`chart-container dc-chart-holder ${
+        props.className ? props.className : ""
+      }`}
       ref={containerRef}
     >
       <div

--- a/static/js/components/tiles/highlight_tile.tsx
+++ b/static/js/components/tiles/highlight_tile.tsx
@@ -56,7 +56,7 @@ export function HighlightTile(props: HighlightTilePropType): JSX.Element {
   };
   const description = formatString(props.description, rs);
   return (
-    <div className="chart-container highlight-tile">
+    <div className="chart-container highlight-tile dc-chart-holder">
       {highlightData && (
         <span className="stat">
           {formatNumber(

--- a/static/js/components/tiles/highlight_tile.tsx
+++ b/static/js/components/tiles/highlight_tile.tsx
@@ -57,7 +57,7 @@ export function HighlightTile(props: HighlightTilePropType): JSX.Element {
   };
   const description = formatString(props.description, rs);
   return (
-    <div className={"chart-container highlight-tile " + CLASS_DC_CHART_HOLDER}>
+    <div className={`chart-container highlight-tile ${CLASS_DC_CHART_HOLDER}`}>
       {highlightData && (
         <span className="stat">
           {formatNumber(

--- a/static/js/components/tiles/highlight_tile.tsx
+++ b/static/js/components/tiles/highlight_tile.tsx
@@ -21,6 +21,7 @@
 import axios from "axios";
 import React, { useEffect, useState } from "react";
 
+import { CLASS_DC_CHART_HOLDER } from "../../constants/css_constants";
 import { formatNumber } from "../../i18n/i18n";
 import { Observation, PointApiResponse } from "../../shared/stat_types";
 import { NamedTypedPlace, StatVarSpec } from "../../shared/types";
@@ -56,7 +57,7 @@ export function HighlightTile(props: HighlightTilePropType): JSX.Element {
   };
   const description = formatString(props.description, rs);
   return (
-    <div className="chart-container highlight-tile dc-chart-holder">
+    <div className={"chart-container highlight-tile " + CLASS_DC_CHART_HOLDER}>
       {highlightData && (
         <span className="stat">
           {formatNumber(

--- a/static/js/components/tiles/place_overview_tile.tsx
+++ b/static/js/components/tiles/place_overview_tile.tsx
@@ -60,9 +60,7 @@ export function PlaceOverviewTile(
   return (
     <>
       <div
-        className={
-          "chart-container place-overview-tile " + CLASS_DC_CHART_HOLDER
-        }
+        className={`chart-container place-overview-tile ${CLASS_DC_CHART_HOLDER}`}
       >
         <RawIntlProvider value={intl}>
           <Overview

--- a/static/js/components/tiles/place_overview_tile.tsx
+++ b/static/js/components/tiles/place_overview_tile.tsx
@@ -58,7 +58,7 @@ export function PlaceOverviewTile(
 
   return (
     <>
-      <div className="chart-container place-overview-tile">
+      <div className="chart-container place-overview-tile dc-chart-holder">
         <RawIntlProvider value={intl}>
           <Overview
             dcid={props.place.dcid}

--- a/static/js/components/tiles/place_overview_tile.tsx
+++ b/static/js/components/tiles/place_overview_tile.tsx
@@ -23,6 +23,7 @@ import _ from "lodash";
 import React, { useEffect, useState } from "react";
 import { RawIntlProvider } from "react-intl";
 
+import { CLASS_DC_CHART_HOLDER } from "../../constants/css_constants";
 import { intl } from "../../i18n/i18n";
 import { Overview } from "../../place/overview";
 import { NamedTypedPlace } from "../../shared/types";
@@ -58,7 +59,11 @@ export function PlaceOverviewTile(
 
   return (
     <>
-      <div className="chart-container place-overview-tile dc-chart-holder">
+      <div
+        className={
+          "chart-container place-overview-tile " + CLASS_DC_CHART_HOLDER
+        }
+      >
         <RawIntlProvider value={intl}>
           <Overview
             dcid={props.place.dcid}

--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -106,7 +106,7 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
 
   return (
     <div
-      className={`chart-container ranking-tile ${props.className}`}
+      className={`chart-container dc-chart-holder ranking-tile ${props.className}`}
       ref={chartContainer}
       style={{
         gridTemplateColumns:

--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -22,6 +22,7 @@ import axios from "axios";
 import _ from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 
+import { CLASS_DC_CHART_HOLDER } from "../../constants/css_constants";
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { ChartEmbed } from "../../place/chart_embed";
 import { USA_NAMED_TYPED_PLACE } from "../../shared/constants";
@@ -106,7 +107,7 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
 
   return (
     <div
-      className={`chart-container dc-chart-holder ranking-tile ${props.className}`}
+      className={`chart-container ${CLASS_DC_CHART_HOLDER} ranking-tile ${props.className}`}
       ref={chartContainer}
       style={{
         gridTemplateColumns:

--- a/static/js/components/tiles/sv_ranking_units.tsx
+++ b/static/js/components/tiles/sv_ranking_units.tsx
@@ -21,6 +21,7 @@ import * as d3 from "d3";
 import _ from "lodash";
 import React, { useEffect, useRef } from "react";
 
+import { CLASS_DC_CHART_EXIST } from "../../constants/css_constants";
 import { DATA_CSS_CLASS } from "../../constants/tile_constants";
 import { formatNumber } from "../../i18n/i18n";
 import { RankingData, RankingPoint } from "../../types/ranking_unit_types";
@@ -121,7 +122,7 @@ export function SvRankingUnits(props: SvRankingUnitsProps): JSX.Element {
       .append("g")
       .attr("transform", `translate(${CHART_PADDING})`)
       .append("svg")
-      .attr("class", "dc-chart-exist")
+      .attr("class", CLASS_DC_CHART_EXIST)
       .append("foreignObject")
       .attr("width", chartDiv.offsetWidth)
       .attr("height", chartDiv.offsetHeight)

--- a/static/js/components/tiles/sv_ranking_units.tsx
+++ b/static/js/components/tiles/sv_ranking_units.tsx
@@ -25,10 +25,7 @@ import { DATA_CSS_CLASS } from "../../constants/tile_constants";
 import { formatNumber } from "../../i18n/i18n";
 import { RankingData, RankingPoint } from "../../types/ranking_unit_types";
 import { RankingTileSpec } from "../../types/subject_page_proto_types";
-import {
-  dataPointsToCsv,
-  rankingPointsToCsv,
-} from "../../utils/chart_csv_utils";
+import { rankingPointsToCsv } from "../../utils/chart_csv_utils";
 import { formatString } from "../../utils/tile_utils";
 import { RankingUnit } from "../ranking_unit";
 import { ChartFooter } from "./chart_footer";
@@ -124,6 +121,7 @@ export function SvRankingUnits(props: SvRankingUnitsProps): JSX.Element {
       .append("g")
       .attr("transform", `translate(${CHART_PADDING})`)
       .append("svg")
+      .attr("class", "dc-chart-exist")
       .append("foreignObject")
       .attr("width", chartDiv.offsetWidth)
       .attr("height", chartDiv.offsetHeight)

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -112,7 +112,7 @@ export const TopEventTile = memo(function TopEventTile(
 
   return (
     <div
-      className={`chart-container ranking-tile ${props.className}`}
+      className={`chart-container dc-chart-holder ranking-tile ${props.className}`}
       ref={chartContainer}
     >
       <div

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -22,6 +22,7 @@ import axios from "axios";
 import _ from "lodash";
 import React, { memo, useEffect, useRef, useState } from "react";
 
+import { CLASS_DC_CHART_HOLDER } from "../../constants/css_constants";
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { formatNumber } from "../../i18n/i18n";
 import { ChartEmbed } from "../../place/chart_embed";
@@ -112,7 +113,7 @@ export const TopEventTile = memo(function TopEventTile(
 
   return (
     <div
-      className={`chart-container dc-chart-holder ranking-tile ${props.className}`}
+      className={`chart-container ${CLASS_DC_CHART_HOLDER} ranking-tile ${props.className}`}
       ref={chartContainer}
     >
       <div

--- a/static/js/constants/css_constants.ts
+++ b/static/js/constants/css_constants.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Constants used for css styling.
+ */
+
+// A class used to indicate a chart element exist.
+export const CLASS_DC_CHART_EXIST = "dc-chart-exist";
+
+// A class used to indicate an element is a holder for inner chart elements.
+export const CLASS_DC_CHART_HOLDER = "dc-chart-holder";

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -243,7 +243,10 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
     });
     return (
       <div className="col">
-        <div className="chart-container" ref={this.chartElement}>
+        <div
+          className="chart-container dc-chart-holder"
+          ref={this.chartElement}
+        >
           <h4>
             {this.props.title}
             <span className="sub-title">{dateString}</span>
@@ -261,7 +264,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
             )}
             {this.props.chartType === chartTypeEnum.RANKING &&
               this.state.rankingGroup && (
-                <div className="ranking-chart-container">
+                <div className="ranking-chart-container dc-chart-exist">
                   <h4>{this.getRankingChartContainerTitle()}</h4>
                   <div className="ranking-chart">
                     <RankingUnit

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -248,7 +248,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
     return (
       <div className="col">
         <div
-          className={"chart-container " + CLASS_DC_CHART_HOLDER}
+          className={`chart-container ${CLASS_DC_CHART_HOLDER}`}
           ref={this.chartElement}
         >
           <h4>

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -39,6 +39,10 @@ import {
 import { RankingUnit } from "../components/ranking_unit";
 import { fetchData } from "../components/tiles/ranking_tile";
 import {
+  CLASS_DC_CHART_EXIST,
+  CLASS_DC_CHART_HOLDER,
+} from "../constants/css_constants";
+import {
   formatNumber,
   intl,
   LocalizedLink,
@@ -244,7 +248,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
     return (
       <div className="col">
         <div
-          className="chart-container dc-chart-holder"
+          className={"chart-container " + CLASS_DC_CHART_HOLDER}
           ref={this.chartElement}
         >
           <h4>
@@ -264,7 +268,9 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
             )}
             {this.props.chartType === chartTypeEnum.RANKING &&
               this.state.rankingGroup && (
-                <div className="ranking-chart-container dc-chart-exist">
+                <div
+                  className={"ranking-chart-container " + CLASS_DC_CHART_EXIST}
+                >
                   <h4>{this.getRankingChartContainerTitle()}</h4>
                   <div className="ranking-chart">
                     <RankingUnit

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -19,7 +19,10 @@ import React from "react";
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 
 import { wrap } from "../chart/base";
-import { CLASS_DC_CHART_EXIST } from "../constants/css_constants";
+import {
+  CLASS_DC_CHART_EXIST,
+  CLASS_DC_CHART_HOLDER,
+} from "../constants/css_constants";
 import { intl } from "../i18n/i18n";
 import { randDomId, saveToFile, urlToDomain } from "../shared/util";
 
@@ -192,8 +195,6 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
         sourcesHeight +
         SOURCES_MARGIN
     );
-    svg.attr("class", CLASS_DC_CHART_EXIST);
-
     const s = new XMLSerializer();
     const svgXml = s.serializeToString(svg.node());
     container.innerHTML = "";
@@ -301,6 +302,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
         "data:image/svg+xml," + encodeURIComponent(chartDownloadXml);
       imageElement.src = chartBase64;
       this.svgContainerElement.current.append(imageElement);
+      imageElement.className = CLASS_DC_CHART_EXIST;
       this.setState({ chartDownloadXml });
     }
 
@@ -310,6 +312,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
       const chartBase64 =
         "data:image/svg+xml," + encodeURIComponent(chartDownloadXml);
       imageElement.src = chartBase64;
+      imageElement.className = CLASS_DC_CHART_EXIST;
       this.svgContainerElement.current.append(imageElement);
       this.setState({ chartDownloadXml });
     }
@@ -360,7 +363,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
         <ModalBody>
           <div
             ref={this.svgContainerElement}
-            className="modal-chart-container"
+            className={`modal-chart-container ${CLASS_DC_CHART_HOLDER}`}
           ></div>
           <textarea
             className="copy-svg mt-3"

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 
 import { wrap } from "../chart/base";
+import { CLASS_DC_CHART_EXIST } from "../constants/css_constants";
 import { intl } from "../i18n/i18n";
 import { randDomId, saveToFile, urlToDomain } from "../shared/util";
 
@@ -126,7 +127,6 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
     const svg = d3
       .select(container)
       .append("svg")
-      .attr("class", "dc-chart-exist")
       .attr("xmlns", SVGNS)
       .attr("xmlns:xlink", XLINKNS)
       .attr("width", chartWidth);
@@ -192,6 +192,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
         sourcesHeight +
         SOURCES_MARGIN
     );
+    svg.attr("class", CLASS_DC_CHART_EXIST);
 
     const s = new XMLSerializer();
     const svgXml = s.serializeToString(svg.node());
@@ -213,7 +214,6 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
     const svg = d3
       .select(container)
       .append("svg")
-      .attr("class", "dc-chart-exist")
       .attr("xmlns", SVGNS)
       .attr("xmlns:xlink", XLINKNS)
       .attr("width", chartWidth);
@@ -274,7 +274,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
         sourcesHeight +
         SOURCES_MARGIN
     );
-
+    svg.attr("class", CLASS_DC_CHART_EXIST);
     const s = new XMLSerializer();
     const svgXml = s.serializeToString(svg.node());
     container.innerHTML = "";

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -275,7 +275,6 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
         sourcesHeight +
         SOURCES_MARGIN
     );
-    svg.attr("class", CLASS_DC_CHART_EXIST);
     const s = new XMLSerializer();
     const svgXml = s.serializeToString(svg.node());
     container.innerHTML = "";

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -126,6 +126,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
     const svg = d3
       .select(container)
       .append("svg")
+      .attr("class", "dc-chart-exist")
       .attr("xmlns", SVGNS)
       .attr("xmlns:xlink", XLINKNS)
       .attr("width", chartWidth);
@@ -212,6 +213,7 @@ class ChartEmbed extends React.Component<unknown, ChartEmbedStateType> {
     const svg = d3
       .select(container)
       .append("svg")
+      .attr("class", "dc-chart-exist")
       .attr("xmlns", SVGNS)
       .attr("xmlns:xlink", XLINKNS)
       .attr("width", chartWidth);

--- a/static/js/place/main_pane.tsx
+++ b/static/js/place/main_pane.tsx
@@ -77,7 +77,7 @@ class MainPane extends React.Component<MainPanePropType> {
     super(props);
   }
 
-  showOverview(): boolean {
+  private showOverview(): boolean {
     // Only Show map and ranking for US places.
     return (
       this.props.isUsaPlace &&
@@ -89,7 +89,7 @@ class MainPane extends React.Component<MainPanePropType> {
   renderChartBlock(data: ChartBlockData, category: string): JSX.Element {
     return (
       <ChartBlock
-        key={data.title + randDomId()}
+        key={data.title + "-" + randDomId()}
         dcid={this.props.dcid}
         placeName={this.props.placeName}
         placeType={this.props.placeType}

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -64,7 +64,7 @@ class RankingHistogram extends React.Component<
         key={this.id}
         id={this.id}
         ref={this.chartElementRef}
-        className="chart-container"
+        className="chart-container dc-chart-holder"
       ></div>
     );
   }

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -18,6 +18,7 @@ import React from "react";
 
 import { DataPoint } from "../chart/base";
 import { drawHistogram } from "../chart/draw";
+import { CLASS_DC_CHART_HOLDER } from "../constants/css_constants";
 import { formatNumber } from "../i18n/i18n";
 import { randDomId } from "../shared/util";
 import { RankInfo, Ranking } from "./ranking_types";
@@ -64,7 +65,7 @@ class RankingHistogram extends React.Component<
         key={this.id}
         id={this.id}
         ref={this.chartElementRef}
-        className="chart-container dc-chart-holder"
+        className={"chart-container " + CLASS_DC_CHART_HOLDER}
       ></div>
     );
   }

--- a/static/js/ranking/ranking_histogram.tsx
+++ b/static/js/ranking/ranking_histogram.tsx
@@ -65,7 +65,7 @@ class RankingHistogram extends React.Component<
         key={this.id}
         id={this.id}
         ref={this.chartElementRef}
-        className={"chart-container " + CLASS_DC_CHART_HOLDER}
+        className={`chart-container  ${CLASS_DC_CHART_HOLDER}`}
       ></div>
     );
   }

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -63,7 +63,6 @@ interface ChartProps {
 
 export const MAP_CONTAINER_ID = "choropleth-map";
 export const LEGEND_CONTAINER_ID = "choropleth-legend";
-export const CHART_CONTAINER_ID = "chart-container";
 const DATE_RANGE_INFO_ID = "date-range-info";
 const DATE_RANGE_INFO_TEXT_ID = "date-range-tooltip-text";
 export const SECTION_CONTAINER_ID = "map-chart";
@@ -98,7 +97,7 @@ export function Chart(props: ChartProps): JSX.Element {
           <div id="map-chart-screen" className="screen">
             <div id="spinner"></div>
           </div>
-          <div className="chart-section">
+          <div className="chart-section dc-chart-holder">
             <div className="map-title">
               <h3>
                 {title}

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -23,6 +23,7 @@ import React, { ReactNode, useContext, useEffect } from "react";
 import { Card, Container, FormGroup, Input, Label } from "reactstrap";
 
 import { GeoJsonData, MapPoint } from "../../chart/types";
+import { CLASS_DC_CHART_HOLDER } from "../../constants/css_constants";
 import { FacetSelectorFacetInfo } from "../../shared/facet_selector";
 import {
   GA_EVENT_TOOL_CHART_PLOT,
@@ -97,7 +98,7 @@ export function Chart(props: ChartProps): JSX.Element {
           <div id="map-chart-screen" className="screen">
             <div id="spinner"></div>
           </div>
-          <div className="chart-section dc-chart-holder">
+          <div className={"chart-section " + CLASS_DC_CHART_HOLDER}>
             <div className="map-title">
               <h3>
                 {title}

--- a/static/js/tools/map/chart.tsx
+++ b/static/js/tools/map/chart.tsx
@@ -98,7 +98,7 @@ export function Chart(props: ChartProps): JSX.Element {
           <div id="map-chart-screen" className="screen">
             <div id="spinner"></div>
           </div>
-          <div className={"chart-section " + CLASS_DC_CHART_HOLDER}>
+          <div className={`chart-section ${CLASS_DC_CHART_HOLDER}`}>
             <div className="map-title">
               <h3>
                 {title}

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -33,6 +33,7 @@ import {
   ScatterPlotProperties,
 } from "../../chart/draw_scatter";
 import { GeoJsonData, GeoJsonFeatureProperties } from "../../chart/types";
+import { CLASS_DC_CHART_HOLDER } from "../../constants/css_constants";
 import { USA_PLACE_DCID } from "../../shared/constants";
 import { FacetSelectorFacetInfo } from "../../shared/facet_selector";
 import {
@@ -169,7 +170,7 @@ export function Chart(props: ChartPropsType): JSX.Element {
           <span>vs</span>
           <h3>{xTitle}</h3>
         </div>
-        <div className="scatter-chart-container dc-chart-holder">
+        <div className={"scatter-chart-container " + CLASS_DC_CHART_HOLDER}>
           <div id={SVG_CONTAINER_ID} ref={svgContainerRef}></div>
           <div id={MAP_LEGEND_CONTAINER_ID} ref={mapLegendRef}></div>
           <div id="scatter-tooltip" ref={tooltipRef} />

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -170,7 +170,7 @@ export function Chart(props: ChartPropsType): JSX.Element {
           <span>vs</span>
           <h3>{xTitle}</h3>
         </div>
-        <div className={"scatter-chart-container " + CLASS_DC_CHART_HOLDER}>
+        <div className={`scatter-chart-container ${CLASS_DC_CHART_HOLDER}`}>
           <div id={SVG_CONTAINER_ID} ref={svgContainerRef}></div>
           <div id={MAP_LEGEND_CONTAINER_ID} ref={mapLegendRef}></div>
           <div id="scatter-tooltip" ref={tooltipRef} />

--- a/static/js/tools/scatter/chart.tsx
+++ b/static/js/tools/scatter/chart.tsx
@@ -169,7 +169,7 @@ export function Chart(props: ChartPropsType): JSX.Element {
           <span>vs</span>
           <h3>{xTitle}</h3>
         </div>
-        <div className="scatter-chart-container">
+        <div className="scatter-chart-container dc-chart-holder">
           <div id={SVG_CONTAINER_ID} ref={svgContainerRef}></div>
           <div id={MAP_LEGEND_CONTAINER_ID} ref={mapLegendRef}></div>
           <div id="scatter-tooltip" ref={tooltipRef} />

--- a/static/js/tools/timeline/__snapshots__/page.test.tsx.snap
+++ b/static/js/tools/timeline/__snapshots__/page.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Single place and single stat var 1`] = `
-"<div class=\\"chart-container\\">
+"<div class=\\"chart-container dc-chart-holder\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
       <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\">Age</span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>
@@ -21,7 +21,7 @@ exports[`Single place and single stat var 1`] = `
 `;
 
 exports[`Single place and single stat var 2`] = `
-"<div class=\\"chart-container\\">
+"<div class=\\"chart-container dc-chart-holder\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
       <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\">Population</span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>
@@ -38,7 +38,7 @@ exports[`Single place and single stat var 2`] = `
   <div class=\\"chart-footer-options-section\\"><span class=\\"chart-option\\"><div class=\\"form-check\\"><label class=\\"form-check-label\\"><input id=\\"count-ratio\\" type=\\"checkbox\\" class=\\"form-check-input\\">Per Capita</label></div></span><span class=\\"chart-option\\"><div class=\\"form-check\\"><label class=\\"form-check-label\\"><input id=\\"delta-cb-count\\" type=\\"checkbox\\" class=\\"is-delta-input form-check-input\\">Delta</label></div></span><button type=\\"button\\" class=\\"source-selector-open-modal-button btn btn-light btn-sm\\">Edit Source</button></div>
   <div class=\\"feedback-link\\"><a href=\\"/feedback\\">Feedback</a></div>
 </div>
-<div class=\\"chart-container\\">
+<div class=\\"chart-container dc-chart-holder\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
       <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\">Age</span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>
@@ -58,7 +58,7 @@ exports[`Single place and single stat var 2`] = `
 `;
 
 exports[`Single place and single stat var 3`] = `
-"<div class=\\"chart-container\\">
+"<div class=\\"chart-container dc-chart-holder\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
       <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\">Population</span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>
@@ -116,7 +116,7 @@ exports[`Single place and single stat var 4`] = `
 `;
 
 exports[`chart options 1`] = `
-"<div class=\\"chart-container\\">
+"<div class=\\"chart-container dc-chart-holder\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
       <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\">Population</span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>
@@ -136,7 +136,7 @@ exports[`chart options 1`] = `
 `;
 
 exports[`statVar not in PV-tree 1`] = `
-"<div class=\\"chart-container\\">
+"<div class=\\"chart-container dc-chart-holder\\">
   <div class=\\"card\\">
     <div class=\\"statVarChipRegion\\">
       <div class=\\"chip\\"><span class=\\"chip-text chip-clickable-text\\"></span><button class=\\"chip-action\\"><i class=\\"material-icons\\">cancel</i></button></div>

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -117,7 +117,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
         sv in this.props.svFacetId ? this.props.svFacetId[sv] : "";
     }
     return (
-      <div className={"chart-container " + CLASS_DC_CHART_HOLDER}>
+      <div className={`chart-container ${CLASS_DC_CHART_HOLDER}`}>
         <div className="card">
           <div className="statVarChipRegion">
             {statVars.map((statVar) => {

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -116,7 +116,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
         sv in this.props.svFacetId ? this.props.svFacetId[sv] : "";
     }
     return (
-      <div className="chart-container">
+      <div className="chart-container dc-chart-holder">
         <div className="card">
           <div className="statVarChipRegion">
             {statVars.map((statVar) => {

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -19,6 +19,7 @@ import { FormGroup, Input, Label } from "reactstrap";
 
 import { computePlotParams, PlotParams } from "../../chart/base";
 import { drawGroupLineChart } from "../../chart/draw";
+import { CLASS_DC_CHART_HOLDER } from "../../constants/css_constants";
 import { formatNumber } from "../../i18n/i18n";
 import { Chip } from "../../shared/chip";
 import { FacetSelectorFacetInfo } from "../../shared/facet_selector";
@@ -116,7 +117,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
         sv in this.props.svFacetId ? this.props.svFacetId[sv] : "";
     }
     return (
-      <div className="chart-container dc-chart-holder">
+      <div className={"chart-container " + CLASS_DC_CHART_HOLDER}>
         <div className="card">
           <div className="statVarChipRegion">
             {statVars.map((statVar) => {


### PR DESCRIPTION
A lot of charts, widgets are fetched async by using react effect and state. For example on place page, there are tens of charts that show up at different times. This makes screenshot unstable.

This PR adds a framework to wait for all the charts/widgets loading before taking a screenshot. The idea is simple, add a class for the holder element that are initially rendered and add a class for the chart/widget element that are updated asynchronously. The tests first gather all the holder elements and check when each holder element has the desired element present.

We should use in other web driver tests as well.