### PR TITLE
NL: reject inappropriate words and improve schools

### DIFF
--- a/nl_server/gcs.py
+++ b/nl_server/gcs.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 BUCKET = 'datcom-nl-models'
-TEMP_DIR = '/tmp/'
 
 import os
 from pathlib import Path
@@ -23,21 +22,15 @@ from typing import Any
 from google.cloud import storage
 from sentence_transformers import SentenceTransformer
 
+from shared.lib import gcs as gcs_lib
 
-# Downloads the `embeddings_file` from GCS to TEMP_DIR
-# and return its path.
-def download_embeddings(embeddings_file: str) -> str:
-  storage_client = storage.Client()
-  bucket = storage_client.bucket(bucket_name=BUCKET)
-  blob = bucket.get_blob(embeddings_file)
-  # Download
-  local_embeddings_path = local_path(embeddings_file)
-  blob.download_to_filename(local_embeddings_path)
-  return local_embeddings_path
+
+def download_embeddings(embeddings_filename: str) -> str:
+  return gcs_lib.download_file(bucket=BUCKET, filename=embeddings_filename)
 
 
 def local_path(embeddings_file: str) -> str:
-  return os.path.join(TEMP_DIR, embeddings_file)
+  return os.path.join(gcs_lib.TEMP_DIR, embeddings_file)
 
 
 def download_model_from_gcs(gcs_bucket: Any, local_dir: str,
@@ -78,7 +71,7 @@ def download_model_from_gcs(gcs_bucket: Any, local_dir: str,
 def download_model_folder(model_folder: str) -> str:
   sc = storage.Client()
   bucket = sc.bucket(bucket_name=BUCKET)
-  directory = TEMP_DIR
+  directory = gcs_lib.TEMP_DIR
 
   # Only download if needed.
   model_path = os.path.join(directory, model_folder)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -35,6 +35,7 @@ from opencensus.trace.samplers import AlwaysOnSampler
 import server.lib.config as libconfig
 from server.lib.disaster_dashboard import get_disaster_dashboard_data
 import server.lib.i18n as i18n
+from server.lib.nl.common import bad_words
 import server.lib.util as libutil
 import server.services.bigtable as bt
 from server.services.discovery import configure_endpoints_from_ingress
@@ -370,6 +371,7 @@ def create_app():
         secret_response = secret_client.access_secret_version(name=secret_name)
         app.config['PALM_API_KEY'] = secret_response.payload.data.decode(
             'UTF-8')
+    app.config['NL_BAD_WORDS'] = bad_words.load_bad_words()
 
   # Get and save the blocklisted svgs.
   blocklist_svg = []

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_7/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_7/chart_config.json
@@ -1,0 +1,620 @@
+{
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_DetailedMiddleSchool"
+                    ],
+                    "title": "Middle School Students in Sunnyvale",
+                    "type": "LINE"
+                  },
+                  {
+                    "statVarKey": [
+                      "Count_Person_DetailedMiddleSchool_pc"
+                    ],
+                    "title": "Per Capita Middle School Students in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_DetailedPrimarySchool"
+                    ],
+                    "title": "Elementary School Students in Sunnyvale",
+                    "type": "LINE"
+                  },
+                  {
+                    "statVarKey": [
+                      "Count_Person_DetailedPrimarySchool_pc"
+                    ],
+                    "title": "Per Capita Elementary School Students in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_DetailedHighSchool"
+                    ],
+                    "title": "High School Students in Sunnyvale",
+                    "type": "LINE"
+                  },
+                  {
+                    "statVarKey": [
+                      "Count_Person_DetailedHighSchool_pc"
+                    ],
+                    "title": "Per Capita High School Students in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_EnrolledInSchool"
+                    ],
+                    "title": "Population Currently Enrolled in School in Sunnyvale",
+                    "type": "LINE"
+                  },
+                  {
+                    "statVarKey": [
+                      "Count_Person_EnrolledInSchool_pc"
+                    ],
+                    "title": "Per Capita Population Currently Enrolled in School in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_EducationalAttainment_LessThan9ThGrade"
+                    ],
+                    "title": "Population Completed Less Than 9th Grade in Sunnyvale",
+                    "type": "LINE"
+                  },
+                  {
+                    "statVarKey": [
+                      "Count_Person_EducationalAttainment_LessThan9ThGrade_pc"
+                    ],
+                    "title": "Per Capita Population Completed Less Than 9th Grade in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "comparisonPlaces": [
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "Count_Person_DetailedMiddleSchool_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInCollegeUndergraduateYears_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade1_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade10_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade11_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade12_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade2_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade3_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade4_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade5_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade6_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade7_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade8_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInGrade9_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInKindergarten_multiple_place_bar_block",
+                      "Count_Person_DetailedEnrolledInNurserySchoolPreschool_multiple_place_bar_block"
+                    ],
+                    "title": "Middle School Students compared with other variables in Sunnyvale (${date})",
+                    "type": "BAR"
+                  },
+                  {
+                    "comparisonPlaces": [
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "Count_Person_DetailedMiddleSchool_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInCollegeUndergraduateYears_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade1_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade10_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade11_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade12_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade2_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade3_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade4_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade5_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade6_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade7_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade8_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInGrade9_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInKindergarten_multiple_place_bar_block_pc",
+                      "Count_Person_DetailedEnrolledInNurserySchoolPreschool_multiple_place_bar_block_pc"
+                    ],
+                    "title": "Per Capita Middle School Students compared with other variables in Sunnyvale (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_EnrolledInSchool",
+                      "Count_Person_NotEnrolledInSchool"
+                    ],
+                    "title": "Population Currently Enrolled in School compared with other variables in Sunnyvale",
+                    "type": "LINE"
+                  },
+                  {
+                    "statVarKey": [
+                      "Count_Person_EnrolledInSchool_pc",
+                      "Count_Person_NotEnrolledInSchool_pc"
+                    ],
+                    "title": "Per Capita Population Currently Enrolled in School compared with other variables in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "comparisonPlaces": [
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "Count_Person_EducationalAttainment_LessThan9ThGrade_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainment10ThGrade_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainment11ThGrade_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainment12ThGradeNoDiploma_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainment9ThGrade_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentAssociatesDegree_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentBachelorsDegree_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentBachelorsDegreeOrHigher_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentDoctorateDegree_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentGraduateOrProfessionalDegree_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentHighSchoolGraduateIncludesEquivalency_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentLessThanHighSchoolGraduate_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentMastersDegree_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentNoSchoolingCompleted_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentProfessionalSchoolDegree_multiple_place_bar_block",
+                      "Count_Person_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree_multiple_place_bar_block"
+                    ],
+                    "title": "Population Completed Less Than 9th Grade compared with other variables in Sunnyvale (${date})",
+                    "type": "BAR"
+                  },
+                  {
+                    "comparisonPlaces": [
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "Count_Person_EducationalAttainment_LessThan9ThGrade_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainment10ThGrade_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainment11ThGrade_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainment12ThGradeNoDiploma_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainment9ThGrade_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentAssociatesDegree_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentBachelorsDegree_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentBachelorsDegreeOrHigher_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentDoctorateDegree_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentGraduateOrProfessionalDegree_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentHighSchoolGraduateIncludesEquivalency_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentLessThanHighSchoolGraduate_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentMastersDegree_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentNoSchoolingCompleted_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentProfessionalSchoolDegree_multiple_place_bar_block_pc",
+                      "Count_Person_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree_multiple_place_bar_block_pc"
+                    ],
+                    "title": "Per Capita Population Completed Less Than 9th Grade compared with other variables in Sunnyvale (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "statVarSpec": {
+          "Count_Person_DetailedEnrolledInCollegeUndergraduateYears_multiple_place_bar_block": {
+            "name": "Population: Enrolled in College Undergraduate Years",
+            "statVar": "Count_Person_DetailedEnrolledInCollegeUndergraduateYears"
+          },
+          "Count_Person_DetailedEnrolledInCollegeUndergraduateYears_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in College Undergraduate Years",
+            "statVar": "Count_Person_DetailedEnrolledInCollegeUndergraduateYears"
+          },
+          "Count_Person_DetailedEnrolledInGrade10_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 10",
+            "statVar": "Count_Person_DetailedEnrolledInGrade10"
+          },
+          "Count_Person_DetailedEnrolledInGrade10_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 10",
+            "statVar": "Count_Person_DetailedEnrolledInGrade10"
+          },
+          "Count_Person_DetailedEnrolledInGrade11_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 11",
+            "statVar": "Count_Person_DetailedEnrolledInGrade11"
+          },
+          "Count_Person_DetailedEnrolledInGrade11_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 11",
+            "statVar": "Count_Person_DetailedEnrolledInGrade11"
+          },
+          "Count_Person_DetailedEnrolledInGrade12_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 12",
+            "statVar": "Count_Person_DetailedEnrolledInGrade12"
+          },
+          "Count_Person_DetailedEnrolledInGrade12_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 12",
+            "statVar": "Count_Person_DetailedEnrolledInGrade12"
+          },
+          "Count_Person_DetailedEnrolledInGrade1_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 1",
+            "statVar": "Count_Person_DetailedEnrolledInGrade1"
+          },
+          "Count_Person_DetailedEnrolledInGrade1_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 1",
+            "statVar": "Count_Person_DetailedEnrolledInGrade1"
+          },
+          "Count_Person_DetailedEnrolledInGrade2_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 2",
+            "statVar": "Count_Person_DetailedEnrolledInGrade2"
+          },
+          "Count_Person_DetailedEnrolledInGrade2_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 2",
+            "statVar": "Count_Person_DetailedEnrolledInGrade2"
+          },
+          "Count_Person_DetailedEnrolledInGrade3_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 3",
+            "statVar": "Count_Person_DetailedEnrolledInGrade3"
+          },
+          "Count_Person_DetailedEnrolledInGrade3_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 3",
+            "statVar": "Count_Person_DetailedEnrolledInGrade3"
+          },
+          "Count_Person_DetailedEnrolledInGrade4_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 4",
+            "statVar": "Count_Person_DetailedEnrolledInGrade4"
+          },
+          "Count_Person_DetailedEnrolledInGrade4_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 4",
+            "statVar": "Count_Person_DetailedEnrolledInGrade4"
+          },
+          "Count_Person_DetailedEnrolledInGrade5_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 5",
+            "statVar": "Count_Person_DetailedEnrolledInGrade5"
+          },
+          "Count_Person_DetailedEnrolledInGrade5_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 5",
+            "statVar": "Count_Person_DetailedEnrolledInGrade5"
+          },
+          "Count_Person_DetailedEnrolledInGrade6_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 6",
+            "statVar": "Count_Person_DetailedEnrolledInGrade6"
+          },
+          "Count_Person_DetailedEnrolledInGrade6_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 6",
+            "statVar": "Count_Person_DetailedEnrolledInGrade6"
+          },
+          "Count_Person_DetailedEnrolledInGrade7_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 7",
+            "statVar": "Count_Person_DetailedEnrolledInGrade7"
+          },
+          "Count_Person_DetailedEnrolledInGrade7_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 7",
+            "statVar": "Count_Person_DetailedEnrolledInGrade7"
+          },
+          "Count_Person_DetailedEnrolledInGrade8_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 8",
+            "statVar": "Count_Person_DetailedEnrolledInGrade8"
+          },
+          "Count_Person_DetailedEnrolledInGrade8_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 8",
+            "statVar": "Count_Person_DetailedEnrolledInGrade8"
+          },
+          "Count_Person_DetailedEnrolledInGrade9_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Grade 9",
+            "statVar": "Count_Person_DetailedEnrolledInGrade9"
+          },
+          "Count_Person_DetailedEnrolledInGrade9_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Grade 9",
+            "statVar": "Count_Person_DetailedEnrolledInGrade9"
+          },
+          "Count_Person_DetailedEnrolledInKindergarten_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten",
+            "statVar": "Count_Person_DetailedEnrolledInKindergarten"
+          },
+          "Count_Person_DetailedEnrolledInKindergarten_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Kindergarten",
+            "statVar": "Count_Person_DetailedEnrolledInKindergarten"
+          },
+          "Count_Person_DetailedEnrolledInNurserySchoolPreschool_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Nursery School Preschool",
+            "statVar": "Count_Person_DetailedEnrolledInNurserySchoolPreschool"
+          },
+          "Count_Person_DetailedEnrolledInNurserySchoolPreschool_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Enrolled in Nursery School Preschool",
+            "statVar": "Count_Person_DetailedEnrolledInNurserySchoolPreschool"
+          },
+          "Count_Person_DetailedHighSchool": {
+            "name": "High School Students",
+            "statVar": "Count_Person_DetailedHighSchool"
+          },
+          "Count_Person_DetailedHighSchool_pc": {
+            "denom": "Count_Person",
+            "name": "High School Students",
+            "statVar": "Count_Person_DetailedHighSchool"
+          },
+          "Count_Person_DetailedMiddleSchool": {
+            "name": "Middle School Students",
+            "statVar": "Count_Person_DetailedMiddleSchool"
+          },
+          "Count_Person_DetailedMiddleSchool_multiple_place_bar_block": {
+            "name": "Middle School Students",
+            "statVar": "Count_Person_DetailedMiddleSchool"
+          },
+          "Count_Person_DetailedMiddleSchool_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Middle School Students",
+            "statVar": "Count_Person_DetailedMiddleSchool"
+          },
+          "Count_Person_DetailedMiddleSchool_pc": {
+            "denom": "Count_Person",
+            "name": "Middle School Students",
+            "statVar": "Count_Person_DetailedMiddleSchool"
+          },
+          "Count_Person_DetailedPrimarySchool": {
+            "name": "Elementary School Students",
+            "statVar": "Count_Person_DetailedPrimarySchool"
+          },
+          "Count_Person_DetailedPrimarySchool_pc": {
+            "denom": "Count_Person",
+            "name": "Elementary School Students",
+            "statVar": "Count_Person_DetailedPrimarySchool"
+          },
+          "Count_Person_EducationalAttainment10ThGrade_multiple_place_bar_block": {
+            "name": "Population: 10th Grade",
+            "statVar": "Count_Person_EducationalAttainment10ThGrade"
+          },
+          "Count_Person_EducationalAttainment10ThGrade_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: 10th Grade",
+            "statVar": "Count_Person_EducationalAttainment10ThGrade"
+          },
+          "Count_Person_EducationalAttainment11ThGrade_multiple_place_bar_block": {
+            "name": "Population: 11th Grade",
+            "statVar": "Count_Person_EducationalAttainment11ThGrade"
+          },
+          "Count_Person_EducationalAttainment11ThGrade_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: 11th Grade",
+            "statVar": "Count_Person_EducationalAttainment11ThGrade"
+          },
+          "Count_Person_EducationalAttainment12ThGradeNoDiploma_multiple_place_bar_block": {
+            "name": "Population: 12th Grade No Diploma",
+            "statVar": "Count_Person_EducationalAttainment12ThGradeNoDiploma"
+          },
+          "Count_Person_EducationalAttainment12ThGradeNoDiploma_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: 12th Grade No Diploma",
+            "statVar": "Count_Person_EducationalAttainment12ThGradeNoDiploma"
+          },
+          "Count_Person_EducationalAttainment9ThGrade_multiple_place_bar_block": {
+            "name": "Population: 9th Grade",
+            "statVar": "Count_Person_EducationalAttainment9ThGrade"
+          },
+          "Count_Person_EducationalAttainment9ThGrade_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: 9th Grade",
+            "statVar": "Count_Person_EducationalAttainment9ThGrade"
+          },
+          "Count_Person_EducationalAttainmentAssociatesDegree_multiple_place_bar_block": {
+            "name": "Population: Associates Degree",
+            "statVar": "Count_Person_EducationalAttainmentAssociatesDegree"
+          },
+          "Count_Person_EducationalAttainmentAssociatesDegree_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Associates Degree",
+            "statVar": "Count_Person_EducationalAttainmentAssociatesDegree"
+          },
+          "Count_Person_EducationalAttainmentBachelorsDegreeOrHigher_multiple_place_bar_block": {
+            "name": "Population: Bachelors Degree or Higher",
+            "statVar": "Count_Person_EducationalAttainmentBachelorsDegreeOrHigher"
+          },
+          "Count_Person_EducationalAttainmentBachelorsDegreeOrHigher_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Bachelors Degree or Higher",
+            "statVar": "Count_Person_EducationalAttainmentBachelorsDegreeOrHigher"
+          },
+          "Count_Person_EducationalAttainmentBachelorsDegree_multiple_place_bar_block": {
+            "name": "Population With a Bachelor's Degree",
+            "statVar": "Count_Person_EducationalAttainmentBachelorsDegree"
+          },
+          "Count_Person_EducationalAttainmentBachelorsDegree_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population With a Bachelor's Degree",
+            "statVar": "Count_Person_EducationalAttainmentBachelorsDegree"
+          },
+          "Count_Person_EducationalAttainmentDoctorateDegree_multiple_place_bar_block": {
+            "name": "Population With a Doctorate Degree",
+            "statVar": "Count_Person_EducationalAttainmentDoctorateDegree"
+          },
+          "Count_Person_EducationalAttainmentDoctorateDegree_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population With a Doctorate Degree",
+            "statVar": "Count_Person_EducationalAttainmentDoctorateDegree"
+          },
+          "Count_Person_EducationalAttainmentGraduateOrProfessionalDegree_multiple_place_bar_block": {
+            "name": "Population: Graduate or Professional Degree",
+            "statVar": "Count_Person_EducationalAttainmentGraduateOrProfessionalDegree"
+          },
+          "Count_Person_EducationalAttainmentGraduateOrProfessionalDegree_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Graduate or Professional Degree",
+            "statVar": "Count_Person_EducationalAttainmentGraduateOrProfessionalDegree"
+          },
+          "Count_Person_EducationalAttainmentHighSchoolGraduateIncludesEquivalency_multiple_place_bar_block": {
+            "name": "Population: High School Graduate Includes Equivalency",
+            "statVar": "Count_Person_EducationalAttainmentHighSchoolGraduateIncludesEquivalency"
+          },
+          "Count_Person_EducationalAttainmentHighSchoolGraduateIncludesEquivalency_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: High School Graduate Includes Equivalency",
+            "statVar": "Count_Person_EducationalAttainmentHighSchoolGraduateIncludesEquivalency"
+          },
+          "Count_Person_EducationalAttainmentLessThanHighSchoolGraduate_multiple_place_bar_block": {
+            "name": "Population: Less Than High School Graduate",
+            "statVar": "Count_Person_EducationalAttainmentLessThanHighSchoolGraduate"
+          },
+          "Count_Person_EducationalAttainmentLessThanHighSchoolGraduate_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Less Than High School Graduate",
+            "statVar": "Count_Person_EducationalAttainmentLessThanHighSchoolGraduate"
+          },
+          "Count_Person_EducationalAttainmentMastersDegree_multiple_place_bar_block": {
+            "name": "Population With a Master's Degree",
+            "statVar": "Count_Person_EducationalAttainmentMastersDegree"
+          },
+          "Count_Person_EducationalAttainmentMastersDegree_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population With a Master's Degree",
+            "statVar": "Count_Person_EducationalAttainmentMastersDegree"
+          },
+          "Count_Person_EducationalAttainmentNoSchoolingCompleted_multiple_place_bar_block": {
+            "name": "Population Who Completed No Schooling",
+            "statVar": "Count_Person_EducationalAttainmentNoSchoolingCompleted"
+          },
+          "Count_Person_EducationalAttainmentNoSchoolingCompleted_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population Who Completed No Schooling",
+            "statVar": "Count_Person_EducationalAttainmentNoSchoolingCompleted"
+          },
+          "Count_Person_EducationalAttainmentProfessionalSchoolDegree_multiple_place_bar_block": {
+            "name": "Population: Professional School Degree",
+            "statVar": "Count_Person_EducationalAttainmentProfessionalSchoolDegree"
+          },
+          "Count_Person_EducationalAttainmentProfessionalSchoolDegree_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Professional School Degree",
+            "statVar": "Count_Person_EducationalAttainmentProfessionalSchoolDegree"
+          },
+          "Count_Person_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree_multiple_place_bar_block": {
+            "name": "Population: Some College 1 or More Years No Degree",
+            "statVar": "Count_Person_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree"
+          },
+          "Count_Person_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population: Some College 1 or More Years No Degree",
+            "statVar": "Count_Person_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree"
+          },
+          "Count_Person_EducationalAttainment_LessThan9ThGrade": {
+            "name": "Population Completed Less Than 9th Grade",
+            "statVar": "Count_Person_EducationalAttainment_LessThan9ThGrade"
+          },
+          "Count_Person_EducationalAttainment_LessThan9ThGrade_multiple_place_bar_block": {
+            "name": "Population Completed Less Than 9th Grade",
+            "statVar": "Count_Person_EducationalAttainment_LessThan9ThGrade"
+          },
+          "Count_Person_EducationalAttainment_LessThan9ThGrade_multiple_place_bar_block_pc": {
+            "denom": "Count_Person",
+            "name": "Population Completed Less Than 9th Grade",
+            "statVar": "Count_Person_EducationalAttainment_LessThan9ThGrade"
+          },
+          "Count_Person_EducationalAttainment_LessThan9ThGrade_pc": {
+            "denom": "Count_Person",
+            "name": "Population Completed Less Than 9th Grade",
+            "statVar": "Count_Person_EducationalAttainment_LessThan9ThGrade"
+          },
+          "Count_Person_EnrolledInSchool": {
+            "name": "Population Currently Enrolled in School",
+            "statVar": "Count_Person_EnrolledInSchool"
+          },
+          "Count_Person_EnrolledInSchool_pc": {
+            "denom": "Count_Person",
+            "name": "Population Currently Enrolled in School",
+            "statVar": "Count_Person_EnrolledInSchool"
+          },
+          "Count_Person_NotEnrolledInSchool": {
+            "name": "Population Not Currently Enrolled in School",
+            "statVar": "Count_Person_NotEnrolledInSchool"
+          },
+          "Count_Person_NotEnrolledInSchool_pc": {
+            "denom": "Count_Person",
+            "name": "Population Not Currently Enrolled in School",
+            "statVar": "Count_Person_NotEnrolledInSchool"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "placeDcid": [
+        "geoId/0677000"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "pastSourceContext": "",
+  "place": {
+    "dcid": "geoId/0677000",
+    "name": "Sunnyvale",
+    "place_type": "City"
+  },
+  "placeFallback": {},
+  "placeSource": "CURRENT_QUERY",
+  "svSource": "CURRENT_QUERY"
+}

--- a/server/integration_tests/test_data/inappropriate_query/query_1/chart_config.json
+++ b/server/integration_tests/test_data/inappropriate_query/query_1/chart_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {},
+  "context": {},
+  "debug": {},
+  "failure": "The query was rejected due to the presence of inappropriate words.",
+  "place": {
+    "dcid": "",
+    "name": "",
+    "place_type": ""
+  }
+}

--- a/server/integration_tests/test_data/place_detection_e2e_dc/query_6/debug_info.json
+++ b/server/integration_tests/test_data/place_detection_e2e_dc/query_6/debug_info.json
@@ -1,7 +1,6 @@
 {
   "places_detected": [
-    "us",
-    "most"
+    "us"
   ],
   "places_resolved": "(name: United States, dcid: country/USA); (name: Most, dcid: wikidataId/Q146363); ",
   "main_place_dcid": "country/USA",

--- a/server/integration_tests/test_data/place_detection_e2e_dc/query_6/debug_info.json
+++ b/server/integration_tests/test_data/place_detection_e2e_dc/query_6/debug_info.json
@@ -2,7 +2,7 @@
   "places_detected": [
     "us"
   ],
-  "places_resolved": "(name: United States, dcid: country/USA); (name: Most, dcid: wikidataId/Q146363); ",
+  "places_resolved": "(name: United States, dcid: country/USA); ",
   "main_place_dcid": "country/USA",
   "main_place_name": "United States"
 }

--- a/server/lib/config.py
+++ b/server/lib/config.py
@@ -17,6 +17,11 @@ import os
 import google.auth
 from werkzeug.utils import import_string
 
+#
+# This is a global config bucket shared by all website instances.
+#
+GLOBAL_CONFIG_BUCKET = 'datcom-website-config'
+
 
 def get_config():
   env = os.environ.get('FLASK_ENV')

--- a/server/lib/nl/common/bad_words.py
+++ b/server/lib/nl/common/bad_words.py
@@ -1,0 +1,52 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Set
+
+from server.lib.config import GLOBAL_CONFIG_BUCKET
+from shared.lib import gcs
+
+BAD_WORDS_FILE = 'nl_bad_words.txt'
+
+
+#
+# Loads a list of bad words from a text file.
+#
+def load_bad_words() -> Set[str]:
+  local_file = gcs.download_file(bucket=GLOBAL_CONFIG_BUCKET,
+                                 filename=BAD_WORDS_FILE)
+  bad_words = set()
+
+  with open(local_file) as fp:
+    for line in fp:
+      line = line.strip()
+      # Ignore comments
+      if line.startswith('#') or line.startswith('//'):
+        continue
+
+      bad_words.add(line.lower())
+
+  return bad_words
+
+
+#
+# Returns false if the query contains any bad word.
+#
+def is_safe(query: str, bad_words: Set[str]) -> bool:
+  for w in query.split():
+    if w.strip() in bad_words:
+      logging.info(f'Found an inappropriate word {w} in {query}')
+      return False
+  return True

--- a/server/lib/nl/common/utils.py
+++ b/server/lib/nl/common/utils.py
@@ -355,10 +355,32 @@ def get_parent_place_type(place_type: types.ContainedInPlaceType,
   return ptype
 
 
-# Checks whether two types are a direct match or are equivalents.
-def is_place_type_match(pt1: types.ContainedInPlaceType,
-                        pt2: types.ContainedInPlaceType) -> bool:
+def is_non_geo_place_type(pt: types.ContainedInPlaceType) -> bool:
+  return pt.value.lower() in shared_constants.NON_GEO_PLACE_TYPES
+
+
+#
+# Checks whether two types are a direct match or are equivalents purely
+# for place type fallback purposes.  If we return false here, then
+# we may report falling back from:
+#    "pt1 in place" -> "pt2 in place" or "pt1 in place" -> "place"
+#
+# We account for AA1/AA2 equivalents.
+#
+# Subtly enough, we also ignore non-geo place-types which can also be
+# legitimate SVs.
+#
+def is_place_type_match_for_fallback(pt1: types.ContainedInPlaceType,
+                                     pt2: types.ContainedInPlaceType) -> bool:
   if pt1 == pt2:
+    return True
+
+  # SCHOOL, for example, is both a place-type and occurs as a stat-var too.
+  # For "school students in CA", if we say we fallback from attempting
+  # to fulfill "schools in CA" to showing results about "CA", which
+  # contains school-related charts, that's quite confusing.
+  if ((pt1 != None and is_non_geo_place_type(pt1)) or
+      (pt2 != None and is_non_geo_place_type(pt2))):
     return True
 
   if pt1 != None and pt2 != None:

--- a/server/lib/nl/detection/utils.py
+++ b/server/lib/nl/detection/utils.py
@@ -18,6 +18,7 @@ from typing import Dict, List
 from server.lib.nl.common import constants
 from server.lib.nl.common import counters as ctr
 from server.lib.nl.detection.types import Detection
+from server.lib.nl.detection.types import PlaceDetection
 from server.lib.nl.detection.types import SVDetection
 from shared.lib import constants as shared_constants
 from shared.lib import detected_variables as dvars
@@ -93,3 +94,11 @@ def create_sv_detection(query: str, svs_scores_dict: Dict) -> SVDetection:
                          sv2sentences=svs_scores_dict['SV_to_Sentences']),
                      multi_sv=dvars.dict_to_multivar_candidates(
                          svs_scores_dict['MultiSV']))
+
+
+def empty_place_detection() -> PlaceDetection:
+  return PlaceDetection(query_original='',
+                        query_without_place_substr='',
+                        query_places_mentioned=[],
+                        places_found=[],
+                        main_place=None)

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -489,7 +489,7 @@ def maybe_set_fallback(state: PopulateState, places: List[Place]):
     else:
       orig_type = pt
 
-  if (utils.is_place_type_match(orig_type, new_type) and
+  if (utils.is_place_type_match_for_fallback(orig_type, new_type) and
       new_place.dcid == orig_place.dcid):
     return
 

--- a/server/lib/nl/fulfillment/size_across_entities.py
+++ b/server/lib/nl/fulfillment/size_across_entities.py
@@ -64,15 +64,24 @@ def _get_vars(pt: ContainedInPlaceType):
 # to infer the ranking.
 #
 def populate(uttr: Utterance):
-  # Only if there are no SVs detected and contained-in is detected, do we consider
-  # the SIZE_TYPE classification.
-  if uttr.svs:
-    uttr.counters.err('size-across-entities_failed_foundvars', uttr.svs)
-    return False
   place_type = utils.get_contained_in_type(uttr)
   size_types = utils.get_size_types(uttr)
   if not place_type or not size_types:
     uttr.counters.err('size-across-entities_failed_noplaceorsizetype', '-')
+    return False
+
+  #
+  # Only if there are no SVs detected, do we consider SIZE_TYPE classification.
+  #
+  # BUT NOTE: The is_non_geo_place_type check is there for non-geo places
+  # like schools which are not removed as stop-words for SV query.
+  # For example, [how big are high schools] query, since we pass in
+  # "high schools", they will indeed often match SVs.  So we let the
+  # `SIZE_TYPE` heuristic override.
+  # TODO: Find a better approach
+  #
+  if not utils.is_non_geo_place_type(place_type) and uttr.svs:
+    uttr.counters.err('size-across-entities_failed_foundvars', uttr.svs)
     return False
 
   uttr.svs = _get_vars(place_type)

--- a/server/routes/nl/api.py
+++ b/server/routes/nl/api.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import time
+from typing import Dict
 
 import flask
 from flask import Blueprint
@@ -26,6 +27,7 @@ from flask import request
 from google.protobuf.json_format import MessageToJson
 from markupsafe import escape
 
+from server.lib.nl.common import bad_words
 import server.lib.nl.common.constants as constants
 import server.lib.nl.common.counters as ctr
 import server.lib.nl.common.debug_utils as dbg
@@ -58,6 +60,10 @@ def data():
   if os.environ.get('FLASK_ENV') == 'production':
     flask.abort(404)
 
+  if not current_app.config.get('NL_BAD_WORDS'):
+    logging.error('Missing NL_BAD_WORDS config!')
+    flask.abort(404)
+
   disaster_config = current_app.config['NL_DISASTER_CONFIG']
   if current_app.config['LOCAL']:
     # Reload configs for faster local iteration.
@@ -69,10 +75,8 @@ def data():
   embeddings_index_type = request.args.get('idx', '')
   original_query = request.args.get('q')
   context_history = []
-  escaped_context_history = []
   if request.get_json():
     context_history = request.get_json().get('contextHistory', [])
-    escaped_context_history = escape(context_history)
 
   detector_type = request.args.get(
       'detector', default=RequestedDetectorType.Heuristic.value, type=str)
@@ -86,37 +90,22 @@ def data():
   else:
     place_detector_type = PlaceDetectorType(place_detector_type)
 
+  #
+  # Check offensive words
+  #
+  if not bad_words.is_safe(original_query, current_app.config['NL_BAD_WORDS']):
+    return _abort(
+        'The query was rejected due to the ' +
+        'presence of inappropriate words.', original_query, context_history)
+
   query = str(escape(shared_utils.remove_punctuations(original_query)))
-  res = {
-      'place': {
-          'dcid': '',
-          'name': '',
-          'place_type': '',
-      },
-      'config': {},
-      'context': escaped_context_history
-  }
+  if not query:
+    return _abort('Received an empty query, please type a few words :)',
+                  original_query, context_history)
 
   counters = ctr.Counters()
   query_detection_debug_logs = {}
   query_detection_debug_logs["original_query"] = query
-
-  if not query:
-    query_detection = Detection(original_query=original_query,
-                                cleaned_query=query,
-                                places_detected=None,
-                                svs_detected=dutils.create_sv_detection(
-                                    query, dutils.empty_svs_score_dict()),
-                                classifications=[],
-                                llm_resp={})
-    data_dict = dbg.result_with_debug_info(
-        data_dict=res,
-        status="Aborted: Query was Empty.",
-        query_detection=query_detection,
-        debug_counters=counters.get(),
-        query_detection_debug_logs=query_detection_debug_logs)
-    logging.info('NL Data API: Empty Exit')
-    return data_dict
 
   # Generate new utterance.
   prev_utterance = nl_utterance.load_utterance(context_history)
@@ -183,7 +172,7 @@ def data():
     if not utterance.svs:
       status_str += '**No SVs Found**.'
 
-  data_dict = dbg.result_with_debug_info(data_dict, status_str, query_detection,
+  data_dict = dbg.result_with_debug_info(data_dict, '', query_detection,
                                          dbg_counters,
                                          query_detection_debug_logs)
   # Convert data_dict to pure json.
@@ -237,3 +226,44 @@ def feedback():
   except Exception as e:
     logging.error(e)
     return 'Failed to record feedback data', 500
+
+
+#
+# Preliminary abort with the given error message
+#
+def _abort(error_message, original_query, context_history) -> Dict:
+  query = str(escape(shared_utils.remove_punctuations(original_query)))
+  escaped_context_history = []
+  for ch in context_history:
+    escaped_context_history.append(escape(ch))
+
+  res = {
+      'place': {
+          'dcid': '',
+          'name': '',
+          'place_type': '',
+      },
+      'config': {},
+      'context': escaped_context_history,
+      'failure': error_message
+  }
+
+  counters = ctr.Counters()
+  query_detection_debug_logs = {}
+  query_detection_debug_logs["original_query"] = query
+
+  query_detection = Detection(original_query=original_query,
+                              cleaned_query=query,
+                              places_detected=dutils.empty_place_detection(),
+                              svs_detected=dutils.create_sv_detection(
+                                  query, dutils.empty_svs_score_dict()),
+                              classifications=[],
+                              llm_resp={})
+  data_dict = dbg.result_with_debug_info(
+      data_dict=res,
+      status=error_message,
+      query_detection=query_detection,
+      debug_counters=counters.get(),
+      query_detection_debug_logs=query_detection_debug_logs)
+  logging.info('NL Data API: Empty Exit')
+  return data_dict

--- a/server/routes/nl/api.py
+++ b/server/routes/nl/api.py
@@ -172,7 +172,7 @@ def data():
     if not utterance.svs:
       status_str += '**No SVs Found**.'
 
-  data_dict = dbg.result_with_debug_info(data_dict, '', query_detection,
+  data_dict = dbg.result_with_debug_info(data_dict, status_str, query_detection,
                                          dbg_counters,
                                          query_detection_debug_logs)
   # Convert data_dict to pure json.

--- a/shared/lib/constants.py
+++ b/shared/lib/constants.py
@@ -376,6 +376,23 @@ PLACE_TYPE_TO_PLURALS: Dict[str, str] = {
     "school": "schools",
 }
 
+#
+# Non-geo place types are listed here.  These typically are part
+# of the SV name as well.  The list here are the keys of
+# PLACE_TYPE_TO_PLURALS and they are not considered for stop-word
+# removal (i.e., they are fed to the SV query index).
+#
+NON_GEO_PLACE_TYPES: FrozenSet[str] = frozenset([
+    # Schools are part of many SVs.
+    "highschool",
+    "middleschool",
+    "elementaryschool",
+    "primaryschool",
+    "publicschool",
+    "privateschool",
+    "school",
+])
+
 # A cosine score differential we use to indicate if scores
 # that differ by up to this amount are "near" SVs.
 # In Multi-SV detection, if the difference between successive scores exceeds

--- a/shared/lib/gcs.py
+++ b/shared/lib/gcs.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TEMP_DIR = '/tmp/'
+
+import os
+
+from google.cloud import storage
+
+
+#
+# Downloads the `filename` from GCS to TEMP_DIR
+# and returns its path.
+#
+def download_file(bucket: str, filename: str) -> str:
+  storage_client = storage.Client()
+  bucket = storage_client.bucket(bucket_name=bucket)
+  blob = bucket.get_blob(filename)
+  # Download
+  local_embeddings_path = os.path.join(TEMP_DIR, filename)
+  blob.download_to_filename(local_embeddings_path)
+  return local_embeddings_path

--- a/shared/lib/utils.py
+++ b/shared/lib/utils.py
@@ -74,6 +74,26 @@ def remove_stop_words(input_str: str, stop_words: Set[str]) -> str:
   return input_str.strip()
 
 
+def list_place_type_stopwords() -> List[str]:
+  # Get plurals correspnding to stop-word exclusion place-types.
+  #
+  # This also helps validate that NON_GEO_PLACE_TYPES has the right keys,
+  stopword_exclusion_place_type_plurals = set([
+      constants.PLACE_TYPE_TO_PLURALS[x] for x in constants.NON_GEO_PLACE_TYPES
+  ])
+  # Get singular stop-words skipping exclusion.
+  place_type_stop_words = [
+      it for it in constants.PLACE_TYPE_TO_PLURALS.keys()
+      if it not in constants.NON_GEO_PLACE_TYPES
+  ]
+  # Get plural stop-words skipping exclusion.
+  place_type_stop_words.extend([
+      it for it in constants.PLACE_TYPE_TO_PLURALS.values()
+      if it not in stopword_exclusion_place_type_plurals
+  ])
+  return place_type_stop_words
+
+
 def combine_stop_words() -> Set[str]:
   """Returns all the combined stop words from the various constants."""
   # Make a copy.
@@ -82,11 +102,7 @@ def combine_stop_words() -> Set[str]:
   # Now add the words in the classification heuristics.
   _add_classification_heuristics(stop_words)
 
-  # Also add the plurals.
-  _add_to_set_from_list(stop_words,
-                        list(constants.PLACE_TYPE_TO_PLURALS.keys()))
-  _add_to_set_from_list(stop_words,
-                        list(constants.PLACE_TYPE_TO_PLURALS.values()))
+  _add_to_set_from_list(stop_words, list_place_type_stopwords())
 
   # Sort stop_words by the length (longer strings should come first) so that the
   # longer sentences can be removed first.

--- a/shared/tests/lib/utils_test.py
+++ b/shared/tests/lib/utils_test.py
@@ -47,10 +47,10 @@ class TestUtilsAddToSet(unittest.TestCase):
       self.assertIn(word.lower(), got)
 
     for key in constants.PLACE_TYPE_TO_PLURALS.keys():
+      if key in constants.NON_GEO_PLACE_TYPES:
+        continue
       self.assertIn(key.lower(), got)
-
-    for val in constants.PLACE_TYPE_TO_PLURALS.values():
-      self.assertIn(val.lower(), got)
+      self.assertIn(constants.PLACE_TYPE_TO_PLURALS[key].lower(), got)
 
     # This is the most complex because the values could we lists or
     # dictionary (of lists). The strings themselves are also sentences
@@ -85,14 +85,14 @@ class TestNLUtilsRemoveStopWordsAndPunctuation(unittest.TestCase):
       ["tell me about the climate extremes in palo alto", "climate palo alto"],
       [
           "How big are the public elementary schools in Sunnyvale",
-          "public sunnyvale"
+          "public elementary schools sunnyvale"
       ],
       [
           "what is relationship between the sickest and healthiest people in the world",
           "people world"
       ],
       ["how does it correlate with heart disease", "heart disease"],
-      ["best high schools in Florida counties", "florida"],
+      ["best high schools in Florida counties", "schools florida"],
       [
           "interest rates among people who are living in poverty across US states",
           "interest rates people living poverty us"

--- a/static/js/apps/nl_interface/query_result.tsx
+++ b/static/js/apps/nl_interface/query_result.tsx
@@ -110,7 +110,6 @@ export const QueryResult = memo(function QueryResult(
           return;
         }
         const context: any = resp.data["context"];
-        props.addContextCallback(context, props.queryIdx);
 
         // Filter out empty categories.
         const categories = _.get(resp, ["data", "config", "categories"], []);
@@ -144,15 +143,18 @@ export const QueryResult = memo(function QueryResult(
                   }
                 : null,
           });
+          props.addContextCallback(context, props.queryIdx);
         } else {
-          // If there was no place recognized, we might end up with 0
-          // categories.  Check if that's the case, and provide a different
-          // error message.
-          if ("placeSource" in resp.data && resp.data["placeSource"]) {
+          if ("failure" in resp.data && resp.data["failure"]) {
+            setErrorMsg(resp.data["failure"]);
+          } else if ("placeSource" in resp.data && resp.data["placeSource"]) {
+            // If there was no place recognized, we might end up with 0
+            // categories, provide a different error message.
             setErrorMsg("Could not recognize any place in the query!");
           } else {
             setErrorMsg("Sorry, we couldn't answer your question.");
           }
+          props.addContextCallback(undefined, props.queryIdx);
         }
         const debugData = resp.data["debug"];
         if (debugData !== undefined) {
@@ -222,11 +224,16 @@ export const QueryResult = memo(function QueryResult(
           {errorMsg && (
             <div className="nl-query-error">
               <p>
-                {errorMsg} Would you like to try{" "}
-                <a href={`https://google.com/?q=${props.query}`}>
-                  searching on Google
-                </a>
-                ?
+                {errorMsg}
+                {redirectToGoogle() && (
+                  <>
+                    Would you like to try{" "}
+                    <a href={`https://google.com/?q=${props.query}`}>
+                      searching on Google
+                    </a>
+                    ?
+                  </>
+                )}
               </p>
             </div>
           )}
@@ -252,5 +259,9 @@ export const QueryResult = memo(function QueryResult(
         sentiment,
       },
     });
+  }
+
+  function redirectToGoogle(): boolean {
+    return errorMsg.includes("Sorry") || errorMsg.includes("sorry");
   }
 });


### PR DESCRIPTION
* The initial bad-word list is located [here](https://storage.mtls.cloud.google.com/datcom-website-config/nl_bad_words.txt).

* Also, avoid school types from being considered as stop-words.  There were two other ripple effects to this change:
   1. It also requires special-handling for fallback logic (to not say "schools in sunnyvale" => "sunnyvale")
   2. It also requires not regressing the demo query [how big are public schools in sunnyvale]

Note: making the schools change also uncovered https://github.com/datacommonsorg/website/issues/2953.   This whole stop-word removal business needs streamlining!  Post fishfood maybe, and as part of fixing 2853.
 
Screenshot

![image](https://github.com/datacommonsorg/website/assets/4375037/55a824e5-2ed3-4358-b928-e421cb9dd99f)
