### PR TITLE
NL: misc fulfillment fixes

### DIFF
--- a/server/lib/nl/common/variable.py
+++ b/server/lib/nl/common/variable.py
@@ -163,7 +163,7 @@ def extend_svs(svs: List[str]):
       if sv2 == sv:
         continue
       reverse_map[sv2] = res[sv]
-  res_ordered = {sv: sorted(ext_svs) for sv, ext_svs in res.items()}
+  res_ordered = {sv: sorted(set(ext_svs)) for sv, ext_svs in res.items()}
   return res_ordered
 
 
@@ -284,6 +284,18 @@ _SV_PARTIAL_DCID_NO_PC = [
     "FertilityRate_",
     "GrowthRate_",
     "sdg/",
+    "FemaNaturalHazardRiskIndex_",
+    "FemaCommunityResilience_",
+    "FemaSocialVulnerability_",
+    "MothersAge_",
+    "IntervalSinceLastBirth_",
+    "BirthWeight_",
+    "Covid19MobilityTrend_",
+    "Average_",
+    "Cancer_Risk",
+    "IncrementalCount_",
+    "HouseholdSize_",
+    "LmpGestationalAge_",
 ]
 
 _SV_FULL_DCID_NO_PC = ["Count_Person"]

--- a/server/lib/nl/fulfillment/correlation.py
+++ b/server/lib/nl/fulfillment/correlation.py
@@ -80,6 +80,8 @@ def _populate_correlation_for_place_type(state: PopulateState) -> bool:
     else:
       state.uttr.counters.err('correlation_failed_populate_main_place', pl.dcid)
   for pl in places_from_context(state.uttr):
+    # Important to set this for maybe_set_fallback().
+    state.uttr.places = [pl]
     if (_populate_correlation_for_place(state, pl)):
       state.uttr.place_source = FulfillmentResult.PAST_QUERY
       state.uttr.past_source_context = pl.name

--- a/server/lib/nl/fulfillment/event.py
+++ b/server/lib/nl/fulfillment/event.py
@@ -62,6 +62,8 @@ def _populate_event(state: base.PopulateState,
       state.uttr.counters.err('event_failed_populate_main_place', pl.dcid)
   if not state.uttr.places:
     for pl in ctx.places_from_context(state.uttr):
+      # Important to set this for maybe_set_fallback().
+      state.uttr.places = [pl]
       if (_populate_event_for_place(state, event_types, pl)):
         state.uttr.place_source = nl_uttr.FulfillmentResult.PAST_QUERY
         state.uttr.past_source_context = pl.name

--- a/server/tests/lib/nl/test_utterance.py
+++ b/server/tests/lib/nl/test_utterance.py
@@ -383,7 +383,12 @@ CONTAINED_IN_UTTR = {
         'contained_in_place_type': 'County',
         'type': ClassificationType.CONTAINED_IN
     }],
-    'places': [],
+    'places': [{
+        'country': 'country/USA',
+        'dcid': 'geoId/06',
+        'name': 'Foo Place',
+        'place_type': 'State'
+    }],
     'llm_resp': {},
     'placeFallback': {},
     'query': 'foo sv in place',
@@ -441,7 +446,12 @@ CORRELATION_UTTR = {
     'classifications': [{
         'type': ClassificationType.CORRELATION
     }],
-    'places': [],
+    'places': [{
+        'country': 'country/USA',
+        'dcid': 'geoId/06',
+        'name': 'Foo Place',
+        'place_type': 'State'
+    }],
     'llm_resp': {},
     'placeFallback': {},
     'query': 'foo sv in place',
@@ -544,7 +554,12 @@ RANKING_ACROSS_PLACES_UTTR = {
         'contained_in_place_type': 'County',
         'type': QueryType.CONTAINED_IN,
     }],
-    'places': [],
+    'places': [{
+        'country': 'country/USA',
+        'dcid': 'geoId/06',
+        'name': 'Foo Place',
+        'place_type': 'State'
+    }],
     'llm_resp': {},
     'placeFallback': {},
     'query': 'foo sv in place',
@@ -581,7 +596,12 @@ RANKING_ACROSS_SVS_UTTR = {
         'ranking_type': [RankingType.HIGH],
         'type': ClassificationType.RANKING
     }],
-    'places': [],
+    'places': [{
+        'country': 'country/USA',
+        'dcid': 'geoId/06',
+        'name': 'Foo Place',
+        'place_type': 'State'
+    }],
     'llm_resp': {},
     'placeFallback': {},
     'query': 'foo sv in place',
@@ -622,7 +642,12 @@ TIME_DELTA_ACROSS_VARS_UTTR = {
         'time_delta_type': [TimeDeltaType.INCREASE],
         'type': ClassificationType.TIME_DELTA
     }],
-    'places': [],
+    'places': [{
+        'country': 'country/USA',
+        'dcid': 'geoId/06',
+        'name': 'Foo Place',
+        'place_type': 'State'
+    }],
     'llm_resp': {},
     'placeFallback': {},
     'query': 'foo sv in place',

--- a/static/js/apps/nl_interface/debug_info.tsx
+++ b/static/js/apps/nl_interface/debug_info.tsx
@@ -25,6 +25,7 @@ import { Col, Row } from "reactstrap";
 import {
   DebugInfo,
   MultiSVCandidate,
+  SearchResult,
   SVScores,
 } from "../../types/app/nl_interface_types";
 
@@ -157,7 +158,7 @@ const multiVarScoresElement = (svScores: SVScores): JSX.Element => {
 
 export interface DebugInfoProps {
   debugData: any; // from the server response
-  pageConfig: any;
+  chartsData: SearchResult;
 }
 
 export function DebugInfo(props: DebugInfoProps): JSX.Element {
@@ -320,6 +321,26 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
           </Row>
           <Row>
             <Col>
+              Place Query Source: {props.chartsData.placeSource}
+              {props.chartsData.pastSourceContext
+                ? "(" + props.chartsData.pastSourceContext + ")"
+                : ""}
+            </Col>
+          </Row>
+          <Row>
+            <Col>Variable Query Source: {props.chartsData.svSource}</Col>
+          </Row>
+          {props.chartsData.placeFallback && (
+            <Row>
+              <Col>
+                Place Fallback: &quot;{props.chartsData.placeFallback.origStr}
+                &quot; to &quot;{props.chartsData.placeFallback.newStr}&quot;
+              </Col>
+            </Row>
+          )}
+          <Row>
+            <Col>
+              <b>Counters:</b>
               <pre>{JSON.stringify(debugInfo.counters, null, 2)}</pre>
             </Col>
           </Row>
@@ -328,7 +349,13 @@ export function DebugInfo(props: DebugInfoProps): JSX.Element {
           </Row>
           <Row>
             <Col>
-              <pre>{JSON.stringify(props.pageConfig, null, 2)}</pre>
+              <pre>
+                {JSON.stringify(
+                  props.chartsData ? props.chartsData.config : null,
+                  null,
+                  2
+                )}
+              </pre>
             </Col>
           </Row>
         </div>

--- a/static/js/apps/nl_interface/query_result.tsx
+++ b/static/js/apps/nl_interface/query_result.tsx
@@ -174,39 +174,65 @@ export const QueryResult = memo(function QueryResult(
           {debugData && (
             <DebugInfo
               debugData={debugData}
-              pageConfig={chartsData ? chartsData.config : null}
+              chartsData={chartsData}
             ></DebugInfo>
           )}
+          {chartsData &&
+            !chartsData.placeFallback &&
+            (chartsData.placeSource === "PAST_QUERY" ||
+              chartsData.placeSource === "PAST_QUERY") && (
+              <div className="nl-query-info">
+                Could not recognize any{" "}
+                {chartsData.placeSource !== "PAST_QUERY" && <span>topic</span>}
+                {chartsData.svSource !== "PAST_QUERY" && <span>place</span>}
+                {chartsData.svSource === "PAST_QUERY" &&
+                  chartsData.placeSource === "PAST_QUERY" && (
+                    <span>place or topic</span>
+                  )}{" "}
+                in this query, so here are relevant statistics for{" "}
+                {chartsData.pastSourceContext} based on what you previously
+                asked.
+              </div>
+            )}
+          {chartsData &&
+            !chartsData.placeFallback &&
+            chartsData.svSource === "UNRECOGNIZED" && (
+              <div className="nl-query-info">
+                Could not recognize any topic from the query, but below are
+                topic categories with statistics for {chartsData.place.name}{" "}
+                that you could explore further.
+              </div>
+            )}
+          {chartsData &&
+            !chartsData.placeFallback &&
+            chartsData.svSource === "UNFULFILLED" && (
+              <div className="nl-query-info">
+                Sorry, there were no relevant statistics about the topic for{" "}
+                {chartsData.place.name}. Below are topic categories with
+                statistics for {chartsData.place.name} that you could explore
+                further.
+              </div>
+            )}
           {chartsData && chartsData.placeFallback && (
             <div className="nl-query-info">
-              Sorry, there was no relevant statistics for &quot;
-              {chartsData.placeFallback.origStr}&quot;. &nbsp; Here are results
-              about &quot;{chartsData.placeFallback.newStr}&quot; instead.
-            </div>
-          )}
-          {chartsData && chartsData.placeSource === "PAST_QUERY" && (
-            <div className="nl-query-info">
-              Could not recognize any place in this query, so using{" "}
-              {chartsData.pastSourceContext} from a prior query in this session.
-            </div>
-          )}
-          {chartsData && chartsData.svSource === "PAST_QUERY" && (
-            <div className="nl-query-info">
-              Could not recognize any topic in this query, so using a topic you
-              previously asked about in this session.
-            </div>
-          )}
-          {chartsData && chartsData.svSource === "UNRECOGNIZED" && (
-            <div className="nl-query-info">
-              Could not recognize any topic from the query. Below are some topic
-              categories with statistics for {chartsData.place.name}.
-            </div>
-          )}
-          {chartsData && chartsData.svSource === "UNFULFILLED" && (
-            <div className="nl-query-info">
-              Sorry, there was no relevant statistics about the topic for{" "}
-              {chartsData.place.name}. Below are some topic categories with
-              data.
+              {chartsData.placeSource !== "PAST_QUERY" &&
+                chartsData.svSource !== "PAST_QUERY" && (
+                  <span>
+                    Sorry, there were no relevant statistics on this topic for
+                    &quot;{chartsData.placeFallback.origStr}&quot;. &nbsp; Here
+                    are results for &quot;{chartsData.placeFallback.newStr}
+                    &quot; instead.
+                  </span>
+                )}
+              {(chartsData.placeSource === "PAST_QUERY" ||
+                chartsData.svSource === "PAST_QUERY") && (
+                <span>
+                  Tried looking up relevant statistics for &quot;
+                  {chartsData.placeFallback.origStr}&quot; based on your prior
+                  queries, but found no results. &nbsp; Here are results for
+                  &quot;{chartsData.placeFallback.newStr}&quot; instead.
+                </span>
+              )}
             </div>
           )}
           {chartsData && chartsData.config && (


### PR DESCRIPTION
#### 1 - Handle mixed fallbacks better

If we retrieve a place or variable from context and also do place fallback, provide a unified message.

Before this PR we would not report place fallback when we fallback from a place in context. [asthma in california] -> [what about blood pressure?]

Now we'll say, `Tried looking up relevant statistics for "California" based on your prior queries, but found no results.   Here are results for "United States" instead.`

#### 2 - Avoid duplicate SVs in comparison bar charts

[How long do workers in Maryland live] from earlier today

#### 3 - Avoid bar charts that have no SV in title

![image](https://github.com/datacommonsorg/website/assets/4375037/243a5c3a-2777-48e5-962d-2f829b0a2607)

These come about because we were expanding a "main SV" even when it doesn't pass existing check, so fix that.

#### 4 - Add fallback info debug page

![image](https://github.com/datacommonsorg/website/assets/4375037/aa8e48ff-49f3-4582-9c75-68b3acb2412c)

#### 5 - Exclude more per-capita SVs

This is a temporary thing until we have [chart controls for per-capita](https://github.com/datacommonsorg/website/issues/2917).
