### PR TITLE
[Library] Add grouped bar charts

### DIFF
--- a/experimental/datacommons-js/example.html
+++ b/experimental/datacommons-js/example.html
@@ -23,12 +23,12 @@
     ></datacommons-bar>
     <datacommons-bar
       title="Median income by gender"
-      variables='["Median_Income_Person_15OrMoreYears_Male_WithIncome", "Median_Income_Person_15OrMoreYears_Female_WithIncome"]'
+      comparisonVariables='["Median_Income_Person_15OrMoreYears_Male_WithIncome", "Median_Income_Person_15OrMoreYears_Female_WithIncome"]'
       comparisonPlaces='["geoId/01", "geoId/02", "geoId/04"]'
     ></datacommons-bar>
     <datacommons-bar
       title="Median income by gender for counties in Alaska"
-      variables="['Median_Income_Person_15OrMoreYears_Male_WithIncome', 'Median_Income_Person_15OrMoreYears_Female_WithIncome']"
+      comparisonVariables="['Median_Income_Person_15OrMoreYears_Male_WithIncome', 'Median_Income_Person_15OrMoreYears_Female_WithIncome']"
       place="geoId/02"
       childPlaceType="County"
     ></datacommons-bar>

--- a/experimental/datacommons-js/example.html
+++ b/experimental/datacommons-js/example.html
@@ -21,6 +21,17 @@
       variable="Count_Person"
       comparisonPlaces='["geoId/01", "geoId/02", "geoId/04"]'
     ></datacommons-bar>
+    <datacommons-bar
+      title="Median income by gender"
+      variables='["Median_Income_Person_15OrMoreYears_Male_WithIncome", "Median_Income_Person_15OrMoreYears_Female_WithIncome"]'
+      comparisonPlaces='["geoId/01", "geoId/02", "geoId/04"]'
+    ></datacommons-bar>
+    <datacommons-bar
+      title="Median income by gender for counties in Alaska"
+      variables="['Median_Income_Person_15OrMoreYears_Male_WithIncome', 'Median_Income_Person_15OrMoreYears_Female_WithIncome']"
+      place="geoId/02"
+      childPlaceType="County"
+    ></datacommons-bar>
     <h2>Map</h2>
     <datacommons-map
       title="Population"

--- a/static/library/bar_component.ts
+++ b/static/library/bar_component.ts
@@ -85,7 +85,6 @@ export class DatacommonsBarComponent extends LitElement {
       ? this.comparisonVariables
       : [this.variable];
     const statVarSpec = [];
-    console.log(statVarDcids);
     statVarDcids.forEach((statVarDcid) => {
       statVarSpec.push({
         denom: "",

--- a/static/library/bar_component.ts
+++ b/static/library/bar_component.ts
@@ -75,14 +75,14 @@ export class DatacommonsBarComponent extends LitElement {
   comparisonPlaces;
 
   // Optional: List of DCIDs of statistical variables to plot
-  // If provided, "variable" (singular) will be ignored.
+  // If provided, the "variable" attribute will be ignored.
   // !Important: variables provided must share the same unit
   @property({ type: Array<string>, converter: convertArrayAttribute })
-  variables;
+  comparisonVariables;
 
   render(): HTMLElement {
-    const statVarDcids: string[] = this.variables
-      ? this.variables
+    const statVarDcids: string[] = this.comparisonVariables
+      ? this.comparisonVariables
       : [this.variable];
     const statVarSpec = [];
     console.log(statVarDcids);

--- a/static/library/bar_component.ts
+++ b/static/library/bar_component.ts
@@ -24,6 +24,7 @@ import tilesCssString from "!!raw-loader!sass-loader!../css/tiles.scss";
 
 import { BarTile, BarTilePropType } from "../js/components/tiles/bar_tile";
 import { DEFAULT_API_ENDPOINT } from "./constants";
+import { convertArrayAttribute } from "./utils";
 
 /**
  * Web component for rendering a bar chart tile.
@@ -39,8 +40,6 @@ import { DEFAULT_API_ENDPOINT } from "./constants";
  * ></datacommons-bar>
  *
  * <!-- Show a bar chart of population for specific US states -->
- * <!-- Note: use single quotes on outside,
- *            and double quotes inside for comparisonPlaces-->
  * <datacommons-bar
  *      title="Population of US States"
  *      variableDcid="Count_Person"
@@ -72,13 +71,31 @@ export class DatacommonsBarComponent extends LitElement {
 
   // Optional: List of DCIDs of places to plot
   // If provided, place and enclosePlaceType will be ignored
-  // !Important: In the web element, use double quotes inside the list, and
-  //             double quotes outside the list.
-  //             E.g. comparisonPlaces = '["dcid1", "dcid2"]'
-  @property({ type: Array<string> })
+  @property({ type: Array<string>, converter: convertArrayAttribute })
   comparisonPlaces;
 
+  // Optional: List of DCIDs of statistical variables to plot
+  // If provided, "variable" (singular) will be ignored.
+  // !Important: variables provided must share the same unit
+  @property({ type: Array<string>, converter: convertArrayAttribute })
+  variables;
+
   render(): HTMLElement {
+    const statVarDcids: string[] = this.variables
+      ? this.variables
+      : [this.variable];
+    const statVarSpec = [];
+    console.log(statVarDcids);
+    statVarDcids.forEach((statVarDcid) => {
+      statVarSpec.push({
+        denom: "",
+        log: false,
+        name: "",
+        scaling: 1,
+        statVar: statVarDcid,
+        unit: "",
+      });
+    });
     const barTileProps: BarTilePropType = {
       apiRoot: DEFAULT_API_ENDPOINT,
       comparisonPlaces: this.comparisonPlaces,
@@ -89,16 +106,7 @@ export class DatacommonsBarComponent extends LitElement {
         name: "",
         types: [],
       },
-      statVarSpec: [
-        {
-          denom: "",
-          log: false,
-          name: "",
-          scaling: 1,
-          statVar: this.variable,
-          unit: "",
-        },
-      ],
+      statVarSpec,
       svgChartHeight: 200,
       title: this.title,
     };

--- a/static/library/utils.ts
+++ b/static/library/utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Library of helper functions shared across web components */
+
+/**
+ * Custom attribute converter for Array<String> type attributes
+ * Models the behavior of the default Lit attribute value converter, but
+ * removes the requirement to use double quotes within a list.
+ * @param attributeValue the attribute value provided to the web component
+ * @returns JSON parsed list of strings
+ */
+export function convertArrayAttribute(attributeValue: string): string[] {
+  // JSON.parse requires double quotes for strings within objects.
+  const cleanedAttributeValue = attributeValue.replaceAll("'", '"');
+  return JSON.parse(cleanedAttributeValue);
+}

--- a/static/tsconfig.json
+++ b/static/tsconfig.json
@@ -5,7 +5,7 @@
         "name": "typescript-tslint-plugin"
       }
     ],
-    "lib": ["dom", "ES2021"],
+    "lib": ["dom", "es2021"],
     "outDir": "./dist/",
     "sourceMap": true,
     "noImplicitAny": false,

--- a/static/tsconfig.json
+++ b/static/tsconfig.json
@@ -5,7 +5,7 @@
         "name": "typescript-tslint-plugin"
       }
     ],
-    "lib": ["dom", "es2021"],
+    "lib": ["dom", "ES2021"],
     "outDir": "./dist/",
     "sourceMap": true,
     "noImplicitAny": false,


### PR DESCRIPTION
![Screenshot 2023-06-28 at 11 54 39 AM](https://github.com/datacommonsorg/website/assets/4034366/e1fc7824-5bc3-4137-b2a9-d836ac90d451)
<br />

This PR:
* Adds support for grouped bar charts to the existing bar chart component. 
* Removes the quirk of requiring users to use double quotes within lists by adding a custom attribute converter
* Switches "ES2021" in tsconfig to lowercase so `replaceAll()` can be loaded properly

The above charts were created with:
```
<datacommons-bar
    title="Median income by gender"
    variables='["Median_Income_Person_15OrMoreYears_Male_WithIncome", "Median_Income_Person_15OrMoreYears_Female_WithIncome"]'
    comparisonPlaces='["geoId/01", "geoId/02", "geoId/04"]'
></datacommons-bar>

<datacommons-bar
    title="Median income by gender for counties in Alaska"
    variables="['Median_Income_Person_15OrMoreYears_Male_WithIncome', 'Median_Income_Person_15OrMoreYears_Female_WithIncome']"
    place="geoId/02"
    childPlaceType="County"
></datacommons-bar>
```

Other changes:
