### PR TITLE
Add landing pages for all verticals

### DIFF
--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -138,17 +138,7 @@ export function App(): JSX.Element {
         </div>
 
         <div className="explore-sources">
-          Our {currentTopic.title.toLocaleLowerCase()} data comprises{" "}
-          <span
-            title={`${formatNumber(
-              currentTopic.meta.dataPointCount,
-              undefined,
-              true
-            )}`}
-          >
-            {formatNumber(currentTopic.meta.dataPointCount)}
-          </span>{" "}
-          data points across{" "}
+          Our {currentTopic.title.toLocaleLowerCase()} data spans over{" "}
           <span
             title={`${formatNumber(
               currentTopic.meta.variableCount,
@@ -158,14 +148,20 @@ export function App(): JSX.Element {
           >
             {formatNumber(currentTopic.meta.variableCount)}
           </span>{" "}
-          statistical variables. We collect our health information from sources
+          statistical variables. We collect our{" "}
+          {currentTopic.title.toLocaleLowerCase()} information from sources such
           such as:{" "}
           {currentTopic.meta.sources.map((s, i) => (
             <>
+              {currentTopic.meta.sources.length > 1 &&
+              i === currentTopic.meta.sources.length - 1
+                ? "and "
+                : ""}
               {s}
-              {i === currentTopic.meta.sources.length - 1 ? ", " : ""}
+              {i === currentTopic.meta.sources.length - 1 ? "" : ", "}
             </>
           ))}
+          {"."}
         </div>
       </Container>
     </div>

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -150,7 +150,7 @@ export function App(): JSX.Element {
           </span>{" "}
           statistical variables. We collect our{" "}
           {currentTopic.title.toLocaleLowerCase()} information from sources such
-          such as:{" "}
+          as:{" "}
           {currentTopic.meta.sources.map((s, i) => (
             <>
               {currentTopic.meta.sources.length > 1 &&

--- a/static/js/apps/explore/topics.json
+++ b/static/js/apps/explore/topics.json
@@ -10,16 +10,34 @@
   "topics": {
     "economy": {
       "title": "Economy",
-      "description": "",
+      "description": "Understanding economics illuminates the intricate web of human choices and resource allocation, guiding governments, businesses, and individuals to make informed decisions for a prosperous and sustainable future. Search for some economic data or click around on one of the suggested searches below to get started.",
       "examples": {
-        "general": [],
-        "specific": [],
-        "comparison": []
+        "general": [
+          "How many businesses are there in the US?",
+          "Most common jobs in Texas",
+          "Median income in Santa Clara County",
+          "What are the top industries in the US?",
+          "How many people in California struggle with poverty?",
+          "US global economic activity"
+        ],
+        "specific": [
+          "How much does the US spend on its military?",
+          "Number of privately owned businesses in California"
+        ],
+        "comparison": [
+          "Income vs health insurance rates in USA"
+        ]
       },
       "meta": {
-        "dataPointCount": 7891011,
-        "variableCount": 3456,
-        "sources": ["United Nations"]
+        "dataPointCount": 0,
+        "variableCount": 67486,
+        "sources": [
+          "U.S. Bureau of Economic Analysis",
+          "U.S. Bureau of Labor Statistics",
+          "U.S. Census Bureau",
+          "U.S. Department of Labor",
+          "World Bank"
+        ]
       }
     },
     "health": {
@@ -37,68 +55,141 @@
           "Conditions that have risen the fastest in Texas",
           "COVID deaths in Florida compared to New Jersey"
         ],
-        "comparison": ["Income vs asthma in US counties"]
+        "comparison": [
+          "Income vs asthma in US counties"
+        ]
       },
       "meta": {
-        "dataPointCount": 7891011,
-        "variableCount": 3456,
-        "sources": ["World Health Organization"]
+        "dataPointCount": 0,
+        "variableCount": 20531,
+        "sources": [
+          "World Health Organization",
+          "U.S. Center for Disease Control and Prevention (CDC)"
+        ]
       }
     },
     "education": {
       "title": "Education",
-      "description": "",
+      "description": "Education is the cornerstone of personal growth and societal progress, empowering individuals with knowledge, skills, and critical thinking abilities to navigate and shape the world around them. Search for some education data or click around on one of the suggested searches below to get started.",
       "examples": {
-        "general": [],
-        "specific": [],
-        "comparison": []
+        "general": [
+          "How many people have degrees in Massachusetts?",
+          "How many people are currently enrolled in school in California?",
+          "Educational degrees earned in the US"
+        ],
+        "specific": [
+          "How do california schools score on achievement tests?"
+        ],
+        "comparison": [
+          "College degrees vs income for US states"
+        ]
       },
       "meta": {
-        "dataPointCount": 7891011,
-        "variableCount": 3456,
-        "sources": ["United Nations"]
+        "dataPointCount": 0,
+        "variableCount": 42422,
+        "sources": [
+          "U.S. Census Bureau",
+          "U.S. Department of Education",
+          "U.S. National Center for Education Statistics"
+        ]
       }
     },
     "environment": {
       "title": "Environment",
-      "description": "",
+      "description": "Environment data serves as the critical compass to understand, monitor, and address the complex interplay between human activities and the natural world, enabling informed decisions towards mitigating environmental challenges and promoting ecological balance. Search for some environment data or click around on one of the suggested searches below to get started.",
       "examples": {
-        "general": [],
-        "specific": [],
-        "comparison": []
+        "general": [
+          "Natural disasters in California",
+          "How does land cover vary over the US?",
+          "Pollution levels in Manhattan",
+          "Projected temperatures in Tulare County"
+        ],
+        "specific": [
+          "Number of wildfires in California",
+          "How much of the US is covered in vegetation?",
+          "AQI levels in Los Angeles County"
+        ],
+        "comparison": [
+          "Wildfire vs people under poverty line in California"
+        ]
       },
       "meta": {
-        "dataPointCount": 7891011,
-        "variableCount": 3456,
-        "sources": ["United Nations"]
+        "dataPointCount": 0,
+        "variableCount": 2992,
+        "sources": [
+          "Climate Trace",
+          "Dynamic World Project",
+          "Federal Emergency Management Agency (FEMA)",
+          "U.S. Environmental Protection Agency (EPA)",
+          "Us.s National Aeornautics and Space Administration (NASA)",
+          "U.S. National Oceanic and Atmostpheric Administration (NOAA)",
+          "United States Geological Service (USGS)"
+        ]
       }
     },
     "demographics": {
       "title": "Demographics",
-      "description": "",
+      "description": "Demographic data is a powerful lens through which we gain insights into human populations, shaping policies and services to meet diverse needs, foster inclusivity, and drive social progress. Search for some demographics data or click around on one of the suggested searches below to get started.",
       "examples": {
-        "general": [],
-        "specific": [],
-        "comparison": []
+        "general": [
+          "Age distribution of the US population",
+          "Most common languages spoken at home in California",
+          "Racial demographics of Texas",
+          "Marriage and divorce in New York"
+        ],
+        "specific": [
+          "Number of non-English speakers in Florida",
+          "Number of naturalized US citizens",
+          "US poverty by race"
+        ],
+        "comparison": [
+          "Old age population vs excessive heat events in Texas"
+        ]
       },
       "meta": {
-        "dataPointCount": 7891011,
-        "variableCount": 3456,
-        "sources": ["United Nations"]
+        "dataPointCount": 0,
+        "variableCount": 35472,
+        "sources": [
+          "U.S. Census Bureau",
+          "United Nations",
+          "World Bank"
+        ]
       }
     },
     "sustainability": {
       "title": "Sustainability",
-      "description": "",
+      "description": "Sustainability data acts as the compass for measuring and managing our environmental, social, and economic impact, guiding us towards a more resilient and regenerative future for both humanity and the planet. Search for some sustainability data or click around on one of the suggested searches below to get started.",
       "examples": {
-        "general": [],
-        "specific": [],
-        "comparison": []
+        "general": [
+          "Excessive heat events in Texas",
+          "Land Usage in USA",
+          "USA forest health",
+          "Commutes in San Francisco Bay Area",
+          "Carbon emissions in US"
+        ],
+        "specific": [
+          "How much of US energy is renewable?",
+          "How many people take public transit in Washington?",
+          "US CO2 emissions by source"
+        ],
+        "comparison": [
+          "Number of farms vs droughts in California"
+        ]
       },
       "meta": {
-        "dataPointCount": 7891011,
-        "variableCount": 3456,
-        "sources": ["United Nations"]
+        "dataPointCount": 0,
+        "variableCount": 12746,
+        "sources": [
+          "Climate Trace",
+          "U.S. Energy Information Administration (EIA)",
+          "U.S. National Reneweable Energy Laboratory (NREL)",
+          "Federal Emergency Management Agency (FEMA)",
+          "U.S. Environmental Protection Agency (EPA)",
+          "Us.s National Aeornautics and Space Administration (NASA)",
+          "U.S. National Oceanic and Atmostpheric Administration (NOAA)",
+          "United States Geological Service (USGS)",
+          "United Nations"
+        ]
       }
     }
   }

--- a/static/js/apps/explore/topics.json
+++ b/static/js/apps/explore/topics.json
@@ -121,7 +121,7 @@
           "Dynamic World Project",
           "Federal Emergency Management Agency (FEMA)",
           "U.S. Environmental Protection Agency (EPA)",
-          "Us.s National Aeornautics and Space Administration (NASA)",
+          "U.S. National Aeornautics and Space Administration (NASA)",
           "U.S. National Oceanic and Atmostpheric Administration (NOAA)",
           "United States Geological Service (USGS)"
         ]
@@ -185,7 +185,7 @@
           "U.S. National Reneweable Energy Laboratory (NREL)",
           "Federal Emergency Management Agency (FEMA)",
           "U.S. Environmental Protection Agency (EPA)",
-          "Us.s National Aeornautics and Space Administration (NASA)",
+          "U.S. National Aeornautics and Space Administration (NASA)",
           "U.S. National Oceanic and Atmostpheric Administration (NOAA)",
           "United States Geological Service (USGS)",
           "United Nations"


### PR DESCRIPTION
Add the rest of the /explore/<vertical> pages to the new homepage.

More example links for each vertical, and the number of datapoints will be added in a followup PR.

<img width="1701" alt="Screenshot 2023-07-27 at 4 03 44 PM" src="https://github.com/datacommonsorg/website/assets/4034366/403dda1b-68d5-4153-9140-48c0de7d5213">
<img width="1709" alt="Screenshot 2023-07-27 at 4 04 04 PM" src="https://github.com/datacommonsorg/website/assets/4034366/30f8ca48-22d7-4c09-8bf1-5a984123f6be">

<img width="1698" alt="Screenshot 2023-07-27 at 4 04 30 PM" src="https://github.com/datacommonsorg/website/assets/4034366/100eb5b7-00b2-44f3-a2c4-2b4fde1d7f7d">
https://github.com/datacommonsorg/website/assets/4034366/e149cff2-b568-4da7-847b-bc9bd73b5895">
<img width="1701" alt="Screenshot 2023-07-27 at 4 05 03 PM" src="https://github.com/datacommonsorg/website/assets/4034366/bb37bb2f-a6b2-4b43-a6f5-5e026f994f31">
<img width="1698" alt="Screenshot 2023-07-27 at 4 05 14 PM" src="https://github.com/datacommonsorg/website/assets/4034366/7ebfa968-6cdc-4462-9d84-b891a636374f">

