### PR TITLE
Implement Explore More for single-SV charts

### DIFF
--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -137,6 +137,15 @@ class IntegrationTest(NLWebServerTestCase):
     }
     self.run_fulfillment('fulfillment_api_basic', req)
 
+  def test_fulfillment_explore_more(self):
+    req = {
+        'entities': ['geoId/06085'],
+        'variables': ['dc/topic/DivorcedPopulationByDemographic'],
+        'dc': '',
+        'exploreMore': '1',
+    }
+    self.run_fulfillment('fulfillment_api_explore_more', req)
+
   def test_fulfillment_expansion(self):
     req = {
         'entities': ['country/BRA'],

--- a/server/integration_tests/test_data/fulfillment_api_basic/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_basic/chart_config.json
@@ -950,6 +950,7 @@
         ]
       }
     ],
+    "exploreMore": {},
     "mainTopic": {
       "dcid": "dc/topic/WorkCommute",
       "name": "Commute",

--- a/server/integration_tests/test_data/fulfillment_api_comparison/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_comparison/chart_config.json
@@ -357,6 +357,7 @@
         ]
       }
     ],
+    "exploreMore": {},
     "mainTopic": {
       "dcid": "dc/topic/WorkCommute",
       "name": "Commute",

--- a/server/integration_tests/test_data/fulfillment_api_correlation/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_correlation/chart_config.json
@@ -508,6 +508,7 @@
         ]
       }
     ],
+    "exploreMore": {},
     "mainTopic": {
       "dcid": "dc/topic/WorkCommute",
       "name": "Commute",

--- a/server/integration_tests/test_data/fulfillment_api_expansion/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_expansion/chart_config.json
@@ -750,6 +750,7 @@
         ]
       }
     ],
+    "exploreMore": {},
     "mainTopic": {
       "dcid": "dc/topic/GlobalEconomicActivity",
       "name": "Global Economic Activity",

--- a/server/integration_tests/test_data/fulfillment_api_explore_more/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_explore_more/chart_config.json
@@ -516,12 +516,12 @@
     "exploreMore": {
       "Count_Person_Divorced": {
         "gender": [
-          "Count_Person_Male_Divorced",
-          "Count_Person_Female_Divorced"
+          "Count_Person_Female_Divorced",
+          "Count_Person_Male_Divorced"
         ],
         "placeOfBirth": [
-          "dc/dj7cvhr91sff5",
           "dc/66sy80vs0b8q7",
+          "dc/dj7cvhr91sff5",
           "dc/drvcnjld04b06",
           "dc/twlffl9b5vgn3"
         ]

--- a/server/integration_tests/test_data/fulfillment_api_explore_more/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_explore_more/chart_config.json
@@ -1,0 +1,602 @@
+{
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "description": "Divorcees in Santa Clara County",
+                    "statVarKey": [
+                      "Count_Person_Divorced"
+                    ],
+                    "title": "Divorcees in Santa Clara County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Divorced"
+                    ],
+                    "title": "Divorcees in Santa Clara County",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Divorcees"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Divorced"
+                    ],
+                    "title": "Divorcees in Santa Clara County (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Divorced"
+                    ],
+                    "title": "Divorcees in Santa Clara County (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Female_Divorced",
+                      "Count_Person_Male_Divorced"
+                    ],
+                    "title": "Divorced Population By Gender in Santa Clara County",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Divorced Population By Gender"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Female_Divorced"
+                    ],
+                    "title": "Divorced Women in Santa Clara County (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Female_Divorced"
+                    ],
+                    "title": "Divorced Women in Santa Clara County (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Male_Divorced"
+                    ],
+                    "title": "Divorced Men in Santa Clara County (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Male_Divorced"
+                    ],
+                    "title": "Divorced Men in Santa Clara County (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_15OrMoreYears_Divorced_AsianAlone",
+                      "Count_Person_15OrMoreYears_Divorced_BlackOrAfricanAmericanAlone",
+                      "Count_Person_15OrMoreYears_Divorced_HispanicOrLatino"
+                    ],
+                    "title": "Divorced Population By Race in Santa Clara County",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Divorced Population By Race"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_15OrMoreYears_Divorced_AsianAlone"
+                    ],
+                    "title": "Divorced Asian Men in Santa Clara County (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_15OrMoreYears_Divorced_AsianAlone"
+                    ],
+                    "title": "Divorced Asian Men in Santa Clara County (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_15OrMoreYears_Divorced_BlackOrAfricanAmericanAlone"
+                    ],
+                    "title": "Population: 15 Years or More, Divorced, Black or African American Alone in Santa Clara County (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_15OrMoreYears_Divorced_BlackOrAfricanAmericanAlone"
+                    ],
+                    "title": "Population: 15 Years or More, Divorced, Black or African American Alone in Santa Clara County (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_15OrMoreYears_Divorced_HispanicOrLatino"
+                    ],
+                    "title": "Divorced Hispanic Men in Santa Clara County (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_15OrMoreYears_Divorced_HispanicOrLatino"
+                    ],
+                    "title": "Divorced Hispanic Men in Santa Clara County (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          }
+        ],
+        "dcid": "dc/topic/DivorcedPopulationByDemographic",
+        "statVarSpec": {
+          "Count_Person_15OrMoreYears_Divorced_AsianAlone": {
+            "name": "Divorced Asian Men",
+            "statVar": "Count_Person_15OrMoreYears_Divorced_AsianAlone"
+          },
+          "Count_Person_15OrMoreYears_Divorced_BlackOrAfricanAmericanAlone": {
+            "name": "Population: 15 Years or More, Divorced, Black or African American Alone",
+            "statVar": "Count_Person_15OrMoreYears_Divorced_BlackOrAfricanAmericanAlone"
+          },
+          "Count_Person_15OrMoreYears_Divorced_HispanicOrLatino": {
+            "name": "Divorced Hispanic Men",
+            "statVar": "Count_Person_15OrMoreYears_Divorced_HispanicOrLatino"
+          },
+          "Count_Person_Divorced": {
+            "name": "Divorcees",
+            "statVar": "Count_Person_Divorced"
+          },
+          "Count_Person_Female_Divorced": {
+            "name": "Divorced Women",
+            "statVar": "Count_Person_Female_Divorced"
+          },
+          "Count_Person_Male_Divorced": {
+            "name": "Divorced Men",
+            "statVar": "Count_Person_Male_Divorced"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "containedPlaceTypes": {
+        "County": "City"
+      },
+      "placeDcid": [
+        "geoId/06085"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "pastSourceContext": "",
+  "place": {
+    "dcid": "geoId/06085",
+    "name": "Santa Clara County",
+    "place_type": "County"
+  },
+  "placeFallback": {},
+  "placeSource": "CURRENT_QUERY",
+  "relatedThings": {
+    "childPlaces": {
+      "City": [
+        {
+          "dcid": "geoId/0601458",
+          "name": "Alum Rock",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0601486",
+          "name": "Alviso",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0608848",
+          "name": "Buena Vista",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0608968",
+          "name": "Burbank",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0610088",
+          "name": "Cambrian Park",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0610345",
+          "name": "Campbell",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0617610",
+          "name": "Cupertino",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0620598",
+          "name": "East Foothills",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0627080",
+          "name": "Fruitdale",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0629504",
+          "name": "Gilroy",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0641282",
+          "name": "Lexington Hills",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0643280",
+          "name": "Los Altos",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0643294",
+          "name": "Los Altos Hills",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0644112",
+          "name": "Los Gatos",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0644378",
+          "name": "Loyola",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0647766",
+          "name": "Milpitas",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0648956",
+          "name": "Monte Sereno",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0649278",
+          "name": "Morgan Hill",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0649670",
+          "name": "Mountain View",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0655282",
+          "name": "Palo Alto",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0668000",
+          "name": "San Jose",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0668238",
+          "name": "San Martin",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0669084",
+          "name": "Santa Clara",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0670280",
+          "name": "Saratoga",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0671074",
+          "name": "Seven Trees",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0673906",
+          "name": "Stanford",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "geoId/0677000",
+          "name": "Sunnyvale",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "wikidataId/Q1911837",
+          "name": "Cambrian Park",
+          "types": [
+            "City"
+          ]
+        },
+        {
+          "dcid": "wikidataId/Q2214519",
+          "name": "Sunol-Midtown",
+          "types": [
+            "City"
+          ]
+        }
+      ]
+    },
+    "childTopics": [],
+    "exploreMore": {
+      "Count_Person_Divorced": {
+        "gender": [
+          "Count_Person_Male_Divorced",
+          "Count_Person_Female_Divorced"
+        ],
+        "placeOfBirth": [
+          "dc/dj7cvhr91sff5",
+          "dc/66sy80vs0b8q7",
+          "dc/drvcnjld04b06",
+          "dc/twlffl9b5vgn3"
+        ]
+      }
+    },
+    "mainTopic": {
+      "dcid": "dc/topic/DivorcedPopulationByDemographic",
+      "name": "Divorced Population",
+      "types": [
+        "Topic"
+      ]
+    },
+    "parentPlaces": [
+      {
+        "dcid": "geoId/06",
+        "name": "California",
+        "types": [
+          "State"
+        ]
+      },
+      {
+        "dcid": "country/USA",
+        "name": "United States",
+        "types": [
+          "Country"
+        ]
+      }
+    ],
+    "parentTopics": [
+      {
+        "dcid": "dc/topic/MaritalStatus",
+        "name": "Marital Status",
+        "types": [
+          "Topic"
+        ]
+      }
+    ],
+    "peerTopics": [
+      {
+        "dcid": "dc/topic/MaritalStatusBreakdown",
+        "name": "Marital Status Breakdown",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/DivorcedPopulationByDemographic",
+        "name": "Divorced Population",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/MarriedPopulationByDemographic",
+        "name": "Married Population",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/NeverMarriedPopulationByDemographic",
+        "name": "Never Married Population",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/WidowedPopulationByDemographic",
+        "name": "Widowed Population",
+        "types": [
+          "Topic"
+        ]
+      }
+    ]
+  },
+  "svSource": "CURRENT_QUERY",
+  "userMessage": ""
+}

--- a/server/integration_tests/test_data/fulfillment_api_sdg/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_sdg/chart_config.json
@@ -518,6 +518,7 @@
         ]
       }
     ],
+    "exploreMore": {},
     "mainTopic": {
       "dcid": "dc/topic/sdg_1",
       "name": "No Poverty",

--- a/server/integration_tests/test_data/fulfillment_api_statvars/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_statvars/chart_config.json
@@ -642,6 +642,7 @@
       ]
     },
     "childTopics": [],
+    "exploreMore": {},
     "mainTopic": {
       "dcid": "dc/topic/IndividualIncomeByIndustry",
       "name": "Individual Income By Industry",

--- a/server/lib/explore/fulfiller.py
+++ b/server/lib/explore/fulfiller.py
@@ -206,6 +206,6 @@ def _chart_vars_to_explore_peer_groups(state: ftypes.PopulateState,
       if sv not in explore_peer_groups:
         explore_peer_groups[sv] = {}
       if cv.source_topic not in explore_peer_groups[sv]:
-        explore_peer_groups[sv][cv.source_topic] = er.exist_svs
+        explore_peer_groups[sv][cv.source_topic] = sorted(er.exist_svs)
 
   return explore_peer_groups

--- a/server/lib/explore/fulfiller.py
+++ b/server/lib/explore/fulfiller.py
@@ -19,6 +19,7 @@ import time
 from typing import Dict, List, Set
 
 from server.config.subject_page_pb2 import SubjectPageConfig
+from server.lib.explore import existence
 from server.lib.explore import page_main
 from server.lib.explore import page_sdg
 import server.lib.explore.extension as extension
@@ -94,7 +95,10 @@ def fulfill(uttr: nl_uttr.Utterance, cb_config: builder.Config) -> FulfillResp:
   existing_svs = set(state.uttr.svs)
   chart_vars_list = []
   topics = []
-  _chart_vars_fetch(tracker, chart_vars_list, existing_svs, topics)
+  single_svs = []
+  _chart_vars_fetch(tracker, chart_vars_list, existing_svs, topics, single_svs)
+
+  explore_peer_groups = {}
 
   # Route to an appropriate page generator.
   if is_sdg(state.uttr.insight_ctx):
@@ -125,14 +129,31 @@ def fulfill(uttr: nl_uttr.Utterance, cb_config: builder.Config) -> FulfillResp:
             sv2chartvarslist=ext_chart_vars_map)
         ext_tracker.perform_existence_check()
         state.uttr.counters.timeit('extension_existence_check', start)
-        _chart_vars_fetch(ext_tracker, ext_chart_vars_list, existing_svs,
-                          topics)
+        _chart_vars_fetch(ext_tracker, ext_chart_vars_list, existing_svs)
+
+    if state.uttr.insight_ctx.get(Params.EXP_MORE):
+      explore_more_chart_vars_map = extension.explore_more(single_svs)
+      if explore_more_chart_vars_map:
+        # Perform existence check and add to `chart_vars_list`
+        start = time.time()
+        ext_tracker = ext.MainExistenceCheckTracker(
+            state,
+            places_to_check,
+            svs=list(explore_more_chart_vars_map.keys()),
+            prep_chart_vars=False,
+            sv2chartvarslist=explore_more_chart_vars_map)
+        ext_tracker.perform_existence_check()
+        state.uttr.counters.timeit('explore_more_existence_check', start)
+
+      explore_peer_groups = _chart_vars_to_explore_peer_groups(
+          state, explore_more_chart_vars_map)
 
     config_resp = page_main.build_config(chart_vars_list, ext_chart_vars_list,
                                          state, existing_svs, cb_config)
 
   related_things = related.compute_related_things(state,
-                                                  config_resp.plotted_orig_vars)
+                                                  config_resp.plotted_orig_vars,
+                                                  explore_peer_groups)
 
   return FulfillResp(chart_pb=config_resp.config_pb,
                      related_things=related_things,
@@ -149,13 +170,17 @@ def _get_place_dcids(places: List[dtypes.Place]) -> List[str]:
 def _chart_vars_fetch(tracker: ext.MainExistenceCheckTracker,
                       chart_vars_list: List[ftypes.ChartVars],
                       existing_svs: Set[str],
-                      topics: List[str] = None):
+                      topics: List[str] = None,
+                      single_svs: List[str] = None):
   for exist_state in tracker.exist_sv_states:
     for exist_cv in exist_state.chart_vars_list:
       cv = tracker.get_chart_vars(exist_cv)
       if cv.svs:
         existing_svs.update(cv.svs)
         chart_vars_list.append(cv)
+        if single_svs != None and len(
+            cv.svs) == 1 and cv.svs[0] not in single_svs:
+          single_svs.append(cv.svs[0])
       if cv.source_topic:
         existing_svs.add(cv.source_topic)
       if cv.svpg_id:
@@ -165,3 +190,22 @@ def _chart_vars_fetch(tracker: ext.MainExistenceCheckTracker,
         if topics != None and cutils.is_topic(
             cv.orig_sv) and cv.orig_sv not in topics:
           topics.append(cv.orig_sv)
+
+
+def _chart_vars_to_explore_peer_groups(state: ftypes.PopulateState,
+                                       explore_more_chart_vars_map) -> Dict:
+  explore_peer_groups = {}
+
+  for sv, cv_list in explore_more_chart_vars_map.items():
+    if not existence.svs4place(state, state.uttr.places[0], [sv]).exist_svs:
+      continue
+    for cv in cv_list:
+      er = existence.svs4place(state, state.uttr.places[0], cv.svs)
+      if len(er.exist_svs) < 2:
+        continue
+      if sv not in explore_peer_groups:
+        explore_peer_groups[sv] = {}
+      if cv.source_topic not in explore_peer_groups[sv]:
+        explore_peer_groups[sv][cv.source_topic] = er.exist_svs
+
+  return explore_peer_groups

--- a/server/lib/explore/params.py
+++ b/server/lib/explore/params.py
@@ -26,6 +26,7 @@ class Params(str, Enum):
   CTX = 'context'
   DC = 'dc'
   EXT_SVGS = 'extensionGroups'
+  EXP_MORE = 'exploreMore'
 
 
 class DCNames(str, Enum):

--- a/server/lib/explore/related.py
+++ b/server/lib/explore/related.py
@@ -24,7 +24,9 @@ import server.lib.nl.fulfillment.types as ftypes
 
 
 def compute_related_things(state: ftypes.PopulateState,
-                           plotted_orig_vars: List[Dict]):
+                           plotted_orig_vars: List[Dict],
+                           explore_peer_groups: Dict[str, Dict[str,
+                                                               List[str]]]):
   # Trim child and parent places based on existence check results.
   _trim_nonexistent_places(state)
 
@@ -35,6 +37,7 @@ def compute_related_things(state: ftypes.PopulateState,
       'peerTopics': [],
       'childTopics': [],
       'mainTopic': {},
+      'exploreMore': explore_peer_groups,
   }
 
   # Convert the places to json.

--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -51,12 +51,13 @@
   margin: 20px 0;
 
   .explore-more-head {
-    font-weight: 400;
-    font-size: 1.5rem;
+    font-weight: 500;
+    font-size: 0.9rem;
     color: var(--dc-gray);
   }
 
   .explore-more-link {
+    font-size: 13px;
     margin-right: 4px;
     color: var(--dc-gray);
     text-decoration: underline;

--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -45,6 +45,25 @@
   }
 }
 
+#explore-more-section {
+  display: flex;
+  flex-direction: column;
+  margin: 20px 0;
+
+  .explore-more-head {
+    font-weight: 400;
+    font-size: 1.5rem;
+    color: var(--dc-gray);
+  }
+
+  .explore-more-link {
+    margin-right: 4px;
+    color: var(--dc-gray);
+    text-decoration: underline;
+    display: inline-block;
+  }
+}
+
 .search-section {
   align-items: center;
   display: flex;

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -321,27 +321,28 @@ export function App(): JSX.Element {
                   onClick={() => setQuery("")}
                 ></ChildPlaces>
               )}
-              {chartData.exploreMore && (
-                <div id="explore-more-section">
-                  <div className="explore-more-head">Explore More</div>
-                  {Object.keys(chartData.exploreMore).map((sv) => {
-                    return Object.keys(chartData.exploreMore[sv]).map(
-                      (prop) => {
-                        const urlSv =
-                          chartData.exploreMore[sv][prop].join(DELIM);
-                        const url = `/explore/#t=${urlSv}&p=${place}&pcmp=${cmpPlace}&pt=${placeType}&dc=${dc}&em=1`;
-                        return (
-                          <>
-                            <a className="explore-more-link" href={url}>
-                              [{sv}] Explore more by {prop}
-                            </a>
-                          </>
-                        );
-                      }
-                    );
-                  })}
-                </div>
-              )}
+              {chartData.exploreMore &&
+                Object.keys(chartData.exploreMore).length > 0 && (
+                  <div id="explore-more-section">
+                    <div className="explore-more-head">Explore More</div>
+                    {Object.keys(chartData.exploreMore).map((sv) => {
+                      return Object.keys(chartData.exploreMore[sv]).map(
+                        (prop) => {
+                          const urlSv =
+                            chartData.exploreMore[sv][prop].join(DELIM);
+                          const url = `/explore/#t=${urlSv}&p=${place}&pcmp=${cmpPlace}&pt=${placeType}&dc=${dc}&em=1`;
+                          return (
+                            <>
+                              <a className="explore-more-link" href={url}>
+                                [{sv}] Explore more by {prop}
+                              </a>
+                            </>
+                          );
+                        }
+                      );
+                    })}
+                  </div>
+                )}
             </>
           )}
         </div>

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -1,7 +1,7 @@
 /**
  * Copyright 2023 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under he Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -107,6 +107,7 @@ export function App(): JSX.Element {
       const origQuery = getSingleParam(hashParams["oq"]);
       const dc = getSingleParam(hashParams["dc"]);
       const svg = getSingleParam(hashParams["svg"]);
+      const exploreMore = getSingleParam(hashParams["em"]);
 
       // Do detection only if `q` is set (from search box) or
       // if `oq` is set without accompanying place and topic.
@@ -147,6 +148,7 @@ export function App(): JSX.Element {
           pt: placeType,
           dc,
           svg,
+          em: exploreMore,
         });
         return;
       } else if (origQuery) {
@@ -181,7 +183,8 @@ export function App(): JSX.Element {
         cmpPlaces,
         cmpTopics,
         dc,
-        svgs
+        svgs,
+        exploreMore
       );
       if (!resp || !resp["place"] || !resp["place"]["dcid"]) {
         setLoadingStatus("fail");
@@ -200,6 +203,7 @@ export function App(): JSX.Element {
         parentTopics: resp["relatedThings"]["parentTopics"],
         childTopics: resp["relatedThings"]["childTopics"],
         peerTopics: resp["relatedThings"]["peerTopics"],
+        exploreMore: resp["relatedThings"]["exploreMore"],
         topic: resp["relatedThings"]["mainTopic"]["dcid"] || "",
         sessionId: "session" in resp ? resp["session"]["id"] : "",
       };
@@ -267,6 +271,7 @@ export function App(): JSX.Element {
     // Don't set placeType here since it gets passed into child places.
     let urlString = "/explore/#p=${placeDcid}";
     urlString += `&t=${topic}&dc=${dc}`;
+    console.log(chartData.exploreMore);
     mainSection = (
       <div className="row explore-charts">
         <div
@@ -354,6 +359,27 @@ export function App(): JSX.Element {
                   />
                 </NlSessionContext.Provider>
               </RankingUnitUrlFuncContext.Provider>
+              {chartData.exploreMore && (
+                <div id="explore-more-section">
+                  <div className="explore-more-head">Explore More</div>
+                  {Object.keys(chartData.exploreMore).map((sv) => {
+                    return Object.keys(chartData.exploreMore[sv]).map(
+                      (prop) => {
+                        const urlSv =
+                          chartData.exploreMore[sv][prop].join(DELIM);
+                        const url = `/explore/#t=${urlSv}&p=${place}&pcmp=${cmpPlace}&pt=${placeType}&dc=${dc}&em=1`;
+                        return (
+                          <>
+                            <a className="explore-more-link" href={url}>
+                              [{sv}] Explore more by {prop}
+                            </a>
+                          </>
+                        );
+                      }
+                    );
+                  })}
+                </div>
+              )}
             </>
           )}
         </div>
@@ -396,7 +422,8 @@ const fetchFulfillData = async (
   cmpPlaces: string[],
   cmpTopics: string[],
   dc: string,
-  svgs: string[]
+  svgs: string[],
+  exploreMore: string
 ) => {
   try {
     const resp = await axios.post(`/api/explore/fulfill`, {
@@ -407,6 +434,7 @@ const fetchFulfillData = async (
       comparisonEntities: cmpPlaces,
       comparisonVariables: cmpTopics,
       extensionGroups: svgs,
+      exploreMore,
     });
     return resp.data;
   } catch (error) {

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -321,6 +321,27 @@ export function App(): JSX.Element {
                   onClick={() => setQuery("")}
                 ></ChildPlaces>
               )}
+              {chartData.exploreMore && (
+                <div id="explore-more-section">
+                  <div className="explore-more-head">Explore More</div>
+                  {Object.keys(chartData.exploreMore).map((sv) => {
+                    return Object.keys(chartData.exploreMore[sv]).map(
+                      (prop) => {
+                        const urlSv =
+                          chartData.exploreMore[sv][prop].join(DELIM);
+                        const url = `/explore/#t=${urlSv}&p=${place}&pcmp=${cmpPlace}&pt=${placeType}&dc=${dc}&em=1`;
+                        return (
+                          <>
+                            <a className="explore-more-link" href={url}>
+                              [{sv}] Explore more by {prop}
+                            </a>
+                          </>
+                        );
+                      }
+                    );
+                  })}
+                </div>
+              )}
             </>
           )}
         </div>
@@ -359,27 +380,6 @@ export function App(): JSX.Element {
                   />
                 </NlSessionContext.Provider>
               </RankingUnitUrlFuncContext.Provider>
-              {chartData.exploreMore && (
-                <div id="explore-more-section">
-                  <div className="explore-more-head">Explore More</div>
-                  {Object.keys(chartData.exploreMore).map((sv) => {
-                    return Object.keys(chartData.exploreMore[sv]).map(
-                      (prop) => {
-                        const urlSv =
-                          chartData.exploreMore[sv][prop].join(DELIM);
-                        const url = `/explore/#t=${urlSv}&p=${place}&pcmp=${cmpPlace}&pt=${placeType}&dc=${dc}&em=1`;
-                        return (
-                          <>
-                            <a className="explore-more-link" href={url}>
-                              [{sv}] Explore more by {prop}
-                            </a>
-                          </>
-                        );
-                      }
-                    );
-                  })}
-                </div>
-              )}
             </>
           )}
         </div>

--- a/static/js/types/subject_page_types.ts
+++ b/static/js/types/subject_page_types.ts
@@ -39,6 +39,7 @@ export interface SubjectPageMetadata {
 
   peerTopics?: NamedTypedNode[];
   childTopics?: NamedTypedNode[];
+  exploreMore?: any;
 
   topic?: string;
   sessionId?: string;


### PR DESCRIPTION
This is enabled by `em=`.

The frontend needs more work.  For now just listing the URLs at the bottom of the charts for debugging.

![image](https://github.com/datacommonsorg/website/assets/4375037/869c5fe4-a3b4-475d-a537-a2e5f4258efa)
