### PR TITLE
[Library] Stacked and Horizontal Lollipop Charts

### DIFF
--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -927,6 +927,191 @@ function drawBars(
 }
 
 /**
+ * Helper function for horizontally plotting dataGroups in a set of axes.
+ *
+ * @param chart SVG element to draw lollipops in
+ * @param colorFn color scale mapping legend labels to colors
+ * @param dataGroups grouped data values to plot
+ * @param xScale main scale for x-axis values
+ * @param xSubScale sub-scale for a single group of lollipops
+ * @param yScale  scale for y-axis values
+ * @param useLollipop whether to use lollipop style
+ */
+function drawHorizontalGroupedBars(
+  chart: d3.Selection<SVGElement, unknown, null, undefined>,
+  colorFn: d3.ScaleOrdinal<string, string, never>,
+  dataGroups: DataGroup[],
+  xScale: d3.ScaleLinear<number, number>,
+  yScale: d3.ScaleBand<string>,
+  useLollipop?: boolean
+): void {
+  const numGroups = dataGroups[0].value.length;
+
+  if (useLollipop) {
+    // Max allowable stem spacing
+    const maxStemSpacing = yScale.bandwidth() / (numGroups + 1);
+    // How far apart each stem should be
+    const stemSpacing = Math.min(15, maxStemSpacing);
+    // How far down bandwidth to start drawing stems
+    const bandwidthPadding =
+      ((numGroups + 1) * (maxStemSpacing - stemSpacing)) / 2;
+    // draw lollipop stems
+    chart
+      .append("g")
+      .selectAll("g")
+      .data(dataGroups)
+      .join("g")
+      .selectAll("line")
+      .data((dg) =>
+        dg.value.map((dgv) => ({
+          dataGroupValue: dgv,
+          label: dg.label,
+        }))
+      )
+      .join("line")
+      .attr("data-dcid", (item) => item.dataGroupValue.dcid)
+      .attr("data-d", (item) => item.dataGroupValue.value)
+      .attr("stroke", (item) => colorFn(item.dataGroupValue.label))
+      .attr("stroke-width", 2)
+      .attr("x1", xScale(0))
+      .attr("x2", (item) => xScale(item.dataGroupValue.value))
+      .attr(
+        "y1",
+        (item, i) =>
+          yScale(item.label) + (i + 1) * stemSpacing + bandwidthPadding
+      )
+      .attr(
+        "y2",
+        (item, i) =>
+          yScale(item.label) + (i + 1) * stemSpacing + bandwidthPadding
+      );
+
+    // draw circles
+    chart
+      .append("g")
+      .selectAll("g")
+      .data(dataGroups)
+      .join("g")
+      .selectAll("line")
+      .data((dg) =>
+        dg.value.map((dgv) => ({
+          dataGroupValue: dgv,
+          label: dg.label,
+        }))
+      )
+      .join("circle")
+      .attr("data-dcid", (item) => item.dataGroupValue.dcid)
+      .attr("data-d", (item) => item.dataGroupValue.value)
+      .attr("fill", (item) => colorFn(item.dataGroupValue.label))
+      .attr("cx", (item) => xScale(item.dataGroupValue.value))
+      .attr(
+        "cy",
+        (item, i) =>
+          yScale(item.label) + (i + 1) * stemSpacing + bandwidthPadding
+      )
+      .attr("r", Math.min(6, stemSpacing));
+  } else {
+    // Draw horizontal bars
+    const barHeight = yScale.bandwidth() / numGroups;
+    chart
+      .selectAll("g")
+      .data(dataGroups)
+      .enter()
+      .append("g")
+      .selectAll("rect")
+      .data((dg) =>
+        dg.value.map((dgv) => ({ dataGroupValue: dgv, label: dg.label }))
+      )
+      .join("rect")
+      .attr("fill", (item) => colorFn(item.dataGroupValue.label))
+      .classed("g-bar", true)
+      .attr("data-dcid", (item) => item.dataGroupValue.dcid)
+      .attr("x", xScale(0))
+      .attr("y", (item, i) => yScale(item.label) + i * barHeight)
+      .attr("width", (item) => xScale(item.dataGroupValue.value))
+      .attr("height", barHeight);
+  }
+}
+
+/**
+ * Helper function for horizontally stacking dataGroups in a set of axes.
+ *
+ * @param chart SVG element to draw lollipops in
+ * @param colorFn color scale mapping legend labels to colors
+ * @param series data values to plot
+ * @param xScale main scale for x-axis values
+ * @param xSubScale sub-scale for a single group of lollipops
+ * @param yScale  scale for y-axis values
+ * @param useLollipop whether to use lollipop style
+ */
+function drawHorizontalStackedBars(
+  chart: d3.Selection<SVGElement, unknown, null, undefined>,
+  colorFn: d3.ScaleOrdinal<string, string, never>,
+  series: d3.Series<{ [key: string]: number }, string>[],
+  xScale: d3.ScaleLinear<number, number>,
+  yScale: d3.ScaleBand<string>,
+  useLollipop?: boolean
+): void {
+  if (useLollipop) {
+    // How much to shift stems so they plot at center of band
+    const yShift = yScale.bandwidth() / 2;
+
+    // draw lollipop stems
+    chart
+      .append("g")
+      .selectAll("g")
+      .data(series)
+      .enter()
+      .append("g")
+      .attr("stroke", (d) => colorFn(d.key))
+      .selectAll("line")
+      .data((d) => d)
+      .join("line")
+      .attr("data-dcid", (d) => d.data.dcid)
+      .attr("data-d", (d) => d.data.value)
+      .attr("stroke-width", 2)
+      .attr("x1", (d) => xScale(d[0]))
+      .attr("x2", (d) => xScale(d[1]))
+      .attr("y1", (d) => yScale(String(d.data.label)) + yShift)
+      .attr("y2", (d) => yScale(String(d.data.label)) + yShift);
+
+    // draw circles
+    chart
+      .append("g")
+      .selectAll("g")
+      .data(series)
+      .enter()
+      .append("g")
+      .attr("fill", (d) => colorFn(d.key))
+      .selectAll("circle")
+      .data((d) => d)
+      .join("circle")
+      .attr("data-dcid", (d) => d.data.dcid)
+      .attr("data-d", (d) => d.data.value)
+      .attr("cx", (d) => xScale(d[1]))
+      .attr("cy", (d) => yScale(String(d.data.label)) + yShift)
+      .attr("r", 6);
+  } else {
+    // Draw horizontal bars, stacked
+    chart
+      .selectAll("g")
+      .data(series)
+      .enter()
+      .append("g")
+      .attr("fill", (d) => colorFn(d.key))
+      .selectAll("rect")
+      .data((d) => d)
+      .join("rect")
+      .classed("g-bar", true)
+      .attr("data-dcid", (d) => d.data.dcid)
+      .attr("x", (d) => xScale(d[0]))
+      .attr("y", (d) => yScale(String(d.data.label)))
+      .attr("width", (d) => xScale(d[1]) - xScale(d[0]))
+      .attr("height", yScale.bandwidth());
+  }
+}
+
+/**
  * Helper function for plotting dataGroups with lollipops (stem and circle).
  * Used by bar charts to render data in lollipop style.
  * @param chart SVG element to draw lollipops in
@@ -1330,41 +1515,9 @@ function drawHorizontalBarChart(
 
   if (options?.stacked) {
     // Stacked bar chart
-    svg
-      .selectAll("g")
-      .data(series)
-      .enter()
-      .append("g")
-      .attr("fill", (d) => color(d.key))
-      .selectAll("rect")
-      .data((d) => d)
-      .join("rect")
-      .classed("g-bar", true)
-      .attr("data-dcid", (d) => d.data.dcid)
-      .attr("x", (d) => x(d[0]))
-      .attr("y", (d) => y(String(d.data.label)))
-      .attr("width", (d) => x(d[1]) - x(d[0]))
-      .attr("height", y.bandwidth());
+    drawHorizontalStackedBars(svg, color, series, x, y, options?.lollipop);
   } else {
-    // Grouped bar chart
-    const barHeight = y.bandwidth() / numGroups;
-    svg
-      .selectAll("g")
-      .data(dataGroups)
-      .enter()
-      .append("g")
-      .selectAll("rect")
-      .data((dg) =>
-        dg.value.map((dgv) => ({ dataGroupValue: dgv, label: dg.label }))
-      )
-      .join("rect")
-      .attr("fill", (item) => color(item.dataGroupValue.label))
-      .classed("g-bar", true)
-      .attr("data-dcid", (item) => item.dataGroupValue.dcid)
-      .attr("x", x(0))
-      .attr("y", (item, i) => y(item.label) + i * barHeight)
-      .attr("width", (item) => x(item.dataGroupValue.value))
-      .attr("height", barHeight);
+    drawHorizontalGroupedBars(svg, color, dataGroups, x, y, options?.lollipop);
   }
 
   // x axis

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -1072,6 +1072,14 @@ function drawHorizontalGroupedBars(
       .join("line")
       .attr("data-dcid", (item) => item.dataGroupValue.dcid)
       .attr("data-d", (item) => item.dataGroupValue.value)
+      .attr("part", (item) =>
+        [
+          "series",
+          `series-place-${item.dataGroupValue.dcid}`,
+          `series-variable-${item.label}`,
+          `series-place-${item.dataGroupValue.dcid}-variable-${item.label}`,
+        ].join(" ")
+      )
       .attr("stroke", (item) => colorFn(item.dataGroupValue.label))
       .attr("stroke-width", 2)
       .attr("x1", xScale(0))
@@ -1103,6 +1111,14 @@ function drawHorizontalGroupedBars(
       .join("circle")
       .attr("data-dcid", (item) => item.dataGroupValue.dcid)
       .attr("data-d", (item) => item.dataGroupValue.value)
+      .attr("part", (item) =>
+        [
+          "series",
+          `series-place-${item.dataGroupValue.dcid}`,
+          `series-variable-${item.label}`,
+          `series-place-${item.dataGroupValue.dcid}-variable-${item.label}`,
+        ].join(" ")
+      )
       .attr("fill", (item) => colorFn(item.dataGroupValue.label))
       .attr("cx", (item) => xScale(item.dataGroupValue.value))
       .attr(
@@ -1175,10 +1191,18 @@ function drawHorizontalStackedBars(
       .append("g")
       .attr("stroke", (d) => colorFn(d.key))
       .selectAll("line")
-      .data((d) => d)
+      .data((d) => d.map((dp) => ({ key: d.key, ...dp })))
       .join("line")
       .attr("data-dcid", (d) => d.data.dcid)
       .attr("data-d", (d) => d.data.value)
+      .attr("part", (d) =>
+        [
+          "series",
+          `series-place-${d.data.dcid}`,
+          `series-variable-${d.key}`,
+          `series-place-${d.data.dcid}-variable-${d.key}`,
+        ].join(" ")
+      )
       .attr("stroke-width", 2)
       .attr("x1", (d) => xScale(d[0]))
       .attr("x2", (d) => xScale(d[1]))
@@ -1194,10 +1218,18 @@ function drawHorizontalStackedBars(
       .append("g")
       .attr("fill", (d) => colorFn(d.key))
       .selectAll("circle")
-      .data((d) => d)
+      .data((d) => d.map((dp) => ({ key: d.key, ...dp })))
       .join("circle")
       .attr("data-dcid", (d) => d.data.dcid)
       .attr("data-d", (d) => d.data.value)
+      .attr("part", (d) =>
+        [
+          "series",
+          `series-place-${d.data.dcid}`,
+          `series-variable-${d.key}`,
+          `series-place-${d.data.dcid}-variable-${d.key}`,
+        ].join(" ")
+      )
       .attr("cx", (d) => xScale(d[1]))
       .attr("cy", (d) => yScale(String(d.data.label)) + yShift)
       .attr("r", 6);

--- a/static/js/chart/draw.ts
+++ b/static/js/chart/draw.ts
@@ -859,21 +859,62 @@ function drawStackBarChart(
 
   const color = getColorFn(keys);
 
-  chart
-    .selectAll("g")
-    .data(series)
-    .enter()
-    .append("g")
-    .attr("fill", (d) => color(d.key))
-    .selectAll("rect")
-    .data((d) => d)
-    .join("rect")
-    .classed("g-bar", true)
-    .attr("data-dcid", (d) => d.data.dcid)
-    .attr("x", (d) => x(String(d.data.label)))
-    .attr("y", (d) => (Number.isNaN(d[1]) ? y(d[0]) : y(d[1])))
-    .attr("width", x.bandwidth())
-    .attr("height", (d) => (Number.isNaN(d[1]) ? 0 : y(d[0]) - y(d[1])));
+  if (options?.lollipop) {
+    // How much to shift stems so they plot at center of band
+    const xShift = x.bandwidth() / 2;
+
+    // draw lollipop stems
+    chart
+      .selectAll("g")
+      .data(series)
+      .enter()
+      .append("g")
+      .attr("stroke", (d) => color(d.key))
+      .selectAll("line")
+      .data((d) => d)
+      .join("line")
+      .attr("data-dcid", (d) => d.data.dcid)
+      .attr("data-d", (d) => d.data.value)
+      .attr("stroke-width", 2)
+      .attr("x1", (d) => x(String(d.data.label)) + xShift)
+      .attr("x2", (d) => x(String(d.data.label)) + xShift)
+      .attr("y1", (d) => y(d[0]))
+      .attr("y2", (d) => y(d[1]));
+
+    // draw circles
+    chart
+      .append("g")
+      .selectAll("g")
+      .data(series)
+      .enter()
+      .append("g")
+      .attr("fill", (d) => color(d.key))
+      .selectAll("circle")
+      .data((d) => d)
+      .join("circle")
+      .attr("data-dcid", (d) => d.data.dcid)
+      .attr("data-d", (d) => d.data.value)
+      .attr("r", 6)
+      .attr("cx", (d) => x(String(d.data.label)) + xShift)
+      .attr("cy", (d) => y(d[1]));
+  } else {
+    // draw bars
+    chart
+      .selectAll("g")
+      .data(series)
+      .enter()
+      .append("g")
+      .attr("fill", (d) => color(d.key))
+      .selectAll("rect")
+      .data((d) => d)
+      .join("rect")
+      .classed("g-bar", true)
+      .attr("data-dcid", (d) => d.data.dcid)
+      .attr("x", (d) => x(String(d.data.label)))
+      .attr("y", (d) => (Number.isNaN(d[1]) ? y(d[0]) : y(d[1])))
+      .attr("width", x.bandwidth())
+      .attr("height", (d) => (Number.isNaN(d[1]) ? 0 : y(d[0]) - y(d[1])));
+  }
 
   appendLegendElem(
     containerElement,

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -293,6 +293,7 @@ export function draw(
       chartData.dataGroup,
       formatNumber,
       {
+        lollipop: props.useLollipop,
         stacked: props.stacked,
         style: {
           barHeight: props.barHeight,

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -312,6 +312,7 @@ export function draw(
         chartData.dataGroup,
         formatNumber,
         {
+          lollipop: props.useLollipop,
           unit: chartData.unit,
         }
       );
@@ -324,8 +325,8 @@ export function draw(
         chartData.dataGroup,
         formatNumber,
         {
-          unit: chartData.unit,
           lollipop: props.useLollipop,
+          unit: chartData.unit,
         }
       );
     }

--- a/web-components/docs/README.md
+++ b/web-components/docs/README.md
@@ -85,8 +85,7 @@ Styling Options:
 - `stacked` _boolean_
   - Set to true to draw as stacked bar chart instead of grouped chart
 - `lollipop` _boolean_
-  - Set to true to draw lollipops instead of bars.
-  - Note: only works when `horizontal` is false.
+  - Set to true to draw lollipops instead of bars
 
 ### Examples
 

--- a/web-components/examples/example.html
+++ b/web-components/examples/example.html
@@ -172,5 +172,18 @@
       horizontal
       stacked
     ></datacommons-bar>
+    <datacommons-bar
+    title="Median income by gender of select US states (stacked)"
+    comparisonVariables="Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
+    comparisonPlaces="geoId/01 geoId/02 geoId/04 geoId/05"
+    stacked
+  ></datacommons-bar>
+  <datacommons-bar
+  title="Median income by gender of select US states (stacked)"
+  comparisonVariables="Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
+  comparisonPlaces="geoId/01 geoId/02 geoId/04 geoId/05"
+  stacked
+  lollipop
+></datacommons-bar>
   </body>
 </html>

--- a/web-components/examples/example.html
+++ b/web-components/examples/example.html
@@ -5,7 +5,8 @@
       rel="stylesheet"
       href="https://datacommons.org/css/nl_interface.min.css"
     />
-    <script src="https://datacommons.org/datacommons.js"></script>
+    <!-- <script src="https://datacommons.org/datacommons.js"></script> -->
+    <script src="http://localhost:8080/datacommons.js"></script>
   </head>
   <body style="max-width: 40vw; margin: auto">
     <h1>Datacommons Web Components</h1>
@@ -153,6 +154,23 @@
       place="geoId/02"
       childPlaceType="County"
       lollipop
+    ></datacommons-bar>
+    <datacommons-bar
+      title="Median income by gender for counties in Alaska"
+      comparisonVariables="Median_Income_Person Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
+      place="geoId/02"
+      childPlaceType="County"
+      horizontal
+      stacked
+    ></datacommons-bar>
+    <datacommons-bar
+      title="Median income by gender for counties in Alaska"
+      comparisonVariables="Median_Income_Person Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
+      place="geoId/02"
+      childPlaceType="County"
+      lollipop
+      horizontal
+      stacked
     ></datacommons-bar>
   </body>
 </html>

--- a/web-components/examples/example.html
+++ b/web-components/examples/example.html
@@ -156,15 +156,7 @@
       lollipop
     ></datacommons-bar>
     <datacommons-bar
-      title="Median income by gender for counties in Alaska"
-      comparisonVariables="Median_Income_Person Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
-      place="geoId/02"
-      childPlaceType="County"
-      horizontal
-      stacked
-    ></datacommons-bar>
-    <datacommons-bar
-      title="Median income by gender for counties in Alaska"
+      title="Median income by gender for counties in Alaska (horizontal, stacked, lollipop)"
       comparisonVariables="Median_Income_Person Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
       place="geoId/02"
       childPlaceType="County"
@@ -172,18 +164,12 @@
       horizontal
       stacked
     ></datacommons-bar>
-    <datacommons-bar
-    title="Median income by gender of select US states (stacked)"
+  <datacommons-bar
+    title="Median income by gender of select US states (stacked, lollipop)"
     comparisonVariables="Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
     comparisonPlaces="geoId/01 geoId/02 geoId/04 geoId/05"
     stacked
+    lollipop
   ></datacommons-bar>
-  <datacommons-bar
-  title="Median income by gender of select US states (stacked)"
-  comparisonVariables="Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
-  comparisonPlaces="geoId/01 geoId/02 geoId/04 geoId/05"
-  stacked
-  lollipop
-></datacommons-bar>
   </body>
 </html>

--- a/web-components/examples/example.html
+++ b/web-components/examples/example.html
@@ -5,8 +5,7 @@
       rel="stylesheet"
       href="https://datacommons.org/css/nl_interface.min.css"
     />
-    <!-- <script src="https://datacommons.org/datacommons.js"></script> -->
-    <script src="http://localhost:8080/datacommons.js"></script>
+    <script src="https://datacommons.org/datacommons.js"></script>
   </head>
   <body style="max-width: 40vw; margin: auto">
     <h1>Datacommons Web Components</h1>

--- a/web-components/examples/example.html
+++ b/web-components/examples/example.html
@@ -6,7 +6,7 @@
       href="https://datacommons.org/css/nl_interface.min.css"
     />
     <script src="https://datacommons.org/datacommons.js"></script>
-    <style>
+      <style>
       /**
        * Example component styling using shadow part identifiers
        */
@@ -266,12 +266,12 @@
       horizontal
       stacked
     ></datacommons-bar>
-  <datacommons-bar
-    title="Median income by gender of select US states (stacked, lollipop)"
-    comparisonVariables="Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
-    comparisonPlaces="geoId/01 geoId/02 geoId/04 geoId/05"
-    stacked
-    lollipop
-  ></datacommons-bar>
+    <datacommons-bar
+      title="Median income by gender of select US states (stacked, lollipop)"
+      comparisonVariables="Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
+      comparisonPlaces="geoId/01 geoId/02 geoId/04 geoId/05"
+      stacked
+      lollipop
+    ></datacommons-bar>
   </body>
 </html>

--- a/web-components/examples/example.html
+++ b/web-components/examples/example.html
@@ -6,7 +6,7 @@
       href="https://datacommons.org/css/nl_interface.min.css"
     />
     <script src="https://datacommons.org/datacommons.js"></script>
-      <style>
+    <style>
       /**
        * Example component styling using shadow part identifiers
        */


### PR DESCRIPTION
This PR adds the ability to draw stacked and horizontal lollipop charts, and updates the docs/examples.

Examples (compare to bar version):
```
  <datacommons-bar
    title="Median income by gender for counties in Alaska (horizontal, stacked, lollipop)"
    comparisonVariables="Median_Income_Person Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
    place="geoId/02"
    childPlaceType="County"
    lollipop
    horizontal
    stacked
  ></datacommons-bar>
```
![Screenshot 2023-07-12 at 9 15 18 AM](https://github.com/datacommonsorg/website/assets/4034366/946e7a3c-e164-486b-ac7d-3e72f0d808c2)

```
<datacommons-bar
  title="Median income by gender of select US states (stacked, lollipop)"
  comparisonVariables="Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
  comparisonPlaces="geoId/01 geoId/02 geoId/04 geoId/05"
  stacked
  lollipop
></datacommons-bar>
```
![Screenshot 2023-07-12 at 9 15 10 AM](https://github.com/datacommonsorg/website/assets/4034366/dec4da4f-7439-4985-8a0f-4aabe96878ed)
