### PR TITLE
[Custom DC] Quick fix for icons misrendering

### DIFF
--- a/server/templates/tools/download.html
+++ b/server/templates/tools/download.html
@@ -26,6 +26,7 @@
 {% block head %}
   <link rel="stylesheet" href={{url_for('static', filename='css/download.min.css')}} >
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
 {% endblock %}
 
 {% block content %}

--- a/server/templates/tools/map.html
+++ b/server/templates/tools/map.html
@@ -26,6 +26,7 @@
 {% block head %}
   <link rel="stylesheet" href={{url_for('static', filename='css/map.min.css')}} >
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
   {% if allow_leaflet %}
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.2/dist/leaflet.css" integrity="sha256-sA+zWATbFveLLNqWO2gtiw3HL/lh1giY/Inf1BJ0z14=" crossorigin="" />
   {% endif %}

--- a/server/templates/tools/stat_var.html
+++ b/server/templates/tools/stat_var.html
@@ -24,6 +24,7 @@
 {% block head %}
   <link rel="stylesheet" href={{url_for('static', filename='css/stat_var.min.css')}} >
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
 {% endblock %}
 
 {% block content %}

--- a/server/templates/tools/timeline_bulk_download.html
+++ b/server/templates/tools/timeline_bulk_download.html
@@ -23,6 +23,7 @@ limitations under the License.
 {% block head %}
 <link rel="stylesheet" href={{url_for('static', filename='css/timeline.min.css' , t=config['VERSION'])}}>
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
After the homepage revamp, the sidebar icons are not rendering properly on some of the pages. This PR is a quick fix to re-add the necessary stylesheets to those pages.

Before:
![Screenshot 2023-08-18 at 11 12 04 AM](https://github.com/datacommonsorg/website/assets/4034366/913b4b22-776f-4c50-83ef-6d8e25e8e338)


After:
![Screenshot 2023-08-18 at 11 12 20 AM](https://github.com/datacommonsorg/website/assets/4034366/d9bc62d8-43fc-4d3c-a4f1-754d1a9e6af9)
