### PR TITLE
fix hardcoded place search

### DIFF
--- a/static/js/shared/place_search_bar.tsx
+++ b/static/js/shared/place_search_bar.tsx
@@ -133,7 +133,7 @@ class PlaceSearchBar extends Component<PlaceSearchBarPropType> {
       const containers = document.getElementsByClassName("pac-container");
       const displayResult = toTitleCase(inputVal);
       if (containers && containers.length) {
-        const container = containers[0];
+        const container = containers[containers.length - 1];
         // Keep this in sync with the Maps API results DOM.
         const result = (
           <div className="pac-item">


### PR DESCRIPTION
- when new place search components are rendered, it adds another pac-container to the html. To get the current pac-container, we want the last one in the list, not the first