### PR TITLE
update the byline logo

### DIFF
--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -24,6 +24,7 @@
   is_hide_sub_footer: boolean, if true, hides the sub footer. Default false
   subpage_title: string, if specified, will be displayed in the header next to Data Commons
   locale: string, value for html lang attr
+  brand_logo_path: string, if set, use this path for the src for the brand logo in the footer
 
   Blocks to override:
   head - additional head elements
@@ -232,8 +233,12 @@
           <div id="sub-footer" class="col-12">
             <!-- {% set homepage_url = "<a href={href}>Data Commons</a>".format(href=url_for('static.homepage'))  %} -->
             {# TRANSLATORS: The label for the Google branding byline. #}
-            <span class="brand-byline"><span class="brand-text">{% trans %}An initiative from{% endtrans %}</span><img class="brand-logo" src="/images/google-logo-reverse.svg" /></span>
-
+            <span class="brand-byline"><span class="brand-text">{% trans %}An initiative from{% endtrans %}</span>
+            {% if brand_logo_path %}
+            <img class="brand-logo" src="{{ brand_logo_path }}" /></span>
+            {% else %}
+            <img class="brand-logo" src="/images/google-logo.svg" /></span>
+            {% endif %}
             <div class="float-md-right mt-3 mt-md-0">
               {% block subfooter_extra %}{% endblock %}
               {# TRANSLATORS: The label for a link to site terms and conditions. #}

--- a/server/templates/static/homepage.html
+++ b/server/templates/static/homepage.html
@@ -18,6 +18,7 @@
  {% set main_id = 'homepage' %}
  {% set page_id = 'page-homepage' %}
  {% set title = 'Home' %}
+ {% set brand_logo_path = "/images/google-logo-reverse.svg" %}
  
  {% macro external_icon() -%}
  <svg class="icon"xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="12px" fill="#660000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>


### PR DESCRIPTION
- footers for every other page besides the homepage is light grey so the reverse logo does not show up well. Add a variable to set which logo to use in the footer

homepage
![Screenshot 2023-08-01 at 7 46 03 AM](https://github.com/datacommonsorg/website/assets/69875368/dfc07f95-0c5b-48c5-b453-42f63acd1e1d)

tools
![Screenshot 2023-08-01 at 7 46 43 AM](https://github.com/datacommonsorg/website/assets/69875368/ee076e61-231c-4941-a6dd-56e8e6e670de)
