### PR TITLE
[library] Added stacked bar chart support to datacommons-bar web component

### DIFF
--- a/experimental/datacommons-js/example.html
+++ b/experimental/datacommons-js/example.html
@@ -30,7 +30,7 @@
       title="Median income by gender"
       comparisonVariables='["Median_Income_Person_15OrMoreYears_Male_WithIncome", "Median_Income_Person_15OrMoreYears_Female_WithIncome"]'
       comparisonPlaces='["geoId/01", "geoId/02", "geoId/04"]'
-      stacked="false"
+      stacked
     ></datacommons-bar>
     <datacommons-bar
       title="Median income by gender for counties in Alaska"

--- a/experimental/datacommons-js/example.html
+++ b/experimental/datacommons-js/example.html
@@ -27,6 +27,12 @@
       comparisonPlaces='["geoId/01", "geoId/02", "geoId/04"]'
     ></datacommons-bar>
     <datacommons-bar
+      title="Median income by gender"
+      comparisonVariables='["Median_Income_Person_15OrMoreYears_Male_WithIncome", "Median_Income_Person_15OrMoreYears_Female_WithIncome"]'
+      comparisonPlaces='["geoId/01", "geoId/02", "geoId/04"]'
+      stacked="false"
+    ></datacommons-bar>
+    <datacommons-bar
       title="Median income by gender for counties in Alaska"
       comparisonVariables="['Median_Income_Person_15OrMoreYears_Male_WithIncome', 'Median_Income_Person_15OrMoreYears_Female_WithIncome']"
       place="geoId/02"

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -717,6 +717,7 @@ function drawHistogram(
  * @param unit
  */
 function drawStackBarChart(
+  containerElement: HTMLDivElement,
   id: string,
   chartWidth: number,
   chartHeight: number,
@@ -724,13 +725,15 @@ function drawStackBarChart(
   formatNumberFn: (value: number, unit?: string) => string,
   unit?: string
 ): void {
+  if (_.isEmpty(dataGroups)) {
+    return;
+  }
   const labelToLink = {};
   for (const dataGroup of dataGroups) {
     labelToLink[dataGroup.label] = dataGroup.link;
   }
 
   const keys = dataGroups[0].value.map((dp) => dp.label);
-
   const data = [];
   for (const dataGroup of dataGroups) {
     const curr: { [property: string]: any } = { label: dataGroup.label };
@@ -742,9 +745,12 @@ function drawStackBarChart(
   }
 
   const series = d3.stack().keys(keys).offset(d3.stackOffsetDiverging)(data);
+  // clear old chart to redraw over
+  const container = d3.select(containerElement);
+  container.selectAll("*").remove();
 
   const svg = d3
-    .select("#" + id)
+    .select(containerElement)
     .append("svg")
     .attr("xmlns", SVGNS)
     .attr("xmlns:xlink", XLINKNS)
@@ -808,7 +814,7 @@ function drawStackBarChart(
     .attr("height", (d) => (Number.isNaN(d[1]) ? 0 : y(d[0]) - y(d[1])));
 
   appendLegendElem(
-    document.getElementById(id),
+    containerElement,
     color,
     dataGroups[0].value.map((dp) => ({
       label: dp.label,

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -23,7 +23,7 @@ import _ from "lodash";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { DataGroup, DataPoint } from "../../chart/base";
-import { drawGroupBarChart } from "../../chart/draw";
+import { drawGroupBarChart, drawStackBarChart } from "../../chart/draw";
 import { DATA_CSS_CLASS } from "../../constants/tile_constants";
 import { formatNumber } from "../../i18n/i18n";
 import { PointApiResponse } from "../../shared/stat_types";
@@ -53,6 +53,8 @@ export interface BarTilePropType {
   comparisonPlaces: string[];
   enclosedPlaceType: string;
   statVarSpec: StatVarSpec[];
+  // Set to true to draw as a stacked chart instead of a grouped chart
+  stacked?: boolean;
   // Height, in px, for the SVG chart.
   svgChartHeight: number;
   // Extra classes to add to the container.
@@ -254,13 +256,25 @@ export function draw(
   svgContainer: HTMLDivElement,
   svgWidth?: number
 ): void {
-  drawGroupBarChart(
-    svgContainer,
-    props.id,
-    svgWidth || svgContainer.offsetWidth,
-    props.svgChartHeight,
-    chartData.dataGroup,
-    formatNumber,
-    chartData.unit
-  );
+  if (props.stacked) {
+    drawStackBarChart(
+      svgContainer,
+      props.id,
+      svgWidth || svgContainer.offsetWidth,
+      props.svgChartHeight,
+      chartData.dataGroup,
+      formatNumber,
+      chartData.unit
+    );
+  } else {
+    drawGroupBarChart(
+      svgContainer,
+      props.id,
+      svgWidth || svgContainer.offsetWidth,
+      props.svgChartHeight,
+      chartData.dataGroup,
+      formatNumber,
+      chartData.unit
+    );
+  }
 }

--- a/static/js/dev_page.tsx
+++ b/static/js/dev_page.tsx
@@ -95,6 +95,7 @@ class DevChart extends React.Component<DevChartPropType> {
       );
     } else if (this.props.type == chartTypeEnum.STACK_BAR) {
       drawStackBarChart(
+        this.svgContainerElement.current,
         this.props.id,
         elem.current.offsetWidth,
         this.props.height,

--- a/static/js/place/chart.tsx
+++ b/static/js/place/chart.tsx
@@ -485,6 +485,7 @@ class Chart extends React.Component<ChartPropType, ChartStateType> {
       }
     } else if (chartType === chartTypeEnum.STACK_BAR) {
       drawStackBarChart(
+        this.svgContainerElement.current,
         this.props.id,
         elem.offsetWidth,
         CHART_HEIGHT,

--- a/static/library/bar_component.ts
+++ b/static/library/bar_component.ts
@@ -53,6 +53,12 @@ export class DatacommonsBarComponent extends LitElement {
     ${unsafeCSS(tilesCssString)}
   `;
 
+  /**
+   * Set to true to draw as a stacked chart instead of grouped chart
+   */
+  @property({ type: Boolean })
+  stacked?: boolean;
+
   // Title of the chart
   @property()
   title!: string;
@@ -105,6 +111,7 @@ export class DatacommonsBarComponent extends LitElement {
         name: "",
         types: [],
       },
+      stacked: this.stacked,
       statVarSpec,
       svgChartHeight: 200,
       title: this.title,

--- a/static/library/bar_component.ts
+++ b/static/library/bar_component.ts
@@ -54,7 +54,7 @@ export class DatacommonsBarComponent extends LitElement {
   `;
 
   /**
-   * Set to true to draw as a stacked chart instead of grouped chart
+   * Draw as a stacked chart instead of grouped chart
    */
   @property({ type: Boolean })
   stacked?: boolean;

--- a/static/library/bar_component.ts
+++ b/static/library/bar_component.ts
@@ -45,6 +45,14 @@ import { convertArrayAttribute } from "./utils";
  *      variableDcid="Count_Person"
  *      comparisonPlaces='["geoId/01", "geoId/02"]'
  * ></datacommons-bar>
+ *
+ * <!-- Stacked bar chart of population for specific US states -->
+ * <datacommons-bar
+ *      title="Population of US States"
+ *      variableDcid="Count_Person"
+ *      comparisonPlaces='["geoId/01", "geoId/02"]'
+ *      stacked
+ * ></datacommons-bar>
  */
 @customElement("datacommons-bar")
 export class DatacommonsBarComponent extends LitElement {


### PR DESCRIPTION
Screenshot:

<img width="705" alt="Screenshot 2023-07-03 at 1 58 37 PM" src="https://github.com/datacommonsorg/website/assets/13766/f2e27a3f-350b-4c53-b40f-b7e09a28840c">
