### PR TITLE
Add Explore Chart Layout, based on a flag

### DIFF
--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_2/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_2/chart_config.json
@@ -15,6 +15,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Asthma in Sunnyvale",
+                    "statVarKey": [
+                      "Percent_Person_WithAsthma"
+                    ],
+                    "title": "Asthma in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ]
           },
@@ -28,6 +40,18 @@
                     ],
                     "title": "Chronic Obstructive Pulmonary Disease in Sunnyvale",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Chronic Obstructive Pulmonary Disease in Sunnyvale",
+                    "statVarKey": [
+                      "Percent_Person_WithChronicObstructivePulmonaryDisease"
+                    ],
+                    "title": "Chronic Obstructive Pulmonary Disease in Sunnyvale",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_7/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_7/chart_config.json
@@ -15,6 +15,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Middle School Students in Sunnyvale",
+                    "statVarKey": [
+                      "Count_Person_DetailedMiddleSchool"
+                    ],
+                    "title": "Middle School Students in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ],
             "denom": "Count_Person"
@@ -59,6 +71,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Elementary School Students in Sunnyvale",
+                    "statVarKey": [
+                      "Count_Person_DetailedPrimarySchool"
+                    ],
+                    "title": "Elementary School Students in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ],
             "denom": "Count_Person"
@@ -73,6 +97,18 @@
                     ],
                     "title": "High School Students in Sunnyvale",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "High School Students in Sunnyvale",
+                    "statVarKey": [
+                      "Count_Person_DetailedHighSchool"
+                    ],
+                    "title": "High School Students in Sunnyvale",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -91,6 +127,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population Currently Enrolled in School in Sunnyvale",
+                    "statVarKey": [
+                      "Count_Person_EnrolledInSchool"
+                    ],
+                    "title": "Population Currently Enrolled in School in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ],
             "denom": "Count_Person"
@@ -105,6 +153,18 @@
                     ],
                     "title": "Population: Primary School, Two or More Races in Sunnyvale",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Primary School, Two or More Races in Sunnyvale",
+                    "statVarKey": [
+                      "dc/jhjdplbeg26k1"
+                    ],
+                    "title": "Population: Primary School, Two or More Races in Sunnyvale",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -123,6 +183,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: 11th Grade in Sunnyvale",
+                    "statVarKey": [
+                      "Count_Person_EducationalAttainment11ThGrade"
+                    ],
+                    "title": "Population: 11th Grade in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ],
             "denom": "Count_Person"
@@ -139,82 +211,16 @@
                     "type": "LINE"
                   }
                 ]
-              }
-            ],
-            "denom": "Count_Person"
-          },
-          {
-            "columns": [
+              },
               {
                 "tiles": [
                   {
-                    "comparisonPlaces": [
-                      "geoId/0677000"
-                    ],
+                    "description": "Population: 7th And 8th Grade in Sunnyvale",
                     "statVarKey": [
-                      "Count_Person_DetailedMiddleSchool_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInCollegeUndergraduateYears_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade1_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade10_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade11_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade12_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade2_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade3_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade4_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade5_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade6_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade7_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade8_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInGrade9_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInKindergarten_multiple_place_bar_block",
-                      "Count_Person_DetailedEnrolledInNurserySchoolPreschool_multiple_place_bar_block"
+                      "Count_Person_Years25Onwards_EducationalAttainment_7ThAnd8ThGrade"
                     ],
-                    "title": "Middle School Students and more in Sunnyvale (${date})",
-                    "type": "BAR"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "comparisonPlaces": [
-                      "geoId/0677000"
-                    ],
-                    "statVarKey": [
-                      "dc/6zbb7s5nx6rxb_multiple_place_bar_block",
-                      "dc/b3nmcj3w1lhed_multiple_place_bar_block",
-                      "dc/c57vzg7l74577_multiple_place_bar_block",
-                      "dc/c75qlm98pmcb2_multiple_place_bar_block",
-                      "dc/e2szvml8jkld8_multiple_place_bar_block",
-                      "dc/g4fthg3t3y5td_multiple_place_bar_block",
-                      "dc/njgzb8knf11n8_multiple_place_bar_block",
-                      "dc/qvf1yrhwzp8rd_multiple_place_bar_block",
-                      "dc/zvr6djt1p9gj3_multiple_place_bar_block"
-                    ],
-                    "title": "Population: Middle School, Some Other Race Alone and more in Sunnyvale (${date})",
-                    "type": "BAR"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_EnrolledInSchool",
-                      "Count_Person_NotEnrolledInSchool"
-                    ],
-                    "title": "Population Currently Enrolled in School and more in Sunnyvale",
-                    "type": "LINE"
+                    "title": "Population: 7th And 8th Grade in Sunnyvale",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -223,75 +229,11 @@
           }
         ],
         "statVarSpec": {
-          "Count_Person_DetailedEnrolledInCollegeUndergraduateYears_multiple_place_bar_block": {
-            "name": "Population: Enrolled in College Undergraduate Years",
-            "statVar": "Count_Person_DetailedEnrolledInCollegeUndergraduateYears"
-          },
-          "Count_Person_DetailedEnrolledInGrade10_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 10",
-            "statVar": "Count_Person_DetailedEnrolledInGrade10"
-          },
-          "Count_Person_DetailedEnrolledInGrade11_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 11",
-            "statVar": "Count_Person_DetailedEnrolledInGrade11"
-          },
-          "Count_Person_DetailedEnrolledInGrade12_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 12",
-            "statVar": "Count_Person_DetailedEnrolledInGrade12"
-          },
-          "Count_Person_DetailedEnrolledInGrade1_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 1",
-            "statVar": "Count_Person_DetailedEnrolledInGrade1"
-          },
-          "Count_Person_DetailedEnrolledInGrade2_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 2",
-            "statVar": "Count_Person_DetailedEnrolledInGrade2"
-          },
-          "Count_Person_DetailedEnrolledInGrade3_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 3",
-            "statVar": "Count_Person_DetailedEnrolledInGrade3"
-          },
-          "Count_Person_DetailedEnrolledInGrade4_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 4",
-            "statVar": "Count_Person_DetailedEnrolledInGrade4"
-          },
-          "Count_Person_DetailedEnrolledInGrade5_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 5",
-            "statVar": "Count_Person_DetailedEnrolledInGrade5"
-          },
-          "Count_Person_DetailedEnrolledInGrade6_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 6",
-            "statVar": "Count_Person_DetailedEnrolledInGrade6"
-          },
-          "Count_Person_DetailedEnrolledInGrade7_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 7",
-            "statVar": "Count_Person_DetailedEnrolledInGrade7"
-          },
-          "Count_Person_DetailedEnrolledInGrade8_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 8",
-            "statVar": "Count_Person_DetailedEnrolledInGrade8"
-          },
-          "Count_Person_DetailedEnrolledInGrade9_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Grade 9",
-            "statVar": "Count_Person_DetailedEnrolledInGrade9"
-          },
-          "Count_Person_DetailedEnrolledInKindergarten_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Kindergarten",
-            "statVar": "Count_Person_DetailedEnrolledInKindergarten"
-          },
-          "Count_Person_DetailedEnrolledInNurserySchoolPreschool_multiple_place_bar_block": {
-            "name": "Population: Enrolled in Nursery School Preschool",
-            "statVar": "Count_Person_DetailedEnrolledInNurserySchoolPreschool"
-          },
           "Count_Person_DetailedHighSchool": {
             "name": "High School Students",
             "statVar": "Count_Person_DetailedHighSchool"
           },
           "Count_Person_DetailedMiddleSchool": {
-            "name": "Middle School Students",
-            "statVar": "Count_Person_DetailedMiddleSchool"
-          },
-          "Count_Person_DetailedMiddleSchool_multiple_place_bar_block": {
             "name": "Middle School Students",
             "statVar": "Count_Person_DetailedMiddleSchool"
           },
@@ -306,10 +248,6 @@
           "Count_Person_EnrolledInSchool": {
             "name": "Population Currently Enrolled in School",
             "statVar": "Count_Person_EnrolledInSchool"
-          },
-          "Count_Person_NotEnrolledInSchool": {
-            "name": "Population Not Currently Enrolled in School",
-            "statVar": "Count_Person_NotEnrolledInSchool"
           },
           "Count_Person_Years25Onwards_EducationalAttainment_7ThAnd8ThGrade": {
             "name": "Population: 7th And 8th Grade",

--- a/server/integration_tests/test_data/demo_fallback/query_3/chart_config.json
+++ b/server/integration_tests/test_data/demo_fallback/query_3/chart_config.json
@@ -15,6 +15,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Criminal Activities in California",
+                    "statVarKey": [
+                      "Count_CriminalActivities_CombinedCrime"
+                    ],
+                    "title": "Criminal Activities in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ],
             "denom": "Count_Person"
@@ -45,32 +57,6 @@
             ],
             "denom": "Count_Person",
             "title": "Crimes by Type"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "comparisonPlaces": [
-                      "geoId/06"
-                    ],
-                    "statVarKey": [
-                      "Count_CriminalActivities_PropertyCrime_multiple_place_bar_block",
-                      "Count_CriminalActivities_AggravatedAssault_multiple_place_bar_block",
-                      "Count_CriminalActivities_Burglary_multiple_place_bar_block",
-                      "Count_CriminalActivities_ForcibleRape_multiple_place_bar_block",
-                      "Count_CriminalActivities_LarcenyTheft_multiple_place_bar_block",
-                      "Count_CriminalActivities_MotorVehicleTheft_multiple_place_bar_block",
-                      "Count_CriminalActivities_Robbery_multiple_place_bar_block",
-                      "Count_CriminalActivities_ViolentCrime_multiple_place_bar_block"
-                    ],
-                    "title": "Property Related Crimes and more in California (${date})",
-                    "type": "BAR"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person"
           }
         ],
         "statVarSpec": {

--- a/server/integration_tests/test_data/demo_fallback/query_4/chart_config.json
+++ b/server/integration_tests/test_data/demo_fallback/query_4/chart_config.json
@@ -15,6 +15,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Prevalence of Obesity in California",
+                    "statVarKey": [
+                      "Percent_Person_Obesity"
+                    ],
+                    "title": "Prevalence of Obesity in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ]
           },
@@ -28,6 +40,18 @@
                     ],
                     "title": "Physical Health Issues in California",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Physical Health Issues in California",
+                    "statVarKey": [
+                      "Percent_Person_WithPhysicalHealthNotGood"
+                    ],
+                    "title": "Physical Health Issues in California",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }

--- a/server/integration_tests/test_data/demo_fallback/query_5/chart_config.json
+++ b/server/integration_tests/test_data/demo_fallback/query_5/chart_config.json
@@ -15,6 +15,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "GDP (Nominal Value) in United States",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+                    ],
+                    "title": "GDP (Nominal Value) in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ],
             "denom": "Count_Person"
@@ -29,6 +41,18 @@
                     ],
                     "title": "Nominal GDP Per Capita in United States",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Nominal GDP Per Capita in United States",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+                    ],
+                    "title": "Nominal GDP Per Capita in United States",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -84,6 +108,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Growth Rate of GDP in United States",
+                    "statVarKey": [
+                      "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
+                    ],
+                    "title": "Growth Rate of GDP in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ]
           },
@@ -97,6 +133,18 @@
                     ],
                     "title": "GDP (Real Value) in United States",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "GDP (Real Value) in United States",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_RealValue"
+                    ],
+                    "title": "GDP (Real Value) in United States",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }

--- a/server/integration_tests/test_data/demo_feb2023/query_4/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_4/chart_config.json
@@ -40,9 +40,357 @@
             ],
             "denom": "Count_Person",
             "title": "Categories of Jobs"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Worker_NAICSTotalAllIndustries"
+                    ],
+                    "title": "Workers in All Industries in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Workers in All Industries in Placer County",
+                    "statVarKey": [
+                      "Count_Worker_NAICSTotalAllIndustries"
+                    ],
+                    "title": "Workers in All Industries in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Worker_NAICSServiceProviding"
+                    ],
+                    "title": "Population of Person: Service-providing (NAICS/102) in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population of Person: Service-providing (NAICS/102) in Placer County",
+                    "statVarKey": [
+                      "Count_Worker_NAICSServiceProviding"
+                    ],
+                    "title": "Population of Person: Service-providing (NAICS/102) in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Employed"
+                    ],
+                    "title": "Population With Current Employment in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population With Current Employment in Placer County",
+                    "statVarKey": [
+                      "Count_Person_Employed"
+                    ],
+                    "title": "Population With Current Employment in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/nfdf9rt7kbggb"
+                    ],
+                    "title": "Population: Worked At Home, Management, Business, Science, And Arts Occupations in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Worked At Home, Management, Business, Science, And Arts Occupations in Placer County",
+                    "statVarKey": [
+                      "dc/nfdf9rt7kbggb"
+                    ],
+                    "title": "Population: Worked At Home, Management, Business, Science, And Arts Occupations in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Establishment_NAICSTotalAllIndustries"
+                    ],
+                    "title": "Count of Establishment: Total, All Industries (NAICS/10) in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Count of Establishment: Total, All Industries (NAICS/10) in Placer County",
+                    "statVarKey": [
+                      "Count_Establishment_NAICSTotalAllIndustries"
+                    ],
+                    "title": "Count of Establishment: Total, All Industries (NAICS/10) in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/7wt44yv38rew"
+                    ],
+                    "title": "Population: Worked At Home, Sales And Office Occupations in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Worked At Home, Sales And Office Occupations in Placer County",
+                    "statVarKey": [
+                      "dc/7wt44yv38rew"
+                    ],
+                    "title": "Population: Worked At Home, Sales And Office Occupations in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/dn2h9yfcgbkg2"
+                    ],
+                    "title": "Population: Worked At Home, Service Occupations in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Worked At Home, Service Occupations in Placer County",
+                    "statVarKey": [
+                      "dc/dn2h9yfcgbkg2"
+                    ],
+                    "title": "Population: Worked At Home, Service Occupations in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Household_MarriedCoupleFamilyHousehold_With2Worker"
+                    ],
+                    "title": "Count of Household: Married Couple Family Household, Worker 2 in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Count of Household: Married Couple Family Household, Worker 2 in Placer County",
+                    "statVarKey": [
+                      "Count_Household_MarriedCoupleFamilyHousehold_With2Worker"
+                    ],
+                    "title": "Count of Household: Married Couple Family Household, Worker 2 in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/cs8fvwkmpmlpg"
+                    ],
+                    "title": "Population: Worked At Home, Production, Transportation, And Material Moving Occupations in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Worked At Home, Production, Transportation, And Material Moving Occupations in Placer County",
+                    "statVarKey": [
+                      "dc/cs8fvwkmpmlpg"
+                    ],
+                    "title": "Population: Worked At Home, Production, Transportation, And Material Moving Occupations in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/j7pej9wer7lkd"
+                    ],
+                    "title": "Population: Car Truck or Van Carpooled, Natural Resources, Construction, And Maintenance Occupations in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Car Truck or Van Carpooled, Natural Resources, Construction, And Maintenance Occupations in Placer County",
+                    "statVarKey": [
+                      "dc/j7pej9wer7lkd"
+                    ],
+                    "title": "Population: Car Truck or Van Carpooled, Natural Resources, Construction, And Maintenance Occupations in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/m615rq99fwf2c"
+                    ],
+                    "title": "Population: Car Truck or Van Carpooled, Service Occupations in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Car Truck or Van Carpooled, Service Occupations in Placer County",
+                    "statVarKey": [
+                      "dc/m615rq99fwf2c"
+                    ],
+                    "title": "Population: Car Truck or Van Carpooled, Service Occupations in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/n99t0lnl3fch6"
+                    ],
+                    "title": "Population: Walked, Natural Resources, Construction, And Maintenance Occupations in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Walked, Natural Resources, Construction, And Maintenance Occupations in Placer County",
+                    "statVarKey": [
+                      "dc/n99t0lnl3fch6"
+                    ],
+                    "title": "Population: Walked, Natural Resources, Construction, And Maintenance Occupations in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
           }
         ],
         "statVarSpec": {
+          "Count_Establishment_NAICSTotalAllIndustries": {
+            "name": "Count of Establishment: Total, All Industries (NAICS/10)",
+            "statVar": "Count_Establishment_NAICSTotalAllIndustries"
+          },
+          "Count_Household_MarriedCoupleFamilyHousehold_With2Worker": {
+            "name": "Count of Household: Married Couple Family Household, Worker 2",
+            "statVar": "Count_Household_MarriedCoupleFamilyHousehold_With2Worker"
+          },
+          "Count_Person_Employed": {
+            "name": "Population With Current Employment",
+            "statVar": "Count_Person_Employed"
+          },
           "Count_Worker_NAICSAccommodationFoodServices_multiple_place_bar_block": {
             "name": "Accomodation/Food Industry",
             "statVar": "Count_Worker_NAICSAccommodationFoodServices"
@@ -99,6 +447,14 @@
             "name": "Real Estate and Rental and Leasing",
             "statVar": "Count_Worker_NAICSRealEstateRentalLeasing"
           },
+          "Count_Worker_NAICSServiceProviding": {
+            "name": "Population of Person: Service-providing (NAICS/102)",
+            "statVar": "Count_Worker_NAICSServiceProviding"
+          },
+          "Count_Worker_NAICSTotalAllIndustries": {
+            "name": "Workers in All Industries",
+            "statVar": "Count_Worker_NAICSTotalAllIndustries"
+          },
           "Count_Worker_NAICSUtilities_multiple_place_bar_block": {
             "name": "Utilities",
             "statVar": "Count_Worker_NAICSUtilities"
@@ -107,13 +463,41 @@
             "name": "Wholesale Trade",
             "statVar": "Count_Worker_NAICSWholesaleTrade"
           },
+          "dc/7wt44yv38rew": {
+            "name": "Population: Worked At Home, Sales And Office Occupations",
+            "statVar": "dc/7wt44yv38rew"
+          },
           "dc/8p97n7l96lgg8_multiple_place_bar_block": {
             "name": "Transportation And Warehousing",
             "statVar": "dc/8p97n7l96lgg8"
           },
+          "dc/cs8fvwkmpmlpg": {
+            "name": "Population: Worked At Home, Production, Transportation, And Material Moving Occupations",
+            "statVar": "dc/cs8fvwkmpmlpg"
+          },
+          "dc/dn2h9yfcgbkg2": {
+            "name": "Population: Worked At Home, Service Occupations",
+            "statVar": "dc/dn2h9yfcgbkg2"
+          },
+          "dc/j7pej9wer7lkd": {
+            "name": "Population: Car Truck or Van Carpooled, Natural Resources, Construction, And Maintenance Occupations",
+            "statVar": "dc/j7pej9wer7lkd"
+          },
+          "dc/m615rq99fwf2c": {
+            "name": "Population: Car Truck or Van Carpooled, Service Occupations",
+            "statVar": "dc/m615rq99fwf2c"
+          },
+          "dc/n99t0lnl3fch6": {
+            "name": "Population: Walked, Natural Resources, Construction, And Maintenance Occupations",
+            "statVar": "dc/n99t0lnl3fch6"
+          },
           "dc/ndg1xk1e9frc2_multiple_place_bar_block": {
             "name": "Manufacturing",
             "statVar": "dc/ndg1xk1e9frc2"
+          },
+          "dc/nfdf9rt7kbggb": {
+            "name": "Population: Worked At Home, Management, Business, Science, And Arts Occupations",
+            "statVar": "dc/nfdf9rt7kbggb"
           },
           "dc/p69tpsldf99h7_multiple_place_bar_block": {
             "name": "Retail Trade",

--- a/server/integration_tests/test_data/demo_feb2023/query_6/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_6/chart_config.json
@@ -38,6 +38,158 @@
               {
                 "tiles": [
                   {
+                    "description": "Percent of Children That Have Asthma in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_Children_WithAsthma"
+                    ],
+                    "title": "Percent of Children That Have Asthma in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_WithAsthma"
+                    ],
+                    "title": "Asthma in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Asthma in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_WithAsthma"
+                    ],
+                    "title": "Asthma in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_WithHighBloodPressure"
+                    ],
+                    "title": "High Blood Pressure in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "High Blood Pressure in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_WithHighBloodPressure"
+                    ],
+                    "title": "High Blood Pressure in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_18OrMoreYears_WithHighBloodPressure_ReceivedTakingBloodPressureMedication"
+                    ],
+                    "title": "Percent of Adults with Blood Pressure Who Take Medication in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Percent of Adults with Blood Pressure Who Take Medication in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_18OrMoreYears_WithHighBloodPressure_ReceivedTakingBloodPressureMedication"
+                    ],
+                    "title": "Percent of Adults with Blood Pressure Who Take Medication in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_WithCancerExcludingSkinCancer"
+                    ],
+                    "title": "Cancer (excluding skin cancer) in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Cancer (excluding skin cancer) in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_WithCancerExcludingSkinCancer"
+                    ],
+                    "title": "Cancer (excluding skin cancer) in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Death_Neoplasms"
+                    ],
+                    "title": "Deaths From Neoplasms (Tumors or Abnormal Growths) in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Deaths From Neoplasms (Tumors or Abnormal Growths) in Placer County",
+                    "statVarKey": [
+                      "Count_Death_Neoplasms"
+                    ],
+                    "title": "Deaths From Neoplasms (Tumors or Abnormal Growths) in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
                     "comparisonPlaces": [
                       "geoId/06061"
                     ],
@@ -84,6 +236,142 @@
               {
                 "tiles": [
                   {
+                    "statVarKey": [
+                      "Percent_Person_WithHighCholesterol"
+                    ],
+                    "title": "High Cholesterol in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "High Cholesterol in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_WithHighCholesterol"
+                    ],
+                    "title": "High Cholesterol in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_ReceivedCholesterolScreening"
+                    ],
+                    "title": "Prevalence: Cholesterol Screening in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Prevalence: Cholesterol Screening in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_ReceivedCholesterolScreening"
+                    ],
+                    "title": "Prevalence: Cholesterol Screening in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_WithMentalHealthNotGood"
+                    ],
+                    "title": "Mental Health Issues in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Mental Health Issues in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_WithMentalHealthNotGood"
+                    ],
+                    "title": "Mental Health Issues in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_18OrMoreYears_WithDepression"
+                    ],
+                    "title": "Depression in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Depression in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_18OrMoreYears_WithDepression"
+                    ],
+                    "title": "Depression in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Death_MentalBehaviouralDisorders"
+                    ],
+                    "title": "Deaths Due To Mental And Behavioural Disorders in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Deaths Due To Mental And Behavioural Disorders in Placer County",
+                    "statVarKey": [
+                      "Count_Death_MentalBehaviouralDisorders"
+                    ],
+                    "title": "Deaths Due To Mental And Behavioural Disorders in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
                     "comparisonPlaces": [
                       "geoId/06061"
                     ],
@@ -100,6 +388,61 @@
             ],
             "denom": "Count_Person",
             "title": "Mental Health Deaths by Age"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_18To64Years_ReceivedNoHealthInsurance"
+                    ],
+                    "title": "Percentage of Population Aged 18-64 With No Health Insurance in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Percentage of Population Aged 18-64 With No Health Insurance in Placer County",
+                    "statVarKey": [
+                      "Percent_Person_18To64Years_ReceivedNoHealthInsurance"
+                    ],
+                    "title": "Percentage of Population Aged 18-64 With No Health Insurance in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_WithVAHealthCare"
+                    ],
+                    "title": "People With VA Health Care in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "People With VA Health Care in Placer County",
+                    "statVarKey": [
+                      "Count_Person_WithVAHealthCare"
+                    ],
+                    "title": "People With VA Health Care in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
           }
         ],
         "statVarSpec": {
@@ -139,6 +482,33 @@
             "name": "Neoplasms Deaths Among 85+ Years Olds",
             "statVar": "Count_Death_85Years_Neoplasms"
           },
+          "Count_Death_MentalBehaviouralDisorders": {
+            "name": "Deaths Due To Mental And Behavioural Disorders",
+            "statVar": "Count_Death_MentalBehaviouralDisorders"
+          },
+          "Count_Death_Neoplasms": {
+            "name": "Deaths From Neoplasms (Tumors or Abnormal Growths)",
+            "statVar": "Count_Death_Neoplasms"
+          },
+          "Count_Person_WithVAHealthCare": {
+            "name": "People With VA Health Care",
+            "statVar": "Count_Person_WithVAHealthCare"
+          },
+          "Percent_Person_18OrMoreYears_WithDepression": {
+            "name": "Depression",
+            "statVar": "Percent_Person_18OrMoreYears_WithDepression",
+            "unit": "%"
+          },
+          "Percent_Person_18OrMoreYears_WithHighBloodPressure_ReceivedTakingBloodPressureMedication": {
+            "name": "Percent of Adults with Blood Pressure Who Take Medication",
+            "statVar": "Percent_Person_18OrMoreYears_WithHighBloodPressure_ReceivedTakingBloodPressureMedication",
+            "unit": "%"
+          },
+          "Percent_Person_18To64Years_ReceivedNoHealthInsurance": {
+            "name": "Percentage of Population Aged 18-64 With No Health Insurance",
+            "statVar": "Percent_Person_18To64Years_ReceivedNoHealthInsurance",
+            "unit": "%"
+          },
           "Percent_Person_21To65Years_Female_ReceivedCervicalCancerScreening_multiple_place_bar_block": {
             "name": "Women 21 - 65 Years Who Received Cervical Cancer Screening",
             "statVar": "Percent_Person_21To65Years_Female_ReceivedCervicalCancerScreening",
@@ -154,14 +524,34 @@
             "statVar": "Percent_Person_50To75Years_ReceivedColorectalCancerScreening",
             "unit": "%"
           },
+          "Percent_Person_Children_WithAsthma": {
+            "name": "Percent of Children That Have Asthma",
+            "statVar": "Percent_Person_Children_WithAsthma",
+            "unit": "%"
+          },
+          "Percent_Person_ReceivedCholesterolScreening": {
+            "name": "Prevalence: Cholesterol Screening",
+            "statVar": "Percent_Person_ReceivedCholesterolScreening",
+            "unit": "%"
+          },
           "Percent_Person_WithArthritis_multiple_place_bar_block": {
             "name": "Arthritis",
             "statVar": "Percent_Person_WithArthritis",
             "unit": "%"
           },
+          "Percent_Person_WithAsthma": {
+            "name": "Asthma",
+            "statVar": "Percent_Person_WithAsthma",
+            "unit": "%"
+          },
           "Percent_Person_WithAsthma_multiple_place_bar_block": {
             "name": "Asthma",
             "statVar": "Percent_Person_WithAsthma",
+            "unit": "%"
+          },
+          "Percent_Person_WithCancerExcludingSkinCancer": {
+            "name": "Cancer (excluding skin cancer)",
+            "statVar": "Percent_Person_WithCancerExcludingSkinCancer",
             "unit": "%"
           },
           "Percent_Person_WithCancerExcludingSkinCancer_multiple_place_bar_block": {
@@ -189,14 +579,29 @@
             "statVar": "Percent_Person_WithDiabetes",
             "unit": "%"
           },
+          "Percent_Person_WithHighBloodPressure": {
+            "name": "High Blood Pressure",
+            "statVar": "Percent_Person_WithHighBloodPressure",
+            "unit": "%"
+          },
           "Percent_Person_WithHighBloodPressure_multiple_place_bar_block": {
             "name": "High Blood Pressure",
             "statVar": "Percent_Person_WithHighBloodPressure",
             "unit": "%"
           },
+          "Percent_Person_WithHighCholesterol": {
+            "name": "High Cholesterol",
+            "statVar": "Percent_Person_WithHighCholesterol",
+            "unit": "%"
+          },
           "Percent_Person_WithHighCholesterol_multiple_place_bar_block": {
             "name": "High Cholesterol",
             "statVar": "Percent_Person_WithHighCholesterol",
+            "unit": "%"
+          },
+          "Percent_Person_WithMentalHealthNotGood": {
+            "name": "Mental Health Issues",
+            "statVar": "Percent_Person_WithMentalHealthNotGood",
             "unit": "%"
           },
           "Percent_Person_WithMentalHealthNotGood_multiple_place_bar_block": {

--- a/server/integration_tests/test_data/international/query_1/chart_config.json
+++ b/server/integration_tests/test_data/international/query_1/chart_config.json
@@ -232,6 +232,34 @@
               {
                 "tiles": [
                   {
+                    "statVarKey": [
+                      "Count_Person_Rural_BelowPovertyLevelInThePast12Months"
+                    ],
+                    "title": "Rural residents, Below Poverty Level in The Past 12 Months in India",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Rural residents, Below Poverty Level in The Past 12 Months in India",
+                    "statVarKey": [
+                      "Count_Person_Rural_BelowPovertyLevelInThePast12Months"
+                    ],
+                    "title": "Rural residents, Below Poverty Level in The Past 12 Months in India",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
                     "rankingTileSpec": {
                       "rankingCount": 10,
                       "showHighest": true
@@ -404,6 +432,10 @@
           "Count_Person_Rural": {
             "name": "Population Living in Rural Areas",
             "statVar": "Count_Person_Rural"
+          },
+          "Count_Person_Rural_BelowPovertyLevelInThePast12Months": {
+            "name": "Rural residents, Below Poverty Level in The Past 12 Months",
+            "statVar": "Count_Person_Rural_BelowPovertyLevelInThePast12Months"
           },
           "Count_Person_Rural_Female": {
             "name": "Population: Female, Rural",

--- a/server/integration_tests/test_data/international/query_3/chart_config.json
+++ b/server/integration_tests/test_data/international/query_3/chart_config.json
@@ -25,6 +25,60 @@
                 "tiles": [
                   {
                     "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+                    ],
+                    "title": "Nominal GDP Per Capita in United Kingdom",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Nominal GDP Per Capita in United Kingdom",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+                    ],
+                    "title": "Nominal GDP Per Capita in United Kingdom",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
+                    ],
+                    "title": "Growth Rate of GDP in United Kingdom",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Growth Rate of GDP in United Kingdom",
+                    "statVarKey": [
+                      "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
+                    ],
+                    "title": "Growth Rate of GDP in United Kingdom",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_AsAFractionOf_Count_Person"
                     ],
                     "title": "Amount of Economic Activity (Nominal): Gross Domestic Production (Per Capita) in Eurostat Nuts 3 Places of United Kingdom (${date})",
@@ -43,6 +97,14 @@
           "Amount_EconomicActivity_GrossDomesticProduction_Nominal_AsAFractionOf_Count_Person": {
             "name": "Amount of Economic Activity (Nominal): Gross Domestic Production (Per Capita)",
             "statVar": "Amount_EconomicActivity_GrossDomesticProduction_Nominal_AsAFractionOf_Count_Person"
+          },
+          "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita": {
+            "name": "Nominal GDP Per Capita",
+            "statVar": "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+          },
+          "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction": {
+            "name": "Growth Rate of GDP",
+            "statVar": "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
           }
         }
       }

--- a/server/integration_tests/test_data/international/query_4/chart_config.json
+++ b/server/integration_tests/test_data/international/query_4/chart_config.json
@@ -35,6 +35,33 @@
               {
                 "tiles": [
                   {
+                    "statVarKey": [
+                      "Count_BirthEvent_LiveBirth_AsFractionOf_Count_Person"
+                    ],
+                    "title": "Count of Birth Event: Live Birth (Per Capita) in Turkey",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Count of Birth Event: Live Birth (Per Capita) in Turkey",
+                    "statVarKey": [
+                      "Count_BirthEvent_LiveBirth_AsFractionOf_Count_Person"
+                    ],
+                    "title": "Count of Birth Event: Live Birth (Per Capita) in Turkey",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
                     "rankingTileSpec": {
                       "rankingCount": 10,
                       "showHighest": true
@@ -62,6 +89,67 @@
               {
                 "tiles": [
                   {
+                    "description": "Prematurity And Low Birth Rate, Per 100,000 in Turkey",
+                    "statVarKey": [
+                      "WHO/SA_0000001432"
+                    ],
+                    "title": "Prematurity And Low Birth Rate, Per 100,000 in Turkey",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "description": "Age-Standardized Death Rates, Prematurity And Low Birth Rate, Per 100,000 in Turkey",
+                    "statVarKey": [
+                      "WHO/SA_0000001451"
+                    ],
+                    "title": "Age-Standardized Death Rates, Prematurity And Low Birth Rate, Per 100,000 in Turkey",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
+                    ],
+                    "title": "Female Infant Mortality Rate in Turkey",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Female Infant Mortality Rate in Turkey",
+                    "statVarKey": [
+                      "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
+                    ],
+                    "title": "Female Infant Mortality Rate in Turkey",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
                     "rankingTileSpec": {
                       "rankingCount": 10,
                       "showHighest": true
@@ -83,12 +171,75 @@
               }
             ],
             "title": "Rate of Population Growth"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/MORT_MATERNALNUM"
+                    ],
+                    "title": "Number Of Maternal Deaths in Turkey",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Number Of Maternal Deaths in Turkey",
+                    "statVarKey": [
+                      "WHO/MORT_MATERNALNUM"
+                    ],
+                    "title": "Number Of Maternal Deaths in Turkey",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SH_STA_MORT.SEX--F"
+                    ],
+                    "title": "Maternal mortality ratio in Turkey",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Maternal mortality ratio in Turkey",
+                    "statVarKey": [
+                      "sdg/SH_STA_MORT.SEX--F"
+                    ],
+                    "title": "Maternal mortality ratio in Turkey",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
           }
         ],
         "statVarSpec": {
           "Count_BirthEvent_AsAFractionOfCount_Person": {
             "name": "Count of Birth Event (Per Capita)",
             "statVar": "Count_BirthEvent_AsAFractionOfCount_Person"
+          },
+          "Count_BirthEvent_LiveBirth_AsFractionOf_Count_Person": {
+            "name": "Count of Birth Event: Live Birth (Per Capita)",
+            "statVar": "Count_BirthEvent_LiveBirth_AsFractionOf_Count_Person"
+          },
+          "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female": {
+            "name": "Female Infant Mortality Rate",
+            "statVar": "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
           },
           "FertilityRate_Person_Female": {
             "name": "Fertility Rate",
@@ -97,6 +248,22 @@
           "GrowthRate_Count_Person": {
             "name": "Rate of Population Growth",
             "statVar": "GrowthRate_Count_Person"
+          },
+          "WHO/MORT_MATERNALNUM": {
+            "name": "Number Of Maternal Deaths",
+            "statVar": "WHO/MORT_MATERNALNUM"
+          },
+          "WHO/SA_0000001432": {
+            "name": "Prematurity And Low Birth Rate, Per 100,000",
+            "statVar": "WHO/SA_0000001432"
+          },
+          "WHO/SA_0000001451": {
+            "name": "Age-Standardized Death Rates, Prematurity And Low Birth Rate, Per 100,000",
+            "statVar": "WHO/SA_0000001451"
+          },
+          "sdg/SH_STA_MORT.SEX--F": {
+            "name": "Maternal mortality ratio",
+            "statVar": "sdg/SH_STA_MORT.SEX--F"
           }
         }
       }

--- a/server/integration_tests/test_data/sdg/query_1/chart_config.json
+++ b/server/integration_tests/test_data/sdg/query_1/chart_config.json
@@ -11,130 +11,35 @@
                     "statVarKey": [
                       "sdg/SI_POV_DAY1"
                     ],
-                    "title": "Population Below International Poverty Line in Countries of Africa (${date})",
-                    "type": "MAP"
+                    "title": "Population Below International Poverty Line in Africa",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population Below International Poverty Line in Africa",
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1"
+                    ],
+                    "title": "Population Below International Poverty Line in Africa",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
             ]
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1.AGE--Y0T14"
-                    ],
-                    "title": "Population Age Under 15 Below International Poverty Line in Countries of Africa (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1.AGE--Y15T64"
-                    ],
-                    "title": "Population Age 15 to 64 Below International Poverty Line in Countries of Africa (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1.AGE--Y_GE65"
-                    ],
-                    "title": "Population Age 65 or Older Below International Poverty Line in Countries of Africa (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              }
-            ],
-            "title": "Population below international poverty line by age"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1.SEX--F"
-                    ],
-                    "title": "Women Below International Poverty Line in Countries of Africa (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1.SEX--M"
-                    ],
-                    "title": "Men Below International Poverty Line in Countries of Africa (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              }
-            ],
-            "title": "Population below international poverty line by gender"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1.URBANISATION--U"
-                    ],
-                    "title": "Urban Population Below International Poverty Line in Countries of Africa (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1.URBANISATION--R"
-                    ],
-                    "title": "Rural Population Below International Poverty Line in Countries of Africa (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              }
-            ],
-            "title": "Population below international poverty line in rural vs. urban areas"
           }
         ],
         "statVarSpec": {
           "sdg/SI_POV_DAY1": {
             "name": "Population Below International Poverty Line",
             "statVar": "sdg/SI_POV_DAY1"
-          },
-          "sdg/SI_POV_DAY1.AGE--Y0T14": {
-            "name": "Population Age Under 15 Below International Poverty Line",
-            "statVar": "sdg/SI_POV_DAY1.AGE--Y0T14"
-          },
-          "sdg/SI_POV_DAY1.AGE--Y15T64": {
-            "name": "Population Age 15 to 64 Below International Poverty Line",
-            "statVar": "sdg/SI_POV_DAY1.AGE--Y15T64"
-          },
-          "sdg/SI_POV_DAY1.AGE--Y_GE65": {
-            "name": "Population Age 65 or Older Below International Poverty Line",
-            "statVar": "sdg/SI_POV_DAY1.AGE--Y_GE65"
-          },
-          "sdg/SI_POV_DAY1.SEX--F": {
-            "name": "Women Below International Poverty Line",
-            "statVar": "sdg/SI_POV_DAY1.SEX--F"
-          },
-          "sdg/SI_POV_DAY1.SEX--M": {
-            "name": "Men Below International Poverty Line",
-            "statVar": "sdg/SI_POV_DAY1.SEX--M"
-          },
-          "sdg/SI_POV_DAY1.URBANISATION--R": {
-            "name": "Rural Population Below International Poverty Line",
-            "statVar": "sdg/SI_POV_DAY1.URBANISATION--R"
-          },
-          "sdg/SI_POV_DAY1.URBANISATION--U": {
-            "name": "Urban Population Below International Poverty Line",
-            "statVar": "sdg/SI_POV_DAY1.URBANISATION--U"
           }
         }
       }
     ],
     "metadata": {
-      "containedPlaceTypes": {
-        "Continent": "Country"
-      },
       "placeDcid": [
         "africa"
       ]

--- a/server/integration_tests/test_data/sdg/query_1/chart_config.json
+++ b/server/integration_tests/test_data/sdg/query_1/chart_config.json
@@ -11,35 +11,130 @@
                     "statVarKey": [
                       "sdg/SI_POV_DAY1"
                     ],
-                    "title": "Population Below International Poverty Line in Africa",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Population Below International Poverty Line in Africa",
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1"
-                    ],
-                    "title": "Population Below International Poverty Line in Africa",
-                    "type": "HIGHLIGHT"
+                    "title": "Population Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
                   }
                 ]
               }
             ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1.AGE--Y0T14"
+                    ],
+                    "title": "Population Age Under 15 Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1.AGE--Y15T64"
+                    ],
+                    "title": "Population Age 15 to 64 Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1.AGE--Y_GE65"
+                    ],
+                    "title": "Population Age 65 or Older Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Population below international poverty line by age"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1.SEX--F"
+                    ],
+                    "title": "Women Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1.SEX--M"
+                    ],
+                    "title": "Men Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Population below international poverty line by gender"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1.URBANISATION--U"
+                    ],
+                    "title": "Urban Population Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1.URBANISATION--R"
+                    ],
+                    "title": "Rural Population Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Population below international poverty line in rural vs. urban areas"
           }
         ],
         "statVarSpec": {
           "sdg/SI_POV_DAY1": {
             "name": "Population Below International Poverty Line",
             "statVar": "sdg/SI_POV_DAY1"
+          },
+          "sdg/SI_POV_DAY1.AGE--Y0T14": {
+            "name": "Population Age Under 15 Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.AGE--Y0T14"
+          },
+          "sdg/SI_POV_DAY1.AGE--Y15T64": {
+            "name": "Population Age 15 to 64 Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.AGE--Y15T64"
+          },
+          "sdg/SI_POV_DAY1.AGE--Y_GE65": {
+            "name": "Population Age 65 or Older Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.AGE--Y_GE65"
+          },
+          "sdg/SI_POV_DAY1.SEX--F": {
+            "name": "Women Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.SEX--F"
+          },
+          "sdg/SI_POV_DAY1.SEX--M": {
+            "name": "Men Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.SEX--M"
+          },
+          "sdg/SI_POV_DAY1.URBANISATION--R": {
+            "name": "Rural Population Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.URBANISATION--R"
+          },
+          "sdg/SI_POV_DAY1.URBANISATION--U": {
+            "name": "Urban Population Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.URBANISATION--U"
           }
         }
       }
     ],
     "metadata": {
+      "containedPlaceTypes": {
+        "Continent": "Country"
+      },
       "placeDcid": [
         "africa"
       ]

--- a/server/integration_tests/test_data/sdg/query_3/chart_config.json
+++ b/server/integration_tests/test_data/sdg/query_3/chart_config.json
@@ -11,20 +11,8 @@
                     "statVarKey": [
                       "LifeExpectancy_Person"
                     ],
-                    "title": "Life Expectancy in the World",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Life Expectancy in the World",
-                    "statVarKey": [
-                      "LifeExpectancy_Person"
-                    ],
-                    "title": "Life Expectancy in the World",
-                    "type": "HIGHLIGHT"
+                    "title": "Life Expectancy in the World (${date})",
+                    "type": "MAP"
                   }
                 ]
               }
@@ -36,11 +24,17 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "LifeExpectancy_Person_Female",
+                      "LifeExpectancy_Person_Female"
+                    ],
+                    "title": "Female Life Expectancy in the World (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
                       "LifeExpectancy_Person_Male"
                     ],
-                    "title": "Life Expectancy by Gender in the World",
-                    "type": "LINE"
+                    "title": "Male Life Expectancy in the World (${date})",
+                    "type": "MAP"
                   }
                 ]
               }
@@ -55,25 +49,81 @@
                     "statVarKey": [
                       "Count_Death_IntentionalSelfHarm_AsFractionOf_Count_Person"
                     ],
-                    "title": "Count of Mortality Event: X60-X84 (Intentional Self-harm) (Per Capita) in the World",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Count of Mortality Event: X60-X84 (Intentional Self-harm) (Per Capita) in the World",
-                    "statVarKey": [
-                      "Count_Death_IntentionalSelfHarm_AsFractionOf_Count_Person"
-                    ],
-                    "title": "Count of Mortality Event: X60-X84 (Intentional Self-harm) (Per Capita) in the World",
-                    "type": "HIGHLIGHT"
+                    "title": "Count of Mortality Event: X60-X84 (Intentional Self-harm) (Per Capita) in the World (${date})",
+                    "type": "MAP"
                   }
                 ]
               }
             ],
             "title": "Causes Of Death"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/WHS4_117"
+                    ],
+                    "title": "Hepatitis B (Hepb3) Immunization Coverage Among 1-Year-Olds (%) in the World (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
+                      "WHO/WHS4_128"
+                    ],
+                    "title": "Neonates Protected At Birth Against Neonatal Tetanus (Pab) (%) in the World (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
+                      "WHO/WHS4_129"
+                    ],
+                    "title": "Hib (Hib3) Immunization Coverage Among 1-Year-Olds (%) in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/M_Est_smk_daily"
+                    ],
+                    "title": "% Daily Tobacco Smokers (Estimate) in the World (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
+                      "WHO/NCD_BMI_18A"
+                    ],
+                    "title": "% Underweight Among Adults, BMI < 18 in the World (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
+                      "WHO/NCD_BMI_30A"
+                    ],
+                    "title": "% Obesity Among Adults, BMI >= 30 in the World (${date})",
+                    "type": "MAP"
+                  },
+                  {
+                    "statVarKey": [
+                      "WHO/NCD_PAC"
+                    ],
+                    "title": "% Insufficient Physical Activity Among Adults Aged 18+ Years (Crude Estimate) in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Health Behaviors"
           }
         ],
         "statVarSpec": {
@@ -92,11 +142,42 @@
           "LifeExpectancy_Person_Male": {
             "name": "Male Life Expectancy",
             "statVar": "LifeExpectancy_Person_Male"
+          },
+          "WHO/M_Est_smk_daily": {
+            "name": "% Daily Tobacco Smokers (Estimate)",
+            "statVar": "WHO/M_Est_smk_daily"
+          },
+          "WHO/NCD_BMI_18A": {
+            "name": "% Underweight Among Adults, BMI < 18",
+            "statVar": "WHO/NCD_BMI_18A"
+          },
+          "WHO/NCD_BMI_30A": {
+            "name": "% Obesity Among Adults, BMI >= 30",
+            "statVar": "WHO/NCD_BMI_30A"
+          },
+          "WHO/NCD_PAC": {
+            "name": "% Insufficient Physical Activity Among Adults Aged 18+ Years (Crude Estimate)",
+            "statVar": "WHO/NCD_PAC"
+          },
+          "WHO/WHS4_117": {
+            "name": "Hepatitis B (Hepb3) Immunization Coverage Among 1-Year-Olds (%)",
+            "statVar": "WHO/WHS4_117"
+          },
+          "WHO/WHS4_128": {
+            "name": "Neonates Protected At Birth Against Neonatal Tetanus (Pab) (%)",
+            "statVar": "WHO/WHS4_128"
+          },
+          "WHO/WHS4_129": {
+            "name": "Hib (Hib3) Immunization Coverage Among 1-Year-Olds (%)",
+            "statVar": "WHO/WHS4_129"
           }
         }
       }
     ],
     "metadata": {
+      "containedPlaceTypes": {
+        "Place": "Country"
+      },
       "placeDcid": [
         "Earth"
       ]

--- a/server/integration_tests/test_data/sdg/query_3/chart_config.json
+++ b/server/integration_tests/test_data/sdg/query_3/chart_config.json
@@ -11,8 +11,20 @@
                     "statVarKey": [
                       "LifeExpectancy_Person"
                     ],
-                    "title": "Life Expectancy in the World (${date})",
-                    "type": "MAP"
+                    "title": "Life Expectancy in the World",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Life Expectancy in the World",
+                    "statVarKey": [
+                      "LifeExpectancy_Person"
+                    ],
+                    "title": "Life Expectancy in the World",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -24,17 +36,11 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "LifeExpectancy_Person_Female"
-                    ],
-                    "title": "Female Life Expectancy in the World (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
+                      "LifeExpectancy_Person_Female",
                       "LifeExpectancy_Person_Male"
                     ],
-                    "title": "Male Life Expectancy in the World (${date})",
-                    "type": "MAP"
+                    "title": "Life Expectancy by Gender in the World",
+                    "type": "LINE"
                   }
                 ]
               }
@@ -49,81 +55,25 @@
                     "statVarKey": [
                       "Count_Death_IntentionalSelfHarm_AsFractionOf_Count_Person"
                     ],
-                    "title": "Count of Mortality Event: X60-X84 (Intentional Self-harm) (Per Capita) in the World (${date})",
-                    "type": "MAP"
+                    "title": "Count of Mortality Event: X60-X84 (Intentional Self-harm) (Per Capita) in the World",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Count of Mortality Event: X60-X84 (Intentional Self-harm) (Per Capita) in the World",
+                    "statVarKey": [
+                      "Count_Death_IntentionalSelfHarm_AsFractionOf_Count_Person"
+                    ],
+                    "title": "Count of Mortality Event: X60-X84 (Intentional Self-harm) (Per Capita) in the World",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
             ],
             "title": "Causes Of Death"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "WHO/WHS4_117"
-                    ],
-                    "title": "Hepatitis B (Hepb3) Immunization Coverage Among 1-Year-Olds (%) in the World (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
-                      "WHO/WHS4_128"
-                    ],
-                    "title": "Neonates Protected At Birth Against Neonatal Tetanus (Pab) (%) in the World (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
-                      "WHO/WHS4_129"
-                    ],
-                    "title": "Hib (Hib3) Immunization Coverage Among 1-Year-Olds (%) in the World (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "WHO/M_Est_smk_daily"
-                    ],
-                    "title": "% Daily Tobacco Smokers (Estimate) in the World (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
-                      "WHO/NCD_BMI_18A"
-                    ],
-                    "title": "% Underweight Among Adults, BMI < 18 in the World (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
-                      "WHO/NCD_BMI_30A"
-                    ],
-                    "title": "% Obesity Among Adults, BMI >= 30 in the World (${date})",
-                    "type": "MAP"
-                  },
-                  {
-                    "statVarKey": [
-                      "WHO/NCD_PAC"
-                    ],
-                    "title": "% Insufficient Physical Activity Among Adults Aged 18+ Years (Crude Estimate) in the World (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Health Behaviors"
           }
         ],
         "statVarSpec": {
@@ -142,42 +92,11 @@
           "LifeExpectancy_Person_Male": {
             "name": "Male Life Expectancy",
             "statVar": "LifeExpectancy_Person_Male"
-          },
-          "WHO/M_Est_smk_daily": {
-            "name": "% Daily Tobacco Smokers (Estimate)",
-            "statVar": "WHO/M_Est_smk_daily"
-          },
-          "WHO/NCD_BMI_18A": {
-            "name": "% Underweight Among Adults, BMI < 18",
-            "statVar": "WHO/NCD_BMI_18A"
-          },
-          "WHO/NCD_BMI_30A": {
-            "name": "% Obesity Among Adults, BMI >= 30",
-            "statVar": "WHO/NCD_BMI_30A"
-          },
-          "WHO/NCD_PAC": {
-            "name": "% Insufficient Physical Activity Among Adults Aged 18+ Years (Crude Estimate)",
-            "statVar": "WHO/NCD_PAC"
-          },
-          "WHO/WHS4_117": {
-            "name": "Hepatitis B (Hepb3) Immunization Coverage Among 1-Year-Olds (%)",
-            "statVar": "WHO/WHS4_117"
-          },
-          "WHO/WHS4_128": {
-            "name": "Neonates Protected At Birth Against Neonatal Tetanus (Pab) (%)",
-            "statVar": "WHO/WHS4_128"
-          },
-          "WHO/WHS4_129": {
-            "name": "Hib (Hib3) Immunization Coverage Among 1-Year-Olds (%)",
-            "statVar": "WHO/WHS4_129"
           }
         }
       }
     ],
     "metadata": {
-      "containedPlaceTypes": {
-        "Place": "Country"
-      },
       "placeDcid": [
         "Earth"
       ]

--- a/server/integration_tests/test_data/textbox_sample/query_1/chart_config.json
+++ b/server/integration_tests/test_data/textbox_sample/query_1/chart_config.json
@@ -15,6 +15,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Average Income for Family Households in California",
+                    "statVarKey": [
+                      "Mean_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Average Income for Family Households in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ]
           },
@@ -28,6 +40,18 @@
                     ],
                     "title": "Median Family Household Income in California",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Median Family Household Income in California",
+                    "statVarKey": [
+                      "Median_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Median Family Household Income in California",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -45,6 +69,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Median Married Couple Family Household Income in California",
+                    "statVarKey": [
+                      "Median_Income_Household_MarriedCoupleFamilyHousehold"
+                    ],
+                    "title": "Median Married Couple Family Household Income in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ]
           },
@@ -58,6 +94,18 @@
                     ],
                     "title": "Average Income for Married Couple Family Households in California",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Average Income for Married Couple Family Households in California",
+                    "statVarKey": [
+                      "Mean_Income_Household_MarriedCoupleFamilyHousehold"
+                    ],
+                    "title": "Average Income for Married Couple Family Households in California",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -75,6 +123,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Average Income for Nonfamily Households in California",
+                    "statVarKey": [
+                      "Mean_Income_Household_NonfamilyHousehold"
+                    ],
+                    "title": "Average Income for Nonfamily Households in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ]
           },
@@ -84,11 +144,49 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "Median_Income_Household",
+                      "Median_Income_Household"
+                    ],
+                    "title": "Household Median Income in California",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Household Median Income in California",
+                    "statVarKey": [
+                      "Median_Income_Household"
+                    ],
+                    "title": "Household Median Income in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
                       "Median_Income_Person"
                     ],
-                    "title": "Household Median Income and more in California",
+                    "title": "Individual Median Income in California",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Individual Median Income in California",
+                    "statVarKey": [
+                      "Median_Income_Person"
+                    ],
+                    "title": "Individual Median Income in California",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -183,6 +281,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Mean Income Deficit of Household: Family Household in California",
+                    "statVarKey": [
+                      "Mean_IncomeDeficit_Household_FamilyHousehold"
+                    ],
+                    "title": "Mean Income Deficit of Household: Family Household in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ]
           },
@@ -196,6 +306,18 @@
                     ],
                     "title": "Count of Household: Family Household, Owner Occupied in California",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Count of Household: Family Household, Owner Occupied in California",
+                    "statVarKey": [
+                      "Count_Household_FamilyHousehold_OwnerOccupied"
+                    ],
+                    "title": "Count of Household: Family Household, Owner Occupied in California",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -214,6 +336,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Count of Household: Family Household in California",
+                    "statVarKey": [
+                      "Count_Household_FamilyHousehold"
+                    ],
+                    "title": "Count of Household: Family Household in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ],
             "denom": "Count_Person"
@@ -228,6 +362,18 @@
                     ],
                     "title": "Average Income for Households in California",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Average Income for Households in California",
+                    "statVarKey": [
+                      "Mean_Income_Household"
+                    ],
+                    "title": "Average Income for Households in California",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -245,6 +391,18 @@
                     "type": "LINE"
                   }
                 ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Count of Household: Other Family Household in California",
+                    "statVarKey": [
+                      "Count_Household_OtherFamilyHousehold"
+                    ],
+                    "title": "Count of Household: Other Family Household in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
               }
             ],
             "denom": "Count_Person"
@@ -259,6 +417,18 @@
                     ],
                     "title": "Mean Income Deficit of Household: Married Couple Family Household in California",
                     "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Mean Income Deficit of Household: Married Couple Family Household in California",
+                    "statVarKey": [
+                      "Mean_IncomeDeficit_Household_MarriedCoupleFamilyHousehold"
+                    ],
+                    "title": "Mean Income Deficit of Household: Married Couple Family Household in California",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }

--- a/server/integration_tests/test_data/usa_map_types/query_2/chart_config.json
+++ b/server/integration_tests/test_data/usa_map_types/query_2/chart_config.json
@@ -24,6 +24,87 @@
                 "tiles": [
                   {
                     "statVarKey": [
+                      "Mean_Income_Household"
+                    ],
+                    "title": "Average Income for Households in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Average Income for Households in Placer County",
+                    "statVarKey": [
+                      "Mean_Income_Household"
+                    ],
+                    "title": "Average Income for Households in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Median_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Median Family Household Income in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Median Family Household Income in Placer County",
+                    "statVarKey": [
+                      "Median_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Median Family Household Income in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Median_Income_Household_NonfamilyHousehold"
+                    ],
+                    "title": "Nonfamily Household Median Income in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Nonfamily Household Median Income in Placer County",
+                    "statVarKey": [
+                      "Median_Income_Household_NonfamilyHousehold"
+                    ],
+                    "title": "Nonfamily Household Median Income in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
                       "Median_Income_Person"
                     ],
                     "title": "Individual Median Income in Census Tracts of Placer County (${date})",
@@ -32,12 +113,117 @@
                 ]
               }
             ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Median_Income_Household_MarriedCoupleFamilyHousehold"
+                    ],
+                    "title": "Median Married Couple Family Household Income in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Median Married Couple Family Household Income in Placer County",
+                    "statVarKey": [
+                      "Median_Income_Household_MarriedCoupleFamilyHousehold"
+                    ],
+                    "title": "Median Married Couple Family Household Income in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Mean_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Average Income for Family Households in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Average Income for Family Households in Placer County",
+                    "statVarKey": [
+                      "Mean_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Average Income for Family Households in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Mean_Income_Household_NonfamilyHousehold"
+                    ],
+                    "title": "Average Income for Nonfamily Households in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Average Income for Nonfamily Households in Placer County",
+                    "statVarKey": [
+                      "Mean_Income_Household_NonfamilyHousehold"
+                    ],
+                    "title": "Average Income for Nonfamily Households in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
           }
         ],
         "statVarSpec": {
+          "Mean_Income_Household": {
+            "name": "Average Income for Households",
+            "statVar": "Mean_Income_Household"
+          },
+          "Mean_Income_Household_FamilyHousehold": {
+            "name": "Average Income for Family Households",
+            "statVar": "Mean_Income_Household_FamilyHousehold"
+          },
+          "Mean_Income_Household_NonfamilyHousehold": {
+            "name": "Average Income for Nonfamily Households",
+            "statVar": "Mean_Income_Household_NonfamilyHousehold"
+          },
           "Median_Income_Household": {
             "name": "Household Median Income",
             "statVar": "Median_Income_Household"
+          },
+          "Median_Income_Household_FamilyHousehold": {
+            "name": "Median Family Household Income",
+            "statVar": "Median_Income_Household_FamilyHousehold"
+          },
+          "Median_Income_Household_MarriedCoupleFamilyHousehold": {
+            "name": "Median Married Couple Family Household Income",
+            "statVar": "Median_Income_Household_MarriedCoupleFamilyHousehold"
+          },
+          "Median_Income_Household_NonfamilyHousehold": {
+            "name": "Nonfamily Household Median Income",
+            "statVar": "Median_Income_Household_NonfamilyHousehold"
           },
           "Median_Income_Person": {
             "name": "Individual Median Income",

--- a/server/integration_tests/test_data/usa_map_types/query_3/chart_config.json
+++ b/server/integration_tests/test_data/usa_map_types/query_3/chart_config.json
@@ -9,10 +9,121 @@
                 "tiles": [
                   {
                     "statVarKey": [
+                      "Count_Person_Unemployed"
+                    ],
+                    "title": "Population: Unemployed in Washington",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Unemployed in Washington",
+                    "statVarKey": [
+                      "Count_Person_Unemployed"
+                    ],
+                    "title": "Population: Unemployed in Washington",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "UnemploymentRate_Person"
+                    ],
+                    "title": "Unemployment Rate in Washington",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Unemployment Rate in Washington",
+                    "statVarKey": [
+                      "UnemploymentRate_Person"
+                    ],
+                    "title": "Unemployment Rate in Washington",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
                       "Count_Person_15OrMoreYears_NoIncome"
                     ],
                     "title": "Population of Working Age With No Income in Census Zip Code Tabulation Areas of Washington (${date})",
                     "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_DidNotWork"
+                    ],
+                    "title": "Population: 16 - 64 Years, Did Not Work in Washington",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: 16 - 64 Years, Did Not Work in Washington",
+                    "statVarKey": [
+                      "Count_Person_DidNotWork"
+                    ],
+                    "title": "Population: 16 - 64 Years, Did Not Work in Washington",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Male_DidNotWork"
+                    ],
+                    "title": "Population: 16 - 64 Years, Male, Did Not Work in Washington",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: 16 - 64 Years, Male, Did Not Work in Washington",
+                    "statVarKey": [
+                      "Count_Person_Male_DidNotWork"
+                    ],
+                    "title": "Population: 16 - 64 Years, Male, Did Not Work in Washington",
+                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -34,12 +145,60 @@
               }
             ],
             "denom": "Count_Person"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Household_FamilyHousehold_With0Worker"
+                    ],
+                    "title": "Count of Household: Family Household, Worker 0 in Washington",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Count of Household: Family Household, Worker 0 in Washington",
+                    "statVarKey": [
+                      "Count_Household_FamilyHousehold_With0Worker"
+                    ],
+                    "title": "Count of Household: Family Household, Worker 0 in Washington",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person"
           }
         ],
         "statVarSpec": {
+          "Count_Household_FamilyHousehold_With0Worker": {
+            "name": "Count of Household: Family Household, Worker 0",
+            "statVar": "Count_Household_FamilyHousehold_With0Worker"
+          },
           "Count_Person_15OrMoreYears_NoIncome": {
             "name": "Population of Working Age With No Income",
             "statVar": "Count_Person_15OrMoreYears_NoIncome"
+          },
+          "Count_Person_DidNotWork": {
+            "name": "Population: 16 - 64 Years, Did Not Work",
+            "statVar": "Count_Person_DidNotWork"
+          },
+          "Count_Person_Male_DidNotWork": {
+            "name": "Population: 16 - 64 Years, Male, Did Not Work",
+            "statVar": "Count_Person_Male_DidNotWork"
+          },
+          "Count_Person_Unemployed": {
+            "name": "Population: Unemployed",
+            "statVar": "Count_Person_Unemployed"
+          },
+          "UnemploymentRate_Person": {
+            "name": "Unemployment Rate",
+            "statVar": "UnemploymentRate_Person"
           },
           "dc/dyhxtqe2pxhl5": {
             "name": "Population: No Income, Foreign Born",

--- a/server/lib/explore/fulfiller.py
+++ b/server/lib/explore/fulfiller.py
@@ -49,7 +49,7 @@ class FulfillResp:
 def fulfill(uttr: nl_uttr.Utterance, cb_config: base.Config) -> FulfillResp:
   # This is a useful thing to set since checks for
   # single-point or not happen downstream.
-  uttr.query_type = nl_uttr.QueryType.SIMPLE
+  uttr.query_type = nl_uttr.QueryType.BASIC
   pt = cutils.get_contained_in_type(uttr)
   state = ftypes.PopulateState(uttr=uttr, place_type=pt)
 

--- a/server/lib/nl/common/utterance.py
+++ b/server/lib/nl/common/utterance.py
@@ -51,10 +51,7 @@ class ChartOriginType(IntEnum):
 # (ranking across vars vs. ranking across places).
 class QueryType(IntEnum):
   OTHER = 0
-  SIMPLE = 1
-  RANKING_ACROSS_PLACES = 2
-  RANKING_ACROSS_VARS = 3
-  CONTAINED_IN = 4
+  BASIC = 1
   CORRELATION_ACROSS_VARS = 5
   COMPARISON_ACROSS_PLACES = 6
   TIME_DELTA_ACROSS_VARS = 7
@@ -71,9 +68,9 @@ class QueryType(IntEnum):
 
 # Type of chart.
 class ChartType(IntEnum):
-  TIMELINE_CHART = 0
+  TIMELINE_WITH_HIGHLIGHT = 0
   MAP_CHART = 1
-  RANKING_CHART = 2
+  RANKING_WITH_MAP = 2
   BAR_CHART = 3
   PLACE_OVERVIEW = 4
   SCATTER_CHART = 5

--- a/server/lib/nl/config_builder/base.py
+++ b/server/lib/nl/config_builder/base.py
@@ -57,14 +57,16 @@ class Builder:
     self.config = config
 
     metadata = self.page_config.metadata
-    first_chart: ChartSpec = uttr.rankedCharts[0]
-    main_place = first_chart.places[0]
+    # TODO: Revisit this choice.
+    main_place = uttr.rankedCharts[0].places[0]
     metadata.place_dcid.append(main_place.dcid)
-    if (first_chart.chart_type == ChartType.MAP_CHART or
-        first_chart.chart_type == ChartType.RANKING_CHART or
-        first_chart.chart_type == ChartType.SCATTER_CHART):
-      metadata.contained_place_types[main_place.place_type] = \
-        first_chart.place_type
+    for ch in uttr.rankedCharts:
+      if (ch.chart_type == ChartType.MAP_CHART or
+          ch.chart_type == ChartType.RANKING_WITH_MAP or
+          ch.chart_type == ChartType.SCATTER_CHART):
+        metadata.contained_place_types[main_place.place_type] = \
+          ch.place_type
+        break
 
     self.category = self.page_config.categories.add()
     self.block = None

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -215,7 +215,9 @@ def _add_charts_with_existence_check(state: PopulateState,
     # for those we would construct a single bar chart comparing the differe
     # variables.  For other query-types like map/ranking/scatter, we will have
     # individual "related" charts, and those don't look good.
-    if qt == QueryType.SIMPLE and existing_svs:
+    #
+    # TODO: Optimize and enable in Explore mode.
+    if qt == QueryType.BASIC and existing_svs and not state.place_type and not state.ranking_types:
       # Note that we want to expand on existing_svs only, and in the
       # order of `svs`
       ordered_existing_svs = [v for v in svs if v in existing_svs]

--- a/server/lib/nl/fulfillment/basic.py
+++ b/server/lib/nl/fulfillment/basic.py
@@ -1,0 +1,99 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+from typing import List
+
+from server.lib.nl.common.utterance import ChartOriginType
+from server.lib.nl.detection.types import Place
+from server.lib.nl.detection.types import RankingType
+from server.lib.nl.fulfillment import containedin
+from server.lib.nl.fulfillment import ranking_across_places
+from server.lib.nl.fulfillment import ranking_across_vars
+from server.lib.nl.fulfillment import simple
+from server.lib.nl.fulfillment.types import ChartVars
+from server.lib.nl.fulfillment.types import PopulateState
+
+#
+# NOTE: basic is a layer on topic of simple, containedin, ranking_across_places and ranking_across_vars
+# The choice of the charts to show depends on the `explore_mode`
+#
+
+
+def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
+             chart_origin: ChartOriginType) -> bool:
+  if chart_vars.event:
+    state.uttr.counters.err('basic_failed_cb_events', 1)
+    return False
+  if not chart_vars:
+    state.uttr.counters.err('basic_failed_cb_missing_chat_vars', 1)
+    return False
+  if not chart_vars.svs:
+    state.uttr.counters.err('basic_failed_cb_missing_svs', 1)
+    return False
+  if not places:
+    state.uttr.counters.err('basic_failed_cb_noplace', places)
+    return False
+  if len(places) > 1:
+    state.uttr.counters.err('basic_failed_cb_toomanyplaces', places)
+    return False
+
+  if state.explore_mode:
+    return _populate_explore(state, chart_vars, places, chart_origin)
+  else:
+    return _populate_chat(state, chart_vars, places, chart_origin)
+
+
+# TODO: Support ranking across vars.
+def _populate_explore(state: PopulateState, chart_vars: ChartVars,
+                      places: List[Place],
+                      chart_origin: ChartOriginType) -> bool:
+  added = False
+  # First add timeline.
+  if chart_vars.is_topic_peer_group:
+    added |= simple.populate(state, chart_vars, places, chart_origin)
+
+  all_svs = copy.deepcopy(chart_vars.svs)
+  for sv in all_svs:
+    chart_vars.svs = [sv]
+    if not chart_vars.is_topic_peer_group:
+      added |= simple.populate(state, chart_vars, places, chart_origin)
+    ranking_orig = state.ranking_types
+    state.ranking_types = [RankingType.HIGH, RankingType.LOW]
+    added |= ranking_across_places.populate(state, chart_vars, places,
+                                            chart_origin)
+    state.ranking_types = ranking_orig
+
+  return added
+
+
+def _populate_chat(state: PopulateState, chart_vars: ChartVars,
+                   places: List[Place], chart_origin: ChartOriginType) -> bool:
+  if state.ranking_types:
+    # Ranking query
+    if state.place_type:
+      # This is ranking across places.
+      if ranking_across_places.populate(state, chart_vars, places,
+                                        chart_origin):
+        return True
+    else:
+      # This is ranking across vars.
+      if ranking_across_vars.populate(state, chart_vars, places, chart_origin):
+        return True
+
+  if state.place_type:
+    if containedin.populate(state, chart_vars, places, chart_origin):
+      return True
+
+  return simple.populate(state, chart_vars, places, chart_origin)

--- a/server/lib/nl/fulfillment/existence.py
+++ b/server/lib/nl/fulfillment/existence.py
@@ -64,7 +64,8 @@ class ExistenceCheckTracker:
 
   def _run(self):
     # Perform batch existence check.
-    if self.state.uttr.query_type == QueryType.SIMPLE:
+    # TODO: Optimize this!
+    if self.state.uttr.query_type == QueryType.BASIC:
       self.existing_svs, existsv2places = \
         utils.sv_existence_for_places_check_single_point(
           self.places, list(self.all_svs), self.state.uttr.counters)
@@ -126,10 +127,6 @@ class ExistenceCheckTracker:
     cv = cv_existence.chart_vars
     # Set existing SVs.
     cv.svs = cv_existence.exist_svs
-    # Set `has_single_point` if all SVs in the ChartVars have a single-data point.
-    # Do so only for SIMPLE charts.
-    if self.state.uttr.query_type == QueryType.SIMPLE:
-      cv.has_single_point = all(self.existing_svs.get(v, False) for v in cv.svs)
     return cv
 
 

--- a/server/lib/nl/fulfillment/fulfiller.py
+++ b/server/lib/nl/fulfillment/fulfiller.py
@@ -35,7 +35,7 @@ import server.lib.nl.fulfillment.utils as futils
 #
 # Populate chart candidates in the utterance.
 #
-def fulfill(uttr: Utterance) -> Utterance:
+def fulfill(uttr: Utterance, explore_mode: bool = False) -> Utterance:
   # Construct a common PopulateState
   state = PopulateState(uttr=uttr)
 
@@ -49,6 +49,7 @@ def fulfill(uttr: Utterance) -> Utterance:
   state.time_delta_types = utils.get_time_delta_types(uttr)
   state.quantity = utils.get_quantity(uttr)
   state.event_types = utils.get_event_types(uttr)
+  state.explore_mode = explore_mode
 
   if not state.query_types:
     uttr.counters.err('fulfill_empty_querytypes', '')

--- a/server/lib/nl/fulfillment/handlers.py
+++ b/server/lib/nl/fulfillment/handlers.py
@@ -16,6 +16,7 @@
 from dataclasses import dataclass
 from typing import List
 
+import server.lib.nl.common.utils as cutils
 from server.lib.nl.common.utterance import FulfillmentResult
 from server.lib.nl.common.utterance import QueryType
 from server.lib.nl.common.utterance import Utterance
@@ -121,12 +122,15 @@ def _maybe_remap_basic(uttr: Utterance) -> QueryType:
   elif len(uttr.places) > 1:
     # Promote to place comparison.
     remapped_type = QueryType.COMPARISON_ACROSS_PLACES
+  else:
+    _maybe_add_containedin(uttr)
   return remapped_type
 
 
 def _maybe_add_containedin(uttr: Utterance) -> bool:
   if (len(uttr.places) == 1 and (uttr.places[0].place_type == 'Continent' or
-                                 uttr.places[0].dcid == 'Earth')):
+                                 uttr.places[0].dcid == 'Earth') and
+      not cutils.get_contained_in_type(uttr)):
     uttr.classifications.append(
         NLClassifier(
             type=ClassificationType.CONTAINED_IN,

--- a/server/lib/nl/fulfillment/handlers.py
+++ b/server/lib/nl/fulfillment/handlers.py
@@ -24,14 +24,11 @@ from server.lib.nl.detection.types import ClassificationType
 from server.lib.nl.detection.types import ContainedInClassificationAttributes
 from server.lib.nl.detection.types import ContainedInPlaceType
 from server.lib.nl.detection.types import NLClassifier
+from server.lib.nl.fulfillment import basic
 from server.lib.nl.fulfillment import comparison
-from server.lib.nl.fulfillment import containedin
 from server.lib.nl.fulfillment import correlation
 from server.lib.nl.fulfillment import filter_with_dual_vars
 from server.lib.nl.fulfillment import filter_with_single_var
-from server.lib.nl.fulfillment import ranking_across_places
-from server.lib.nl.fulfillment import ranking_across_vars
-from server.lib.nl.fulfillment import simple
 from server.lib.nl.fulfillment import size_across_entities
 from server.lib.nl.fulfillment import time_delta_across_places
 from server.lib.nl.fulfillment import time_delta_across_vars
@@ -52,57 +49,41 @@ class QueryHandlerConfig:
 
 
 QUERY_HANDLERS = {
-    QueryType.SIMPLE:
-        QueryHandlerConfig(module=simple,
+    QueryType.BASIC:
+        QueryHandlerConfig(module=basic,
                            rank=1,
                            direct_fallback=QueryType.OVERVIEW),
 
-    # Important to have CONTAINED_IN be right after SIMPLE.
-    # Because we often promote SIMPLE to CONTAINED_IN, and
-    # for larger places they are very similar.
-    QueryType.CONTAINED_IN:
-        QueryHandlerConfig(module=containedin,
-                           rank=2,
-                           direct_fallback=QueryType.SIMPLE),
     # Comparison has a more complex fallback logic captured in next_query_type().
     QueryType.COMPARISON_ACROSS_PLACES:
-        QueryHandlerConfig(module=comparison, rank=3),
-    QueryType.RANKING_ACROSS_VARS:
-        QueryHandlerConfig(module=ranking_across_vars,
-                           rank=4,
-                           direct_fallback=QueryType.SIMPLE),
-    QueryType.RANKING_ACROSS_PLACES:
-        QueryHandlerConfig(module=ranking_across_places,
-                           rank=5,
-                           direct_fallback=QueryType.SIMPLE),
+        QueryHandlerConfig(module=comparison, rank=2),
 
     # Correlation has a more complex fallback logic captured in next_query_type().
     QueryType.CORRELATION_ACROSS_VARS:
-        QueryHandlerConfig(module=correlation, rank=6),
+        QueryHandlerConfig(module=correlation, rank=3),
     QueryType.TIME_DELTA_ACROSS_VARS:
         QueryHandlerConfig(module=time_delta_across_vars,
-                           rank=7,
-                           direct_fallback=QueryType.SIMPLE),
+                           rank=4,
+                           direct_fallback=QueryType.BASIC),
     QueryType.TIME_DELTA_ACROSS_PLACES:
         QueryHandlerConfig(module=time_delta_across_places,
-                           rank=8,
-                           direct_fallback=QueryType.SIMPLE),
+                           rank=5,
+                           direct_fallback=QueryType.BASIC),
     QueryType.EVENT:
-        QueryHandlerConfig(module=None,
-                           rank=9,
-                           direct_fallback=QueryType.SIMPLE),
+        QueryHandlerConfig(module=None, rank=6,
+                           direct_fallback=QueryType.BASIC),
     QueryType.SIZE_ACROSS_ENTITIES:
         QueryHandlerConfig(module=size_across_entities,
-                           rank=10,
-                           direct_fallback=QueryType.SIMPLE),
+                           rank=7,
+                           direct_fallback=QueryType.BASIC),
     QueryType.FILTER_WITH_SINGLE_VAR:
         QueryHandlerConfig(module=filter_with_single_var,
-                           rank=11,
-                           direct_fallback=QueryType.CONTAINED_IN),
+                           rank=8,
+                           direct_fallback=QueryType.BASIC),
     QueryType.FILTER_WITH_DUAL_VARS:
         QueryHandlerConfig(module=filter_with_dual_vars,
-                           rank=12,
-                           direct_fallback=QueryType.CONTAINED_IN),
+                           rank=9,
+                           direct_fallback=QueryType.BASIC),
 
     # Overview trumps everything else ("tell us about"), and
     # has no fallback.
@@ -116,7 +97,7 @@ QUERY_HANDLERS = {
 # The first query_type to try for the given utterance.  If there are multiple
 # classifications, we pick from among them.
 def first_query_type(uttr: Utterance):
-  query_types = [QueryType.SIMPLE]
+  query_types = [QueryType.BASIC]
   for cl in uttr.classifications:
     qtype = _classification_to_query_type(cl, uttr)
     if qtype != None and qtype not in query_types:
@@ -130,8 +111,8 @@ def first_query_type(uttr: Utterance):
   return None
 
 
-def _maybe_remap_simple(uttr: Utterance) -> QueryType:
-  remapped_type = QueryType.SIMPLE
+def _maybe_remap_basic(uttr: Utterance) -> QueryType:
+  remapped_type = QueryType.BASIC
   if (uttr.detection and uttr.detection.places_detected and
       uttr.detection.places_detected.places_found and
       not uttr.detection.places_detected.query_without_place_substr):
@@ -140,8 +121,6 @@ def _maybe_remap_simple(uttr: Utterance) -> QueryType:
   elif len(uttr.places) > 1:
     # Promote to place comparison.
     remapped_type = QueryType.COMPARISON_ACROSS_PLACES
-  elif _maybe_add_containedin(uttr):
-    remapped_type = QueryType.CONTAINED_IN
   return remapped_type
 
 
@@ -160,16 +139,16 @@ def _maybe_add_containedin(uttr: Utterance) -> bool:
 def _classification_to_query_type(cl: NLClassifier,
                                   uttr: Utterance) -> QueryType:
   if cl.type == ClassificationType.CONTAINED_IN:
-    query_type = QueryType.CONTAINED_IN
+    query_type = QueryType.BASIC
   elif cl.type == ClassificationType.EVENT:
     query_type = QueryType.EVENT
   elif cl.type == ClassificationType.SIZE_TYPE:
     query_type = QueryType.SIZE_ACROSS_ENTITIES
   elif cl.type == ClassificationType.SIMPLE:
-    query_type = QueryType.SIMPLE
+    query_type = QueryType.BASIC
   elif cl.type == ClassificationType.OVERVIEW:
     if uttr.svs and uttr.sv_source == FulfillmentResult.CURRENT_QUERY:
-      query_type = QueryType.SIMPLE
+      query_type = QueryType.BASIC
     else:
       # We detected some overview words ("tell me about") *and* there were
       # no SVs in current utterance, so consider it a place overview.
@@ -180,10 +159,7 @@ def _classification_to_query_type(cl: NLClassifier,
     _maybe_add_containedin(uttr)
     classification = futils.classifications_of_type_from_utterance(
         uttr, ClassificationType.CONTAINED_IN)
-    if classification:
-      query_type = QueryType.RANKING_ACROSS_PLACES
-    else:
-      query_type = QueryType.RANKING_ACROSS_VARS
+    query_type = QueryType.BASIC
   elif cl.type == ClassificationType.TIME_DELTA:
     _maybe_add_containedin(uttr)
     classification = futils.classifications_of_type_from_utterance(
@@ -201,12 +177,12 @@ def _classification_to_query_type(cl: NLClassifier,
     else:
       query_type = QueryType.FILTER_WITH_SINGLE_VAR
   else:
-    # For any unsupported type, fallback to SIMPLE
+    # For any unsupported type, fallback to BASIC
     # TODO: Handle this better.
-    query_type = QueryType.SIMPLE
+    query_type = QueryType.BASIC
 
-  if query_type == QueryType.SIMPLE:
-    query_type = _maybe_remap_simple(uttr)
+  if query_type == QueryType.BASIC:
+    query_type = _maybe_remap_basic(uttr)
 
   return query_type
 
@@ -228,12 +204,12 @@ def next_query_type(query_types: List[QueryType]) -> QueryType:
     if QueryType.CORRELATION_ACROSS_VARS not in query_types:
       next_type = QueryType.CORRELATION_ACROSS_VARS
     else:
-      next_type = QueryType.CONTAINED_IN
+      next_type = QueryType.BASIC
   elif prev_type == QueryType.CORRELATION_ACROSS_VARS:
     if QueryType.COMPARISON_ACROSS_PLACES not in query_types:
       next_type = QueryType.COMPARISON_ACROSS_PLACES
     else:
-      next_type = QueryType.CONTAINED_IN
+      next_type = QueryType.BASIC
 
   return next_type
 

--- a/server/lib/nl/fulfillment/ranking_across_places.py
+++ b/server/lib/nl/fulfillment/ranking_across_places.py
@@ -62,5 +62,5 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
 
     if not utils.has_map(state.place_type, places):
       chart_vars.skip_map_for_ranking = True
-    return add_chart_to_utterance(ChartType.RANKING_CHART, state, chart_vars,
+    return add_chart_to_utterance(ChartType.RANKING_WITH_MAP, state, chart_vars,
                                   places, chart_origin)

--- a/server/lib/nl/fulfillment/simple.py
+++ b/server/lib/nl/fulfillment/simple.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from typing import List
 
 import server.lib.explore.existence as ext
@@ -41,25 +42,45 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
     return add_chart_to_utterance(ChartType.EVENT_CHART, state, chart_vars,
                                   places, chart_origin)
 
-  exist_svs = ext.svs4place(state, places[0], chart_vars.svs).exist_svs
-  if not exist_svs:
-    state.uttr.counters.err('simple_failed_existence', 1)
-    return False
-  chart_vars.svs = exist_svs
+  if chart_vars.is_topic_peer_group:
+    eres = ext.svs4place(state, places[0], chart_vars.svs)
+    if not eres.exist_svs:
+      state.uttr.counters.err('simple_failed_existence', 1)
+      return False
+    chart_vars.svs = eres.exist_svs
 
-  if len(chart_vars.svs) <= _MAX_VARS_PER_CHART:
-    # For fewer SVs, comparing trends over time is nicer.
-    chart_type = ChartType.TIMELINE_CHART
-  else:
-    # When there are too many, comparing latest values is better
-    # (than, say, breaking it into multiple timeline charts)
-    chart_type = ChartType.BAR_CHART
-  if chart_type == ChartType.TIMELINE_CHART:
-    if chart_vars.has_single_point:
-      # Demote to bar chart if single point.
-      # TODO: eventually for single SV case, make it a highlight chart
+    if len(chart_vars.svs) <= _MAX_VARS_PER_CHART:
+      # For fewer SVs, comparing trends over time is nicer.
+      chart_type = ChartType.TIMELINE_WITH_HIGHLIGHT
+    else:
+      # When there are too many, comparing latest values is better
+      # (than, say, breaking it into multiple timeline charts)
       chart_type = ChartType.BAR_CHART
-      state.uttr.counters.info('simple_timeline_to_bar_demotions', 1)
+    chart_type = _maybe_demote(chart_type, eres.is_single_point, state)
+    return add_chart_to_utterance(chart_type, state, chart_vars, places,
+                                  chart_origin)
+  else:
+    # If its not a peer-group add one chart at a time.
+    added = False
+    all_svs = copy.deepcopy(chart_vars.svs)
+    for sv in all_svs:
+      chart_vars.svs = [sv]
+      eres = ext.svs4place(state, places[0], chart_vars.svs)
+      if not eres.exist_svs:
+        state.uttr.counters.err('simple_failed_existence', 1)
+        return False
+      chart_type = _maybe_demote(ChartType.TIMELINE_WITH_HIGHLIGHT,
+                                 eres.is_single_point, state)
+      added |= add_chart_to_utterance(chart_type, state, chart_vars, places,
+                                      chart_origin)
+    return added
 
-  return add_chart_to_utterance(chart_type, state, chart_vars, places,
-                                chart_origin)
+
+def _maybe_demote(chart_type: ChartType, is_single_point: bool,
+                  state: PopulateState) -> ChartType:
+  if chart_type == ChartType.TIMELINE_WITH_HIGHLIGHT and is_single_point:
+    state.uttr.counters.info('simple_timeline_to_bar_demotions', 1)
+    # Demote to bar chart if single point.
+    # TODO: eventually for single SV case, make it a highlight chart
+    return ChartType.BAR_CHART
+  return chart_type

--- a/server/lib/nl/fulfillment/size_across_entities.py
+++ b/server/lib/nl/fulfillment/size_across_entities.py
@@ -126,5 +126,5 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
   # No map chart for these.
   chart_vars.skip_map_for_ranking = True
   # We want all the ranking tables lined up in a single block.
-  return add_chart_to_utterance(ChartType.RANKING_CHART, state, chart_vars,
+  return add_chart_to_utterance(ChartType.RANKING_WITH_MAP, state, chart_vars,
                                 places, chart_origin)

--- a/server/lib/nl/fulfillment/types.py
+++ b/server/lib/nl/fulfillment/types.py
@@ -62,8 +62,6 @@ class ChartVars:
   # When `svs` has multiple entries and corresponds to expansion, this represents
   # the original SV.
   orig_sv: str = ""
-  # Set for SIMPLE query when all SVs have only one data point.
-  has_single_point: bool = False
 
   # Relevant only when chart_type is RANKED_TIMELINE_COLLECTION
   growth_direction: TimeDeltaType = None
@@ -93,6 +91,8 @@ class PopulateState:
   # SV -> Place Keys
   # Where Place Key may be the place DCID, or place DCID + child-type.
   exist_checks: Dict[str, Set[str]] = field(default_factory=dict)
+  # Whether this is explore mode of fulfillment.
+  explore_mode: bool = False
 
 
 @dataclass

--- a/server/tests/lib/nl/test_utterance.py
+++ b/server/tests/lib/nl/test_utterance.py
@@ -149,7 +149,7 @@ SIMPLE_UTTR = {
     },
     'placeFallback': {},
     'query': 'foo sv in place',
-    'query_type': QueryType.SIMPLE,
+    'query_type': QueryType.BASIC,
     'ranked_charts': [{
         'chart_vars': {
             'description': '',
@@ -229,7 +229,7 @@ SIMPLE_WITH_SV_EXT_UTTR = {
     },
     'placeFallback': {},
     'query': 'foo sv in place',
-    'query_type': QueryType.SIMPLE,
+    'query_type': QueryType.BASIC,
     'ranked_charts': [{
         'chart_vars': {
             'description': '',
@@ -309,7 +309,7 @@ SIMPLE_WITH_TOPIC_UTTR = {
     },
     'placeFallback': {},
     'query': 'foo sv in place',
-    'query_type': QueryType.SIMPLE,
+    'query_type': QueryType.BASIC,
     'ranked_charts': [{
         'chart_vars': {
             'description': '',
@@ -518,7 +518,7 @@ CONTAINED_IN_UTTR = {
     },
     'placeFallback': {},
     'query': 'foo sv in place',
-    'query_type': QueryType.CONTAINED_IN,
+    'query_type': QueryType.BASIC,
     'ranked_charts': [{
         'chart_vars': {
             'description': '',
@@ -749,7 +749,7 @@ RANKING_ACROSS_PLACES_UTTR = {
     },
     'placeFallback': {},
     'query': 'foo sv in place',
-    'query_type': QueryType.RANKING_ACROSS_PLACES,
+    'query_type': QueryType.BASIC,
     'ranked_charts': [{
         'chart_vars': {
             'description': '',
@@ -805,7 +805,7 @@ RANKING_ACROSS_SVS_UTTR = {
     },
     'placeFallback': {},
     'query': 'foo sv in place',
-    'query_type': QueryType.RANKING_ACROSS_VARS,
+    'query_type': QueryType.BASIC,
     'ranked_charts': [{
         'chart_vars': {
             'description': '',
@@ -992,7 +992,7 @@ SIMPLE_BAR_DOWNGRADE_UTTR = {
     },
     'placeFallback': {},
     'query': 'foo sv in place',
-    'query_type': QueryType.SIMPLE,
+    'query_type': QueryType.BASIC,
     'ranked_charts': [{
         'chart_vars': {
             'description': '',

--- a/server/tests/lib/nl/test_utterance.py
+++ b/server/tests/lib/nl/test_utterance.py
@@ -168,7 +168,7 @@ SIMPLE_UTTR = {
         },
         'ranking_types': [],
         'place_type': None,
-        'chart_type': ChartType.TIMELINE_CHART,
+        'chart_type': ChartType.TIMELINE_WITH_HIGHLIGHT,
         'places': [{
             'dcid': 'geoId/06',
             'name': 'Foo Place',
@@ -195,7 +195,7 @@ SIMPLE_UTTR = {
         },
         'ranking_types': [],
         'place_type': None,
-        'chart_type': ChartType.TIMELINE_CHART,
+        'chart_type': ChartType.TIMELINE_WITH_HIGHLIGHT,
         'places': [{
             'dcid': 'geoId/06',
             'name': 'Foo Place',
@@ -248,7 +248,7 @@ SIMPLE_WITH_SV_EXT_UTTR = {
         },
         'ranking_types': [],
         'place_type': None,
-        'chart_type': ChartType.TIMELINE_CHART,
+        'chart_type': ChartType.TIMELINE_WITH_HIGHLIGHT,
         'places': [{
             'dcid': 'geoId/06',
             'name': 'Foo Place',
@@ -275,7 +275,7 @@ SIMPLE_WITH_SV_EXT_UTTR = {
         },
         'ranking_types': [],
         'place_type': None,
-        'chart_type': ChartType.TIMELINE_CHART,
+        'chart_type': ChartType.TIMELINE_WITH_HIGHLIGHT,
         'places': [{
             'dcid': 'geoId/06',
             'name': 'Foo Place',
@@ -328,7 +328,7 @@ SIMPLE_WITH_TOPIC_UTTR = {
         },
         'ranking_types': [],
         'place_type': None,
-        'chart_type': ChartType.TIMELINE_CHART,
+        'chart_type': ChartType.TIMELINE_WITH_HIGHLIGHT,
         'places': [{
             'dcid': 'geoId/06',
             'name': 'Foo Place',
@@ -354,7 +354,7 @@ SIMPLE_WITH_TOPIC_UTTR = {
             'title_suffix': ''
         },
         'ranking_types': [],
-        'chart_type': ChartType.TIMELINE_CHART,
+        'chart_type': ChartType.TIMELINE_WITH_HIGHLIGHT,
         'place_type': None,
         'places': [{
             'dcid': 'geoId/06',
@@ -382,7 +382,7 @@ SIMPLE_WITH_TOPIC_UTTR = {
         },
         'ranking_types': [],
         'place_type': None,
-        'chart_type': ChartType.TIMELINE_CHART,
+        'chart_type': ChartType.TIMELINE_WITH_HIGHLIGHT,
         'places': [{
             'dcid': 'geoId/06',
             'name': 'Foo Place',
@@ -768,7 +768,7 @@ RANKING_ACROSS_PLACES_UTTR = {
         },
         'ranking_types': [RankingType.HIGH],
         'place_type': 'County',
-        'chart_type': ChartType.RANKING_CHART,
+        'chart_type': ChartType.RANKING_WITH_MAP,
         'places': [{
             'dcid': 'geoId/06',
             'name': 'Foo Place',


### PR DESCRIPTION
This change adds a new fulfillment handler called "basic" which encompasses:
* simple
* containedin
* ranking_across_places
* ranking_across_vars
(the names need some tweaking, like what's basic vs. simple, but that's in followup)

The "basic" handler, depending on whether it is explore vs. chat, will route to one or more of these components appropriately.

Also, for every single-line timeline (in both modes), add a highlight, and demote a single-bar barchart to highlight.

IMPORTANT NOTE:  This change makes all of the existence checks to require "is it single point", so that makes things a LOT more expensive, esp for [What are the projected temperature extremes across california].

REGRESSION NOTES:

1.  After this change, chat will show a bunch more charts.  As an example, for query [asthma in california counties], suppose it returns asthma and childhood asthma, and suppose asthma doesn't exist at county-level (it does exist, but just suppose), then today we'll not show asthma at all.  After this change we'll show asthma line chart and childhood asthma map.

2. There are cases where the "extension SVs" maybe removed (in diffs), that will be fixed in upcoming PRs.