### PR TITLE
Parity: Enable event charts and ranking-across-vars

### DIFF
--- a/server/integration_tests/test_data/demo_fallback/query_3/chart_config.json
+++ b/server/integration_tests/test_data/demo_fallback/query_3/chart_config.json
@@ -37,6 +37,9 @@
               {
                 "tiles": [
                   {
+                    "barTileSpec": {
+                      "sort": "DESCENDING"
+                    },
                     "comparisonPlaces": [
                       "geoId/06"
                     ],

--- a/server/integration_tests/test_data/demo_feb2023/query_2/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_2/chart_config.json
@@ -32,8 +32,315 @@
               }
             ],
             "type": "DISASTER_EVENT"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "Count_WildlandFireEvent"
+                    ],
+                    "title": "Count of Wildland Fire Event in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_WildlandFireEvent"
+                    ],
+                    "title": "Count of Wildland Fire Event in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Count of Wildland Fire Event"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "BurnedArea_FireEvent"
+                    ],
+                    "title": "Total area that burned (Acres) in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "BurnedArea_FireEvent"
+                    ],
+                    "title": "Total area that burned (Acres) in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Total area that burned (Acres)"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "Percent_BurnedArea_FireEvent"
+                    ],
+                    "title": "Percent of area that burned in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_BurnedArea_FireEvent"
+                    ],
+                    "title": "Percent of area that burned in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Percent of area that burned"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "Percent_BurnedArea_FireEvent_Forest_HighSeverity"
+                    ],
+                    "title": "Percent of forest area that experienced high-severity fire in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_BurnedArea_FireEvent_Forest_HighSeverity"
+                    ],
+                    "title": "Percent of forest area that experienced high-severity fire in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Percent of forest area that experienced high-severity fire"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/06"
+                    ],
+                    "statVarKey": [
+                      "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_Ammonia_multiple_place_bar_block",
+                      "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_CarbonMonoxide_multiple_place_bar_block",
+                      "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_OxidesOfNitrogen_multiple_place_bar_block",
+                      "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_PM10_multiple_place_bar_block",
+                      "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_PM2.5_multiple_place_bar_block",
+                      "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_SulfurDioxide_multiple_place_bar_block",
+                      "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_VolatileOrganicCompound_multiple_place_bar_block"
+                    ],
+                    "title": "Wildfire Emissions by Pollutant in California (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Wildfire Emissions by Pollutant"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "Count_WildfireEvent"
+                    ],
+                    "title": "Wildfires in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_WildfireEvent"
+                    ],
+                    "title": "Wildfires in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Wildfires"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "Count_FireIncidentComplex"
+                    ],
+                    "title": "Count of Fire Incident Complex Event in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_FireIncidentComplex"
+                    ],
+                    "title": "Count of Fire Incident Complex Event in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Count of Fire Incident Complex Event"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "Annual_ExpectedLoss_NaturalHazardImpact_WildfireEvent"
+                    ],
+                    "title": "Annual Expected Loss from Natural Hazard Impact: Wildfire in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Annual_ExpectedLoss_NaturalHazardImpact_WildfireEvent"
+                    ],
+                    "title": "Annual Expected Loss from Natural Hazard Impact: Wildfire in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Annual Expected Loss from Natural Hazard Impact: Wildfire"
           }
-        ]
+        ],
+        "statVarSpec": {
+          "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_Ammonia_multiple_place_bar_block": {
+            "name": "Annual Amount of Emissions: Wildfire, Non Biogenic Emission Source, Ammonia",
+            "statVar": "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_Ammonia"
+          },
+          "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_CarbonMonoxide_multiple_place_bar_block": {
+            "name": "Annual Amount of Emissions: Wildfire, Non Biogenic Emission Source, Carbon Monoxide",
+            "statVar": "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_CarbonMonoxide"
+          },
+          "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_OxidesOfNitrogen_multiple_place_bar_block": {
+            "name": "Annual Amount of Emissions: Wildfire, Non Biogenic Emission Source, Oxides of Nitrogen",
+            "statVar": "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_OxidesOfNitrogen"
+          },
+          "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_PM10_multiple_place_bar_block": {
+            "name": "Annual Amount of Emissions: Wildfire, Non Biogenic Emission Source, PM 10",
+            "statVar": "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_PM10"
+          },
+          "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_PM2.5_multiple_place_bar_block": {
+            "name": "Annual Amount of Emissions: Wildfire, Non Biogenic Emission Source, PM 2.5",
+            "statVar": "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_PM2.5"
+          },
+          "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_SulfurDioxide_multiple_place_bar_block": {
+            "name": "Annual Amount of Emissions: Wildfire, Non Biogenic Emission Source, Sulfur Dioxide",
+            "statVar": "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_SulfurDioxide"
+          },
+          "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_VolatileOrganicCompound_multiple_place_bar_block": {
+            "name": "Annual Amount of Emissions: Wildfire, Non Biogenic Emission Source, Volatile Organic Compound",
+            "statVar": "Annual_Amount_Emissions_Wildfire_NonBiogenicEmissionSource_VolatileOrganicCompound"
+          },
+          "Annual_ExpectedLoss_NaturalHazardImpact_WildfireEvent": {
+            "name": "Annual Expected Loss from Natural Hazard Impact: Wildfire",
+            "statVar": "Annual_ExpectedLoss_NaturalHazardImpact_WildfireEvent"
+          },
+          "BurnedArea_FireEvent": {
+            "name": "Total area that burned (Acres)",
+            "statVar": "BurnedArea_FireEvent"
+          },
+          "Count_FireIncidentComplex": {
+            "name": "Count of Fire Incident Complex Event",
+            "statVar": "Count_FireIncidentComplex"
+          },
+          "Count_WildfireEvent": {
+            "name": "Wildfires",
+            "statVar": "Count_WildfireEvent"
+          },
+          "Count_WildlandFireEvent": {
+            "name": "Count of Wildland Fire Event",
+            "statVar": "Count_WildlandFireEvent"
+          },
+          "Percent_BurnedArea_FireEvent": {
+            "name": "Percent of area that burned",
+            "statVar": "Percent_BurnedArea_FireEvent",
+            "unit": "%"
+          },
+          "Percent_BurnedArea_FireEvent_Forest_HighSeverity": {
+            "name": "Percent of forest area that experienced high-severity fire",
+            "statVar": "Percent_BurnedArea_FireEvent_Forest_HighSeverity",
+            "unit": "%"
+          }
+        }
       }
     ],
     "metadata": {

--- a/server/integration_tests/test_data/demo_feb2023/query_4/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_4/chart_config.json
@@ -8,29 +8,32 @@
               {
                 "tiles": [
                   {
+                    "barTileSpec": {
+                      "sort": "DESCENDING"
+                    },
                     "comparisonPlaces": [
                       "geoId/06061"
                     ],
                     "statVarKey": [
-                      "Count_Worker_NAICSHealthCareSocialAssistance_multiple_place_bar_block",
-                      "dc/p69tpsldf99h7_multiple_place_bar_block",
                       "Count_Worker_NAICSAccommodationFoodServices_multiple_place_bar_block",
+                      "Count_Worker_NAICSAdministrativeSupportWasteManagementRemediationServices_multiple_place_bar_block",
+                      "Count_Worker_NAICSAgricultureForestryFishingHunting_multiple_place_bar_block",
                       "Count_Worker_NAICSConstruction_multiple_place_bar_block",
                       "Count_Worker_NAICSEducationalServices_multiple_place_bar_block",
-                      "Count_Worker_NAICSAdministrativeSupportWasteManagementRemediationServices_multiple_place_bar_block",
-                      "Count_Worker_NAICSProfessionalScientificTechnicalServices_multiple_place_bar_block",
-                      "Count_Worker_NAICSFinanceInsurance_multiple_place_bar_block",
-                      "Count_Worker_NAICSOtherServices_multiple_place_bar_block",
-                      "Count_Worker_NAICSArtsEntertainmentRecreation_multiple_place_bar_block",
-                      "Count_Worker_NAICSPublicAdministration_multiple_place_bar_block",
+                      "Count_Worker_NAICSHealthCareSocialAssistance_multiple_place_bar_block",
                       "dc/ndg1xk1e9frc2_multiple_place_bar_block",
-                      "Count_Worker_NAICSRealEstateRentalLeasing_multiple_place_bar_block",
-                      "Count_Worker_NAICSWholesaleTrade_multiple_place_bar_block",
+                      "Count_Worker_NAICSFinanceInsurance_multiple_place_bar_block",
                       "Count_Worker_NAICSInformation_multiple_place_bar_block",
+                      "Count_Worker_NAICSArtsEntertainmentRecreation_multiple_place_bar_block",
+                      "Count_Worker_NAICSMiningQuarryingOilGasExtraction_multiple_place_bar_block",
+                      "Count_Worker_NAICSOtherServices_multiple_place_bar_block",
                       "dc/8p97n7l96lgg8_multiple_place_bar_block",
-                      "Count_Worker_NAICSAgricultureForestryFishingHunting_multiple_place_bar_block",
                       "Count_Worker_NAICSUtilities_multiple_place_bar_block",
-                      "Count_Worker_NAICSMiningQuarryingOilGasExtraction_multiple_place_bar_block"
+                      "dc/p69tpsldf99h7_multiple_place_bar_block",
+                      "Count_Worker_NAICSRealEstateRentalLeasing_multiple_place_bar_block",
+                      "Count_Worker_NAICSPublicAdministration_multiple_place_bar_block",
+                      "Count_Worker_NAICSWholesaleTrade_multiple_place_bar_block",
+                      "Count_Worker_NAICSProfessionalScientificTechnicalServices_multiple_place_bar_block"
                     ],
                     "title": "Categories of Jobs in Placer County (${date})",
                     "type": "BAR"

--- a/server/integration_tests/test_data/demo_feb2023/query_6/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_6/chart_config.json
@@ -8,21 +8,24 @@
               {
                 "tiles": [
                   {
+                    "barTileSpec": {
+                      "sort": "DESCENDING"
+                    },
                     "comparisonPlaces": [
                       "geoId/06061"
                     ],
                     "statVarKey": [
-                      "Percent_Person_WithHighCholesterol_multiple_place_bar_block",
-                      "Percent_Person_WithHighBloodPressure_multiple_place_bar_block",
                       "Percent_Person_WithArthritis_multiple_place_bar_block",
-                      "Percent_Person_WithMentalHealthNotGood_multiple_place_bar_block",
                       "Percent_Person_WithAsthma_multiple_place_bar_block",
-                      "Percent_Person_WithPhysicalHealthNotGood_multiple_place_bar_block",
-                      "Percent_Person_WithDiabetes_multiple_place_bar_block",
                       "Percent_Person_WithCancerExcludingSkinCancer_multiple_place_bar_block",
+                      "Percent_Person_WithChronicKidneyDisease_multiple_place_bar_block",
                       "Percent_Person_WithChronicObstructivePulmonaryDisease_multiple_place_bar_block",
                       "Percent_Person_WithCoronaryHeartDisease_multiple_place_bar_block",
-                      "Percent_Person_WithChronicKidneyDisease_multiple_place_bar_block",
+                      "Percent_Person_WithDiabetes_multiple_place_bar_block",
+                      "Percent_Person_WithHighBloodPressure_multiple_place_bar_block",
+                      "Percent_Person_WithHighCholesterol_multiple_place_bar_block",
+                      "Percent_Person_WithMentalHealthNotGood_multiple_place_bar_block",
+                      "Percent_Person_WithPhysicalHealthNotGood_multiple_place_bar_block",
                       "Percent_Person_WithStroke_multiple_place_bar_block"
                     ],
                     "title": "Prevalence of Health Conditions in Placer County (${date})",
@@ -196,16 +199,19 @@
               {
                 "tiles": [
                   {
+                    "barTileSpec": {
+                      "sort": "DESCENDING"
+                    },
                     "comparisonPlaces": [
                       "geoId/06061"
                     ],
                     "statVarKey": [
-                      "Count_Death_75To84Years_Neoplasms_multiple_place_bar_block",
-                      "Count_Death_65To74Years_Neoplasms_multiple_place_bar_block",
-                      "Count_Death_85Years_Neoplasms_multiple_place_bar_block",
-                      "Count_Death_55To64Years_Neoplasms_multiple_place_bar_block",
+                      "Count_Death_35To44Years_Neoplasms_multiple_place_bar_block",
                       "Count_Death_45To54Years_Neoplasms_multiple_place_bar_block",
-                      "Count_Death_35To44Years_Neoplasms_multiple_place_bar_block"
+                      "Count_Death_55To64Years_Neoplasms_multiple_place_bar_block",
+                      "Count_Death_65To74Years_Neoplasms_multiple_place_bar_block",
+                      "Count_Death_75To84Years_Neoplasms_multiple_place_bar_block",
+                      "Count_Death_85Years_Neoplasms_multiple_place_bar_block"
                     ],
                     "title": "Cancer Deaths by Age in Placer County (${date})",
                     "type": "BAR"
@@ -221,6 +227,9 @@
               {
                 "tiles": [
                   {
+                    "barTileSpec": {
+                      "sort": "DESCENDING"
+                    },
                     "comparisonPlaces": [
                       "geoId/06061"
                     ],
@@ -383,13 +392,16 @@
               {
                 "tiles": [
                   {
+                    "barTileSpec": {
+                      "sort": "DESCENDING"
+                    },
                     "comparisonPlaces": [
                       "geoId/06061"
                     ],
                     "statVarKey": [
-                      "Count_Death_85Years_MentalBehaviouralDisorders_multiple_place_bar_block",
+                      "Count_Death_65To74Years_MentalBehaviouralDisorders_multiple_place_bar_block",
                       "Count_Death_75To84Years_MentalBehaviouralDisorders_multiple_place_bar_block",
-                      "Count_Death_65To74Years_MentalBehaviouralDisorders_multiple_place_bar_block"
+                      "Count_Death_85Years_MentalBehaviouralDisorders_multiple_place_bar_block"
                     ],
                     "title": "Mental Health Deaths by Age in Placer County (${date})",
                     "type": "BAR"

--- a/server/integration_tests/test_data/international/query_5/chart_config.json
+++ b/server/integration_tests/test_data/international/query_5/chart_config.json
@@ -21,8 +21,74 @@
             ],
             "title": "Floods in Brazil",
             "type": "DISASTER_EVENT"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Area_FloodEvent"
+                    ],
+                    "title": "Area of Flood Event in Brazil",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Area of Flood Event in Brazil",
+                    "statVarKey": [
+                      "Area_FloodEvent"
+                    ],
+                    "title": "Area of Flood Event in Brazil",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Area of Flood Event"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_FloodEvent"
+                    ],
+                    "title": "Floods in Brazil",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Floods in Brazil",
+                    "statVarKey": [
+                      "Count_FloodEvent"
+                    ],
+                    "title": "Floods in Brazil",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Floods"
           }
-        ]
+        ],
+        "statVarSpec": {
+          "Area_FloodEvent": {
+            "name": "Area of Flood Event",
+            "statVar": "Area_FloodEvent"
+          },
+          "Count_FloodEvent": {
+            "name": "Floods",
+            "statVar": "Count_FloodEvent"
+          }
+        }
       }
     ],
     "metadata": {

--- a/server/integration_tests/test_data/international/query_6/chart_config.json
+++ b/server/integration_tests/test_data/international/query_6/chart_config.json
@@ -21,8 +21,74 @@
             ],
             "title": "Droughts in Africa",
             "type": "DISASTER_EVENT"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Area_DroughtEvent"
+                    ],
+                    "title": "Area of Drought Event in Africa",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Area of Drought Event in Africa",
+                    "statVarKey": [
+                      "Area_DroughtEvent"
+                    ],
+                    "title": "Area of Drought Event in Africa",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Area of Drought Event"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_DroughtEvent"
+                    ],
+                    "title": "Droughts in Africa",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Droughts in Africa",
+                    "statVarKey": [
+                      "Count_DroughtEvent"
+                    ],
+                    "title": "Droughts in Africa",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Droughts"
           }
-        ]
+        ],
+        "statVarSpec": {
+          "Area_DroughtEvent": {
+            "name": "Area of Drought Event",
+            "statVar": "Area_DroughtEvent"
+          },
+          "Count_DroughtEvent": {
+            "name": "Droughts",
+            "statVar": "Count_DroughtEvent"
+          }
+        }
       }
     ],
     "metadata": {

--- a/server/lib/explore/page_type/builder.py
+++ b/server/lib/explore/page_type/builder.py
@@ -121,7 +121,6 @@ class Builder:
       return
 
     for cat in self.page_config.categories:
-      # TODO: Check if we need more work here.
       if self.plotted_orig_vars and self.plotted_orig_vars[0][
           'dcid'] == cat.dcid:
         # The overall topic matches the category, so clear out the title.

--- a/server/lib/nl/common/rank_utils.py
+++ b/server/lib/nl/common/rank_utils.py
@@ -47,33 +47,6 @@ _TIME_DELTA_SORT_MAP = {
 }
 
 
-# Given a place and a list of existing SVs, this API ranks the SVs
-# per the ranking order.
-# TODO: The per-capita for this should be computed here.
-def rank_svs_by_latest_value(place: str, svs: List[str],
-                             order: types.RankingType,
-                             counters: ctr.Counters) -> List[str]:
-  start = time.time()
-  points_data = fetch.point_core(entities=[place],
-                                 variables=svs,
-                                 date='LATEST',
-                                 all_facets=False)
-  counters.timeit('rank_svs_by_latest_value', start)
-
-  svs_with_vals = []
-  for sv, place_data in points_data['data'].items():
-    if place not in place_data:
-      continue
-    point = place_data[place]
-    svs_with_vals.append((sv, point['value']))
-
-  reverse = False if order == types.RankingType.LOW else True
-  svs_with_vals = sorted(svs_with_vals,
-                         key=lambda pair: (pair[1], pair[0]),
-                         reverse=reverse)
-  return [sv for sv, _ in svs_with_vals]
-
-
 # List of vars or places ranked by abs and pct growth.
 class GrowthRankedLists(NamedTuple):
   abs: List[str]

--- a/server/lib/nl/config_builder/bar.py
+++ b/server/lib/nl/config_builder/bar.py
@@ -14,15 +14,22 @@
 
 from typing import List
 
+from server.config.subject_page_pb2 import BarTileSpec
 from server.config.subject_page_pb2 import StatVarSpec
 from server.config.subject_page_pb2 import Tile
 from server.lib.nl.config_builder import base
 from server.lib.nl.detection.types import Place
+from server.lib.nl.detection.types import RankingType
 from server.lib.nl.fulfillment.types import ChartVars
 
 
-def multiple_place_bar_block(column, places: List[Place], svs: List[str],
-                             sv2thing: base.SV2Thing, cv: ChartVars):
+# TODO: Support ranking_count for limit on number of vars.
+def multiple_place_bar_block(column,
+                             places: List[Place],
+                             svs: List[str],
+                             sv2thing: base.SV2Thing,
+                             cv: ChartVars,
+                             ranking_types: List[RankingType] = []):
   """A column with two charts, main stat var and per capita"""
   stat_var_spec_map = {}
 
@@ -67,6 +74,9 @@ def multiple_place_bar_block(column, places: List[Place], svs: List[str],
     stat_var_spec_map[sv_key] = StatVarSpec(stat_var=sv,
                                             name=sv2thing.name[sv],
                                             unit=sv2thing.unit[sv])
-
+  if RankingType.HIGH in ranking_types:
+    tile.bar_tile_spec.sort = BarTileSpec.DESCENDING
+  elif RankingType.LOW in ranking_types:
+    tile.bar_tile_spec.sort = BarTileSpec.ASCENDING
   column.tiles.append(tile)
   return stat_var_spec_map

--- a/server/lib/nl/config_builder/builder.py
+++ b/server/lib/nl/config_builder/builder.py
@@ -34,7 +34,6 @@ from server.lib.nl.fulfillment.types import ChartVars
 
 #
 # Given an Utterance, build the final Chart config proto.
-# TODO: Do fine-grained existence checks while adding charts.
 #
 def build(uttr: Utterance, config: Config) -> SubjectPageConfig:
   # Get names of all SVs
@@ -96,7 +95,12 @@ def build(uttr: Utterance, config: Config) -> SubjectPageConfig:
                                                      cspec.svs[0], sv2thing)
       else:
         stat_var_spec_map = bar.multiple_place_bar_block(
-            block.columns.add(), cspec.places, cspec.svs, sv2thing, cv)
+            column=block.columns.add(),
+            places=cspec.places,
+            svs=cspec.svs,
+            sv2thing=sv2thing,
+            cv=cv,
+            ranking_types=cspec.ranking_types)
 
     elif cspec.chart_type == ChartType.MAP_CHART:
       if not base.is_map_or_ranking_compatible(cspec):

--- a/server/lib/nl/fulfillment/basic.py
+++ b/server/lib/nl/fulfillment/basic.py
@@ -57,7 +57,6 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
     return _populate_chat(state, chart_vars, places, chart_origin)
 
 
-# TODO: Support ranking across vars.
 def _populate_explore(state: PopulateState, chart_vars: ChartVars,
                       places: List[Place],
                       chart_origin: ChartOriginType) -> bool:

--- a/server/lib/nl/fulfillment/fulfiller.py
+++ b/server/lib/nl/fulfillment/fulfiller.py
@@ -79,8 +79,8 @@ def fulfill(uttr: Utterance,
     done = overview.populate(uttr)
   elif main_qt == QueryType.EVENT:
     # TODO: Port `event` to work in the normal flow.
-    # TODO: Don't consider it "done", try showing SVs too.
-    done = event.populate(uttr)
+    # Don't consider it done and fallthrough to show SV stuff
+    event.populate(uttr)
     state.query_types.remove(QueryType.EVENT)
 
   elif main_qt == QueryType.COMPARISON_ACROSS_PLACES:

--- a/server/lib/nl/fulfillment/ranking_across_vars.py
+++ b/server/lib/nl/fulfillment/ranking_across_vars.py
@@ -15,6 +15,7 @@
 import logging
 from typing import List
 
+import server.lib.explore.existence as ext
 from server.lib.nl.common import rank_utils
 from server.lib.nl.common.utterance import ChartOriginType
 from server.lib.nl.common.utterance import ChartType
@@ -63,14 +64,12 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
 
   # TODO: Use ranking chart.
   # Ranking among peer group of SVs.
-  ranked_svs = rank_utils.rank_svs_by_latest_value(places[0].dcid,
-                                                   chart_vars.svs,
-                                                   state.ranking_types[0],
-                                                   state.uttr.counters)
-  state.uttr.counters.info('ranking-across-vars_reranked_svs', {
-      'orig': chart_vars.svs,
-      'ranked': ranked_svs,
-  })
-  chart_vars.svs = ranked_svs[:_MAX_VARS_IN_A_CHART]
+  eres = ext.svs4place(state, places[0], chart_vars.svs)
+  if not eres.exist_svs:
+    state.uttr.counters.err('ranking_across_vars_failed_existence', 1)
+    return False
+  # TODO: Add limit back after chart-config supports it natively.
+  chart_vars.svs = eres.exist_svs
+
   return add_chart_to_utterance(ChartType.BAR_CHART, state, chart_vars, places,
                                 chart_origin)

--- a/server/lib/nl/fulfillment/ranking_across_vars.py
+++ b/server/lib/nl/fulfillment/ranking_across_vars.py
@@ -62,7 +62,6 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
                             chart_vars.svs)
     return False
 
-  # TODO: Use ranking chart.
   # Ranking among peer group of SVs.
   eres = ext.svs4place(state, places[0], chart_vars.svs)
   if not eres.exist_svs:

--- a/server/lib/nl/fulfillment/types.py
+++ b/server/lib/nl/fulfillment/types.py
@@ -53,7 +53,6 @@ class ChartVars:
   description: str = ""
   title_suffix: str = ""
   # Represents a peer-group of SVs from a Topic.
-  # TODO: deprecate this in favor of svpg_id
   is_topic_peer_group: bool = False
   # If svs came from a topic, the topic dcid.
   source_topic: str = ""

--- a/server/tests/lib/nl/fulfiller_test.py
+++ b/server/tests/lib/nl/fulfiller_test.py
@@ -403,11 +403,10 @@ class TestDataSpecNext(unittest.TestCase):
   # Example: [what are the most grown agricultural things?]
   @unittest.skip
   @patch.object(variable, 'extend_svs')
-  @patch.object(rank_utils, 'rank_svs_by_latest_value')
   @patch.object(topic, 'compute_chart_vars')
   @patch.object(utils, 'sv_existence_for_places')
   def test_ranking_across_svs(self, mock_sv_existence, mock_topic_to_svs,
-                              mock_rank_svs, mock_extend_svs):
+                              mock_extend_svs):
     # Ranking, no place.
     detection = _detection(None, ['dc/topic/Agriculture'], [0.6],
                            ClassificationType.RANKING)
@@ -430,12 +429,6 @@ class TestDataSpecNext(unittest.TestCase):
         'FarmInventory_Wheat': False,
         'FarmInventory_Barley': False
     }, {})]
-    # Differently order result
-    mock_rank_svs.return_value = [
-        'FarmInventory_Barley',
-        'FarmInventory_Rice',
-        'FarmInventory_Wheat',
-    ]
 
     # Pass in just simple utterance
     got = _run(detection, [SIMPLE_UTTR])


### PR DESCRIPTION
This does two main things:

1.  Enables event charts in Explore, and blends in SV stuff along with event charts.
2.  Drops custom ranking logic of vars across bar chart and relies on the bar-chart-spec option Julia added.

![image](https://github.com/datacommonsorg/website/assets/4375037/e7406774-c425-495a-9075-35a4fc940da6)
