### PR TITLE
[topic page] fix bug

### DIFF
--- a/server/routes/topic_page/html.py
+++ b/server/routes/topic_page/html.py
@@ -143,5 +143,5 @@ def topic_page(topic_id=None, place_dcid=None):
       more_places=json.dumps(more_places),
       topic_id=topic_id,
       topic_name=topic_place_config.metadata.topic_name or "",
-      config=MessageToJson(topic_place_config),
+      page_config=MessageToJson(topic_place_config),
       topics_summary=topics_summary)

--- a/server/templates/topic_page.html
+++ b/server/templates/topic_page.html
@@ -35,7 +35,7 @@
   <div id="place-name" data-pn="{{ place_name }}"></div>
   <div id="place-type" data-pt="{{ place_type }}"></div>
   <div id="locale" data-lc="{{ locale }}"></div>
-  <div id="topic-config" data-config="{{ config }}" data-topics-summary=" {{ topics_summary }}"></div>
+  <div id="topic-config" data-config="{{ page_config }}" data-topics-summary=" {{ topics_summary }}"></div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
- base.html uses "config" assuming it is the app config, but topic page was passing in the page config as "config" causing the page to fail to load: https://autopush.datacommons.org/topic/poverty/country/USA