### PR TITLE
[Library] Add support for comparing specific places to Bar Chart

### DIFF
--- a/experimental/datacommons-js/example.html
+++ b/experimental/datacommons-js/example.html
@@ -5,7 +5,7 @@
       rel="stylesheet"
       href="https://datacommons.org/css/nl_interface.min.css"
     />
-    <script src="http://localhost:8080/datacommons.js"></script>
+    <script src="https://datacommons.org/datacommons.js"></script>
   </head>
   <body>
     <h1>Datacommons Web Components</h1>

--- a/experimental/datacommons-js/example.html
+++ b/experimental/datacommons-js/example.html
@@ -5,7 +5,7 @@
       rel="stylesheet"
       href="https://datacommons.org/css/nl_interface.min.css"
     />
-    <script src="https://datacommons.org/datacommons.js"></script>
+    <script src="http://localhost:8080/datacommons.js"></script>
   </head>
   <body>
     <h1>Datacommons Web Components</h1>
@@ -16,6 +16,11 @@
       enclosedPlaceType="State"
       variableDcid="Count_Person"
     ></datacommons-bar>
+    <datacommons-bar
+    title="Population in States of United States"
+    variableDcid="Count_Person"
+    comparisonPlaces='["geoId/01", "geoId/02", "geoId/04"]'
+  ></datacommons-bar>
     <h2>Map</h2>
     <datacommons-map
       title="Population"

--- a/static/library/bar_component.ts
+++ b/static/library/bar_component.ts
@@ -37,6 +37,15 @@ import { DEFAULT_API_ENDPOINT } from "./constants";
  *      enclosedPlaceType="State"
  *      variableDcid="Count_Person"
  * ></datacommons-bar>
+ *
+ * <!-- Show a bar chart of population for specific US states -->
+ * <!-- Note: use single quotes on outside,
+ *            and double quotes inside for comparisonPlaces-->
+ * <datacommons-bar
+ *      title="Population of US States"
+ *      variableDcid="Count_Person"
+ *      comparisonPlaces='["geoId/01", "geoId/02"]'
+ * ></datacommons-bar>
  */
 @customElement("datacommons-bar")
 export class DatacommonsBarComponent extends LitElement {
@@ -61,10 +70,18 @@ export class DatacommonsBarComponent extends LitElement {
   @property()
   variableDcid!: string;
 
+  // Optional: List of DCIDs of places to plot
+  // If provided, placeDcid and enclosePlaceType will be ignored
+  // !Important: In the web element, use double quotes inside the list, and
+  //             double quotes outside the list.
+  //             E.g. comparisonPlaces = '["dcid1", "dcid2"]'
+  @property({ type: Array<string> })
+  comparisonPlaces;
+
   render(): HTMLElement {
     const barTileProps: BarTilePropType = {
       apiRoot: DEFAULT_API_ENDPOINT,
-      comparisonPlaces: [],
+      comparisonPlaces: this.comparisonPlaces,
       enclosedPlaceType: this.enclosedPlaceType,
       id: `chart-${_.uniqueId()}`,
       place: {


### PR DESCRIPTION
Add support for the user to select specific places to plot in the bar chart

With this change, users can also now use
```
<script src="https://datacommons.org/datacommons.js"></script>
<datacommons-bar
  title="Population in States of United States"
  variableDcid="Count_Person"
  comparisonPlaces='["geoId/01", "geoId/02", "geoId/04"]'
></datacommons-bar>
```

to create the bar chart below:
![image](https://github.com/datacommonsorg/website/assets/4034366/c6d82cb2-4070-4031-b0ef-0c2ac8aed7cf)
