### PR TITLE
[NL Interface] Bug fix: check if the predownloaded model can successfully be loaded

### DIFF
--- a/nl_server/gcs.py
+++ b/nl_server/gcs.py
@@ -17,9 +17,11 @@ TEMP_DIR = '/tmp/'
 
 import os
 from pathlib import Path
+import shutil
 from typing import Any
 
 from google.cloud import storage
+from sentence_transformers import SentenceTransformer
 
 
 # Downloads the `embeddings_file` from GCS to TEMP_DIR
@@ -79,10 +81,20 @@ def download_model_folder(model_folder: str) -> str:
   directory = TEMP_DIR
 
   # Only download if needed.
-  if os.path.exists(os.path.join(directory, model_folder)):
-    return os.path.join(directory, model_folder)
+  model_path = os.path.join(directory, model_folder)
+  if os.path.exists(model_path):
+    # Check if this path can still be loaded as a Sentence Transformer
+    # model. If not, delete it and download anew.
+    try:
+      _ = SentenceTransformer(model_path)
+      return model_path
+    except:
+      print(f"Could not load the model from ({model_path}).")
+      print("Deleting this path and re-downloading.")
+      shutil.rmtree(model_path)
+      assert (not os.path.exists(model_path))
 
   print(
-      f"Model ({model_folder}) was not previously downloaded. Downloading to: {os.path.join(directory, model_folder)}"
+      f"Model ({model_folder}) was either not previously downloaded or cannot successfully be loaded. Downloading to: {model_path}"
   )
   return download_model_from_gcs(bucket, directory, model_folder)


### PR DESCRIPTION
This bug was preventing the local nl_server from starting. 

Issue: on OS X any folders/files under the `/tmp/` folder are deleted if unused for some time (ref thanks to @pradh : https://apple.stackexchange.com/questions/438930/does-macos-delete-files-in-tmp-periodically). But looks like this cleanup does not properly remove a parent folder if there is an empty folder contained in it. This resulted in our nl_server's initialization to think the model is already downloaded (because we were only checking for path existence) but when loading the model it threw an error.

Fix is to check at startup time if the model can actually be loaded successfully. If not, remove the path entirely and then re-download the model folder and files.