### PR TITLE
Allow bar tiles to sort by variable when there is only one place

### DIFF
--- a/static/js/chart/draw_bar.ts
+++ b/static/js/chart/draw_bar.ts
@@ -146,7 +146,8 @@ export function drawStackBarChart(
   addYAxis(yAxis, chartWidth, y, TEXT_FONT_FAMILY, options?.unit);
   updateXAxis(xAxis, bottomHeight, chartHeight, y);
 
-  const colorFn = getColorFn(keys, options?.colors);
+  const colorOrder = options?.statVarColorOrder || keys;
+  const colorFn = getColorFn(colorOrder, options?.colors);
 
   if (options?.lollipop) {
     // How much to shift stems so they plot at center of band
@@ -630,7 +631,6 @@ function drawLollipops(
  * @param chartHeight height of chart
  * @param dataGroups data values to plot
  * @param options chart options
- * @param useLollipop whether to use lollipops instead of bars
  */
 export function drawGroupBarChart(
   containerElement: HTMLDivElement,
@@ -714,7 +714,8 @@ export function drawGroupBarChart(
   addYAxis(yAxis, chartWidth, y, TEXT_FONT_FAMILY, options?.unit);
   updateXAxis(xAxis, bottomHeight, chartHeight, y);
 
-  const colorFn = getColorFn(keys, options.colors);
+  const colorOrder = options?.statVarColorOrder || keys;
+  const colorFn = getColorFn(colorOrder, options.colors);
 
   if (options?.lollipop) {
     drawLollipops(chart, colorFn, dataGroups, x0, x1, y);
@@ -787,7 +788,8 @@ export function drawHorizontalBarChart(
     : Math.ceil((dataGroups.length + 0.1) * barHeight * numGroups) +
       marginTop +
       marginBottom;
-  const color = getColorFn(keys, options?.colors);
+  const colorOrder = options?.statVarColorOrder || keys;
+  const color = getColorFn(colorOrder, options?.colors);
   const [displayUnit, label] = getDisplayUnitAndLabel(options?.unit);
 
   // Create the SVG container.

--- a/static/js/chart/types.ts
+++ b/static/js/chart/types.ts
@@ -144,6 +144,8 @@ export interface ChartOptions {
   colors?: string[];
   // whether to draw chart in lollipop style, used for bar charts
   lollipop?: boolean;
+  // list of stat var DCIDs, in the order the colors should be applied
+  statVarColorOrder?: string[];
   unit?: string;
 }
 

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -239,7 +239,7 @@ function rawToChart(
   const dataGroups: DataGroup[] = [];
   const sources = new Set<string>();
   // Track original order of stat vars in props, to maintain 1:1 pairing of
-  // colors to stat vars event after sorting
+  // colors to stat vars even after sorting
   const statVarOrder: string[] = [];
 
   let unit = "";

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -99,6 +99,7 @@ export interface BarChartData {
   unit: string;
   dateRange: string;
   props: BarTilePropType;
+  statVarOrder: string[];
 }
 
 export function BarTile(props: BarTilePropType): JSX.Element {
@@ -237,6 +238,9 @@ function rawToChart(
   const raw = _.cloneDeep(rawData);
   const dataGroups: DataGroup[] = [];
   const sources = new Set<string>();
+  // Track original order of stat vars in props, to maintain 1:1 pairing of
+  // colors to stat vars event after sorting
+  const statVarOrder: string[] = [];
 
   let unit = "";
   const dates: Set<string> = new Set();
@@ -245,12 +249,14 @@ function rawToChart(
     const dataPoints: DataPoint[] = [];
     for (const spec of props.statVarSpec) {
       const statVar = spec.statVar;
+      const statVarName = statVarNames[statVar];
+      statVarOrder.push(statVarName);
       if (!raw.data[statVar] || _.isEmpty(raw.data[statVar][placeDcid])) {
         continue;
       }
       const stat = raw.data[statVar][placeDcid];
       const dataPoint = {
-        label: statVarNames[statVar],
+        label: statVarName,
         value: stat.value || 0,
         dcid: placeDcid,
       };
@@ -284,19 +290,28 @@ function rawToChart(
   }
   // Optionally sort ascending/descending by value
   if (props.sort === "ascending" || props.sort === "descending") {
-    dataGroups.sort(
-      (a, b) =>
-        (d3.sum(a.value.map((v) => v.value)) -
-          d3.sum(b.value.map((v) => v.value))) *
-        (props.sort === "ascending" ? 1 : -1)
-    );
+    if (popPoints.length === 1 && !_.isEmpty(dataGroups)) {
+      // Only one place, sort should be by variable, not by group.
+      dataGroups[0].value.sort(
+        (a, b) => (a.value - b.value) * (props.sort === "ascending" ? 1 : -1)
+      );
+    } else {
+      dataGroups.sort(
+        (a, b) =>
+          (d3.sum(a.value.map((v) => v.value)) -
+            d3.sum(b.value.map((v) => v.value))) *
+          (props.sort === "ascending" ? 1 : -1)
+      );
+    }
   }
+
   return {
     dataGroup: dataGroups.slice(0, props.maxPlaces || NUM_PLACES),
     sources,
     dateRange: getDateRange(Array.from(dates)),
     unit,
     props,
+    statVarOrder,
   };
 }
 
@@ -315,6 +330,7 @@ export function draw(
         colors: props.colors,
         lollipop: props.useLollipop,
         stacked: props.stacked,
+        statVarColorOrder: chartData.statVarOrder,
         style: {
           barHeight: props.barHeight,
           yAxisMargin: props.yAxisMargin,
@@ -333,6 +349,7 @@ export function draw(
         {
           colors: props.colors,
           lollipop: props.useLollipop,
+          statVarColorOrder: chartData.statVarOrder,
           unit: chartData.unit,
         }
       );
@@ -346,6 +363,7 @@ export function draw(
         {
           colors: props.colors,
           lollipop: props.useLollipop,
+          statVarColorOrder: chartData.statVarOrder,
           unit: chartData.unit,
         }
       );

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -239,8 +239,10 @@ function rawToChart(
   const dataGroups: DataGroup[] = [];
   const sources = new Set<string>();
   // Track original order of stat vars in props, to maintain 1:1 pairing of
-  // colors to stat vars even after sorting
-  const statVarOrder: string[] = [];
+  // colors to stat var labels even after sorting
+  const statVarOrder = props.statVarSpec.map(
+    (spec) => statVarNames[spec.statVar]
+  );
 
   let unit = "";
   const dates: Set<string> = new Set();
@@ -249,14 +251,12 @@ function rawToChart(
     const dataPoints: DataPoint[] = [];
     for (const spec of props.statVarSpec) {
       const statVar = spec.statVar;
-      const statVarName = statVarNames[statVar];
-      statVarOrder.push(statVarName);
       if (!raw.data[statVar] || _.isEmpty(raw.data[statVar][placeDcid])) {
         continue;
       }
       const stat = raw.data[statVar][placeDcid];
       const dataPoint = {
-        label: statVarName,
+        label: statVarNames[statVar],
         value: stat.value || 0,
         dcid: placeDcid,
       };


### PR DESCRIPTION
This PR allows setting `sort="ascending"` and `sort="descending"` to sort bars/lollipops by variable when there is only 1 place.

Currently, we only sort by place, so when a single place but multiple variables are passed to the bar tile, no sorting happens even though there are multiple bars. With this change, we'll sort by variable when there is only 1 place available. This allows `sort` to behave more intuitively for users.

Screenshots:
![Screenshot 2023-08-16 at 2 53 17 PM](https://github.com/datacommonsorg/website/assets/4034366/12c2403c-039b-42c5-ad29-6ff5c00c1ccf)
![Screenshot 2023-08-16 at 2 53 26 PM](https://github.com/datacommonsorg/website/assets/4034366/e116d375-487e-41d2-8121-873c392e57ca)
![Screenshot 2023-08-16 at 2 53 53 PM](https://github.com/datacommonsorg/website/assets/4034366/1eccc402-54cb-4af0-b885-7c2a8499fa75)
![Screenshot 2023-08-16 at 2 54 00 PM](https://github.com/datacommonsorg/website/assets/4034366/a39f2af2-de45-437e-99d1-b33d4984277d)
![Screenshot 2023-08-16 at 2 53 43 PM](https://github.com/datacommonsorg/website/assets/4034366/0ee950ba-5f57-4494-a939-f5fcf183744b)
![Screenshot 2023-08-16 at 2 53 35 PM](https://github.com/datacommonsorg/website/assets/4034366/dbbbf977-ff79-4da3-9637-b61247cac13e)
