### PR TITLE
[library] Add optional custom footer with slots

### DIFF
--- a/packages/web-components/examples/all-charts.html
+++ b/packages/web-components/examples/all-charts.html
@@ -1,11 +1,16 @@
 <html>
   <head>
     <!-- https://gist.github.com/dwnoble/822ce6018bb41113c866d703760c1def -->
-    <link
+    <!-- <link
       rel="stylesheet"
       href="https://datacommons.org/css/datacommons.min.css"
+    /> -->
+    <link
+      rel="stylesheet"
+      href="http://localhost:8080/css/datacommons.min.css"
     />
-    <script src="https://datacommons.org/datacommons.js"></script>
+    <!-- <script src="https://datacommons.org/datacommons.js"></script> -->
+    <script src="http://localhost:8080/datacommons.js"></script>
     <style>
       /**
        * Example component styling using shadow part identifiers
@@ -76,7 +81,9 @@
       childPlaceType="State"
       variables="Count_Person"
       maxPlaces="15"
-    ></datacommons-bar>
+    >
+      <p slot="footer">Override. This is a very long override. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </datacommons-bar>
     <datacommons-bar
       title="Population of select US states"
       variables="Count_Person"
@@ -140,7 +147,14 @@
       title="California Farms by Size"
       place="geoId/06"
       variables="Count_Farm_1To9.9Acre Count_Farm_10To49.9Acre Count_Farm_50To179Acre Count_Farm_180To499Acre Count_Farm_500To999Acre Count_1000OnwardsAcre"
-    ></datacommons-pie>
+    >
+      <div slot="footer">
+        <ul>
+            <li>custom footer item 1</li>
+            <li>custom footer item 2</li>
+        </ul>
+      </div>
+    </datacommons-pie>
     <datacommons-pie
       title="California Farms by Size"
       place="geoId/06"

--- a/packages/web-components/examples/all-charts.html
+++ b/packages/web-components/examples/all-charts.html
@@ -1,16 +1,11 @@
 <html>
   <head>
     <!-- https://gist.github.com/dwnoble/822ce6018bb41113c866d703760c1def -->
-    <!-- <link
-      rel="stylesheet"
-      href="https://datacommons.org/css/datacommons.min.css"
-    /> -->
     <link
       rel="stylesheet"
-      href="http://localhost:8080/css/datacommons.min.css"
+      href="https://datacommons.org/css/datacommons.min.css"
     />
-    <!-- <script src="https://datacommons.org/datacommons.js"></script> -->
-    <script src="http://localhost:8080/datacommons.js"></script>
+    <script src="https://datacommons.org/datacommons.js"></script>
     <style>
       /**
        * Example component styling using shadow part identifiers
@@ -82,7 +77,7 @@
       variables="Count_Person"
       maxPlaces="15"
     >
-      <p slot="footer">Override. This is a very long override. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p slot="footer">Custom footer here. This is a long custom footer. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </datacommons-bar>
     <datacommons-bar
       title="Population of select US states"

--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -48,6 +48,7 @@ $box-shadow-8dp: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
     .outlinks {
       display: flex;
       gap: 0.5rem;
+      margin-top: auto;
     }
   }
 }

--- a/static/js/components/tiles/chart_footer.tsx
+++ b/static/js/components/tiles/chart_footer.tsx
@@ -69,9 +69,13 @@ function getSourcesJsx(sources: Set<string>): JSX.Element[] {
 export function ChartFooter(props: ChartFooterPropType): JSX.Element {
   return (
     <footer id="chart-container-footer">
-      {!_.isEmpty(props.sources) && (
-        <div className="sources">Data from {getSourcesJsx(props.sources)}.</div>
-      )}
+      <slot name="footer">
+        {!_.isEmpty(props.sources) && (
+          <div className="sources">
+            Data from {getSourcesJsx(props.sources)}.
+          </div>
+        )}
+      </slot>
       <div className="outlinks">
         {props.handleEmbed && (
           <a

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -48,6 +48,8 @@ interface ChartTileContainerProp {
   isInitialLoading?: boolean;
   // Url to use for the explore more button.
   exploreMoreUrl?: string;
+  // Whether to use custom footer slot. Use default ChartFooter if false.
+  useCustomFooter?: boolean;
 }
 
 export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -48,8 +48,6 @@ interface ChartTileContainerProp {
   isInitialLoading?: boolean;
   // Url to use for the explore more button.
   exploreMoreUrl?: string;
-  // Whether to use custom footer slot. Use default ChartFooter if false.
-  useCustomFooter?: boolean;
 }
 
 export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {


### PR DESCRIPTION
Add the ability for users to add a custom source attribution as a chart footer, replacing our default "Data from <domain>" text.

More concretely, this adds a "footer" slot to our web components, so users can use syntax like this:
```
<datacommons-pie
  title="California Farms by Size"
  place="geoId/06"
  variables="Count_Farm_1To9.9Acre Count_Farm_10To49.9Acre Count_Farm_50To179Acre Count_Farm_180To499Acre Count_Farm_500To999Acre Count_1000OnwardsAcre"
>
  <div slot="footer">
    <ul>
        <li>custom footer item 1</li>
        <li>custom footer item 2</li>
    </ul>
  </div>
</datacommons-pie>
```

To create a chart like:
![Screenshot 2023-08-04 at 12 58 19 PM](https://github.com/datacommonsorg/website/assets/4034366/86aedbb5-09ac-45bd-9cb6-c998bca9583d)

Another example, for what happens when the provided footer is very long:
```
<datacommons-bar
  title="Most populous states in the US"
  parentPlace="country/USA"
  childPlaceType="State"
  variables="Count_Person"
  maxPlaces="15"
>
  <p slot="footer">Custom footer here. This is a long custom footer. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
</datacommons-bar>
```
![Screenshot 2023-08-04 at 12 58 09 PM](https://github.com/datacommonsorg/website/assets/4034366/703482bd-17ce-4347-9fe9-3149fc10d348)
