### PR TITLE
Extend flask cache expiration from 1 day to 7 days

### DIFF
--- a/server/cache.py
+++ b/server/cache.py
@@ -18,6 +18,9 @@ import os
 from flask_caching import Cache
 import requests
 
+# Cache expires set to 7 days
+TIMEOUT = 3600 * 24 * 7
+
 # Per GCP region redis config. This is a mounted volume for the website container.
 REDIS_CONFIG = '/datacommons/redis/redis.json'
 

--- a/server/routes/browser/api.py
+++ b/server/routes/browser/api.py
@@ -19,7 +19,7 @@ import flask
 from flask import request
 from flask import Response
 
-from server.cache import cache
+from server import cache
 from server.lib import fetch
 import server.services.datacommons as dc
 
@@ -30,7 +30,7 @@ NO_OBSPERIOD_KEY = 'no_obsPeriod'
 
 
 @bp.route('/provenance')
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def provenance():
   """Returns all the provenance information."""
   prov_resp = fetch.property_values(['Provenance'], 'typeOf', False)
@@ -63,7 +63,7 @@ WHERE {{
   return sparql_query
 
 
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 @bp.route('/observation-id')
 def get_observation_id():
   """Returns the observation node dcid for a combination of

--- a/server/routes/disaster/api.py
+++ b/server/routes/disaster/api.py
@@ -21,7 +21,7 @@ from flask import current_app
 from flask import request
 from flask import Response
 
-from server.cache import cache
+from server import cache
 import server.lib.fetch as fetch
 import server.lib.util as lib_util
 
@@ -199,7 +199,7 @@ def json_event_data():
 
 
 @bp.route('/event-data')
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def event_data():
   """Gets the event data for a given eventType, date range, place, and
       filter information (filter prop, unit, lower limit, and upper limit).

--- a/server/routes/disease/api.py
+++ b/server/routes/disease/api.py
@@ -20,7 +20,7 @@ from json import JSONEncoder
 import flask
 from flask import Response
 
-from server.cache import cache
+from server import cache
 from server.lib import fetch
 import server.services.datacommons as dc
 
@@ -44,8 +44,7 @@ class DiseaseParentEncoder(JSONEncoder):
     return o.__dict__
 
 
-# Cache for one day.
-@cache.memoize(timeout=3600 * 24)
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 @bp.route('/<path:dcid>')
 def get_node(dcid):
   """Returns data given a disease node."""

--- a/server/routes/event/html.py
+++ b/server/routes/event/html.py
@@ -24,7 +24,7 @@ from flask import render_template
 from google.protobuf.json_format import MessageToJson
 from markupsafe import escape
 
-from server.cache import cache
+from server import cache
 from server.lib import fetch
 import server.lib.shared as shared_api
 import server.lib.subject_page_config as lib_subject_page_config
@@ -137,7 +137,7 @@ def find_best_place_for_config(places: Dict[str, List[str]]) -> str:
 
 @bp.route('/')
 @bp.route('/<path:dcid>', strict_slashes=False)
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def event_node(dcid=DEFAULT_EVENT_DCID):
   # Get node properties
   node_name = escape(dcid)

--- a/server/routes/place/api.py
+++ b/server/routes/place/api.py
@@ -31,7 +31,7 @@ from flask import Response
 from flask import url_for
 from flask_babel import gettext
 
-from server.cache import cache
+from server import cache
 import server.lib.range as lib_range
 import server.routes.shared_api.place as place_api
 import server.services.datacommons as dc
@@ -394,7 +394,7 @@ def has_data(data):
 
 
 @bp.route('/data/<path:dcid>')
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def data(dcid):
   """Get chart spec and stats data of the landing page for a given place.
   """

--- a/server/routes/place_list/html.py
+++ b/server/routes/place_list/html.py
@@ -17,7 +17,7 @@ import collections
 from flask import Blueprint
 from flask import render_template
 
-from server.cache import cache
+from server import cache
 from server.lib.fetch import raw_property_values
 from server.routes.shared_api.place import child_fetch
 
@@ -30,7 +30,7 @@ bp = Blueprint(
 
 @bp.route('/placelist')
 @bp.route('/place-list')
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 def index():
   resp = raw_property_values(['Country'], 'typeOf', False)
   resp['Country'].sort(key=lambda x: x['name'])
@@ -38,7 +38,7 @@ def index():
 
 
 @bp.route('/place-list/<path:dcid>')
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 def node(dcid):
   child_places = child_fetch(dcid)
   place_by_type = collections.defaultdict(list)

--- a/server/routes/protein/api.py
+++ b/server/routes/protein/api.py
@@ -21,7 +21,7 @@ from flask import request
 from flask import Response
 from markupsafe import escape
 
-from server.cache import cache
+from server import cache
 from server.lib import fetch
 import server.services.datacommons as dc
 
@@ -37,7 +37,7 @@ BAD_REQUEST_CODE = 400
 bp = Blueprint('api_protein', __name__, url_prefix='/api/protein')
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 @bp.route('/<path:dcid>')
 def get_node(dcid):
   """Returns data given a protein node."""

--- a/server/routes/screenshot/html.py
+++ b/server/routes/screenshot/html.py
@@ -26,7 +26,7 @@ from github import Github
 from google.cloud import secretmanager
 from markupsafe import escape
 
-from server.cache import cache
+from server import cache
 from server.lib.gcs import list_folder
 from server.lib.gcs import list_png
 from server.routes.screenshot.diff import img_diff
@@ -113,7 +113,7 @@ def home():
 
 
 @bp.route('/commit/<path:sha>')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def commit(sha):
   if not env_valid():
     flask.abort(404)
@@ -127,7 +127,7 @@ def commit(sha):
 
 
 @bp.route('/date/<path:date>')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def date(date):
   if not env_valid():
     flask.abort(404)
@@ -142,7 +142,7 @@ def date(date):
 
 
 @bp.route('/compare/<path:compare>')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def compare(compare):
   """
   compare is an expression in the form of "githash1...githash2".

--- a/server/routes/shared_api/choropleth.py
+++ b/server/routes/shared_api/choropleth.py
@@ -26,7 +26,7 @@ from flask import send_file
 from flask import url_for
 from geojson_rewind import rewind
 
-from server.cache import cache
+from server import cache
 import server.lib.fetch as fetch
 from server.lib.shared import is_float
 import server.lib.shared as shared
@@ -81,7 +81,7 @@ MULTIPOLYGON_GEOJSON_TYPE = "MultiPolygon"
 POLYGON_GEOJSON_TYPE = "Polygon"
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 def get_choropleth_display_level(geoDcid):
   """ Get the display level of places to show on a choropleth chart for a
   given place.
@@ -200,7 +200,7 @@ def get_geojson_feature(geo_id: str, geo_name: str, json_text: List[str]):
 
 
 @bp.route('/geojson')
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def geojson():
   """Get geoJson data for places enclosed within the given dcid"""
   place_dcid = request.args.get("placeDcid")
@@ -431,7 +431,7 @@ def choropleth_data(dcid):
 
 
 @bp.route('/map-points')
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def get_map_points():
   """Get map point data for the given place type enclosed within the given dcid
   """

--- a/server/routes/shared_api/observation/point.py
+++ b/server/routes/shared_api/observation/point.py
@@ -15,7 +15,7 @@
 from flask import Blueprint
 from flask import request
 
-from server.cache import cache
+from server import cache
 from server.lib import fetch
 
 # Define blueprint
@@ -23,7 +23,7 @@ bp = Blueprint('point', __name__, url_prefix='/api/observations/point')
 
 
 @bp.route('', strict_slashes=False)
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def point():
   """Handler to get the observation point given multiple stat vars and places."""
   entities = list(filter(lambda x: x != "", request.args.getlist('entities')))
@@ -37,7 +37,7 @@ def point():
 
 
 @bp.route('/all')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def point_all():
   """Handler to get all the observation points given multiple stat vars and entities."""
   entities = list(filter(lambda x: x != "", request.args.getlist('entities')))
@@ -51,7 +51,7 @@ def point_all():
 
 
 @bp.route('/within')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def point_within():
   """Gets the observations for child entities of a certain place
   type contained in a parent entity at a given date. If no date given, will
@@ -74,7 +74,7 @@ def point_within():
 
 
 @bp.route('/within/all')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def point_within_all():
   """Gets the observations for child entities of a certain place
   type contained in a parent entity at a given date. If no date given, will

--- a/server/routes/shared_api/observation/series.py
+++ b/server/routes/shared_api/observation/series.py
@@ -15,7 +15,7 @@
 from flask import Blueprint
 from flask import request
 
-from server.cache import cache
+from server import cache
 from server.lib import fetch
 from server.lib import shared
 
@@ -38,7 +38,7 @@ bp = Blueprint("series", __name__, url_prefix='/api/observations/series')
 
 
 @bp.route('', strict_slashes=False)
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def series():
   """Handler to get preferred time series given multiple stat vars and entities."""
   entities = list(filter(lambda x: x != "", request.args.getlist('entities')))
@@ -51,7 +51,7 @@ def series():
 
 
 @bp.route('/all')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def series_all():
   """Handler to get all the time series given multiple stat vars and places."""
   entities = list(filter(lambda x: x != "", request.args.getlist('entities')))
@@ -64,7 +64,7 @@ def series_all():
 
 
 @bp.route('/within')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def series_within():
   """Gets the observation for child entities of a certain place
   type contained in a parent entity at a given date.
@@ -98,7 +98,7 @@ def series_within():
 
 
 @bp.route('/within/all')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def series_within_all():
   """Gets the observation for child entities of a certain place
   type contained in a parent entity at a given date.

--- a/server/routes/shared_api/place.py
+++ b/server/routes/shared_api/place.py
@@ -24,7 +24,7 @@ from flask import url_for
 from flask_babel import gettext
 from markupsafe import escape
 
-from server.cache import cache
+from server import cache
 from server.lib import fetch
 import server.lib.i18n as i18n
 from server.lib.shared import names
@@ -133,7 +133,7 @@ def get_place_types(place_dcids):
 
 
 @bp.route('/type/<path:place_dcid>')
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 def get_place_type(place_dcid):
   return get_place_types([place_dcid])[place_dcid]
 
@@ -269,7 +269,7 @@ def get_place_variable_count():
 
 
 @bp.route('/child/<path:dcid>')
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 def child(dcid):
   """Get top child places for a place."""
   child_places = child_fetch(dcid)
@@ -279,7 +279,7 @@ def child(dcid):
   return Response(json.dumps(child_places), 200, mimetype='application/json')
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 def child_fetch(parent_dcid):
   # Get contained places
   contained_response = fetch.property_values([parent_dcid], 'containedInPlace',
@@ -340,7 +340,7 @@ def child_fetch(parent_dcid):
 
 
 @bp.route('/parent/<path:dcid>')
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 def api_parent_places(dcid):
   result = parent_places([dcid])[dcid]
   return Response(json.dumps(result), 200, mimetype='application/json')
@@ -370,7 +370,7 @@ def parent_places(dcids):
   return result
 
 
-@cache.memoize(timeout=3600 * 24)  # Cache for one day.
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 @bp.route('/mapinfo/<path:dcid>')
 def api_mapinfo(dcid):
   """
@@ -436,7 +436,7 @@ def get_ranking_url(containing_dcid,
   return url
 
 
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 @bp.route('/ranking/<path:dcid>')
 def api_ranking(dcid):
   """Get the ranking information for a given place."""
@@ -608,7 +608,7 @@ def descendent():
 
 
 @bp.route('/descendent/name')
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def descendent_names():
   """Gets names of places of a certain type contained in a place.
 

--- a/server/routes/shared_api/stats.py
+++ b/server/routes/shared_api/stats.py
@@ -19,7 +19,7 @@ from flask import current_app
 from flask import request
 from flask import Response
 
-from server.cache import cache
+from server import cache
 from server.lib import fetch
 import server.services.datacommons as dc
 
@@ -86,7 +86,7 @@ def stat_var_property():
 
 
 @bp.route('/stat-var-search')
-@cache.cached(timeout=3600 * 24, query_string=True)
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def search_statvar():
   """Gets the statvars and statvar groups that match the tokens in the query."""
   query = request.args.get("query")

--- a/server/routes/sustainability/html.py
+++ b/server/routes/sustainability/html.py
@@ -23,7 +23,7 @@ from flask import redirect
 from flask import url_for
 from google.protobuf.json_format import MessageToJson
 
-from server.cache import cache
+from server import cache
 import server.lib.subject_page_config as lib_subject_page_config
 import server.lib.util
 
@@ -40,7 +40,7 @@ bp = Blueprint("sustainability", __name__, url_prefix='/sustainability')
 
 @bp.route('/')
 @bp.route('/<path:place_dcid>', strict_slashes=False)
-@cache.cached(timeout=3600 * 24, query_string=True)  # Cache for one day.
+@cache.cache.cached(timeout=cache.TIMEOUT, query_string=True)
 def sustainability_explorer(place_dcid=None):
   if not place_dcid:
     return redirect(url_for(

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -21,7 +21,7 @@ import urllib.parse
 from flask import current_app
 import requests
 
-from server.cache import cache
+from server import cache
 import server.lib.config as libconfig
 from server.services.discovery import get_health_check_urls
 from server.services.discovery import get_service_url
@@ -29,8 +29,7 @@ from server.services.discovery import get_service_url
 cfg = libconfig.get_config()
 
 
-# Cache for one day.
-@cache.memoize(timeout=3600 * 24)
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 def get(url: str):
   headers = {'Content-Type': 'application/json'}
   mixer_api_key = current_app.config.get('MIXER_API_KEY', '')
@@ -54,8 +53,7 @@ def post(url: str, req: Dict):
   return post_wrapper(url, req_str)
 
 
-# Cache for one day.
-@cache.memoize(timeout=3600 * 24)
+@cache.cache.memoize(timeout=cache.TIMEOUT)
 def post_wrapper(url, req_str: str):
   req = json.loads(req_str)
   headers = {'Content-Type': 'application/json'}


### PR DESCRIPTION
After a deployment, only branch cache is updated which can cause data update. Since only covid is in branch cache and it's of low interest, we would increase the cache expiration from 1 day to 7 days. This would improve the latency a lot.