### PR TITLE
Use default 3 digits precision for ranking tile; Do not auto focus explore query box

### DIFF
--- a/static/js/apps/nl_interface/debug_info.tsx
+++ b/static/js/apps/nl_interface/debug_info.tsx
@@ -118,8 +118,8 @@ const multiVarPartsElement = (c: MultiSVCandidate): JSX.Element => {
 };
 
 const multiVarScoresElement = (svScores: SVScores): JSX.Element => {
-  const monovar_scores = Object.values(svScores.CosineScore);
-  const max_monovar_score = monovar_scores.length > 0 ? monovar_scores[0] : 0;
+  const monovarScores = Object.values(svScores.CosineScore);
+  const maxMonovarScore = monovarScores.length > 0 ? monovarScores[0] : 0;
   const candidates = svScores.MultiSV.Candidates;
   return (
     <div id="multi-sv-scores-list">
@@ -142,7 +142,7 @@ const multiVarScoresElement = (svScores: SVScores): JSX.Element => {
                   </td>
                   <td>
                     {c.AggCosineScore}{" "}
-                    {c.AggCosineScore > max_monovar_score
+                    {c.AggCosineScore > maxMonovarScore
                       ? " (> best single var)"
                       : ""}
                   </td>

--- a/static/js/apps/nl_interface/query_result.tsx
+++ b/static/js/apps/nl_interface/query_result.tsx
@@ -19,8 +19,7 @@
  */
 
 import axios from "axios";
-import _ from "lodash";
-import React, { createRef, memo, useEffect, useRef, useState } from "react";
+import React, { createRef, memo, useEffect, useRef } from "react";
 import { Container } from "reactstrap";
 
 import { SubjectPageMainPane } from "../../components/subject_page/main_pane";

--- a/static/js/components/ranking_unit.tsx
+++ b/static/js/components/ranking_unit.tsx
@@ -25,8 +25,6 @@ import { ASYNC_ELEMENT_CLASS } from "../constants/css_constants";
 import { formatNumber, LocalizedLink } from "../i18n/i18n";
 import { RankingPoint } from "../types/ranking_unit_types";
 
-const NUM_FRACTION_DIGITS = 2;
-
 interface RankingUnitPropType {
   title: string;
   points: RankingPoint[];
@@ -133,8 +131,7 @@ export function RankingUnit(props: RankingUnitPropType): JSX.Element {
                           ? point.value * props.scaling[0]
                           : point.value,
                         props.unit && props.unit.length ? props.unit[0] : "",
-                        false,
-                        NUM_FRACTION_DIGITS
+                        false
                       )}
                     </span>
                   </td>
@@ -155,8 +152,7 @@ export function RankingUnit(props: RankingUnitPropType): JSX.Element {
                             ? v * props.scaling[i]
                             : v,
                           props.unit && props.unit.length ? props.unit[i] : "",
-                          false,
-                          NUM_FRACTION_DIGITS
+                          false
                         )}
                       </span>
                     </td>

--- a/static/js/components/text_search_bar.tsx
+++ b/static/js/components/text_search_bar.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import React, { createRef, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button, Input, InputGroup } from "reactstrap";
 
 interface TextSearchBarPropType {
   allowEmptySearch?: boolean;
   inputId: string;
-  onSearch: (string) => void;
+  onSearch: (q: string) => void;
   initialValue: string;
   placeholder: string;
   shouldAutoFocus?: boolean;


### PR DESCRIPTION
2 digits gives inaccurate result as we use M, K (1000 step) as unit. Also it makes per capita value very weak (all 0.1 or all 0)

Fix some lint issues as well.