### PR TITLE
Bumped nl default chart height to 200

### DIFF
--- a/static/js/constants/app/nl_interface_constants.ts
+++ b/static/js/constants/app/nl_interface_constants.ts
@@ -48,4 +48,4 @@ export const NL_DETECTOR_VALS = {
 
 export const MAX_QUERY_COUNT = 10;
 
-export const SVG_CHART_HEIGHT = 160;
+export const SVG_CHART_HEIGHT = 200;


### PR DESCRIPTION
... to account for map tile no longer defaulting to a height of 200