### PR TITLE
[NL Interface] Fixing the local cache bug

### DIFF
--- a/nl_server/loader.py
+++ b/nl_server/loader.py
@@ -23,6 +23,7 @@ nl_embeddings_cache_key_base = 'nl_embeddings'
 nl_ner_cache_key = 'nl_ner'
 nl_cache_path = '~/.datacommons/'
 nl_cache_expire = 3600 * 24  # Cache for 1 day
+nl_cache_size_limit = 16e9  # 16Gb local cache size
 
 DEFAULT_INDEX_TYPE = 'small'
 
@@ -68,7 +69,7 @@ def load_embeddings(app, embeddings_map, models_downloaded_paths):
   # the embeddings again.
   if _use_cache(flask_env):
     from diskcache import Cache
-    cache = Cache(nl_cache_path)
+    cache = Cache(nl_cache_path, size_limit=nl_cache_size_limit)
     cache.expire()
 
     nl_ner_places = cache.get(nl_ner_cache_key)
@@ -111,7 +112,7 @@ def load_embeddings(app, embeddings_map, models_downloaded_paths):
   app.config["NL_NER_PLACES"] = nl_ner_places
 
   if _use_cache(flask_env):
-    with Cache(cache.directory) as reference:
+    with Cache(cache.directory, size_limit=nl_cache_size_limit) as reference:
       for sz in embeddings_map.keys():
         reference.set(nl_embeddings_cache_key(sz),
                       app.config[embeddings_config_key(sz)],

--- a/nl_server/tests/embeddings_test.py
+++ b/nl_server/tests/embeddings_test.py
@@ -33,6 +33,7 @@ _root_dir = os.path.dirname(
 _test_data = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           'test_data')
 
+_tuned_model_key = "tuned_model"
 
 # TODO(pradh): Expand tests to other index sizes.
 def _get_embeddings_file_path() -> str:
@@ -42,6 +43,13 @@ def _get_embeddings_file_path() -> str:
     embeddings_file = embeddings[loader.DEFAULT_INDEX_TYPE]
     return gcs.download_embeddings(embeddings_file)
 
+def _get_tuned_model_path() -> str:
+  models_config_path = os.path.join(_root_dir, 'deploy/nl/models.yaml')
+  with open(models_config_path) as f:
+    models_map = yaml.full_load(f)
+    tuned_model_dict = {_tuned_model_key: models_map[_tuned_model_key]}
+    models_downloaded_paths = loader.download_models(tuned_model_dict)
+    return models_downloaded_paths[models_map[_tuned_model_key]]
 
 class TestEmbeddings(unittest.TestCase):
 
@@ -56,8 +64,11 @@ class TestEmbeddings(unittest.TestCase):
       print(
           "Could not load the embeddings from the cache for these tests. Loading a new embeddings object."
       )
-      # Using the default NER model.
-      cls.nl_embeddings = Embeddings(_get_embeddings_file_path())
+      # Building a new Embeddings object. It might require downloading the embeddings file
+      # and a finetuned model.
+      # This uses the default embeddings pointed to in embeddings.yaml file and the fine tuned 
+      # model pointed to in models.yaml.
+      cls.nl_embeddings = Embeddings(_get_embeddings_file_path(), _get_tuned_model_path())
 
   @parameterized.expand([
       # All these queries should detect one of the SVs as the top choice.

--- a/nl_server/tests/embeddings_test.py
+++ b/nl_server/tests/embeddings_test.py
@@ -33,8 +33,6 @@ _root_dir = os.path.dirname(
 _test_data = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           'test_data')
 
-_tuned_model_key = "tuned_model"
-
 
 # TODO(pradh): Expand tests to other index sizes.
 def _get_embeddings_file_path() -> str:
@@ -43,15 +41,6 @@ def _get_embeddings_file_path() -> str:
     embeddings = yaml.full_load(f)
     embeddings_file = embeddings[loader.DEFAULT_INDEX_TYPE]
     return gcs.download_embeddings(embeddings_file)
-
-
-def _get_tuned_model_path() -> str:
-  models_config_path = os.path.join(_root_dir, 'deploy/nl/models.yaml')
-  with open(models_config_path) as f:
-    models_map = yaml.full_load(f)
-    tuned_model_dict = {_tuned_model_key: models_map[_tuned_model_key]}
-    models_downloaded_paths = loader.download_models(tuned_model_dict)
-    return models_downloaded_paths[models_map[_tuned_model_key]]
 
 
 class TestEmbeddings(unittest.TestCase):
@@ -67,12 +56,8 @@ class TestEmbeddings(unittest.TestCase):
       print(
           "Could not load the embeddings from the cache for these tests. Loading a new embeddings object."
       )
-      # Building a new Embeddings object. It might require downloading the embeddings file
-      # and a finetuned model.
-      # This uses the default embeddings pointed to in embeddings.yaml file and the fine tuned
-      # model pointed to in models.yaml.
-      cls.nl_embeddings = Embeddings(_get_embeddings_file_path(),
-                                     _get_tuned_model_path())
+      # Building a new Embeddings object.
+      cls.nl_embeddings = Embeddings(_get_embeddings_file_path())
 
   @parameterized.expand([
       # All these queries should detect one of the SVs as the top choice.

--- a/nl_server/tests/embeddings_test.py
+++ b/nl_server/tests/embeddings_test.py
@@ -35,6 +35,7 @@ _test_data = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 
 _tuned_model_key = "tuned_model"
 
+
 # TODO(pradh): Expand tests to other index sizes.
 def _get_embeddings_file_path() -> str:
   embeddings_config_path = os.path.join(_root_dir, 'deploy/nl/embeddings.yaml')
@@ -43,6 +44,7 @@ def _get_embeddings_file_path() -> str:
     embeddings_file = embeddings[loader.DEFAULT_INDEX_TYPE]
     return gcs.download_embeddings(embeddings_file)
 
+
 def _get_tuned_model_path() -> str:
   models_config_path = os.path.join(_root_dir, 'deploy/nl/models.yaml')
   with open(models_config_path) as f:
@@ -50,6 +52,7 @@ def _get_tuned_model_path() -> str:
     tuned_model_dict = {_tuned_model_key: models_map[_tuned_model_key]}
     models_downloaded_paths = loader.download_models(tuned_model_dict)
     return models_downloaded_paths[models_map[_tuned_model_key]]
+
 
 class TestEmbeddings(unittest.TestCase):
 
@@ -66,9 +69,10 @@ class TestEmbeddings(unittest.TestCase):
       )
       # Building a new Embeddings object. It might require downloading the embeddings file
       # and a finetuned model.
-      # This uses the default embeddings pointed to in embeddings.yaml file and the fine tuned 
+      # This uses the default embeddings pointed to in embeddings.yaml file and the fine tuned
       # model pointed to in models.yaml.
-      cls.nl_embeddings = Embeddings(_get_embeddings_file_path(), _get_tuned_model_path())
+      cls.nl_embeddings = Embeddings(_get_embeddings_file_path(),
+                                     _get_tuned_model_path())
 
   @parameterized.expand([
       # All these queries should detect one of the SVs as the top choice.


### PR DESCRIPTION
We are now exceeding the local cache default size (1Gb) which meant that the local development caching was not working. Fixing this issue by increasing the cache size.

This PR also ensures that if an Embeddings object was not found in the local cache (used in the server/embeddings_test.py) then the finetuned model is downloaded/loaded and associated with the embeddings index in a new Embeddings object.