### PR TITLE
[tools revamp] handle when there are no child places

### DIFF
--- a/static/js/apps/visualization/app_context.tsx
+++ b/static/js/apps/visualization/app_context.tsx
@@ -83,7 +83,7 @@ export function AppContextProvider(
   const [visType, setVisType] = useState(
     getParamValue(URL_PARAMS.VIS_TYPE) || ORDERED_VIS_TYPE[0].valueOf()
   );
-  const [childPlaceTypes, setChildPlaceTypes] = useState([]);
+  const [childPlaceTypes, setChildPlaceTypes] = useState(null);
   const [samplePlaces, setSamplePlaces] = useState([]);
   const prevSamplePlaces = useRef(samplePlaces);
   const prevStatVars = useRef(statVars);
@@ -145,7 +145,7 @@ export function AppContextProvider(
   // when list of places or vistype changes, re-fetch child place types
   useEffect(() => {
     if (_.isEmpty(places) || visTypeConfig.skipEnclosedPlaceType) {
-      setChildPlaceTypes([]);
+      setChildPlaceTypes(null);
       setSamplePlaces([]);
       return;
     }

--- a/static/js/apps/visualization/place_type_selector.tsx
+++ b/static/js/apps/visualization/place_type_selector.tsx
@@ -22,6 +22,7 @@ import _ from "lodash";
 import React, { useContext } from "react";
 import { FormGroup, Input, Label } from "reactstrap";
 
+import { Spinner } from "../../components/spinner";
 import { AppContext } from "./app_context";
 
 interface PlaceTypeSelectorPropType {
@@ -31,30 +32,38 @@ interface PlaceTypeSelectorPropType {
 export function PlaceTypeSelector(
   props: PlaceTypeSelectorPropType
 ): JSX.Element {
-  const { enclosedPlaceType, setEnclosedPlaceType, childPlaceTypes } =
+  const { enclosedPlaceType, setEnclosedPlaceType, childPlaceTypes, places } =
     useContext(AppContext);
 
   return (
     <div className="place-type-selector">
       <div className="selector-body place-type">
-        {childPlaceTypes.map((type) => {
-          return (
-            <FormGroup key={type} radio="true" row>
-              <Label radio="true">
-                <Input
-                  type="radio"
-                  name="childPlaceType"
-                  checked={type === enclosedPlaceType}
-                  onChange={() => {
-                    setEnclosedPlaceType(type);
-                    props.onNewSelection();
-                  }}
-                />
-                {type}
-              </Label>
-            </FormGroup>
-          );
-        })}
+        {!_.isNull(childPlaceTypes) && _.isEmpty(childPlaceTypes) && (
+          <span>
+            Sorry, we don&apos;t support {places[0].name}. Please select a
+            different place.
+          </span>
+        )}
+        {!_.isEmpty(childPlaceTypes) &&
+          childPlaceTypes.map((type) => {
+            return (
+              <FormGroup key={type} radio="true" row>
+                <Label radio="true">
+                  <Input
+                    type="radio"
+                    name="childPlaceType"
+                    checked={type === enclosedPlaceType}
+                    onChange={() => {
+                      setEnclosedPlaceType(type);
+                      props.onNewSelection();
+                    }}
+                  />
+                  {type}
+                </Label>
+              </FormGroup>
+            );
+          })}
+        <Spinner isOpen={_.isNull(childPlaceTypes)} />
       </div>
       {props.onContinueClicked && !_.isEmpty(enclosedPlaceType) && (
         <div className="selector-footer">

--- a/static/js/apps/visualization/selected_options.tsx
+++ b/static/js/apps/visualization/selected_options.tsx
@@ -56,7 +56,9 @@ export function SelectedOptions(): JSX.Element {
       <div className="selected-options-places">
         {!_.isEmpty(places) && (
           <div className="selected-option">
-            <span className="selected-option-label">Plot places in</span>
+            <span className="selected-option-label">
+              Plot places{visTypeConfig.skipEnclosedPlaceType ? "" : " in"}
+            </span>
             <div className="selected-option-values">
               {places.map((place) => {
                 return (

--- a/static/js/apps/visualization/selector_wrapper.tsx
+++ b/static/js/apps/visualization/selector_wrapper.tsx
@@ -43,7 +43,9 @@ export function SelectorWrapper(props: SelectorWrapperPropType): JSX.Element {
           <span>{props.headerTitle}</span>
           <span
             className="material-icons-outlined"
-            onClick={() => props.disabled ? null : props.setCollapsed(!props.collapsed)}
+            onClick={() =>
+              props.disabled ? null : props.setCollapsed(!props.collapsed)
+            }
           >
             {props.collapsed ? "expand_more" : "expand_less"}
           </span>

--- a/static/js/apps/visualization/selector_wrapper.tsx
+++ b/static/js/apps/visualization/selector_wrapper.tsx
@@ -43,7 +43,7 @@ export function SelectorWrapper(props: SelectorWrapperPropType): JSX.Element {
           <span>{props.headerTitle}</span>
           <span
             className="material-icons-outlined"
-            onClick={() => props.setCollapsed(!props.collapsed)}
+            onClick={() => props.disabled ? null : props.setCollapsed(!props.collapsed)}
           >
             {props.collapsed ? "expand_more" : "expand_less"}
           </span>

--- a/static/js/apps/visualization/stat_var_selector.tsx
+++ b/static/js/apps/visualization/stat_var_selector.tsx
@@ -70,7 +70,7 @@ export function StatVarSelector(props: StatVarSelectorPropType): JSX.Element {
       </div>
       {props.selectOnContinue && (
         <div className="selector-footer">
-          {!_.isEmpty(selectedStatVars) && (
+          {selectedStatVars.length >= (visTypeConfig.numSv || 1) && (
             <div
               className="continue-button"
               onClick={() => setStatVars(selectedStatVars)}


### PR DESCRIPTION
- if there are no allowed child place types, render a message telling user to select a different place so that user doesn't get into a bad state
- update the place label for timeline vis type to say "plot places" instead of "plot places in"

<img width="1021" alt="Screenshot 2023-07-26 at 6 32 45 PM" src="https://github.com/datacommonsorg/website/assets/69875368/aa801ca3-479f-4e57-b13a-459f6eea491e">
