### PR TITLE
Improve feedback UI

### DIFF
--- a/static/js/apps/nl_interface/app.tsx
+++ b/static/js/apps/nl_interface/app.tsx
@@ -40,6 +40,7 @@ export function App(): JSX.Element {
   const [contextList, setContextList] = useState<any[]>([]);
   // If autoRun is enabled, runs every prompt (';' separated) from the url.
   const autoRun = useRef(!!getUrlToken("a"));
+  const demoMode = useRef(!!getUrlToken("enable_demo"));
   const delayDisabled = useRef(!!getUrlToken("d"));
   const [indexType, setIndexType] = useState(
     getUrlTokenOrDefault(NL_URL_PARAMS.IDX, NL_INDEX_VALS.SMALL)
@@ -184,6 +185,7 @@ export function App(): JSX.Element {
         contextHistory={getContextHistory(i)}
         addContextCallback={addContext}
         showData={false}
+        demoMode={demoMode.current}
       ></QueryResult>
     );
   });

--- a/static/js/apps/nl_interface/data_app/app.tsx
+++ b/static/js/apps/nl_interface/data_app/app.tsx
@@ -33,6 +33,7 @@ export function App(): JSX.Element {
   const [queries, setQueries] = useState<string[]>([]);
   const [contextList, setContextList] = useState<any[]>([]);
   const autoRun = useRef(!!getUrlToken("a"));
+  const demoMode = useRef(!!getUrlToken("enable_demo"));
   const [indexType, setIndexType] = useState(
     getUrlTokenOrDefault(NL_URL_PARAMS.IDX, NL_INDEX_VALS.SMALL)
   );
@@ -142,6 +143,7 @@ export function App(): JSX.Element {
         contextHistory={getContextHistory(i)}
         addContextCallback={addContext}
         showData={true}
+        demoMode={demoMode.current}
       ></QueryResult>
     );
   });

--- a/static/js/apps/nl_interface/query_result.tsx
+++ b/static/js/apps/nl_interface/query_result.tsx
@@ -41,6 +41,7 @@ export interface QueryResultProps {
   contextHistory: any[];
   addContextCallback: (any, number) => void;
   showData: boolean;
+  demoMode: boolean;
 }
 
 export const QueryResult = memo(function QueryResult(
@@ -111,7 +112,10 @@ export const QueryResult = memo(function QueryResult(
               types: [mainPlace["place_type"]],
             },
             config: resp.data["config"],
-            sessionId: "session" in resp.data ? resp.data["session"]["id"] : "",
+            sessionId:
+              !props.demoMode && "session" in resp.data
+                ? resp.data["session"]["id"]
+                : "",
           });
         } else {
           setErrorMsg("Sorry, we couldn't answer your question.");
@@ -143,12 +147,14 @@ export const QueryResult = memo(function QueryResult(
           <a href={feedbackLink} target="_blank" rel="noreferrer">
             Feedback
           </a>
-          <span
-            className={`thumb-down ${isThumbClicked ? "thumb-dim" : ""}`}
-            onClick={onThumbDownClick}
-          >
-            &nbsp;&nbsp;&#128078;
-          </span>
+          {chartsData && chartsData.sessionId && (
+            <span
+              className={`thumb-down ${isThumbClicked ? "thumb-dim" : ""}`}
+              onClick={onThumbDownClick}
+            >
+              &nbsp;&nbsp;&#128078;
+            </span>
+          )}
         </Container>
         <Container>
           {debugData && (

--- a/static/js/components/nl_feedback.tsx
+++ b/static/js/components/nl_feedback.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Per-chart feedback for NL.
+ */
+
+import axios from "axios";
+import React, { useContext, useState } from "react";
+
+import { NlSessionContext } from "../shared/context";
+import {
+  CHART_FEEDBACK_SENTIMENT,
+  getNlChartId,
+} from "../utils/nl_interface_utils";
+
+interface NLChartFeedbackPropType {
+  id: string;
+}
+
+export function NLChartFeedback(props: NLChartFeedbackPropType): JSX.Element {
+  const nlSessionId = useContext(NlSessionContext);
+  const [isThumbClicked, setIsThumbClicked] = useState(false);
+  if (!nlSessionId) {
+    return <></>;
+  }
+  return (
+    <div className="nl-feedback">
+      <span
+        className={`thumb-down ${isThumbClicked ? "thumb-dim" : ""}`}
+        onClick={() => {
+          return onChartThumbDownClick(
+            props.id,
+            nlSessionId,
+            isThumbClicked,
+            setIsThumbClicked
+          );
+        }}
+      >
+        &#128078;
+      </span>
+    </div>
+  );
+}
+
+//
+// Invoked when thumb-down is clicked on a chart.
+//
+function onChartThumbDownClick(
+  idStr: string,
+  nlSessionId: string,
+  isThumbClicked: boolean,
+  setIsThumbClicked: (boolean) => void
+): void {
+  if (isThumbClicked) {
+    return;
+  }
+  setIsThumbClicked(true);
+  axios.post("/api/nl/feedback", {
+    feedbackData: {
+      chartId: getNlChartId(idStr),
+      sentiment: CHART_FEEDBACK_SENTIMENT.THUMBS_DOWN,
+    },
+    sessionId: nlSessionId,
+  });
+}

--- a/static/js/components/nl_feedback.tsx
+++ b/static/js/components/nl_feedback.tsx
@@ -27,11 +27,13 @@ import {
   getNlChartId,
 } from "../utils/nl_interface_utils";
 
-interface NLChartFeedbackPropType {
+interface NlChartFeedbackPropType {
+  // This is a fixed ID format string
+  // e.g., "pg0_cat_1_blk_2_col_3_tile_4"
   id: string;
 }
 
-export function NLChartFeedback(props: NLChartFeedbackPropType): JSX.Element {
+export function NlChartFeedback(props: NlChartFeedbackPropType): JSX.Element {
   const nlSessionId = useContext(NlSessionContext);
   const [isThumbClicked, setIsThumbClicked] = useState(false);
   if (!nlSessionId) {

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -18,17 +18,13 @@
  * A container for any tile containing a chart.
  */
 
-import axios from "axios";
 import React, { useContext, useRef, useState } from "react";
 
 import { ASYNC_ELEMENT_HOLDER_CLASS } from "../../constants/css_constants";
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { ChartEmbed } from "../../place/chart_embed";
 import { NlSessionContext } from "../../shared/context";
-import {
-  CHART_FEEDBACK_SENTIMENT,
-  getNlChartId,
-} from "../../utils/nl_interface_utils";
+import { onChartThumbDownClick } from "../../utils/nl_interface_utils";
 import {
   formatString,
   getChartTitle,
@@ -92,7 +88,14 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
         <div className="nl-feedback">
           <span
             className={`thumb-down ${isThumbClicked ? "thumb-dim" : ""}`}
-            onClick={onThumbDownClick}
+            onClick={() => {
+              return onChartThumbDownClick(
+                props.id,
+                nlSessionId,
+                isThumbClicked,
+                setIsThumbClicked
+              );
+            }}
           >
             &#128078;
           </span>
@@ -119,19 +122,5 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
       "",
       Array.from(props.sources)
     );
-  }
-
-  function onThumbDownClick(): void {
-    if (isThumbClicked) {
-      return;
-    }
-    setIsThumbClicked(true);
-    axios.post("/api/nl/feedback", {
-      feedbackData: {
-        chartId: getNlChartId(props.id),
-        sentiment: CHART_FEEDBACK_SENTIMENT.THUMBS_DOWN,
-      },
-      sessionId: nlSessionId,
-    });
   }
 }

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -29,7 +29,7 @@ import {
   getMergedSvg,
   ReplacementStrings,
 } from "../../utils/tile_utils";
-import { NLChartFeedback } from "../nl_feedback";
+import { NlChartFeedback } from "../nl_feedback";
 import { ChartFooter } from "./chart_footer";
 interface ChartTileContainerProp {
   id: string;
@@ -80,7 +80,7 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
         sources={props.sources}
         handleEmbed={showEmbed ? handleEmbed : null}
       />
-      <NLChartFeedback id={props.id} />
+      <NlChartFeedback id={props.id} />
       {showEmbed && <ChartEmbed ref={embedModalElement} />}
     </div>
   );

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -18,19 +18,18 @@
  * A container for any tile containing a chart.
  */
 
-import React, { useContext, useRef, useState } from "react";
+import React, { useRef } from "react";
 
 import { ASYNC_ELEMENT_HOLDER_CLASS } from "../../constants/css_constants";
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { ChartEmbed } from "../../place/chart_embed";
-import { NlSessionContext } from "../../shared/context";
-import { onChartThumbDownClick } from "../../utils/nl_interface_utils";
 import {
   formatString,
   getChartTitle,
   getMergedSvg,
   ReplacementStrings,
 } from "../../utils/tile_utils";
+import { NLChartFeedback } from "../nl_feedback";
 import { ChartFooter } from "./chart_footer";
 interface ChartTileContainerProp {
   id: string;
@@ -50,10 +49,8 @@ interface ChartTileContainerProp {
 }
 
 export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
-  const nlSessionId = useContext(NlSessionContext);
   const containerRef = useRef(null);
   const embedModalElement = useRef<ChartEmbed>(null);
-  const [isThumbClicked, setIsThumbClicked] = useState(false);
 
   // on initial loading, hide the title text
   const title = !props.isInitialLoading
@@ -83,25 +80,7 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
         sources={props.sources}
         handleEmbed={showEmbed ? handleEmbed : null}
       />
-
-      {nlSessionId && (
-        <div className="nl-feedback">
-          <span
-            className={`thumb-down ${isThumbClicked ? "thumb-dim" : ""}`}
-            onClick={() => {
-              return onChartThumbDownClick(
-                props.id,
-                nlSessionId,
-                isThumbClicked,
-                setIsThumbClicked
-              );
-            }}
-          >
-            &#128078;
-          </span>
-        </div>
-      )}
-
+      <NLChartFeedback id={props.id} />
       {showEmbed && <ChartEmbed ref={embedModalElement} />}
     </div>
   );

--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -40,7 +40,7 @@ import { getPlaceDisplayNames, getPlaceNames } from "../../utils/place_utils";
 import { getUnit } from "../../utils/stat_metadata_utils";
 import { getDateRange } from "../../utils/string_utils";
 import { getStatVarName } from "../../utils/tile_utils";
-import { NLChartFeedback } from "../nl_feedback";
+import { NlChartFeedback } from "../nl_feedback";
 import { SvRankingUnits } from "./sv_ranking_units";
 
 const RANKING_COUNT = 5;
@@ -140,7 +140,7 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
             />
           );
         })}
-      <NLChartFeedback id={props.id} />
+      <NlChartFeedback id={props.id} />
       <ChartEmbed ref={embedModalElement} />
     </div>
   );

--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -20,13 +20,12 @@
 
 import axios from "axios";
 import _ from "lodash";
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { ASYNC_ELEMENT_HOLDER_CLASS } from "../../constants/css_constants";
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { ChartEmbed } from "../../place/chart_embed";
 import { USA_NAMED_TYPED_PLACE } from "../../shared/constants";
-import { NlSessionContext } from "../../shared/context";
 import { PointApiResponse } from "../../shared/stat_types";
 import { NamedTypedPlace, StatVarSpec } from "../../shared/types";
 import {
@@ -37,11 +36,11 @@ import {
 import { RankingTileSpec } from "../../types/subject_page_proto_types";
 import { stringifyFn } from "../../utils/axios";
 import { rankingPointsToCsv } from "../../utils/chart_csv_utils";
-import { onChartThumbDownClick } from "../../utils/nl_interface_utils";
 import { getPlaceDisplayNames, getPlaceNames } from "../../utils/place_utils";
 import { getUnit } from "../../utils/stat_metadata_utils";
 import { getDateRange } from "../../utils/string_utils";
 import { getStatVarName } from "../../utils/tile_utils";
+import { NLChartFeedback } from "../nl_feedback";
 import { SvRankingUnits } from "./sv_ranking_units";
 
 const RANKING_COUNT = 5;
@@ -64,10 +63,8 @@ export interface RankingTilePropType {
 
 // TODO: Use ChartTileContainer like other tiles.
 export function RankingTile(props: RankingTilePropType): JSX.Element {
-  const nlSessionId = useContext(NlSessionContext);
   const [rankingData, setRankingData] = useState<RankingData | undefined>(null);
   const embedModalElement = useRef<ChartEmbed>(null);
-  const [isThumbClicked, setIsThumbClicked] = useState(false);
   const chartContainer = useRef(null);
 
   useEffect(() => {
@@ -143,25 +140,7 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
             />
           );
         })}
-
-      {nlSessionId && (
-        <div className="nl-feedback">
-          <span
-            className={`thumb-down ${isThumbClicked ? "thumb-dim" : ""}`}
-            onClick={() => {
-              return onChartThumbDownClick(
-                props.id,
-                nlSessionId,
-                isThumbClicked,
-                setIsThumbClicked
-              );
-            }}
-          >
-            &#128078;
-          </span>
-        </div>
-      )}
-
+      <NLChartFeedback id={props.id} />
       <ChartEmbed ref={embedModalElement} />
     </div>
   );

--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -20,12 +20,13 @@
 
 import axios from "axios";
 import _ from "lodash";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 
 import { ASYNC_ELEMENT_HOLDER_CLASS } from "../../constants/css_constants";
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { ChartEmbed } from "../../place/chart_embed";
 import { USA_NAMED_TYPED_PLACE } from "../../shared/constants";
+import { NlSessionContext } from "../../shared/context";
 import { PointApiResponse } from "../../shared/stat_types";
 import { NamedTypedPlace, StatVarSpec } from "../../shared/types";
 import {
@@ -36,6 +37,7 @@ import {
 import { RankingTileSpec } from "../../types/subject_page_proto_types";
 import { stringifyFn } from "../../utils/axios";
 import { rankingPointsToCsv } from "../../utils/chart_csv_utils";
+import { onChartThumbDownClick } from "../../utils/nl_interface_utils";
 import { getPlaceDisplayNames, getPlaceNames } from "../../utils/place_utils";
 import { getUnit } from "../../utils/stat_metadata_utils";
 import { getDateRange } from "../../utils/string_utils";
@@ -60,9 +62,12 @@ export interface RankingTilePropType {
   apiRoot?: string;
 }
 
+// TODO: Use ChartTileContainer like other tiles.
 export function RankingTile(props: RankingTilePropType): JSX.Element {
+  const nlSessionId = useContext(NlSessionContext);
   const [rankingData, setRankingData] = useState<RankingData | undefined>(null);
   const embedModalElement = useRef<ChartEmbed>(null);
+  const [isThumbClicked, setIsThumbClicked] = useState(false);
   const chartContainer = useRef(null);
 
   useEffect(() => {
@@ -138,6 +143,25 @@ export function RankingTile(props: RankingTilePropType): JSX.Element {
             />
           );
         })}
+
+      {nlSessionId && (
+        <div className="nl-feedback">
+          <span
+            className={`thumb-down ${isThumbClicked ? "thumb-dim" : ""}`}
+            onClick={() => {
+              return onChartThumbDownClick(
+                props.id,
+                nlSessionId,
+                isThumbClicked,
+                setIsThumbClicked
+              );
+            }}
+          >
+            &#128078;
+          </span>
+        </div>
+      )}
+
       <ChartEmbed ref={embedModalElement} />
     </div>
   );

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -20,7 +20,7 @@
 
 import axios from "axios";
 import _ from "lodash";
-import React, { memo, useEffect, useRef, useState } from "react";
+import React, { memo, useContext, useEffect, useRef, useState } from "react";
 
 import {
   ASYNC_ELEMENT_CLASS,
@@ -29,6 +29,7 @@ import {
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { formatNumber } from "../../i18n/i18n";
 import { ChartEmbed } from "../../place/chart_embed";
+import { NlSessionContext } from "../../shared/context";
 import { NamedPlace, NamedTypedPlace } from "../../shared/types";
 import {
   DisasterEventPoint,
@@ -41,6 +42,7 @@ import {
 } from "../../types/subject_page_proto_types";
 import { stringifyFn } from "../../utils/axios";
 import { rankingPointsToCsv } from "../../utils/chart_csv_utils";
+import { onChartThumbDownClick } from "../../utils/nl_interface_utils";
 import { getPlaceNames } from "../../utils/place_utils";
 import { formatPropertyValue } from "../../utils/property_value_utils";
 import { ChartFooter } from "./chart_footer";
@@ -60,9 +62,12 @@ interface TopEventTilePropType {
   className?: string;
 }
 
+// TODO: Use ChartTileContainer like other tiles.
 export const TopEventTile = memo(function TopEventTile(
   props: TopEventTilePropType
 ): JSX.Element {
+  const nlSessionId = useContext(NlSessionContext);
+  const [isThumbClicked, setIsThumbClicked] = useState(false);
   const embedModalElement = useRef<ChartEmbed>(null);
   const chartContainer = useRef(null);
   const [eventPlaces, setEventPlaces] =
@@ -210,6 +215,23 @@ export const TopEventTile = memo(function TopEventTile(
           />
         </div>
       </div>
+      {nlSessionId && (
+        <div className="nl-feedback">
+          <span
+            className={`thumb-down ${isThumbClicked ? "thumb-dim" : ""}`}
+            onClick={() => {
+              return onChartThumbDownClick(
+                props.id,
+                nlSessionId,
+                isThumbClicked,
+                setIsThumbClicked
+              );
+            }}
+          >
+            &#128078;
+          </span>
+        </div>
+      )}
       <ChartEmbed ref={embedModalElement} />
     </div>
   );

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -20,7 +20,7 @@
 
 import axios from "axios";
 import _ from "lodash";
-import React, { memo, useContext, useEffect, useRef, useState } from "react";
+import React, { memo, useEffect, useRef, useState } from "react";
 
 import {
   ASYNC_ELEMENT_CLASS,
@@ -29,7 +29,6 @@ import {
 import { INITAL_LOADING_CLASS } from "../../constants/tile_constants";
 import { formatNumber } from "../../i18n/i18n";
 import { ChartEmbed } from "../../place/chart_embed";
-import { NlSessionContext } from "../../shared/context";
 import { NamedPlace, NamedTypedPlace } from "../../shared/types";
 import {
   DisasterEventPoint,
@@ -42,9 +41,9 @@ import {
 } from "../../types/subject_page_proto_types";
 import { stringifyFn } from "../../utils/axios";
 import { rankingPointsToCsv } from "../../utils/chart_csv_utils";
-import { onChartThumbDownClick } from "../../utils/nl_interface_utils";
 import { getPlaceNames } from "../../utils/place_utils";
 import { formatPropertyValue } from "../../utils/property_value_utils";
+import { NLChartFeedback } from "../nl_feedback";
 import { ChartFooter } from "./chart_footer";
 
 const DEFAULT_RANKING_COUNT = 10;
@@ -66,8 +65,6 @@ interface TopEventTilePropType {
 export const TopEventTile = memo(function TopEventTile(
   props: TopEventTilePropType
 ): JSX.Element {
-  const nlSessionId = useContext(NlSessionContext);
-  const [isThumbClicked, setIsThumbClicked] = useState(false);
   const embedModalElement = useRef<ChartEmbed>(null);
   const chartContainer = useRef(null);
   const [eventPlaces, setEventPlaces] =
@@ -215,23 +212,7 @@ export const TopEventTile = memo(function TopEventTile(
           />
         </div>
       </div>
-      {nlSessionId && (
-        <div className="nl-feedback">
-          <span
-            className={`thumb-down ${isThumbClicked ? "thumb-dim" : ""}`}
-            onClick={() => {
-              return onChartThumbDownClick(
-                props.id,
-                nlSessionId,
-                isThumbClicked,
-                setIsThumbClicked
-              );
-            }}
-          >
-            &#128078;
-          </span>
-        </div>
-      )}
+      <NLChartFeedback id={props.id} />
       <ChartEmbed ref={embedModalElement} />
     </div>
   );

--- a/static/js/components/tiles/top_event_tile.tsx
+++ b/static/js/components/tiles/top_event_tile.tsx
@@ -43,7 +43,7 @@ import { stringifyFn } from "../../utils/axios";
 import { rankingPointsToCsv } from "../../utils/chart_csv_utils";
 import { getPlaceNames } from "../../utils/place_utils";
 import { formatPropertyValue } from "../../utils/property_value_utils";
-import { NLChartFeedback } from "../nl_feedback";
+import { NlChartFeedback } from "../nl_feedback";
 import { ChartFooter } from "./chart_footer";
 
 const DEFAULT_RANKING_COUNT = 10;
@@ -212,7 +212,7 @@ export const TopEventTile = memo(function TopEventTile(
           />
         </div>
       </div>
-      <NLChartFeedback id={props.id} />
+      <NlChartFeedback id={props.id} />
       <ChartEmbed ref={embedModalElement} />
     </div>
   );

--- a/static/js/utils/nl_interface_utils.ts
+++ b/static/js/utils/nl_interface_utils.ts
@@ -18,7 +18,6 @@
  * Utils used for the nl interface
  */
 
-import axios from "axios";
 const FEEDBACK_LINK =
   "https://docs.google.com/forms/d/e/1FAIpQLSfqndIayVhN1bN5oeZT0Te-MhhBMBR1hn97Lgr77QTOpga8Iw/viewform?usp=pp_url";
 // Param prefixes found when following the instructions here to get a prefilled
@@ -58,28 +57,6 @@ export function getNlChartId(idStr: string): ChartId {
     tileIdx: numbers[4],
   };
   return chartId;
-}
-
-//
-// Invoked when thumb-down is clicked on a chart.
-//
-export function onChartThumbDownClick(
-  idStr: string,
-  nlSessionId: string,
-  isThumbClicked: boolean,
-  setIsThumbClicked: (boolean) => void
-): void {
-  if (isThumbClicked) {
-    return;
-  }
-  setIsThumbClicked(true);
-  axios.post("/api/nl/feedback", {
-    feedbackData: {
-      chartId: getNlChartId(idStr),
-      sentiment: CHART_FEEDBACK_SENTIMENT.THUMBS_DOWN,
-    },
-    sessionId: nlSessionId,
-  });
 }
 
 export function isNlInterface(): boolean {

--- a/static/js/utils/nl_interface_utils.ts
+++ b/static/js/utils/nl_interface_utils.ts
@@ -18,6 +18,7 @@
  * Utils used for the nl interface
  */
 
+import axios from "axios";
 const FEEDBACK_LINK =
   "https://docs.google.com/forms/d/e/1FAIpQLSfqndIayVhN1bN5oeZT0Te-MhhBMBR1hn97Lgr77QTOpga8Iw/viewform?usp=pp_url";
 // Param prefixes found when following the instructions here to get a prefilled
@@ -57,6 +58,28 @@ export function getNlChartId(idStr: string): ChartId {
     tileIdx: numbers[4],
   };
   return chartId;
+}
+
+//
+// Invoked when thumb-down is clicked on a chart.
+//
+export function onChartThumbDownClick(
+  idStr: string,
+  nlSessionId: string,
+  isThumbClicked: boolean,
+  setIsThumbClicked: (boolean) => void
+): void {
+  if (isThumbClicked) {
+    return;
+  }
+  setIsThumbClicked(true);
+  axios.post("/api/nl/feedback", {
+    feedbackData: {
+      chartId: getNlChartId(idStr),
+      sentiment: CHART_FEEDBACK_SENTIMENT.THUMBS_DOWN,
+    },
+    sessionId: nlSessionId,
+  });
 }
 
 export function isNlInterface(): boolean {


### PR DESCRIPTION
Includes the following changes:

* Ranking tile and top-events tile includes thumbs-down
   * TODO: the top-events tile might need some css tweaks
* When LOG_QUERY is False, no query-level thumbs-down shown (chart-level already doens't show)
* With `enable_demo=True` url param, no thumbs-down shown

Screenshots:

![image](https://github.com/datacommonsorg/website/assets/4375037/5a53f64e-f770-4dc2-8771-945ad4aa4178)

![image](https://github.com/datacommonsorg/website/assets/4375037/6a3a2e74-5f03-41b0-b3eb-9e812f9a9e60)
