### PR TITLE
[Library] Update map web component properties

### DIFF
--- a/experimental/datacommons-js/example.html
+++ b/experimental/datacommons-js/example.html
@@ -22,8 +22,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/js/bootstrap.min.js"></script>
-    <!-- <script src="https://autopush.datacommons.org/datacommons.js"></script> -->
-    <script src="http://localhost:8080/datacommons.js"></script>
+    <script src="https://autopush.datacommons.org/datacommons.js"></script>
     <style>
       .my-chart {
         height: auto;

--- a/experimental/datacommons-js/example.html
+++ b/experimental/datacommons-js/example.html
@@ -22,7 +22,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/js/bootstrap.min.js"></script>
-    <script src="https://autopush.datacommons.org/datacommons.js"></script>
+    <!-- <script src="https://autopush.datacommons.org/datacommons.js"></script> -->
+    <script src="http://localhost:8080/datacommons.js"></script>
     <style>
       .my-chart {
         height: auto;
@@ -125,8 +126,7 @@
         title="Population Below Poverty Level Status in Past Year in States of United States (2020)"
         placeDcid="country/USA"
         enclosedPlaceType="State"
-        statVarName="Population Below Poverty Level Status in Past Year"
-        statVarDcid="Count_Person_BelowPovertyLevelInThePast12Months"
+        variableDcid="Count_Person_BelowPovertyLevelInThePast12Months"
       ></datacommons-map>
       <!-- Map chart-->
       <h2 class="mt-4 mb-4">JS Map Chart</h2>

--- a/static/library/map_component.ts
+++ b/static/library/map_component.ts
@@ -34,8 +34,7 @@ import { DEFAULT_API_ENDPOINT } from "./constants";
  *      title="Population Below Poverty Level Status in Past Year in States of United States (2020)"
  *      placeDcid="country/USA"
  *      enclosedPlaceType="State"
- *      statVarName="Population Below Poverty Level Status in Past Year"
- *      statVarDcid="Count_Person_BelowPovertyLevelInThePast12Months"
+ *      variableDcid="Count_Person_BelowPovertyLevelInThePast12Months"
  *    ></datacommons-map>
  */
 @customElement("datacommons-map")
@@ -55,10 +54,7 @@ export class DatacommonsMapComponent extends LitElement {
   enclosedPlaceType!: string;
 
   @property()
-  statVarName!: string;
-
-  @property()
-  statVarDcid!: string;
+  variableDcid!: string;
 
   render(): HTMLElement {
     const mapTileProps: MapTilePropType = {
@@ -73,9 +69,9 @@ export class DatacommonsMapComponent extends LitElement {
       statVarSpec: {
         denom: "",
         log: false,
-        name: this.statVarName,
+        name: "",
         scaling: 1,
-        statVar: this.statVarDcid,
+        statVar: this.variableDcid,
         unit: "",
       },
       svgChartHeight: 200,


### PR DESCRIPTION
Update the properties of the map web component to bring in line with other components

Specifically:
(1) Remove "statVarName", it is unused
(2) Rename "statVarDcid" to "variableDcid" to match convention of other components

As a result, a minimal example of embedding a datacommons map now looks like:
```
<script src="https://autopush.datacommons.org/datacommons.js"></script>
<datacommons-map
  title="Population Below Poverty Level Status in Past Year in States of United States (2020)"
  placeDcid="country/USA"
  enclosedPlaceType="State"
  variableDcid="Count_Person_BelowPovertyLevelInThePast12Months"
></datacommons-map>
```