### PR TITLE
A few parity bugs for NL vs. Explore

### DIFF
--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -114,7 +114,8 @@ class IntegrationTest(NLWebServerTestCase):
   def test_detection_context(self):
     self.run_detection('detection_api_context', [
         'Commute in tracts of California', 'Compare with Nevada',
-        'Correlate with asthma'
+        'Correlate with asthma', 'countries with greenhouse gas emissions',
+        'median income in Santa Clara county and Alameda county'
     ])
 
   def test_detection_statvars(self):

--- a/server/integration_tests/test_data/detection_api_basic/chart_config.json
+++ b/server/integration_tests/test_data/detection_api_basic/chart_config.json
@@ -1,4 +1,5 @@
 {
+  "childEntityType": "",
   "comparisonEntities": [],
   "comparisonVariables": [],
   "context": {},

--- a/server/integration_tests/test_data/detection_api_context/comparewithnevada/chart_config.json
+++ b/server/integration_tests/test_data/detection_api_context/comparewithnevada/chart_config.json
@@ -1,4 +1,5 @@
 {
+  "childEntityType": "",
   "comparisonEntities": [
     "geoId/06"
   ],

--- a/server/integration_tests/test_data/detection_api_context/correlatewithasthma/chart_config.json
+++ b/server/integration_tests/test_data/detection_api_context/correlatewithasthma/chart_config.json
@@ -1,4 +1,5 @@
 {
+  "childEntityType": "",
   "comparisonEntities": [],
   "comparisonVariables": [
     "dc/topic/CommuteTime",

--- a/server/integration_tests/test_data/detection_api_context/countrieswithgreenhousegasemissions/chart_config.json
+++ b/server/integration_tests/test_data/detection_api_context/countrieswithgreenhousegasemissions/chart_config.json
@@ -1,0 +1,23 @@
+{
+  "childEntityType": "Country",
+  "comparisonEntities": [],
+  "comparisonVariables": [],
+  "context": {},
+  "debug": {},
+  "entities": [
+    "Earth"
+  ],
+  "sessionId": "007_999999999",
+  "variables": [
+    "dc/topic/GreenhouseGasEmissions",
+    "Annual_Emissions_GreenhouseGas",
+    "Annual_Emissions_GreenhouseGas_ClimateTrace_OtherEnergyUse",
+    "Annual_Emissions_CarbonDioxide_ClimateTrace_OtherEnergyUse",
+    "Annual_Emissions_GreenhouseGas_OilAndGas",
+    "Annual_Emissions_CarbonDioxide_Power",
+    "Annual_Emissions_CarbonDioxide_FossilFuelOperations",
+    "Annual_Emissions_GreenhouseGas_WasteManagement",
+    "Annual_Emissions_CarbonDioxide_ClimateTrace_OtherFossilFuelOperations",
+    "Annual_Emissions_GreenhouseGas_Agriculture"
+  ]
+}

--- a/server/integration_tests/test_data/detection_api_context/medianincomeinsantaclaracountyandalamedacounty/chart_config.json
+++ b/server/integration_tests/test_data/detection_api_context/medianincomeinsantaclaracountyandalamedacounty/chart_config.json
@@ -1,0 +1,25 @@
+{
+  "childEntityType": "",
+  "comparisonEntities": [
+    "geoId/06085"
+  ],
+  "comparisonVariables": [],
+  "context": {},
+  "debug": {},
+  "entities": [
+    "geoId/06001"
+  ],
+  "sessionId": "007_999999999",
+  "variables": [
+    "Median_Income_Person",
+    "Median_Income_Household",
+    "Median_Earnings_Person",
+    "Median_Income_Household_NonfamilyHousehold",
+    "Median_Income_Household_FamilyHousehold",
+    "Median_Income_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolGraduate_WithIncome",
+    "Mean_Income_Household",
+    "dc/x3gghqtglpr59",
+    "Median_Income_Person_25OrMoreYears_EducationalAttainmentBachelorsDegree_WithIncome",
+    "dc/topic/IncomeEquity"
+  ]
+}

--- a/server/integration_tests/test_data/detection_api_statvars/correlatewithgdpofcalifornia/chart_config.json
+++ b/server/integration_tests/test_data/detection_api_statvars/correlatewithgdpofcalifornia/chart_config.json
@@ -1,4 +1,5 @@
 {
+  "childEntityType": "",
   "comparisonEntities": [],
   "comparisonVariables": [
     "ReceiptsOrRevenue_Establishment_NAICSInformation_WithPayroll",

--- a/server/integration_tests/test_data/detection_api_statvars/incomeininformationindustryinnevada/chart_config.json
+++ b/server/integration_tests/test_data/detection_api_statvars/incomeininformationindustryinnevada/chart_config.json
@@ -1,4 +1,5 @@
 {
+  "childEntityType": "",
   "comparisonEntities": [],
   "comparisonVariables": [],
   "context": {},

--- a/server/lib/explore/detector.py
+++ b/server/lib/explore/detector.py
@@ -21,10 +21,12 @@ import copy
 from enum import Enum
 from typing import Dict, List
 
+from server.lib.nl.common import constants
 import server.lib.nl.common.topic as topic
 import server.lib.nl.common.utils as utils
 import server.lib.nl.common.utterance as nl_uttr
 from server.lib.nl.detection.types import ClassificationType
+from server.lib.nl.detection.types import ContainedInPlaceType
 import server.lib.nl.detection.utils as dutils
 from server.lib.nl.fulfillment.handlers import route_comparison_or_correlation
 
@@ -58,25 +60,32 @@ def detect_with_context(uttr: nl_uttr.Utterance) -> Dict:
   if cl_type != None:
     query_type = route_comparison_or_correlation(cl_type, uttr)
 
-  # 3. Detect places (and comparison type) leveraging context.
-  places, cmp_places = _detect_places(
-      uttr, past_ctx, query_type == nl_uttr.QueryType.COMPARISON_ACROSS_PLACES)
+  # 3. Get place-type.
+  place_type = utils.get_contained_in_type(uttr)
+  if place_type:
+    if place_type == ContainedInPlaceType.SCHOOL:
+      # HACK: Promote school to public school since we don't have data
+      # for just School.
+      place_type = ContainedInPlaceType.PUBLIC_SCHOOL
 
-  # 4. Detect SVs leveraging context.
+  # 4. Detect places (and comparison type) leveraging context.
+  places, cmp_places = _detect_places(
+      uttr, place_type, past_ctx,
+      query_type == nl_uttr.QueryType.COMPARISON_ACROSS_PLACES)
+
+  # 5. Detect SVs leveraging context.
   vars, cmp_vars = _detect_vars(
       uttr, past_ctx, query_type == nl_uttr.QueryType.CORRELATION_ACROSS_VARS)
 
-  # 5. Populate the returned dict
+  # 6. Populate the returned dict
   data_dict.update({
       Params.ENTITIES.value: places,
       Params.VARS.value: vars[:_MAX_RETURNED_VARS],
       Params.SESSION_ID: uttr.session_id,
       Params.CMP_ENTITIES.value: cmp_places,
       Params.CMP_VARS.value: cmp_vars[:_MAX_RETURNED_VARS],
+      Params.CHILD_TYPE: '' if not place_type else place_type.value,
   })
-  place_type = utils.get_contained_in_type(uttr)
-  if place_type:
-    data_dict[Params.CHILD_TYPE.value] = place_type.value
 
   # 6. Set the detected params in uttr ctx and clear past contexts.
   uttr.insight_ctx = copy.deepcopy(data_dict)
@@ -117,6 +126,9 @@ def _get_comparison_or_correlation(
         ClassificationType.COMPARISON, ClassificationType.CORRELATION
     ]:
       return cl.type
+  # Mimic NL behavior when there are multiple places.
+  if len(uttr.places) > 1:
+    return ClassificationType.COMPARISON
   return None
 
 
@@ -146,8 +158,8 @@ def _hoist_topic(svs: List[str]):
       return
 
 
-def _detect_places(uttr: nl_uttr.Utterance, past_ctx: Dict,
-                   is_cmp: bool) -> List[str]:
+def _detect_places(uttr: nl_uttr.Utterance, child_type: ContainedInPlaceType,
+                   past_ctx: Dict, is_cmp: bool) -> List[str]:
   places = []
   cmp_places = []
   if is_cmp:
@@ -180,8 +192,14 @@ def _detect_places(uttr: nl_uttr.Utterance, past_ctx: Dict,
       # words earlier in the query interpreted incorrectly as a place
       places.reverse()
     else:
-      # Find place from context.
-      places = past_ctx.get(Params.ENTITIES.value, [])
-      uttr.counters.info('insight_place_ctx', places)
+      # Match NL behavior in `populate_charts()` by not using context
+      # when the place-type is country.
+      if child_type == ContainedInPlaceType.COUNTRY:
+        places = [constants.EARTH_DCID]
+        uttr.counters.info('insight_place_earth', places)
+      else:
+        # Find place from context.
+        places = past_ctx.get(Params.ENTITIES.value, [])
+        uttr.counters.info('insight_place_ctx', places)
 
   return places, cmp_places

--- a/server/lib/nl/detection/detector.py
+++ b/server/lib/nl/detection/detector.py
@@ -139,10 +139,6 @@ def construct(entities: List[str], vars: List[str], child_type: str,
         counters.err('failed_detection_badChildEntityType', child_type)
         return None, f'Bad childEntityType value {child_type}!'
       child_type = types.ContainedInPlaceType(child_type)
-      if child_type == types.ContainedInPlaceType.SCHOOL:
-        # HACK: Promote school to public school since we don't have data
-        # for just School.
-        child_type = types.ContainedInPlaceType.PUBLIC_SCHOOL
     else:
       child_type = utils.get_default_child_place_type(places[0], is_nl=False)
   else:

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -108,11 +108,12 @@ export function App(): JSX.Element {
         }
         setQuery(query);
         const detectResp = await fetchDetectData(query, savedContext);
+        if (!detectResp) {
+          setLoadingStatus("fail");
+          return;
+        }
         setSavedContext(detectResp["context"] || {});
-        if (
-          _.isEmpty(detectResp["entities"]) ||
-          _.isEmpty(detectResp["variables"])
-        ) {
+        if (_.isEmpty(detectResp["entities"])) {
           setLoadingStatus("fail");
           return;
         }
@@ -212,7 +213,7 @@ export function App(): JSX.Element {
         <TextSearchBar
           inputId="query-search-input"
           onSearch={(q) => {
-            updateHash({ q, oq: "", t: "", p: "" });
+            updateHash({ q, oq: "", t: "", p: "", pt: "", pcmp: "", tcmp: "" });
           }}
           placeholder={query}
           initialValue={query}


### PR DESCRIPTION
1. Make [Median income in Sunnyvale and San Francisco] be treated as comparison query
2. Infer world, without relying on context, for [countries with highest GHG] query
3. Allow for just [california] query to not return failure
4. Allow for server-side crashes to more gracefully throw error
5. Move School type detection hack from last night from `/fulfill` to `/detect` where it should belong