### PR TITLE
[explore] fix bugs

### DIFF
--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -324,18 +324,15 @@ export function App(): JSX.Element {
         });
     } else {
       setQuery("");
-      const currentContext = !_.isEmpty(savedContext.current)
-        ? savedContext.current[0].insightCtx
-        : {};
       fetchFulfillData(
         toApiList(place || DEFAULT_PLACE),
         toApiList(topic || DEFAULT_TOPIC),
         "",
-        currentContext.comparisonEntities || [],
-        currentContext.comparisonVariables || [],
+        [],
+        [],
         dc,
-        currentContext.extensionGroups || [],
-        currentContext.classifications || [],
+        [],
+        [],
         disableExploreMore,
         nlFulfillment
       )

--- a/static/js/apps/explore/result_header_section.tsx
+++ b/static/js/apps/explore/result_header_section.tsx
@@ -44,7 +44,7 @@ export function ResultHeaderSection(
   const topicList = [];
   if (!_.isEmpty(topics)) {
     for (const topic of topics) {
-      if (topic.dcid == DEFAULT_TOPIC) {
+      if (topic.dcid == DEFAULT_TOPIC || !topic.name) {
         // Do not show the root topic.
         continue;
       }


### PR DESCRIPTION
- don't use context when fetching data for topic + place
- filter out empty topic names in the relevant topics section in the header
    - autopush: https://screenshot.googleplex.com/6mYfHPZqXeTxY54
    - new: https://screenshot.googleplex.com/6kWSd6cXkEXfdDs 