### PR TITLE
[Library] Add date attribute to map component

### DIFF
--- a/static/js/components/tiles/map_tile.tsx
+++ b/static/js/components/tiles/map_tile.tsx
@@ -69,6 +69,8 @@ export interface MapTilePropType {
   apiRoot?: string;
   // Parent places of the current place showing map for
   parentPlaces?: NamedPlace[];
+  // Specific date to show data for
+  date?: string;
 }
 
 interface RawData {
@@ -205,7 +207,9 @@ export const fetchData = async (
       nodes: [props.place.dcid],
     })
     .then((resp) => resp.data);
-  const dataDate = getCappedStatVarDate(props.statVarSpec.statVar);
+  const dataDate = props.date
+    ? props.date
+    : getCappedStatVarDate(props.statVarSpec.statVar);
   const placeStatPromise: Promise<PointApiResponse> = axios
     .get(`${props.apiRoot || ""}/api/observations/point/within`, {
       params: {

--- a/static/library/map_component.ts
+++ b/static/library/map_component.ts
@@ -84,12 +84,17 @@ export class DatacommonsMapComponent extends LitElement {
   @property()
   statVarDcid: string;
 
+  // Optional: specific date to show data for
+  @property()
+  date: string;
+
   render(): HTMLElement {
     const place = this.place || this.placeDcid;
     const variable = this.variable || this.statVarDcid;
     const childPlaceType = this.childPlaceType || this.enclosedPlaceType;
     const mapTileProps: MapTilePropType = {
       apiRoot: DEFAULT_API_ENDPOINT,
+      date: this.date,
       enclosedPlaceType: childPlaceType,
       id: `chart-${_.uniqueId()}`,
       place: {


### PR DESCRIPTION
Allow users to specify a specific date to display on a map component.

Example usage:
```
<datacommons-map
    title="Population"
    place="country/USA"
    childPlaceType="State"
    variable="Count_Person"
    date="2010"
></datacommons-map>
```