### PR TITLE
[tools revamp] stat var selector updates

### DIFF
--- a/static/js/apps/visualization/selector_pane.tsx
+++ b/static/js/apps/visualization/selector_pane.tsx
@@ -44,16 +44,18 @@ export function SelectorPane(): JSX.Element {
   const placeHeaderTitle = `1. Select${
     visTypeConfig.singlePlace ? " a" : ""
   } place${visTypeConfig.singlePlace ? "" : "s"}`;
-  let titleNumVariables = "";
-  if (visTypeConfig.numSv) {
-    titleNumVariables =
-      visTypeConfig.numSv === 1 ? "a" : String(visTypeConfig.numSv);
+  // Header title for the stat var selector
+  let svHeaderTitle = visTypeConfig.skipEnclosedPlaceType ? "2. " : "3. ";
+  if (!visTypeConfig.numSv) {
+    svHeaderTitle += "Select variables";
+  } else if (visTypeConfig.numSv === 1) {
+    svHeaderTitle += "Select a variable";
+  } else {
+    const numSvMissing = visTypeConfig.numSv - statVars.length;
+    svHeaderTitle += `Select ${numSvMissing}${
+      numSvMissing < visTypeConfig.numSv ? " more" : ""
+    } variable${numSvMissing > 1 ? "s" : ""}`;
   }
-  const svHeaderTitle = `${
-    visTypeConfig.skipEnclosedPlaceType ? "2. " : "3. "
-  }Select ${titleNumVariables ? titleNumVariables + " " : ""}Variable${
-    visTypeConfig.numSv === 1 ? "" : "s"
-  }`;
 
   if (isSelectionComplete(visType, places, enclosedPlaceType, statVars)) {
     return null;

--- a/static/js/apps/visualization/stat_var_selector.tsx
+++ b/static/js/apps/visualization/stat_var_selector.tsx
@@ -37,6 +37,7 @@ import { StatVarHierarchy } from "../../stat_var_hierarchy/stat_var_hierarchy";
 import { AppContext } from "./app_context";
 import { VIS_TYPE_CONFIG } from "./vis_type_configs";
 
+const NUM_ENTITIES_EXISTENCE = 10;
 interface StatVarSelectorPropType {
   selectOnContinue?: boolean;
 }
@@ -65,7 +66,11 @@ export function StatVarSelector(props: StatVarSelectorPropType): JSX.Element {
           selectSV={addSv}
           searchLabel={""}
           deselectSV={removeSv}
-          numEntitiesExistence={1}
+          numEntitiesExistence={
+            visTypeConfig.skipEnclosedPlaceType
+              ? 1
+              : Math.min(samplePlaces.length, NUM_ENTITIES_EXISTENCE)
+          }
         />
       </div>
       {props.selectOnContinue && (
@@ -75,7 +80,7 @@ export function StatVarSelector(props: StatVarSelectorPropType): JSX.Element {
               className="continue-button"
               onClick={() => setStatVars(selectedStatVars)}
             >
-              Continue
+              Display
             </div>
           )}
         </div>


### PR DESCRIPTION
- change "continue" to "display"
- if going from map to scatter, make the selector header say "Select 1 more variable"
- on scatter or map, only show stat vars that are available for at least 10 places

![screen-recording-2023-07-27T135434 502](https://github.com/datacommonsorg/website/assets/69875368/ecaa164a-048b-47c5-8940-8c62f37c479e)
