### PR TITLE
Added datacommons-map deprecated attributes for backwards compatibility

### DIFF
--- a/experimental/datacommons-js/example.html
+++ b/experimental/datacommons-js/example.html
@@ -28,6 +28,13 @@
       childPlaceType="State"
       variable="Count_Person"
     ></datacommons-map>
+    <!-- Test deprecated attributes placeDcid, enclosedPlaceType, and statVarDcid -->
+    <datacommons-map
+      title="California: Annual_ExpectedLoss_NaturalHazardImpact"
+      placeDcid="geoId/06"
+      enclosedPlaceType="County"
+      statVarDcid="Annual_ExpectedLoss_NaturalHazardImpact"
+    ></datacommons-map>
     <h2>Ranking</h2>
     <datacommons-ranking
       title="US States with the Highest Population"

--- a/static/library/map_component.ts
+++ b/static/library/map_component.ts
@@ -52,21 +52,48 @@ export class DatacommonsMapComponent extends LitElement {
   @property()
   place!: string;
 
+  /**
+   * @deprecated
+   * DCID of the parent place
+   * Deprecated. Use place instead.
+   */
+  @property()
+  placeDcid: string;
+
   // Type of child place to rank (ex: State, County)
   @property()
   childPlaceType!: string;
+
+  /**
+   * @deprecated
+   * Type of child place to rank (ex: State, County)
+   * Deprecated. Use childPlaceType instead.
+   */
+  @property()
+  enclosedPlaceType: string;
 
   // Statistical variable DCID
   @property()
   variable!: string;
 
+  /**
+   * @deprecated
+   * Statistical variable DCID
+   * Deprecated. Use variable instead.
+   */
+  @property()
+  statVarDcid: string;
+
   render(): HTMLElement {
+    const place = this.place || this.placeDcid;
+    const variable = this.variable || this.statVarDcid;
+    const childPlaceType = this.childPlaceType || this.enclosedPlaceType;
     const mapTileProps: MapTilePropType = {
       apiRoot: DEFAULT_API_ENDPOINT,
-      enclosedPlaceType: this.childPlaceType,
+      enclosedPlaceType: childPlaceType,
       id: `chart-${_.uniqueId()}`,
       place: {
-        dcid: this.place,
+        dcid: place,
         name: "",
         types: [],
       },
@@ -75,7 +102,7 @@ export class DatacommonsMapComponent extends LitElement {
         log: false,
         name: "",
         scaling: 1,
-        statVar: this.variable,
+        statVar: variable,
         unit: "",
       },
       svgChartHeight: 200,


### PR DESCRIPTION
Added back `datacommons-map` attributes `placeDcid`, `statVarDcid`, and `enclosedPlaceType` for backwards compatibility. 

@pradh FYI