### PR TITLE
[library] Add subtitle slot to web components

### DIFF
--- a/packages/web-components/examples/all-charts.html
+++ b/packages/web-components/examples/all-charts.html
@@ -76,7 +76,9 @@
       childPlaceType="State"
       variables="Count_Person"
       maxPlaces="15"
-    ></datacommons-bar>
+    >
+    <p slot="subtitle" style="text-align:center; color: grey; font-size: 0.85rem">(top 15 places)</p>  
+    </datacommons-bar>
     <datacommons-bar
       title="Population of select US states"
       variables="Count_Person"

--- a/static/css/shared/story_chart.scss
+++ b/static/css/shared/story_chart.scss
@@ -23,6 +23,10 @@
   font-weight: 600;
   font-size: 0.85rem;
   display: block;
+}
+
+.chart-container .chart-headers {
+  display: block;
   min-height: 2.2rem;
 }
 

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -72,11 +72,14 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
           props.isInitialLoading ? INITAL_LOADING_CLASS : ""
         }`}
       >
-        {
-          /* If props.title is not empty, we want to render this header element
-              even if title is empty to keep the space on the page */
-          props.title && <h4 {...{ part: "title" }}>{title}</h4>
-        }
+        <div className="chart-headers">
+          {
+            /* If props.title is not empty, we want to render this header element
+                even if title is empty to keep the space on the page */
+            props.title && <h4 {...{ part: "title" }}>{title}</h4>
+          }
+          <slot name="subtitle"></slot>
+        </div>
         {props.children}
       </div>
       <ChartFooter

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -74,8 +74,8 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
       >
         <div className="chart-headers">
           {
-            /* If props.title is not empty, we want to render this header element
-                even if title is empty to keep the space on the page */
+            /* We want to render this header element even if title is empty
+            to keep the space on the page */
             props.title && <h4 {...{ part: "title" }}>{title}</h4>
           }
           <slot name="subtitle"></slot>


### PR DESCRIPTION
Adds a slot to the web components to add an optional subtitle.

Note that based on the inline comment in `chart_tile.tsx`, it looks like intended behavior was for space for the header to remain even if a title is not provided. The CSS changes are to maintain this behavior, while avoiding awkward blank space between the title and subtitle.

Also confirmed these changes don't change the way our tiles are rendered in our Search/Chat interfaces.

Example:
```
<datacommons-bar
  title="Most populous states in the US"
  parentPlace="country/USA"
  childPlaceType="State"
  variables="Count_Person"
  maxPlaces="15"
>
<p slot="subtitle" style="text-align:center; color: grey; font-size: 0.85rem">(top 15 places)</p>  
</datacommons-bar>
```
<img width="428" alt="Screenshot 2023-08-04 at 5 30 42 PM" src="https://github.com/datacommonsorg/website/assets/4034366/096f9fa3-dfea-407c-b2c2-eae1143edbcf">
