### PR TITLE
PaLM API: support 7 additional classification types

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -355,6 +355,7 @@ def create_app():
 
     # Get the API key from environment first.
     if cfg.USE_PALM:
+      app.config['PALM_PROMPT_TEXT'] = libutil.get_llm_prompt_text()
       if os.environ.get('PALM_API_KEY'):
         app.config['PALM_API_KEY'] = os.environ.get('PALM_API_KEY')
       else:

--- a/server/app_env/autopush.py
+++ b/server/app_env/autopush.py
@@ -21,3 +21,4 @@ class Config(_base.Config):
   LOG_QUERY = True
   SHOW_TOPIC = True
   SHOW_SUSTAINABILITY = True
+  USE_PALM = True

--- a/server/config/nl_page/palm_prompt.txt
+++ b/server/config/nl_page/palm_prompt.txt
@@ -1,0 +1,227 @@
+You are going to be a super helpful assistant that will convert an english sentence to a JSON object.
+
+The generated JSON object must conform to the following JSON Schema:
+
+{
+  "type": "object",
+  "properties": {
+    "PLACES": {
+      "type": "array",
+      "description": "Set to a list of substrings in the sentence that are places.  This must only have words found in the original sentence.",
+      "items": { "type": "string" }
+    },
+    "METRICS": {
+      "type": "array",
+      "description": "Set to a list of substrings in the sentence that are metrics.",
+      "items": { "type": "string" }
+    },
+    "DISASTER_EVENT": {
+      "type": "string",
+      "description": "Set if the sentence refers to a type of natural hazard like cyclones, earthquakes, floods, etc.",
+      "enum":  [ "FIRE", "DROUGHT", "FLOOD", "CYCLONE", "EARTHQUAKE", "EXTREME_HEAT", "EXTREME_COLD", "HIGH_WETBULB_TEMPERATURE" ]
+    },
+    "RANK": {
+      "type": "string",
+      "description": "Set to HIGH, if the sentence includes has a superlative like most, highest, greatest, etc. Set to LOW, if sentence includes has superlatives like lowest, least, smallest, etc.",
+      "enum":  [ "HIGH", "LOW" ]
+    },
+    "SUB_PLACE_TYPE": {
+      "type": "string",
+      "description": "Set to the specific place type mentioned in the sentence.",
+      "enum": ["CITY", "COUNTY", "PROVINCE", "DISTRICT", "STATE", "COUNTRY", "HIGH_SCHOOL", "MIDDLE_SCHOOL", "ELEMENTARY_SCHOOL", "PUBLIC_SCHOOL"]
+    },
+    "COMPARE": {
+      "type": "string",
+      "description": "Set to COMPARE_PLACES if the sentence asks to compare multiple PLACES. Set to COMPARE_METRICS if the sentence asks to compare multiple METRICS.",
+      "enum":  [ "COMPARE_PLACES", "COMPARE_METRICS" ]
+    },
+    "GROWTH": {
+      "type": "string",
+      "description": "Set to growth direction, INCREASE or DECREASE, if the sentence asks about growth of METRICS.",
+      "enum":  [ "INCREASE", "DECREASE" ]
+    },
+    "SIZE": {
+      "type": "string",
+      "description": "Set to BIG or SMALL, if the sentence asks about the size of PLACES.",
+      "enum": [ "BIG", "SMALL" ]
+    },
+    "COMPARISON_FILTER": {
+      "type": "array",
+      "description": "Represents the conditions used to filter places. Only `and` is supported as a logical operator.",
+      "items": {
+        "type": "object",
+        "description": "Represents a condition made up of a COMPARISON_METRIC, COMPARISON_OPERATOR and VALUE.",
+        "properties": {
+          "COMPARISON_METRIC": {
+            "type": "string",
+            "description": "The metric to filter on"
+          },
+          "COMPARISON_OPERATOR": {
+            "type": "string",
+            "description": "Used to compare the COMPARISON_METRIC against the VALUE.",
+            "enum": [ "EQUAL", "GREATER_THAN", "LESSER_THAN", "GREATER_THAN_OR_EQUAL", "LESSER_THAN_OR_EQUAL" ]
+          },
+          "VALUE": {
+            "type": "number",
+            "description": "Numeric value"
+          }
+        }
+      }
+    },
+    "RANKING_FILTER": {
+      "type": "array",
+      "description": "Represents conditions that select the lowest or highest values of the RANKING_METRIC, like `where the hispanic population is lowest`.",
+      "items": {
+        "type": "object",
+        "description": "Represents a single condition which is made up of a RANKING_METRIC and RANKING_OPERATOR.",
+        "properties": {
+          "RANKING_METRIC": {
+            "type": "string",
+            "description": "The metric to filter on"
+          },
+          "RANKING_OPERATOR": {
+            "type": "string",
+            "enum": ["IS_HIGHEST", "IS_LOWEST"]
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+}
+
+Here are some examples:
+
+Input Sentences: "Tell me more about San Jose"
+Output JSON:
+```
+{
+  "PLACES": ["San Jose"]
+}
+```
+
+Input Sentences: "States of USA"
+Output JSON:
+```
+{
+  "PLACES": ["USA"],
+  "SUB_PLACE_TYPE": "STATE"
+}
+```
+
+Input Sentences: "Most common diseases in San Jose"
+Output JSON:
+```
+{
+  "PLACES": ["San Jose"],
+  "METRICS": ["diseases"],
+  "RANK": "HIGH"
+}
+```
+
+Input Sentence: "Counties in California with the fewest number of poor people"
+Output JSON:
+```
+{
+  "PLACES": ["california"],
+  "METRICS": ["poor people"],
+  "RANK": "LOW",
+  "SUB_PLACE_TYPE": "COUNTY"
+}
+```
+
+Input Sentence: "Compare obesity vs. blood pressure across US cities"
+Output JSON:
+```
+{
+  "PLACES": ["the US"],
+  "METRICS": ["obesity", "blood pressure"],
+  "SUB_PLACE_TYPE": "CITY",
+  "COMPARE": "COMPARE_METRICS"
+}
+```
+
+Input Sentence: "Give me info on prevalence of asthma, gender inequality and per capita hispanic population in nevada, california and north dakota"
+Output JSON:
+```
+{
+  "PLACES":  ["nevada", "california", "north dakota"],
+  "METRICS": ["prevalence of asthma", "gender inequality", "per capita"],
+  "COMPARE": "COMPARE_PLACES"
+}
+```
+
+Input Sentence: "Countries of the world where poverty has increased the least?"
+Output JSON:
+```
+{
+  "PLACES":  ["world"],
+  "METRICS": ["poverty"],
+  "GROWTH": "INCREASE",
+  "RANK": "LOW",
+  "SUB_PLACE_TYPE": "COUNTRY"
+}
+```
+
+Input Sentence: "how big are cities in california?"
+Output JSON:
+```
+{
+  "PLACES":  ["california"],
+  "METRICS": ["size"],
+  "SIZE": "BIG",
+  "SUB_PLACE_TYPE": "CITY"
+}
+```
+
+Input Sentence: "prevalence of asthma vs. temperature rise in US cities where median age is over 30 and income is under $100K."
+Output JSON:
+```
+{
+  "PLACES": ["US"],
+  "METRICS": ["prevalence of asthma", "temperature rise"],
+  "SUB_PLACE_TYPE": "CITY",
+  "COMPARE": "COMPARE_METRICS",
+  "COMPARISON_FILTER": [
+    {
+      "COMPARISON_METRIC": "median age",
+      "COMPARISON_OPERATOR": "GREATER_THAN",
+      "VALUE": 30
+    },
+    {
+      "COMPARISON_METRIC": "income",
+      "COMPARISON_OPERATOR": "LESSER_THAN",
+      "VALUE": 100000
+    }
+  ]
+}
+```
+
+Input Sentence: "Blood pressure prevalence in US cities with highest income levels"
+Output JSON:
+```
+{
+  "PLACES": ["US"],
+  "METRICS": ["blood pressure prevalence"],
+  "SUB_PLACE_TYPE": "CITY",
+  "RANK": "HIGH",
+  "RANKING_FILTER": [
+    {
+      "RANKING_METRIC": "income levels",
+      "RANKING_OPERATOR": "IS_HIGHEST"
+    }
+  ]
+}
+```
+
+Input Sentence: "What are some of the biggest floods in the US?"
+Output JSON:
+```
+{
+  "PLACES": ["US"],
+  "RANK": "HIGH",
+  "DISASTER_EVENT": "FLOOD"
+}
+```
+
+Do not make up new JSON properties outside of the JSON Schema.

--- a/server/lib/nl/common/utterance.py
+++ b/server/lib/nl/common/utterance.py
@@ -33,6 +33,8 @@ from server.lib.nl.detection.types import Place
 from server.lib.nl.detection.types import RankingClassificationAttributes
 from server.lib.nl.detection.types import RankingType
 from server.lib.nl.detection.types import SimpleClassificationAttributes
+from server.lib.nl.detection.types import SizeType
+from server.lib.nl.detection.types import SizeTypeClassificationAttributes
 from server.lib.nl.detection.types import TimeDeltaClassificationAttributes
 from server.lib.nl.detection.types import TimeDeltaType
 from shared.lib.detected_variables import MultiVarCandidates
@@ -169,7 +171,7 @@ def _dict_to_place(places_dict: List[Dict]) -> List[Place]:
   return places
 
 
-def _classification_to_dict(classifications: List[NLClassifier]) -> List[Dict]:
+def classification_to_dict(classifications: List[NLClassifier]) -> List[Dict]:
   classifications_dict = []
   for c in classifications:
     cdict = {}
@@ -188,12 +190,14 @@ def _classification_to_dict(classifications: List[NLClassifier]) -> List[Dict]:
       cdict['ranking_type'] = c.attributes.ranking_type
     elif isinstance(c.attributes, TimeDeltaClassificationAttributes):
       cdict['time_delta_type'] = c.attributes.time_delta_types
+    elif isinstance(c.attributes, SizeTypeClassificationAttributes):
+      cdict['size_type'] = c.attributes.size_types
 
     classifications_dict.append(cdict)
   return classifications_dict
 
 
-def _dict_to_classification(
+def dict_to_classification(
     classifications_dict: List[Dict]) -> List[NLClassifier]:
   classifications = []
   for cdict in classifications_dict:
@@ -214,6 +218,10 @@ def _dict_to_classification(
       attributes = TimeDeltaClassificationAttributes(
           time_delta_types=[TimeDeltaType(t) for t in cdict['time_delta_type']],
           time_delta_trigger_words=[])
+    elif 'size_type' in cdict:
+      attributes = SizeTypeClassificationAttributes(
+          size_types=[SizeType(t) for t in cdict['size_type']],
+          size_types_trigger_words=[])
     classifications.append(
         NLClassifier(type=ClassificationType(cdict['type']),
                      attributes=attributes))
@@ -258,7 +266,7 @@ def save_utterance(uttr: Utterance) -> List[Dict]:
     udict['query_type'] = u.query_type
     udict['svs'] = u.svs
     udict['places'] = _place_to_dict(u.places)
-    udict['classifications'] = _classification_to_dict(u.classifications)
+    udict['classifications'] = classification_to_dict(u.classifications)
     udict['ranked_charts'] = _chart_spec_to_dict(u.rankedCharts)
     udict['session_id'] = u.session_id
     udict['llm_resp'] = u.llm_resp
@@ -284,7 +292,7 @@ def load_utterance(uttr_dicts: List[Dict]) -> Utterance:
                      query_type=QueryType(udict['query_type']),
                      svs=udict['svs'],
                      places=_dict_to_place(udict['places']),
-                     classifications=_dict_to_classification(
+                     classifications=dict_to_classification(
                          udict['classifications']),
                      rankedCharts=_dict_to_chart_spec(udict['ranked_charts']),
                      detection=None,

--- a/server/lib/nl/detection/heuristic_detector.py
+++ b/server/lib/nl/detection/heuristic_detector.py
@@ -31,7 +31,7 @@ from server.lib.nl.detection.types import SVDetection
 
 
 def _empty_svs_score_dict():
-  return {"SV": [], "CosineScore": [], "SV_to_Sentences": {}}
+  return {"SV": [], "CosineScore": [], "SV_to_Sentences": {}, "MultiSV": {}}
 
 
 def detect(orig_query: str, cleaned_query: str, index_type: str,

--- a/server/lib/nl/detection/palm_api.py
+++ b/server/lib/nl/detection/palm_api.py
@@ -26,237 +26,6 @@ from server.lib.nl.common import counters
 _API_URL_BASE = f"https://generativelanguage.googleapis.com/v1beta2/models/chat-bison-001:generateMessage"
 _API_HEADER = {'content-type': 'application/json'}
 
-# TODO: Move this to a text file.
-_PROMPT_CONTEXT_ORIG = \
-("""You are going to be a super helpful assistant that will convert an english sentence to a JSON object.
-
-The generated JSON object must conform to the following JSON Schema:
-
-{
-  "type": "object",
-  "properties": {
-    "PLACES": {
-      "type": "array",
-      "description": "Set to a list of substrings in the sentence that are places.  This must only have words found in the original sentence.",
-      "items": { "type": "string" }
-    },
-    "METRICS": {
-      "type": "array",
-      "description": "Set to a list of substrings in the sentence that are metrics.",
-      "items": { "type": "string" }
-    },
-    "DISASTER_EVENT": {
-      "type": "string",
-      "description": "Set if the sentence refers to a type of natural hazard like cyclones, earthquakes, floods, etc.",
-      "enum":  [ "FIRE", "DROUGHT", "FLOOD", "CYCLONE", "EARTHQUAKE", "EXTREME_HEAT", "EXTREME_COLD", "HIGH_WETBULB_TEMPERATURE" ]
-    },
-    "RANK": {
-      "type": "string",
-      "description": "Set to HIGH, if the sentence includes has a superlative like most, highest, greatest, etc. Set to LOW, if sentence includes has superlatives like lowest, least, smallest, etc.",
-      "enum":  [ "HIGH", "LOW" ]
-    },
-    "SUB_PLACE_TYPE": {
-      "type": "string",
-      "description": "Set to the specific place type mentioned in the sentence.",
-      "enum": ["CITY", "COUNTY", "PROVINCE", "DISTRICT", "STATE", "COUNTRY", "HIGH_SCHOOL", "MIDDLE_SCHOOL", "ELEMENTARY_SCHOOL", "PUBLIC_SCHOOL"]
-    },
-    "COMPARE": {
-      "type": "string",
-      "description": "Set to COMPARE_PLACES if the sentence asks to compare multiple PLACES. Set to COMPARE_METRICS if the sentence asks to compare multiple METRICS.",
-      "enum":  [ "COMPARE_PLACES", "COMPARE_METRICS" ]
-    },
-    "GROWTH": {
-      "type": "string",
-      "description": "Set to growth direction, INCREASE or DECREASE, if the sentence asks about growth of METRICS.",
-      "enum":  [ "INCREASE", "DECREASE" ]
-    },
-    "SIZE": {
-      "type": "string",
-      "description": "Set to BIG or SMALL, if the sentence asks about the size of PLACES.",
-      "enum": [ "BIG", "SMALL" ]
-    },
-    "COMPARISON_FILTER": {
-      "type": "array",
-      "description": "Represents the conditions used to filter places. Only `and` is supported as a logical operator.",
-      "items": {
-        "type": "object",
-        "description": "Represents a condition made up of a COMPARISON_METRIC, COMPARISON_OPERATOR and VALUE.",
-        "properties": {
-          "COMPARISON_METRIC": {
-            "type": "string",
-            "description": "The metric to filter on"
-          },
-          "COMPARISON_OPERATOR": {
-            "type": "string",
-            "description": "Used to compare the COMPARISON_METRIC against the VALUE.",
-            "enum": [ "EQUAL", "GREATER_THAN", "LESSER_THAN", "GREATER_THAN_OR_EQUAL", "LESSER_THAN_OR_EQUAL" ]
-          },
-          "VALUE": {
-            "type": "number",
-            "description": "Numeric value"
-          }
-        }
-      }
-    },
-    "RANKING_FILTER": {
-      "type": "array",
-      "description": "Represents conditions that select the lowest or highest values of the RANKING_METRIC, like `where the hispanic population is lowest`.",
-      "items": {
-        "type": "object",
-        "description": "Represents a single condition which is made up of a RANKING_METRIC and RANKING_OPERATOR.",
-        "properties": {
-          "RANKING_METRIC": {
-            "type": "string",
-            "description": "The metric to filter on"
-          },
-          "RANKING_OPERATOR": {
-            "type": "string",
-            "enum": ["IS_HIGHEST", "IS_LOWEST"]
-          }
-        }
-      }
-    }
-  },
-  "additionalProperties": false,
-}
-
-Here are some examples:
-
-Input Sentences: "Tell me more about San Jose"
-Output JSON:
-```
-{
-  "PLACES": ["San Jose"]
-}
-```
-
-Input Sentences: "States of USA"
-Output JSON:
-```
-{
-  "PLACES": ["USA"],
-  "SUB_PLACE_TYPE": "STATE"
-}
-```
-
-Input Sentences: "Most common diseases in San Jose"
-Output JSON:
-```
-{
-  "PLACES": ["San Jose"],
-  "METRICS": ["diseases"],
-  "RANK": "HIGH"
-}
-```
-
-Input Sentence: "Counties in California with the fewest number of poor people"
-Output JSON:
-```
-{
-  "PLACES": ["california"],
-  "METRICS": ["poor people"],
-  "RANK": "LOW",
-  "SUB_PLACE_TYPE": "COUNTY"
-}
-```
-
-Input Sentence: "Compare obesity vs. blood pressure across US cities"
-Output JSON:
-```
-{
-  "PLACES": ["the US"],
-  "METRICS": ["obesity", "blood pressure"],
-  "SUB_PLACE_TYPE": "CITY",
-  "COMPARE": "COMPARE_METRICS"
-}
-```
-
-Input Sentence: "Give me info on prevalence of asthma, gender inequality and per capita hispanic population in nevada, california and north dakota"
-Output JSON:
-```
-{
-  "PLACES":  ["nevada", "california", "north dakota"],
-  "METRICS": ["prevalence of asthma", "gender inequality", "per capita"],
-  "COMPARE": "COMPARE_PLACES"
-}
-```
-
-Input Sentence: "Countries of the world where poverty has increased the least?"
-Output JSON:
-```
-{
-  "PLACES":  ["world"],
-  "METRICS": ["poverty"],
-  "GROWTH": "INCREASE",
-  "RANK": "LOW",
-  "SUB_PLACE_TYPE": "COUNTRY"
-}
-```
-
-Input Sentence: "how big are cities in california?"
-Output JSON:
-```
-{
-  "PLACES":  ["california"],
-  "METRICS": ["size"],
-  "SIZE": "BIG",
-  "SUB_PLACE_TYPE": "CITY"
-}
-```
-
-Input Sentence: "prevalence of asthma vs. temperature rise in US cities where median age is over 30 and income is under $100K."
-Output JSON:
-```
-{
-  "PLACES": ["US"],
-  "METRICS": ["prevalence of asthma", "temperature rise"],
-  "SUB_PLACE_TYPE": "CITY",
-  "COMPARE": "COMPARE_METRICS",
-  "COMPARISON_FILTER": [
-    {
-      "COMPARISON_METRIC": "median age",
-      "COMPARISON_OPERATOR": "GREATER_THAN",
-      "VALUE": 30
-    },
-    {
-      "COMPARISON_METRIC": "income",
-      "COMPARISON_OPERATOR": "LESSER_THAN",
-      "VALUE": 100000
-    }
-  ]
-}
-```
-
-Input Sentence: "Blood pressure prevalence in US cities with highest income levels"
-Output JSON:
-```
-{
-  "PLACES": ["US"],
-  "METRICS": ["blood pressure prevalence"],
-  "SUB_PLACE_TYPE": "CITY",
-  "RANK": "HIGH",
-  "RANKING_FILTER": [
-    {
-      "RANKING_METRIC": "income levels",
-      "RANKING_OPERATOR": "IS_HIGHEST"
-    }
-  ]
-}
-```
-
-Input Sentence: "What are some of the biggest floods in the US?"
-Output JSON:
-```
-{
-  "PLACES": ["US"],
-  "RANK": "HIGH",
-  "DISASTER_EVENT": "FLOOD"
-}
-```
-
-Do not make up new JSON properties outside of the JSON Schema.
-""")
-
 _SUFFIX = '\n\nIn your response, include just the JSON adhering to the above schema. Do not add JSON keys outside the schema.  Also, explain why you set specific enum values.'
 
 # TODO: Consider tweaking this. And maybe consider passing as url param.
@@ -266,7 +35,6 @@ _CANDIDATE_COUNT = 1
 
 _REQ_DATA = {
     'prompt': {
-        'context': _PROMPT_CONTEXT_ORIG,
         'messages': {},
         'examples': [],
     },
@@ -280,6 +48,7 @@ _SKIP_BEGIN_CHARS = ['`', '*']
 def call(query: str, history: str, ctr: counters.Counters) -> str:
   req_data = _REQ_DATA.copy()
 
+  req_data['prompt']['context'] = current_app.config['PALM_PROMPT_TEXT']
   if not history:
     # For the first query in the session.
     q = 'Convert this sentence to JSON: "' + query + '"'
@@ -316,6 +85,7 @@ def _parse_response(query: str, resp: Dict, ctr: counters.Counters) -> Dict:
     content = resp['candidates'][0]['content']
     ans = _extract_ans(content)
     if not ans:
+      logging.error(f'ERROR: empty parsed result for {query}')
       ctr.err('failed_palm_api_emptyparsedresult', content)
       return {}
 

--- a/server/lib/util.py
+++ b/server/lib/util.py
@@ -141,6 +141,15 @@ def get_disaster_event_config():
   return get_subject_page_config(filepath)
 
 
+# Returns LLM prompt text
+def get_llm_prompt_text():
+  filepath = os.path.join(get_repo_root(), "config", "nl_page",
+                          "palm_prompt.txt")
+  with open(filepath, 'r') as f:
+    data = f.read()
+  return data
+
+
 # Returns disaster sustainability config loaded as SubjectPageConfig protos
 def get_disaster_sustainability_config():
   filepath = os.path.join(get_repo_root(), "config", "subject_page",


### PR DESCRIPTION
This is a straightforward PR that maps json enums from LLM to Classification enums.

Now LLM supports queries like:

* commute in california vs. nevada (COMPARISON)
* what are some bad USA counties for asthma (RANK, SUB_PLACE_TYPE)
* fires in california (DISASTER_EVENT)
* poverty vs. income in california cities (CORRELATION, SUB_PLACE_TYPE)
* countries where gdp has grown the most (GROWTH, SUB_PLACE_TYPE, RANK)
* how big is nevada (SIZE)
