### PR TITLE
Enable expando at block level

### DIFF
--- a/static/css/nl_interface.scss
+++ b/static/css/nl_interface.scss
@@ -591,6 +591,10 @@ h3,
 .expando {
   font-size: 0.9rem;
 }
+.block .expando {
+  display: inline-block;
+  margin-top: 12px;
+}
 
 .expando,
 .debug-info-toggle {

--- a/static/css/nl_interface.scss
+++ b/static/css/nl_interface.scss
@@ -490,7 +490,8 @@ $feedback-link-font-color: #70757a;
     display: none;
   }
 
-  .tile-hidden {
+  .tile-hidden,
+  .column-hidden {
     position: absolute;
     top: -10000px;
     visibility: hidden;

--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -120,13 +120,10 @@ export function Block(props: BlockPropType): JSX.Element {
           props.columns.map((column, idx) => {
             const id = getId(props.id, COLUMN_ID_PREFIX, idx);
             const columnTileClassName = getColumnTileClassName(column);
-            let className = "";
-            if (idx >= minIdxToHide) {
-              className = HIDE_TILE_CLASS;
-            }
+            const shouldHideColumn = idx >= minIdxToHide;
             return (
               <Column
-                className={className}
+                shouldHideColumn={shouldHideColumn}
                 key={id}
                 id={id}
                 config={column}

--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -22,6 +22,7 @@ import axios from "axios";
 import React, { useEffect, useState } from "react";
 import { Input } from "reactstrap";
 
+import { NL_NUM_BLOCKS_SHOWN } from "../../constants/app/nl_interface_constants";
 import {
   COLUMN_ID_PREFIX,
   HIDE_TILE_CLASS,
@@ -119,8 +120,13 @@ export function Block(props: BlockPropType): JSX.Element {
           props.columns.map((column, idx) => {
             const id = getId(props.id, COLUMN_ID_PREFIX, idx);
             const columnTileClassName = getColumnTileClassName(column);
+            let className = "";
+            if (idx >= minIdxToHide) {
+              className = HIDE_TILE_CLASS;
+            }
             return (
               <Column
+                className={className}
                 key={id}
                 id={id}
                 config={column}
@@ -138,9 +144,29 @@ export function Block(props: BlockPropType): JSX.Element {
             );
           })}
       </div>
+      {isNlInterface() && props.columns.length > NL_NUM_BLOCKS_SHOWN && (
+        <a className="expando" onClick={expandoCallback}>
+          Show more
+        </a>
+      )}
     </>
   );
 }
+
+const expandoCallback = function (e) {
+  // Callback to remove HIDE_TILE_CLASS from all sibling elements. Assumes
+  // target link is the child of the container with elements to toggle.
+  const selfEl = e.target as HTMLAnchorElement;
+  const parentEl = selfEl.parentElement;
+  const tiles = parentEl.getElementsByClassName(
+    HIDE_TILE_CLASS
+  ) as HTMLCollectionOf<HTMLElement>;
+  for (let i = 0; i < tiles.length; i++) {
+    tiles[i].classList.remove(HIDE_TILE_CLASS);
+  }
+  selfEl.hidden = true;
+  e.preventDefault();
+};
 
 function renderTiles(
   tiles: TileConfig[],

--- a/static/js/components/subject_page/column.tsx
+++ b/static/js/components/subject_page/column.tsx
@@ -21,7 +21,10 @@
 import React from "react";
 
 import { NL_NUM_TILES_SHOWN } from "../../constants/app/nl_interface_constants";
-import { HIDE_TILE_CLASS } from "../../constants/subject_page_constants";
+import {
+  HIDE_COLUMN_CLASS,
+  HIDE_TILE_CLASS,
+} from "../../constants/subject_page_constants";
 import { ColumnConfig } from "../../types/subject_page_proto_types";
 import { isNlInterface } from "../../utils/nl_interface_utils";
 
@@ -34,7 +37,7 @@ export interface ColumnPropType {
   width: string;
   // tiles to render within the column
   tiles: JSX.Element;
-  className?: string;
+  shouldHideColumn?: boolean;
 }
 
 export function Column(props: ColumnPropType): JSX.Element {
@@ -42,7 +45,9 @@ export function Column(props: ColumnPropType): JSX.Element {
     <div
       key={props.id}
       id={props.id}
-      className={`${props.className} block-column`}
+      className={`${
+        props.shouldHideColumn ? HIDE_COLUMN_CLASS : ""
+      } block-column`}
       style={{ width: props.width }}
     >
       {props.tiles}

--- a/static/js/components/subject_page/column.tsx
+++ b/static/js/components/subject_page/column.tsx
@@ -34,6 +34,7 @@ export interface ColumnPropType {
   width: string;
   // tiles to render within the column
   tiles: JSX.Element;
+  className?: string;
 }
 
 export function Column(props: ColumnPropType): JSX.Element {
@@ -41,7 +42,7 @@ export function Column(props: ColumnPropType): JSX.Element {
     <div
       key={props.id}
       id={props.id}
-      className="block-column"
+      className={`${props.className} block-column`}
       style={{ width: props.width }}
     >
       {props.tiles}

--- a/static/js/constants/app/nl_interface_constants.ts
+++ b/static/js/constants/app/nl_interface_constants.ts
@@ -23,6 +23,7 @@ export const NL_MED_TILE_CLASS = "tile-md";
 export const NL_LARGE_TILE_CLASS = "tile-lg";
 // Number of tiles to show.
 export const NL_NUM_TILES_SHOWN = 3;
+export const NL_NUM_BLOCKS_SHOWN = 3;
 export const NL_SOURCE_REPLACEMENTS = {
   "https://www.datacommons.org/": "https://www.google.com",
   "https://datacommons.org/": "https://www.google.com",

--- a/static/js/constants/subject_page_constants.ts
+++ b/static/js/constants/subject_page_constants.ts
@@ -22,6 +22,7 @@
 export const DEFAULT_PAGE_PLACE_TYPE = "Place";
 // Class name for hidden tiles.
 export const HIDE_TILE_CLASS = "tile-hidden";
+export const HIDE_COLUMN_CLASS = "column-hidden";
 // Id prefixes for each type of subject page component
 export const CATEGORY_ID_PREFIX = "cat";
 export const BLOCK_ID_PREFIX = "blk";


### PR DESCRIPTION
With the recent layout change, there is only one tile per column. So the expando should be at block level instead of column level now.