### PR TITLE
Do not deploy to us-west1 for dev and autopush

### DIFF
--- a/deploy/gke/autopush.yaml
+++ b/deploy/gke/autopush.yaml
@@ -18,7 +18,7 @@ domain: autopush.datacommons.org
 region:
   primary: us-central1
   others:
-    - us-west1
+    -
 nodes: 3
 storage_project: datcom-store
 model_bucket: "gs://datcom-ipragma-models"

--- a/deploy/gke/dev.yaml
+++ b/deploy/gke/dev.yaml
@@ -18,7 +18,7 @@ domain: dev.datacommons.org
 region:
   primary: us-central1
   others:
-    - us-west1
+    -
 nodes: 1
 storage_project: datcom-store
 model_bucket: "gs://datcom-ipragma-models"

--- a/deploy/gke/staging.yaml
+++ b/deploy/gke/staging.yaml
@@ -18,6 +18,6 @@ domain: staging.datacommons.org
 region:
   primary: us-central1
   others:
-    - us-west1
+    -
 nodes: 2
 storage_project: datcom-store

--- a/deploy/helm_charts/envs/autopush.yaml
+++ b/deploy/helm_charts/envs/autopush.yaml
@@ -21,7 +21,7 @@ namespace:
 
 website:
   flaskEnv: autopush
-  replicas: 10
+  replicas: 15
 
 mixer:
   hostProject:
@@ -36,14 +36,14 @@ nl:
 serviceGroups:
   recon: null
   svg:
-    replicas: 5
+    replicas: 8
   node:
-    replicas: 10
+    replicas: 15
   observation:
-    replicas: 10
+    replicas: 15
   default:
-    replicas: 10
+    replicas: 15
 
 nodejs:
   enabled: true
-  replicas: 10
+  replicas: 15

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -144,12 +144,10 @@ gcloud auth login
 gcloud auth configure-docker
 ./scripts/push_image.sh
 ./scripts/deploy_gke_helm.sh -e dev
-./scripts/deploy_gke_helm.sh -e dev -l us-west1
 ```
 
 The script builds docker image locally and tags it with the local git commit
-hash at HEAD, then deploys to dev instance in GKE. Need to deploy it to both
-us-central1 (which is the default) and us-west1.
+hash at HEAD, then deploys to dev instance in GKE.
 
 View the deployoment at [link](https://dev.datacommons.org).
 


### PR DESCRIPTION
us-west1 is not co-located with the BT cache, and could have longer mixer->web server latency.
it also makes deployment longer as the deployment need to happen sequentially for two clusters.