### PR TITLE
[highlight tile] add space between number and unit

### DIFF
--- a/static/js/components/tiles/highlight_tile.tsx
+++ b/static/js/components/tiles/highlight_tile.tsx
@@ -35,6 +35,7 @@ import {
 } from "../../utils/tile_utils";
 
 const NUM_FRACTION_DIGITS = 1;
+const NO_SPACE_UNITS = new Set(["%"]);
 
 export interface HighlightTilePropType {
   // API root for data fetch
@@ -78,6 +79,9 @@ export function HighlightTile(props: HighlightTilePropType): JSX.Element {
   // TODO: The {...{ part: "container"}} syntax to set a part is a hacky
   // workaround to add a "part" attribute to a React element without npm errors.
   // This hack should be cleaned up.
+  const unitString = translateUnit(
+    props.statVarSpec.unit || highlightData.unitDisplayName
+  );
   return (
     <div
       className={`chart-container highlight-tile ${ASYNC_ELEMENT_HOLDER_CLASS}`}
@@ -94,11 +98,11 @@ export function HighlightTile(props: HighlightTilePropType): JSX.Element {
                 NUM_FRACTION_DIGITS
               )}
             </span>
-            <span className="metadata">
-              {translateUnit(
-                props.statVarSpec.unit || highlightData.unitDisplayName
-              )}
-            </span>
+            {unitString && (
+              <span className="metadata">
+                {`${NO_SPACE_UNITS.has(unitString) ? "" : " "}${unitString}`}
+              </span>
+            )}
           </span>
         </>
       )}


### PR DESCRIPTION
<img width="823" alt="Screenshot 2023-08-16 at 4 14 20 PM" src="https://github.com/datacommonsorg/website/assets/69875368/3f16bb42-dd5f-412a-ba4f-a22a9e4f0d58">

except when the unit is %
<img width="866" alt="Screenshot 2023-08-16 at 4 15 02 PM" src="https://github.com/datacommonsorg/website/assets/69875368/300bd14a-505d-405a-8a05-8f1337ca9332">
