### PR TITLE
Fix a performance issue for fetching map point names; Run screenshot test in parallel

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -144,7 +144,7 @@ function run_screenshot_test {
   export ENABLE_MODEL=true
   export MIXER_API_KEY=
   export PALM_API_KEY=
-  python3 -m pytest server/webdriver/screenshot/
+  python3 -m pytest -n 2 --reruns 2 server/webdriver/screenshot/
 }
 
 # Run integration test for NL interface

--- a/server/routes/shared_api/choropleth.py
+++ b/server/routes/shared_api/choropleth.py
@@ -449,7 +449,7 @@ def get_map_points():
   geos = fetch.descendent_places([place_dcid], place_type).get(place_dcid, [])
   if not geos:
     return Response(json.dumps([]), 200, mimetype='application/json')
-  names_by_geo = place_api.get_display_name(geos)
+  names_by_geo = place_api.get_i18n_name(geos)
   # For some places, lat long is attached to the place node, but for other
   # places, the lat long is attached to the location value of the place node.
   # If a place has location, we will use the location value to find the lat

--- a/server/webdriver/screenshot/local/page.json
+++ b/server/webdriver/screenshot/local/page.json
@@ -135,82 +135,82 @@
     "async": true
   },
   {
-    "url": "/explore#oq=Obesity+vs+Unemployment+in+the+US+counties",
+    "url": "/explore#q=Obesity+vs+Unemployment+in+the+US+counties",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#p=geoId/36&t=dc/topic/NumberOfBusinessesByIndustry&oq=Businesses+by+industry+in+New+York+State",
+    "url": "/explore#q=Businesses+by+industry+in+New+York+State",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#oq=Health+equity+in+Santa+Clara+County&t=dc/topic/HealthEquity&p=geoId/06085",
+    "url": "/explore#q=Health+equity+in+Santa+Clara+County",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#oq=Incarceration+rates+by+race+in+the+US&t=dc/topic/JusticeSystemEquity&p=country/USA",
+    "url": "/explore#q=Incarceration+rates+by+race+in+the+US",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#oq=health+behaviors+in+India+vs+Norway",
+    "url": "/explore#q=health+behaviors+in+India+vs+Norway",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#oq=High+blood+pressure+vs+Asthma+in+Alabama",
+    "url": "/explore#q=High+blood+pressure+vs+Asthma+in+Alabama",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#p=geoId/06&t=dc/topic/Schools&oq=School+Enrollment+in+California",
+    "url": "/explore#q=School+Enrollment+in+California",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#oq=Student+demographics+among+schools+in+Sunnyvale",
+    "url": "/explore#q=Student+demographics+among+schools+in+Sunnyvale",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#p=geoId/0653000&t=dc/topic/Housing&oq=Housing+in+Oakland",
+    "url": "/explore#q=Housing+in+Oakland",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#p=geoId/1714000&pcmp=geoId/3651000&t=dc/topic/CommuteMode&oq=Compare+modes+of+commute+between+NYC+and+Chicago",
+    "url": "/explore#q=Compare+modes+of+commute+between+NYC+and+Chicago",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#p=geoId/0606000&pcmp=geoId/0653000&t=dc/topic/RentalHouses&oq=Rental+prices+in+Oakland+vs+Berkeley",
+    "url": "/explore#q=Rental+prices+in+Oakland+vs+Berkeley",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#oq=Median+home+value+vs.+hypertension+in+US+counties",
+    "url": "/explore#q=Median+home+value+vs.+hypertension+in+US+counties",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#p=country/USA&t=dc/topic/Gender&oq=Gender+distribution+in+the+US",
+    "url": "/explore#q=Gender+distribution+in+the+US",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#oq=Foreign+born+population+vs.+PhD+holders+in+California+counties",
+    "url": "/explore#q=Foreign+born+population+vs.+PhD+holders+in+California+counties",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#oq=Green+jobs+in+the+US&p=country/USA&t=dc/topic/GreenJobs",
+    "url": "/explore#q=Green+jobs+in+the+US",
     "height": 1080,
     "async": true
   },
   {
-    "url": "/explore#oq=AQI+vs+blood+pressure+in+New+Jersey&p=geoId/34&t=dc/topic/AirQualityIndex&tcmp=dc/topic/BloodPressure",
+    "url": "/explore#q=AQI+vs+blood+pressure+in+New+Jersey",
     "height": 1080,
     "async": true
   },

--- a/server/webdriver/screenshot/local/test_run.py
+++ b/server/webdriver/screenshot/local/test_run.py
@@ -16,9 +16,17 @@ from server.webdriver.base import WebdriverBaseTest
 from server.webdriver.screenshot import runner
 
 
-# Class to test screenshot capture.
-class Test(WebdriverBaseTest):
+def create_test_function(page_config):
 
-  def test_run_local(self):
-    """Test these page can show correctly and do screenshot."""
-    self.assertTrue(runner.run(self.driver, self.url_, 'local'))
+  def test_function(self):
+    assert runner.run(self.driver, self.url_, page_config)
+
+  return test_function
+
+
+test_functions = {
+    f"test_{page}": create_test_function(page)
+    for page in runner.prepare('local')
+}
+
+TestDynamic = type("TestDynamic", (WebdriverBaseTest,), test_functions)

--- a/server/webdriver/screenshot/remote/main.py
+++ b/server/webdriver/screenshot/remote/main.py
@@ -31,5 +31,6 @@ if __name__ == "__main__":
   args = parser.parse_args()
   logging.info(args.domain)
   driver = base.create_driver()
-  runner.run(driver, 'https://' + args.domain, f'remote/{args.domain}')
+  for page in runner.prepare(f'remote/{args.domain}'):
+    runner.run(driver, 'https://' + args.domain, page)
   driver.quit()


### PR DESCRIPTION
* Right now facilities fetch parent place via place info cache. In USA map, this involves around 10K facilities and result in server error. Use regular name instead.

* Refactor the screenshot a bit to allow parallel run.