### PR TITLE
Insights: Fix a bunch of minor things

### DIFF
--- a/server/integration_tests/test_data/demo_feb2023/query_1/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_1/chart_config.json
@@ -137,6 +137,642 @@
                       "showHighest": true
                     },
                     "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+                    ],
+                    "title": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+                    ],
+                    "title": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+                    ],
+                    "title": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+                    ],
+                    "title": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc"
+                    ],
+                    "title": "Per Capita Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+                    ],
+                    "title": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+                    ],
+                    "title": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+                    ],
+                    "title": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+                    ],
+                    "title": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  },
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc"
+                    ],
+                    "title": "Per Capita Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
                       "Temperature"
                     ],
                     "title": "Temperature in a Location in Counties of California (${date})",
@@ -295,6 +931,60 @@
             "name": "Count of Heat Temperature Event",
             "statVar": "Count_HeatTemperatureEvent"
           },
+          "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical": {
+            "name": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical",
+            "statVar": "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+          },
+          "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc": {
+            "denom": "Count_Person",
+            "name": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical",
+            "statVar": "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+          },
+          "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245": {
+            "name": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245",
+            "statVar": "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc": {
+            "denom": "Count_Person",
+            "name": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245",
+            "statVar": "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585": {
+            "name": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585",
+            "statVar": "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
+          "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc": {
+            "denom": "Count_Person",
+            "name": "Max Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585",
+            "statVar": "MaxTemp_Daily_GaussianMixture_1PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
+          "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical": {
+            "name": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical",
+            "statVar": "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+          },
+          "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc": {
+            "denom": "Count_Person",
+            "name": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical",
+            "statVar": "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+          },
+          "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245": {
+            "name": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245",
+            "statVar": "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc": {
+            "denom": "Count_Person",
+            "name": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245",
+            "statVar": "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585": {
+            "name": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585",
+            "statVar": "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
+          "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc": {
+            "denom": "Count_Person",
+            "name": "Max Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585",
+            "statVar": "MaxTemp_Daily_GaussianMixture_5PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
           "Max_Temperature": {
             "name": "Maximum Temperature",
             "statVar": "Max_Temperature"
@@ -306,6 +996,60 @@
           "Mean_Temperature": {
             "name": "Mean Temperature",
             "statVar": "Mean_Temperature"
+          },
+          "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical": {
+            "name": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical",
+            "statVar": "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+          },
+          "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc": {
+            "denom": "Count_Person",
+            "name": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, Historical",
+            "statVar": "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+          },
+          "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245": {
+            "name": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245",
+            "statVar": "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc": {
+            "denom": "Count_Person",
+            "name": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP245",
+            "statVar": "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585": {
+            "name": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585",
+            "statVar": "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
+          "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc": {
+            "denom": "Count_Person",
+            "name": "Min Temperature With 1% Chance Once In Decade: CMIP6 Ensemble, SSP585",
+            "statVar": "MinTemp_Daily_GaussianMixture_1PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
+          "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical": {
+            "name": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical",
+            "statVar": "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+          },
+          "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical_pc": {
+            "denom": "Count_Person",
+            "name": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, Historical",
+            "statVar": "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_Historical"
+          },
+          "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245": {
+            "name": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245",
+            "statVar": "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245_pc": {
+            "denom": "Count_Person",
+            "name": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP245",
+            "statVar": "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585": {
+            "name": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585",
+            "statVar": "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
+          "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585_pc": {
+            "denom": "Count_Person",
+            "name": "Min Temperature With 5% Chance Once In Decade: CMIP6 Ensemble, SSP585",
+            "statVar": "MinTemp_Daily_GaussianMixture_5PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
           },
           "Min_Temperature": {
             "name": "Min Temperature",
@@ -379,6 +1123,22 @@
       "NL_RELATED_PLACE": {},
       "NL_RELATED_VAR": {
         "items": [
+          {
+            "displayName": "Temperature in a Location",
+            "nlQuery": "Temperature in a Location California"
+          },
+          {
+            "displayName": "Min Temperature",
+            "nlQuery": "Min Temperature California"
+          },
+          {
+            "displayName": "Mean Temperature",
+            "nlQuery": "Mean Temperature California"
+          },
+          {
+            "displayName": "Maximum Temperature",
+            "nlQuery": "Maximum Temperature California"
+          },
           {
             "displayName": "Count of Heat Temperature Event",
             "nlQuery": "Count of Heat Temperature Event California"

--- a/server/integration_tests/test_data/fulfillment_api_basic/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_basic/chart_config.json
@@ -63,7 +63,8 @@
                 ]
               }
             ],
-            "denom": "Count_Person"
+            "denom": "Count_Person",
+            "title": "Modes of Commute"
           }
         ],
         "dcid": "dc/topic/WorkCommute",
@@ -100,8 +101,7 @@
             "name": "Carpool",
             "statVar": "dc/wc8q05drd74bd"
           }
-        },
-        "title": "Modes of Commute"
+        }
       }
     ],
     "metadata": {

--- a/server/integration_tests/test_data/fulfillment_api_comparison/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_comparison/chart_config.json
@@ -26,7 +26,8 @@
                 ]
               }
             ],
-            "denom": "Count_Person"
+            "denom": "Count_Person",
+            "title": "Modes of Commute"
           }
         ],
         "dcid": "dc/topic/WorkCommute",
@@ -55,8 +56,7 @@
             "name": "Carpool",
             "statVar": "dc/wc8q05drd74bd"
           }
-        },
-        "title": "Modes of Commute"
+        }
       }
     ],
     "metadata": {

--- a/server/lib/insights/page_type/builder.py
+++ b/server/lib/insights/page_type/builder.py
@@ -129,10 +129,12 @@ class Builder:
       self.page_config.categories.extend(out_cats)
 
     for cat in self.page_config.categories:
+      if self.first_chart_sv == cat.dcid:
+        # The overall topic matches the category, so clear out the title.
+        cat.title = ''
+
       if len(cat.blocks) == 1 and cat.title and cat.blocks[0].title:
         # Note: Category title will be topic name and block title
         # will be SVPG.  The latter is better curated, so for now
         # use that.
-        # TODO: Revisit after topic names are better.
-        cat.title = cat.blocks[0].title
         cat.blocks[0].title = ''

--- a/server/lib/insights/related.py
+++ b/server/lib/insights/related.py
@@ -35,7 +35,7 @@ def compute_related_things(state: ftypes.PopulateState, top_chart_sv: str):
   # Convert the places to json.
   pd = state.uttr.detection.places_detected
   related_things['parentPlaces'] = _get_json_places(pd.parent_places)
-  if state.place_type:
+  if state.place_type and pd.child_places:
     related_things['childPlaces'] = {
         state.place_type.value: _get_json_places(pd.child_places)
     }

--- a/server/routes/insights/api.py
+++ b/server/routes/insights/api.py
@@ -87,11 +87,9 @@ def fulfill():
 
   req_json = request.get_json()
   if not req_json:
-    helpers.abort('Missing input', '', [])
-    return {}
-  if (not req_json.get('entities') or not req_json.get('variables')):
-    helpers.abort('Entities and variables must be provided', '', [])
-    return {}
+    return helpers.abort('Missing input', '', [])
+  if not req_json.get('entities'):
+    return helpers.abort('`entities` must be provided', '', [])
 
   entities = req_json.get(Params.ENTITIES.value, [])
   cmp_entities = req_json.get(Params.CMP_ENTITIES.value, [])
@@ -118,8 +116,7 @@ def fulfill():
                                                      debug_logs, counters)
   counters.timeit('query_detection', start)
   if not query_detection:
-    helpers.abort(error_msg, '', [])
-    return {}
+    return helpers.abort(error_msg, '', [])
 
   utterance = create_utterance(query_detection, None, counters, session_id)
   utterance.insight_ctx = req_json

--- a/server/templates/insights.html
+++ b/server/templates/insights.html
@@ -19,7 +19,7 @@
  {% set is_hide_sub_footer = true %}
  {% set main_id = 'nl-interface' %}
  {% set page_id = 'nl-interface-page' %}
- {% set title = 'Insights' %}
+ {% set title = 'Explore' %}
  {% set subpage_title = '' %}
  {% set subpage_url = url_for('nl.page') %}
 

--- a/static/js/apps/insights/app.tsx
+++ b/static/js/apps/insights/app.tsx
@@ -64,6 +64,7 @@ export function App(): JSX.Element {
   const [hashParams, setHashParams] = useState<ParsedQuery<string>>({});
   const [query, setQuery] = useState<string>("");
   const [savedContext, setSavedContext] = useState<any>({});
+  const [fromSearch, setFromSearch] = useState<boolean>(false);
 
   useEffect(() => {
     const handleHashChange = () => {
@@ -133,7 +134,7 @@ export function App(): JSX.Element {
         cmpPlaces,
         cmpTopics
       );
-      if (!resp || !resp["place"]) {
+      if (!resp || !resp["place"] || !resp["place"]["dcid"]) {
         setLoadingStatus("fail");
         return;
       }
@@ -171,11 +172,14 @@ export function App(): JSX.Element {
   let mainSection;
   const place = getSingleParam(hashParams["p"]);
   const cmpPlace = getSingleParam(hashParams["pcmp"]);
+  const topic = getSingleParam(hashParams["t"]);
   if (loadingStatus == "fail") {
-    mainSection = <div>No data is found</div>;
+    mainSection = (
+      <div id="user-message">Sorry, could not complete your request.</div>
+    );
   } else if (loadingStatus == "loaded" && chartData) {
     let urlString = "/insights/#p=${placeDcid}";
-    urlString += `&t=${chartData.topic}`;
+    urlString += `&t=${topic}`;
     mainSection = (
       <div className="row insights-charts">
         <div
@@ -192,19 +196,21 @@ export function App(): JSX.Element {
                 categories={chartData.pageConfig.categories}
                 peerTopics={chartData.peerTopics}
               />
-              {chartData && chartData.parentTopics.length > 0 && (
-                <div className="topics-box">
-                  <div className="topics-head">Broader Topics</div>
-                  {chartData.parentTopics.map((parentTopic, idx) => {
-                    const url = `/insights/#t=${parentTopic.dcid}&p=${place}&pcmp={cmpPlace}`;
-                    return (
-                      <a className="topic-link" key={idx} href={url}>
-                        {parentTopic.name}
-                      </a>
-                    );
-                  })}
-                </div>
-              )}
+              {chartData &&
+                chartData.parentTopics.length > 0 &&
+                chartData.parentTopics.at(0).dcid != "dc/topic/Root" && (
+                  <div className="topics-box">
+                    <div className="topics-head">Broader Topics</div>
+                    {chartData.parentTopics.map((parentTopic, idx) => {
+                      const url = `/insights/#t=${parentTopic.dcid}&p=${place}&pcmp=${cmpPlace}`;
+                      return (
+                        <a className="topic-link" key={idx} href={url}>
+                          {parentTopic.name}
+                        </a>
+                      );
+                    })}
+                  </div>
+                )}
               <ChildPlaces
                 childPlaces={chartData.childPlaces}
                 parentPlace={chartData.place}

--- a/static/js/apps/insights/app.tsx
+++ b/static/js/apps/insights/app.tsx
@@ -64,7 +64,6 @@ export function App(): JSX.Element {
   const [hashParams, setHashParams] = useState<ParsedQuery<string>>({});
   const [query, setQuery] = useState<string>("");
   const [savedContext, setSavedContext] = useState<any>({});
-  const [fromSearch, setFromSearch] = useState<boolean>(false);
 
   useEffect(() => {
     const handleHashChange = () => {

--- a/static/js/apps/insights/parent_breadcrumbs.tsx
+++ b/static/js/apps/insights/parent_breadcrumbs.tsx
@@ -36,9 +36,7 @@ class ParentPlace extends React.Component<ParentPlacePropsType> {
     }
     return (
       <div id="parent-places">
-        {num > 0 && (
-          <span id="parent-place-head">{this.props.placeType} in </span>
-        )}
+        {num > 0 && <span id="parent-place-head">Located in </span>}
         {num > 0 &&
           this.props.parentPlaces.map((parent, index) => {
             if (index === num - 1) {

--- a/static/js/shared/child_places.tsx
+++ b/static/js/shared/child_places.tsx
@@ -36,17 +36,31 @@ export function ChildPlaces(props: ChildPlacesPropType): JSX.Element {
   if (_.isEmpty(props.childPlaces) || !props.parentPlace) {
     return null;
   }
+  const firstType = displayNameForPlaceType(
+    Object.keys(props.childPlaces)[0],
+    true /* isPlural */
+  );
+  const numTypes = Object.keys(props.childPlaces).length;
 
   return (
     <div id="child-places">
-      <span id="child-place-head">Places in {props.parentPlace.name}</span>
+      {numTypes == 1 && (
+        <span id="child-place-head">
+          {firstType} in {props.parentPlace.name}
+        </span>
+      )}
+      {numTypes > 1 && (
+        <span id="child-place-head">Places in {props.parentPlace.name}</span>
+      )}
       {Object.keys(props.childPlaces)
         .sort()
         .map((placeType) => (
           <div key={placeType} className="child-place-group">
-            <div className="child-place-type">
-              {displayNameForPlaceType(placeType, true /* isPlural */)}
-            </div>
+            {numTypes > 1 && (
+              <div className="child-place-type">
+                {displayNameForPlaceType(placeType, true /* isPlural */)}
+              </div>
+            )}
             {props.childPlaces[placeType].map((place, i) => {
               const rs: ReplacementStrings = {
                 placeDcid: place.dcid,


### PR DESCRIPTION
1.  Do not show a category for the display topic (i.e., Economy -> Economy)
2. Use the immediate sub-topic, rather than some further descendent sub-topics, as categories
3. Avoid showing "Places in X" when things are empty.
4. Instead of "Places in X Counties" say "Counties in X"
5. For parent places, say "Located in".... its weird to see "County in USA" for SC county when there's no state-level data.
6. Avoid showing "Statistics" (aka dc/topic/Root) in Broad topics.
7. Change the title from Insights -> Explore