### PR TITLE
NL: log embeddings versions to BT

### DIFF
--- a/nl_server/__init__.py
+++ b/nl_server/__init__.py
@@ -42,6 +42,7 @@ def create_app():
       logging.error("No configuration found for embeddings")
       return
 
+    app.config['EMBEDDINGS_VERSION_MAP'] = embeddings_map
     loader.load_embeddings(app, embeddings_map)
 
   return app

--- a/nl_server/routes.py
+++ b/nl_server/routes.py
@@ -73,3 +73,8 @@ def search_places():
   except Exception as e:
     logging.error(f'NER place detection failed with error: {e}')
     return json.dumps({'places': []})
+
+
+@bp.route('/api/embeddings_version_map/', methods=['GET'])
+def embeddings_version_map():
+  return json.dumps(current_app.config['EMBEDDINGS_VERSION_MAP'])

--- a/server/services/bigtable.py
+++ b/server/services/bigtable.py
@@ -83,6 +83,7 @@ async def write_row(session_info: Dict, data: Dict, ctr: Dict):
       'website_hash': os.environ.get("WEBSITE_HASH"),
       'mixer_hash': mixer_version.get('gitHash', ''),
       'table': mixer_version.get('tables', ''),
+      'embeddings': dc.nl_embeddings_version_map()
   }
   # Rely on timestamp in BT server
   row.set_cell(_COLUMN_FAMILY, _COL_PROJECT.encode(), project_id)

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -291,6 +291,10 @@ def nl_detect_place_ner(query):
   return get(url).get('places', [])
 
 
+def nl_embeddings_version_map():
+  return get(f'{cfg.NL_ROOT}/api/embeddings_version_map')
+
+
 # =======================   V0 V0 V0 ================================
 def search(query_text, max_results):
   url = get_service_url('/search')


### PR DESCRIPTION
To validate, I added a log statement in write_row() locally.

```
【11:55:34】【INFO】【 bigtable.py:89 】 {'website_hash': None,
'mixer_hash': 'f32cb9d',
'table': ['dcbranch_2023_06_28_18_34_13', 'auto1d_2023_06_28_21_07_45', 'frequent_2023_06_28_20_02_43', 'auto1w_2023_06_25_21_05_05', 'auto2w_2023_06_27_10_30_37', 'ipcc_2023_06_22_12_08_25', 'biomedical_2023_06_27_16_09_49', 'disaster_2023_06_25_21_29_58', 'country_2023_06_28_22_33_14', 'experimental_2023_06_04_03_44_11', 'infrequent_2023_06_26_11_53_15', 'place_2023_06_12_21_08_19'],
'embeddings': {
  'small': 'embeddings_small_2023_05_24_23_17_03.csv',
  'medium': 'embeddings_medium_2023_05_24_22_15_24.csv'
}}
```