### PR TITLE
LLM: Use JSON5 to parse LLM response

### DIFF
--- a/server/lib/nl/detection/palm_api.py
+++ b/server/lib/nl/detection/palm_api.py
@@ -93,8 +93,9 @@ def parse_response(query: str, resp: Dict, ctr: counters.Counters) -> Dict:
 
     try:
       # Use json5 to load since it is a lot more lenient (e.g.,
-      # allows trailing commas) even if ~600x slower
-      # (and with current LLM latencies that's fine)
+      # allows trailing commas), even if ~600x slower (e.g.,
+      # from 2us to 1.2ms for one loads).
+      # But with current LLM latencies that's fine.
       ans_json = json5.loads(ans, allow_duplicate_keys=False)
     except Exception as e:
       logging.error(f'ERROR: json decoding failed {e}')

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -16,6 +16,7 @@ google-cloud-storage==2.8.0
 gunicorn==20.1.0
 isort==5.10.0
 jinja2==3.1.2
+json5==0.9.14
 opencensus==0.10.0
 opencensus-ext-flask==0.8.0
 opencensus-ext-stackdriver==0.8.0

--- a/server/tests/lib/nl/detection/palm_api_test.py
+++ b/server/tests/lib/nl/detection/palm_api_test.py
@@ -62,6 +62,18 @@ _INPUT3 = """
 I'm a fancy LLM that makes up stuff willy-nilly when humans bore me with their stupid questions.
 """
 
+_INPUT4 = """
+Sure. Here is the JSON that corresponds to the sentence "which cities in california have a population more than 1000000":
+```
+{
+  "PLACES": [
+    "Los Angeles",
+  ]
+}
+```
+I set the enum value for the "SUB_PLACE_TYPE" property to "CITY" because all of the places in the list are cities.
+"""
+
 
 class TestParseResponse(unittest.TestCase):
 
@@ -84,6 +96,9 @@ class TestParseResponse(unittest.TestCase):
           'SUB_PLACE_TYPE': 'COUNTRY'
       }),
       (_INPUT3, {}),
+      (_INPUT4, {
+          'PLACES': ['Los Angeles']
+      }),
   ])
   def test_main(self, input, want):
     self.maxDiff = None


### PR DESCRIPTION
JSON5 is a lot more lenient in parsing JSON strings that LLM returns.

The docs say JSON5 can be 1000-3000x slower.  I did some benchmarking ([code](https://gist.github.com/pradh/63e5b9085505a7906062575314d1365a)), it is ~600x slower.