### PR TITLE
Revert previous mixer-api-key change and don't require it in prod

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -390,7 +390,8 @@ def create_app():
             'UTF-8')
     app.config['NL_BAD_WORDS'] = bad_words.load_bad_words()
     app.config['NL_CHART_TITLES'] = libutil.get_nl_chart_titles()
-    app.config['TOPIC_CACHE'] = topic_cache.load(app.config['MIXER_API_KEY'])
+    mixer_key = app.config.get('MIXER_API_KEY', '')
+    app.config['TOPIC_CACHE'] = topic_cache.load(mixer_key)
 
   # Get and save the list of variables that we should not allow per capita for.
   app.config['NOPC_VARS'] = libutil.get_nl_no_percapita_vars()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -347,7 +347,17 @@ def create_app():
 
   # Need to fetch the API key for non gcp environment.
   if cfg.LOCAL or cfg.WEBDRIVER or cfg.INTEGRATION:
-    app.config['MIXER_API_KEY'] = libutil.get_mixer_api_key(cfg)
+    # Get the API key from environment first.
+    if os.environ.get('MIXER_API_KEY'):
+      app.config['MIXER_API_KEY'] = os.environ.get('MIXER_API_KEY')
+    elif os.environ.get('mixer_api_key'):
+      app.config['MIXER_API_KEY'] = os.environ.get('mixer_api_key')
+    else:
+      secret_client = secretmanager.SecretManagerServiceClient()
+      secret_name = secret_client.secret_version_path(cfg.SECRET_PROJECT,
+                                                      'mixer-api-key', 'latest')
+      secret_response = secret_client.access_secret_version(name=secret_name)
+      app.config['MIXER_API_KEY'] = secret_response.payload.data.decode('UTF-8')
 
   # Initialize translations
   babel = Babel(app, default_domain='all')
@@ -380,8 +390,7 @@ def create_app():
             'UTF-8')
     app.config['NL_BAD_WORDS'] = bad_words.load_bad_words()
     app.config['NL_CHART_TITLES'] = libutil.get_nl_chart_titles()
-    mixer_api_key = libutil.get_mixer_api_key(cfg)
-    app.config['TOPIC_CACHE'] = topic_cache.load(mixer_api_key)
+    app.config['TOPIC_CACHE'] = topic_cache.load(app.config['MIXER_API_KEY'])
 
   # Get and save the list of variables that we should not allow per capita for.
   app.config['NOPC_VARS'] = libutil.get_nl_no_percapita_vars()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -390,8 +390,7 @@ def create_app():
             'UTF-8')
     app.config['NL_BAD_WORDS'] = bad_words.load_bad_words()
     app.config['NL_CHART_TITLES'] = libutil.get_nl_chart_titles()
-    mixer_key = app.config.get('MIXER_API_KEY', '')
-    app.config['TOPIC_CACHE'] = topic_cache.load(mixer_key)
+    app.config['TOPIC_CACHE'] = topic_cache.load(app.config)
 
   # Get and save the list of variables that we should not allow per capita for.
   app.config['NOPC_VARS'] = libutil.get_nl_no_percapita_vars()

--- a/server/integration_tests/test_data/fulfillment_api_statvars/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_statvars/chart_config.json
@@ -42,6 +42,7 @@
                 ]
               }
             ],
+            "denom": "Count_Person",
             "title": "Median Incomes in Information industry"
           },
           {

--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -280,7 +280,7 @@ def entity_variables(entities):
   return result
 
 
-def properties(nodes, out=True, mixer_api_key=''):
+def properties(nodes, out=True, app_config=None):
   """Returns the properties for a list of nodes.
 
   The response is in the following format:
@@ -289,14 +289,14 @@ def properties(nodes, out=True, mixer_api_key=''):
   }
 
   """
-  resp = dc.v2node(nodes, '->' if out else '<-', mixer_api_key)
+  resp = dc.v2node(nodes, '->' if out else '<-', app_config)
   result = {node: [] for node in nodes}
   for node, val in resp.get('data', {}).items():
     result[node] = val.get('properties', [])
   return result
 
 
-def property_values(nodes, prop, out=True, constraints='', mixer_api_key=''):
+def property_values(nodes, prop, out=True, constraints='', app_config=None):
   """Returns a compact property values data out of REST API response.
 
   The response is the following format:
@@ -305,7 +305,7 @@ def property_values(nodes, prop, out=True, constraints='', mixer_api_key=''):
   }
   """
   resp = dc.v2node(nodes, '{}{}{}'.format('->' if out else '<-', prop,
-                                          constraints), mixer_api_key)
+                                          constraints), app_config)
   result = {}
   for node, node_arcs in resp.get('data', {}).items():
     result[node] = []
@@ -317,11 +317,7 @@ def property_values(nodes, prop, out=True, constraints='', mixer_api_key=''):
   return result
 
 
-def raw_property_values(nodes,
-                        prop,
-                        out=True,
-                        constraints='',
-                        mixer_api_key=''):
+def raw_property_values(nodes, prop, out=True, constraints='', app_config=None):
   """Returns full property values data out of REST API response.
 
   The response is the following format:
@@ -339,14 +335,14 @@ def raw_property_values(nodes,
 
   """
   resp = dc.v2node(nodes, '{}{}{}'.format('->' if out else '<-', prop,
-                                          constraints), mixer_api_key)
+                                          constraints), app_config)
   result = {}
   for node, node_arcs in resp.get('data', {}).items():
     result[node] = node_arcs.get('arcs', {}).get(prop, {}).get('nodes', [])
   return result
 
 
-def triples(nodes, out=True, mixer_api_key=''):
+def triples(nodes, out=True, app_config=None):
   """Fetch triples for given nodes.
 
   The response is the following format:
@@ -365,7 +361,7 @@ def triples(nodes, out=True, mixer_api_key=''):
   }
 
   """
-  resp = dc.v2node(nodes, '->*' if out else '<-*', mixer_api_key)
+  resp = dc.v2node(nodes, '->*' if out else '<-*', app_config)
   result = {}
   for node, arcs in resp['data'].items():
     result[node] = {}

--- a/server/lib/util.py
+++ b/server/lib/util.py
@@ -24,7 +24,6 @@ from typing import List
 import urllib
 
 from flask import make_response
-from google.cloud import secretmanager
 from google.protobuf import text_format
 
 from server.config import subject_page_pb2
@@ -324,17 +323,3 @@ def gzip_compress_response(raw_content, is_json):
   if is_json:
     response.headers['Content-Type'] = 'application/json'
   return response
-
-
-def get_mixer_api_key(cfg):
-  # Get the API key from environment first.
-  if os.environ.get('MIXER_API_KEY'):
-    return os.environ.get('MIXER_API_KEY')
-  elif os.environ.get('mixer_api_key'):
-    return os.environ.get('mixer_api_key')
-  else:
-    secret_client = secretmanager.SecretManagerServiceClient()
-    secret_name = secret_client.secret_version_path(cfg.SECRET_PROJECT,
-                                                    'mixer-api-key', 'latest')
-    secret_response = secret_client.access_secret_version(name=secret_name)
-    return secret_response.payload.data.decode('UTF-8')

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -45,20 +45,22 @@ def get(url: str):
   return response.json()
 
 
-def post(url: str, req: Dict, mixer_api_key: str = ''):
+def post(url: str, req: Dict, app_config=None):
   # Get json string so the request can be flask cached.
   # Also to have deterministic req string, the repeated fields in request
   # are sorted.
   req_str = json.dumps(req, sort_keys=True)
-  return post_wrapper(url, req_str, mixer_api_key)
+  return post_wrapper(url, req_str, app_config)
 
 
 @cache.cache.memoize(timeout=cache.TIMEOUT)
-def post_wrapper(url, req_str: str, mixer_api_key: str = ''):
+def post_wrapper(url, req_str: str, app_config=None):
   req = json.loads(req_str)
   headers = {'Content-Type': 'application/json'}
-  if not mixer_api_key:
+  if not app_config:
     mixer_api_key = current_app.config.get('MIXER_API_KEY', '')
+  else:
+    mixer_api_key = app_config.get('MIXER_API_KEY', '')
   if mixer_api_key:
     headers['x-api-key'] = mixer_api_key
   # Send the request and verify the request succeeded
@@ -191,7 +193,7 @@ def v2observation(select, entity, variable):
   })
 
 
-def v2node(nodes, prop, mixer_api_key=''):
+def v2node(nodes, prop, app_config=None):
   """Wrapper to call V2 Node REST API.
 
   Args:
@@ -202,7 +204,7 @@ def v2node(nodes, prop, mixer_api_key=''):
   return post(url, {
       'nodes': sorted(nodes),
       'property': prop,
-  }, mixer_api_key)
+  }, app_config)
 
 
 def v2event(node, prop):

--- a/server/tests/routes/api/point_test.py
+++ b/server/tests/routes/api/point_test.py
@@ -104,7 +104,7 @@ class TestApiPointWithin(unittest.TestCase):
         },
     }
 
-    def post_side_effect(url, data, _=''):
+    def post_side_effect(url, data, _=None):
       if url.endswith('/v2/observation') and data == {
           'select': ['date', 'value', 'variable', 'entity'],
           'entity': {

--- a/server/tests/routes/api/series_test.py
+++ b/server/tests/routes/api/series_test.py
@@ -198,7 +198,7 @@ class TestApiSeriesWithin(unittest.TestCase):
         },
     }
 
-    def side_effect(url, data, _=''):
+    def side_effect(url, data, _=None):
       if url.endswith('/v2/observation') and data == {
           'select': ['date', 'value', 'variable', 'entity'],
           'entity': {

--- a/server/tests/routes/api/stats_test.py
+++ b/server/tests/routes/api/stats_test.py
@@ -24,7 +24,7 @@ class TestApiStatsProperty(unittest.TestCase):
   @mock.patch('server.services.datacommons.post')
   def test_api_get_stats_property(self, mock_post):
 
-    def side_effect(url, req_json, _=''):
+    def side_effect(url, req_json, _=None):
       if req_json == {
           'nodes': ['DifferenceRelativeToBaseDate1990_Temperature'],
           'property': '->*'


### PR DESCRIPTION
Essentially undo https://github.com/datacommonsorg/website/pull/3072, and instead of API key plumb through the context.  That way, it will work on prod and local.