### PR TITLE
NL: Add demo queries hack, disable Show More, implement multi-place timeline

### DIFF
--- a/server/integration_tests/test_data/e2e_electrification_demo/howdothesecountriescomparewiththeusandgermany/chart_config.json
+++ b/server/integration_tests/test_data/e2e_electrification_demo/howdothesecountriescomparewiththeusandgermany/chart_config.json
@@ -11,16 +11,16 @@
                     "comparisonPlaces": [
                       "country/USA",
                       "country/DEU",
-                      "country/SWZ",
-                      "country/COM",
                       "country/KEN",
                       "country/SOM",
-                      "country/LSO",
-                      "country/BWA",
                       "country/GHA",
                       "country/ETH",
-                      "country/LBR",
-                      "country/MLI"
+                      "country/MLI",
+                      "country/MAR",
+                      "country/RWA",
+                      "country/SEN",
+                      "country/GIN",
+                      "country/UGA"
                     ],
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS_multiple_place_bar_block"
@@ -42,16 +42,16 @@
                     "comparisonPlaces": [
                       "country/USA",
                       "country/DEU",
-                      "country/SWZ",
-                      "country/COM",
                       "country/KEN",
                       "country/SOM",
-                      "country/LSO",
-                      "country/BWA",
                       "country/GHA",
                       "country/ETH",
-                      "country/LBR",
-                      "country/MLI"
+                      "country/MLI",
+                      "country/MAR",
+                      "country/RWA",
+                      "country/SEN",
+                      "country/GIN",
+                      "country/UGA"
                     ],
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_UR_ZS_multiple_place_bar_block",
@@ -74,9 +74,10 @@
                       "country/USA",
                       "country/DEU",
                       "country/KEN",
-                      "country/BWA",
                       "country/GHA",
-                      "country/ETH"
+                      "country/ETH",
+                      "country/MAR",
+                      "country/SEN"
                     ],
                     "statVarKey": [
                       "Amount_Consumption_Electricity_PerCapita_multiple_place_bar_block"
@@ -97,16 +98,16 @@
                     "comparisonPlaces": [
                       "country/USA",
                       "country/DEU",
-                      "country/SWZ",
-                      "country/COM",
                       "country/KEN",
                       "country/SOM",
-                      "country/LSO",
-                      "country/BWA",
                       "country/GHA",
                       "country/ETH",
-                      "country/LBR",
-                      "country/MLI"
+                      "country/MLI",
+                      "country/MAR",
+                      "country/RWA",
+                      "country/SEN",
+                      "country/GIN",
+                      "country/UGA"
                     ],
                     "statVarKey": [
                       "Annual_Consumption_Electricity_multiple_place_bar_block"
@@ -128,14 +129,15 @@
                     "comparisonPlaces": [
                       "country/USA",
                       "country/DEU",
-                      "country/SWZ",
-                      "country/COM",
                       "country/KEN",
-                      "country/LSO",
-                      "country/BWA",
                       "country/GHA",
                       "country/ETH",
-                      "country/MLI"
+                      "country/MLI",
+                      "country/MAR",
+                      "country/RWA",
+                      "country/SEN",
+                      "country/GIN",
+                      "country/UGA"
                     ],
                     "statVarKey": [
                       "Annual_Consumption_Electricity_Households_multiple_place_bar_block"
@@ -157,16 +159,16 @@
                     "comparisonPlaces": [
                       "country/USA",
                       "country/DEU",
-                      "country/SWZ",
-                      "country/COM",
                       "country/KEN",
                       "country/SOM",
-                      "country/LSO",
-                      "country/BWA",
                       "country/GHA",
                       "country/ETH",
-                      "country/LBR",
-                      "country/MLI"
+                      "country/MLI",
+                      "country/MAR",
+                      "country/RWA",
+                      "country/SEN",
+                      "country/GIN",
+                      "country/UGA"
                     ],
                     "statVarKey": [
                       "worldBank/4_1_1_TOTAL_ELECTRICITY_OUTPUT_multiple_place_bar_block"
@@ -189,16 +191,16 @@
                     "comparisonPlaces": [
                       "country/USA",
                       "country/DEU",
-                      "country/SWZ",
-                      "country/COM",
                       "country/KEN",
                       "country/SOM",
-                      "country/LSO",
-                      "country/BWA",
                       "country/GHA",
                       "country/ETH",
-                      "country/LBR",
-                      "country/MLI"
+                      "country/MLI",
+                      "country/MAR",
+                      "country/RWA",
+                      "country/SEN",
+                      "country/GIN",
+                      "country/UGA"
                     ],
                     "statVarKey": [
                       "Annual_Generation_Electricity_multiple_place_bar_block"
@@ -220,16 +222,16 @@
                     "comparisonPlaces": [
                       "country/USA",
                       "country/DEU",
-                      "country/SWZ",
-                      "country/COM",
                       "country/KEN",
                       "country/SOM",
-                      "country/LSO",
-                      "country/BWA",
                       "country/GHA",
                       "country/ETH",
-                      "country/LBR",
-                      "country/MLI"
+                      "country/MLI",
+                      "country/MAR",
+                      "country/RWA",
+                      "country/SEN",
+                      "country/GIN",
+                      "country/UGA"
                     ],
                     "statVarKey": [
                       "Annual_Consumption_Electricity_ElectricityGeneration_EnergyIndustryOwnUse_multiple_place_bar_block"
@@ -251,16 +253,16 @@
                     "comparisonPlaces": [
                       "country/USA",
                       "country/DEU",
-                      "country/SWZ",
-                      "country/COM",
                       "country/KEN",
                       "country/SOM",
-                      "country/LSO",
-                      "country/BWA",
                       "country/GHA",
                       "country/ETH",
-                      "country/LBR",
-                      "country/MLI"
+                      "country/MLI",
+                      "country/MAR",
+                      "country/RWA",
+                      "country/SEN",
+                      "country/GIN",
+                      "country/UGA"
                     ],
                     "statVarKey": [
                       "Annual_Consumption_Electricity_OtherSector_multiple_place_bar_block"
@@ -347,16 +349,6 @@
       "place_type": "Country"
     },
     {
-      "dcid": "country/SWZ",
-      "name": "Eswatini",
-      "place_type": "Country"
-    },
-    {
-      "dcid": "country/COM",
-      "name": "Comoros",
-      "place_type": "Country"
-    },
-    {
       "dcid": "country/KEN",
       "name": "Kenya",
       "place_type": "Country"
@@ -364,16 +356,6 @@
     {
       "dcid": "country/SOM",
       "name": "Somalia",
-      "place_type": "Country"
-    },
-    {
-      "dcid": "country/LSO",
-      "name": "Lesotho",
-      "place_type": "Country"
-    },
-    {
-      "dcid": "country/BWA",
-      "name": "Botswana",
       "place_type": "Country"
     },
     {
@@ -387,13 +369,33 @@
       "place_type": "Country"
     },
     {
-      "dcid": "country/LBR",
-      "name": "Liberia",
+      "dcid": "country/MLI",
+      "name": "Mali",
       "place_type": "Country"
     },
     {
-      "dcid": "country/MLI",
-      "name": "Mali",
+      "dcid": "country/MAR",
+      "name": "Morocco",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/RWA",
+      "name": "Rwanda",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/SEN",
+      "name": "Senegal",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/GIN",
+      "name": "Guinea",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/UGA",
+      "name": "Uganda",
       "place_type": "Country"
     }
   ],

--- a/server/integration_tests/test_data/e2e_electrification_demo/howhaspovertyreducedintheseplaces/chart_config.json
+++ b/server/integration_tests/test_data/e2e_electrification_demo/howhaspovertyreducedintheseplaces/chart_config.json
@@ -8,11 +8,23 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/SWZ",
+                    "placeDcidOverride": "country/MLI",
                     "statVarKey": [
                       "sdg/SI_POV_DAY1_growth_abs"
                     ],
-                    "title": "Eswatini",
+                    "title": "Mali",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/SEN",
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1_growth_abs"
+                    ],
+                    "title": "Senegal",
                     "type": "LINE"
                   }
                 ]
@@ -32,6 +44,18 @@
               {
                 "tiles": [
                   {
+                    "placeDcidOverride": "country/RWA",
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1_growth_abs"
+                    ],
+                    "title": "Rwanda",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
                     "placeDcidOverride": "country/GHA",
                     "statVarKey": [
                       "sdg/SI_POV_DAY1_growth_abs"
@@ -44,23 +68,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/BWA",
+                    "placeDcidOverride": "country/MAR",
                     "statVarKey": [
                       "sdg/SI_POV_DAY1_growth_abs"
                     ],
-                    "title": "Botswana",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/LSO",
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1_growth_abs"
-                    ],
-                    "title": "Lesotho",
+                    "title": "Morocco",
                     "type": "LINE"
                   }
                 ]
@@ -97,35 +109,47 @@
               {
                 "tiles": [
                   {
+                    "placeDcidOverride": "country/MLI",
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1_growth_pct"
+                    ],
+                    "title": "Mali",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/SEN",
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1_growth_pct"
+                    ],
+                    "title": "Senegal",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/MAR",
+                    "statVarKey": [
+                      "sdg/SI_POV_DAY1_growth_pct"
+                    ],
+                    "title": "Morocco",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
                     "placeDcidOverride": "country/ETH",
                     "statVarKey": [
                       "sdg/SI_POV_DAY1_growth_pct"
                     ],
                     "title": "Ethiopia",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/SWZ",
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1_growth_pct"
-                    ],
-                    "title": "Eswatini",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/BWA",
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1_growth_pct"
-                    ],
-                    "title": "Botswana",
                     "type": "LINE"
                   }
                 ]
@@ -145,11 +169,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/USA",
+                    "placeDcidOverride": "country/RWA",
                     "statVarKey": [
                       "sdg/SI_POV_DAY1_growth_pct"
                     ],
-                    "title": "United States",
+                    "title": "Rwanda",
                     "type": "LINE"
                   }
                 ]
@@ -157,11 +181,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/LSO",
+                    "placeDcidOverride": "country/USA",
                     "statVarKey": [
                       "sdg/SI_POV_DAY1_growth_pct"
                     ],
-                    "title": "Lesotho",
+                    "title": "United States",
                     "type": "LINE"
                   }
                 ]
@@ -196,7 +220,7 @@
     ],
     "metadata": {
       "placeDcid": [
-        "country/SWZ"
+        "country/MLI"
       ]
     }
   },
@@ -222,16 +246,6 @@
       "place_type": "Country"
     },
     {
-      "dcid": "country/SWZ",
-      "name": "Eswatini",
-      "place_type": "Country"
-    },
-    {
-      "dcid": "country/COM",
-      "name": "Comoros",
-      "place_type": "Country"
-    },
-    {
       "dcid": "country/KEN",
       "name": "Kenya",
       "place_type": "Country"
@@ -242,16 +256,6 @@
       "place_type": "Country"
     },
     {
-      "dcid": "country/LSO",
-      "name": "Lesotho",
-      "place_type": "Country"
-    },
-    {
-      "dcid": "country/BWA",
-      "name": "Botswana",
-      "place_type": "Country"
-    },
-    {
       "dcid": "country/GHA",
       "name": "Ghana",
       "place_type": "Country"
@@ -259,6 +263,26 @@
     {
       "dcid": "country/ETH",
       "name": "Ethiopia",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/MLI",
+      "name": "Mali",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/MAR",
+      "name": "Morocco",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/RWA",
+      "name": "Rwanda",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/SEN",
+      "name": "Senegal",
       "place_type": "Country"
     }
   ],

--- a/server/integration_tests/test_data/e2e_electrification_demo/howhasthegdpgrown/chart_config.json
+++ b/server/integration_tests/test_data/e2e_electrification_demo/howhasthegdpgrown/chart_config.json
@@ -44,6 +44,18 @@
               {
                 "tiles": [
                   {
+                    "placeDcidOverride": "country/MAR",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_abs"
+                    ],
+                    "title": "Morocco",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
                     "placeDcidOverride": "country/KEN",
                     "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_abs"
@@ -68,11 +80,35 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/BWA",
+                    "placeDcidOverride": "country/SEN",
                     "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_abs"
                     ],
-                    "title": "Botswana",
+                    "title": "Senegal",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/MLI",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_abs"
+                    ],
+                    "title": "Mali",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/RWA",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_abs"
+                    ],
+                    "title": "Rwanda",
                     "type": "LINE"
                   }
                 ]
@@ -88,42 +124,6 @@
                     "type": "LINE"
                   }
                 ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/SWZ",
-                    "statVarKey": [
-                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_abs"
-                    ],
-                    "title": "Eswatini",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/LSO",
-                    "statVarKey": [
-                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_abs"
-                    ],
-                    "title": "Lesotho",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/COM",
-                    "statVarKey": [
-                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_abs"
-                    ],
-                    "title": "Comoros",
-                    "type": "LINE"
-                  }
-                ]
               }
             ],
             "denom": "Count_Person",
@@ -131,18 +131,6 @@
           },
           {
             "columns": [
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/BWA",
-                    "statVarKey": [
-                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pct"
-                    ],
-                    "title": "Botswana",
-                    "type": "LINE"
-                  }
-                ]
-              },
               {
                 "tiles": [
                   {
@@ -158,11 +146,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/SWZ",
+                    "placeDcidOverride": "country/RWA",
                     "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pct"
                     ],
-                    "title": "Eswatini",
+                    "title": "Rwanda",
                     "type": "LINE"
                   }
                 ]
@@ -170,11 +158,23 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/LSO",
+                    "placeDcidOverride": "country/MLI",
                     "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pct"
                     ],
-                    "title": "Lesotho",
+                    "title": "Mali",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/MAR",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pct"
+                    ],
+                    "title": "Morocco",
                     "type": "LINE"
                   }
                 ]
@@ -218,6 +218,18 @@
               {
                 "tiles": [
                   {
+                    "placeDcidOverride": "country/SEN",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pct"
+                    ],
+                    "title": "Senegal",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
                     "placeDcidOverride": "country/DEU",
                     "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pct"
@@ -235,18 +247,6 @@
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pct"
                     ],
                     "title": "Ethiopia",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/COM",
-                    "statVarKey": [
-                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pct"
-                    ],
-                    "title": "Comoros",
                     "type": "LINE"
                   }
                 ]
@@ -284,23 +284,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/BWA",
+                    "placeDcidOverride": "country/MAR",
                     "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pc"
                     ],
-                    "title": "Botswana",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/SWZ",
-                    "statVarKey": [
-                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pc"
-                    ],
-                    "title": "Eswatini",
+                    "title": "Morocco",
                     "type": "LINE"
                   }
                 ]
@@ -332,11 +320,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/COM",
+                    "placeDcidOverride": "country/SEN",
                     "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pc"
                     ],
-                    "title": "Comoros",
+                    "title": "Senegal",
                     "type": "LINE"
                   }
                 ]
@@ -356,11 +344,23 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/LSO",
+                    "placeDcidOverride": "country/MLI",
                     "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pc"
                     ],
-                    "title": "Lesotho",
+                    "title": "Mali",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/RWA",
+                    "statVarKey": [
+                      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_growth_pc"
+                    ],
+                    "title": "Rwanda",
                     "type": "LINE"
                   }
                 ]
@@ -426,16 +426,6 @@
       "place_type": "Country"
     },
     {
-      "dcid": "country/SWZ",
-      "name": "Eswatini",
-      "place_type": "Country"
-    },
-    {
-      "dcid": "country/COM",
-      "name": "Comoros",
-      "place_type": "Country"
-    },
-    {
       "dcid": "country/KEN",
       "name": "Kenya",
       "place_type": "Country"
@@ -446,16 +436,6 @@
       "place_type": "Country"
     },
     {
-      "dcid": "country/LSO",
-      "name": "Lesotho",
-      "place_type": "Country"
-    },
-    {
-      "dcid": "country/BWA",
-      "name": "Botswana",
-      "place_type": "Country"
-    },
-    {
       "dcid": "country/GHA",
       "name": "Ghana",
       "place_type": "Country"
@@ -463,6 +443,26 @@
     {
       "dcid": "country/ETH",
       "name": "Ethiopia",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/MLI",
+      "name": "Mali",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/MAR",
+      "name": "Morocco",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/RWA",
+      "name": "Rwanda",
+      "place_type": "Country"
+    },
+    {
+      "dcid": "country/SEN",
+      "name": "Senegal",
       "place_type": "Country"
     }
   ],

--- a/server/integration_tests/test_data/e2e_electrification_demo/whichcountriesinafricahavehadthegreatestincreaseinelectricityaccess/chart_config.json
+++ b/server/integration_tests/test_data/e2e_electrification_demo/whichcountriesinafricahavehadthegreatestincreaseinelectricityaccess/chart_config.json
@@ -8,30 +8,6 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/SWZ",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_abs"
-                    ],
-                    "title": "Eswatini",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/COM",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_abs"
-                    ],
-                    "title": "Comoros",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
                     "placeDcidOverride": "country/KEN",
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS_growth_abs"
@@ -49,30 +25,6 @@
                       "worldBank/EG_ELC_ACCS_ZS_growth_abs"
                     ],
                     "title": "Somalia",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/LSO",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_abs"
-                    ],
-                    "title": "Lesotho",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/BWA",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_abs"
-                    ],
-                    "title": "Botswana",
                     "type": "LINE"
                   }
                 ]
@@ -104,11 +56,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/LBR",
+                    "placeDcidOverride": "country/MLI",
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS_growth_abs"
                     ],
-                    "title": "Liberia",
+                    "title": "Mali",
                     "type": "LINE"
                   }
                 ]
@@ -116,11 +68,59 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/MLI",
+                    "placeDcidOverride": "country/MAR",
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS_growth_abs"
                     ],
-                    "title": "Mali",
+                    "title": "Morocco",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/RWA",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_abs"
+                    ],
+                    "title": "Rwanda",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/SEN",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_abs"
+                    ],
+                    "title": "Senegal",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/GIN",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_abs"
+                    ],
+                    "title": "Guinea",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/UGA",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_abs"
+                    ],
+                    "title": "Uganda",
                     "type": "LINE"
                   }
                 ]
@@ -131,18 +131,6 @@
           },
           {
             "columns": [
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/GNB",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_pct"
-                    ],
-                    "title": "Guinea-Bissau",
-                    "type": "LINE"
-                  }
-                ]
-              },
               {
                 "tiles": [
                   {
@@ -170,35 +158,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/LBR",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_pct"
-                    ],
-                    "title": "Liberia",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
                     "placeDcidOverride": "country/SSD",
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS_growth_pct"
                     ],
                     "title": "South Sudan",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "country/LSO",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_pct"
-                    ],
-                    "title": "Lesotho",
                     "type": "LINE"
                   }
                 ]
@@ -242,11 +206,47 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "country/BWA",
+                    "placeDcidOverride": "country/TZA",
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS_growth_pct"
                     ],
-                    "title": "Botswana",
+                    "title": "Tanzania",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/TCD",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_pct"
+                    ],
+                    "title": "Chad",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/MOZ",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_pct"
+                    ],
+                    "title": "Mozambique",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "country/ETH",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_pct"
+                    ],
+                    "title": "Ethiopia",
                     "type": "LINE"
                   }
                 ]
@@ -270,7 +270,7 @@
     ],
     "metadata": {
       "placeDcid": [
-        "country/SWZ"
+        "country/KEN"
       ]
     }
   },

--- a/server/integration_tests/test_data/e2e_india_demo/howdoestheliteracyratecompare/chart_config.json
+++ b/server/integration_tests/test_data/e2e_india_demo/howdoestheliteracyratecompare/chart_config.json
@@ -9,16 +9,16 @@
                 "tiles": [
                   {
                     "comparisonPlaces": [
-                      "wikidataId/Q26927",
-                      "wikidataId/Q66710",
-                      "wikidataId/Q1162",
-                      "wikidataId/Q43433",
-                      "wikidataId/Q1502",
-                      "wikidataId/Q1505",
+                      "wikidataId/Q1168",
+                      "wikidataId/Q1184",
                       "wikidataId/Q1193",
-                      "wikidataId/Q1599",
-                      "wikidataId/Q1363",
-                      "wikidataId/Q1195"
+                      "wikidataId/Q1162",
+                      "wikidataId/Q1165",
+                      "wikidataId/Q22048",
+                      "wikidataId/Q1164",
+                      "wikidataId/Q1188",
+                      "wikidataId/Q1498",
+                      "wikidataId/Q43433"
                     ],
                     "statVarKey": [
                       "Count_Person_Literate_multiple_place_bar_block",
@@ -39,16 +39,16 @@
                 "tiles": [
                   {
                     "comparisonPlaces": [
-                      "wikidataId/Q26927",
-                      "wikidataId/Q66710",
-                      "wikidataId/Q1162",
-                      "wikidataId/Q43433",
-                      "wikidataId/Q1502",
-                      "wikidataId/Q1505",
+                      "wikidataId/Q1168",
+                      "wikidataId/Q1184",
                       "wikidataId/Q1193",
-                      "wikidataId/Q1599",
-                      "wikidataId/Q1363",
-                      "wikidataId/Q1195"
+                      "wikidataId/Q1162",
+                      "wikidataId/Q1165",
+                      "wikidataId/Q22048",
+                      "wikidataId/Q1164",
+                      "wikidataId/Q1188",
+                      "wikidataId/Q1498",
+                      "wikidataId/Q43433"
                     ],
                     "statVarKey": [
                       "Count_Person_Literate_Female_multiple_place_bar_block"
@@ -68,16 +68,16 @@
                 "tiles": [
                   {
                     "comparisonPlaces": [
-                      "wikidataId/Q26927",
-                      "wikidataId/Q66710",
-                      "wikidataId/Q1162",
-                      "wikidataId/Q43433",
-                      "wikidataId/Q1502",
-                      "wikidataId/Q1505",
+                      "wikidataId/Q1168",
+                      "wikidataId/Q1184",
                       "wikidataId/Q1193",
-                      "wikidataId/Q1599",
-                      "wikidataId/Q1363",
-                      "wikidataId/Q1195"
+                      "wikidataId/Q1162",
+                      "wikidataId/Q1165",
+                      "wikidataId/Q22048",
+                      "wikidataId/Q1164",
+                      "wikidataId/Q1188",
+                      "wikidataId/Q1498",
+                      "wikidataId/Q43433"
                     ],
                     "statVarKey": [
                       "Count_Person_Literate_Rural_multiple_place_bar_block"
@@ -97,16 +97,16 @@
                 "tiles": [
                   {
                     "comparisonPlaces": [
-                      "wikidataId/Q26927",
-                      "wikidataId/Q66710",
-                      "wikidataId/Q1162",
-                      "wikidataId/Q43433",
-                      "wikidataId/Q1502",
-                      "wikidataId/Q1505",
+                      "wikidataId/Q1168",
+                      "wikidataId/Q1184",
                       "wikidataId/Q1193",
-                      "wikidataId/Q1599",
-                      "wikidataId/Q1363",
-                      "wikidataId/Q1195"
+                      "wikidataId/Q1162",
+                      "wikidataId/Q1165",
+                      "wikidataId/Q22048",
+                      "wikidataId/Q1164",
+                      "wikidataId/Q1188",
+                      "wikidataId/Q1498",
+                      "wikidataId/Q43433"
                     ],
                     "statVarKey": [
                       "Count_Person_Literate_Urban_multiple_place_bar_block"
@@ -126,15 +126,16 @@
                 "tiles": [
                   {
                     "comparisonPlaces": [
-                      "wikidataId/Q66710",
-                      "wikidataId/Q1162",
-                      "wikidataId/Q43433",
-                      "wikidataId/Q1502",
-                      "wikidataId/Q1505",
+                      "wikidataId/Q1168",
+                      "wikidataId/Q1184",
                       "wikidataId/Q1193",
-                      "wikidataId/Q1599",
-                      "wikidataId/Q1363",
-                      "wikidataId/Q1195"
+                      "wikidataId/Q1162",
+                      "wikidataId/Q1165",
+                      "wikidataId/Q22048",
+                      "wikidataId/Q1164",
+                      "wikidataId/Q1188",
+                      "wikidataId/Q1498",
+                      "wikidataId/Q43433"
                     ],
                     "statVarKey": [
                       "Count_Person_Houseless_Literate_multiple_place_bar_block"
@@ -154,16 +155,16 @@
                 "tiles": [
                   {
                     "comparisonPlaces": [
-                      "wikidataId/Q26927",
-                      "wikidataId/Q66710",
-                      "wikidataId/Q1162",
-                      "wikidataId/Q43433",
-                      "wikidataId/Q1502",
-                      "wikidataId/Q1505",
+                      "wikidataId/Q1168",
+                      "wikidataId/Q1184",
                       "wikidataId/Q1193",
-                      "wikidataId/Q1599",
-                      "wikidataId/Q1363",
-                      "wikidataId/Q1195"
+                      "wikidataId/Q1162",
+                      "wikidataId/Q1165",
+                      "wikidataId/Q22048",
+                      "wikidataId/Q1164",
+                      "wikidataId/Q1188",
+                      "wikidataId/Q1498",
+                      "wikidataId/Q43433"
                     ],
                     "statVarKey": [
                       "Count_Person_Illiterate_Rural_multiple_place_bar_block"
@@ -183,16 +184,16 @@
                 "tiles": [
                   {
                     "comparisonPlaces": [
-                      "wikidataId/Q26927",
-                      "wikidataId/Q66710",
-                      "wikidataId/Q1162",
-                      "wikidataId/Q43433",
-                      "wikidataId/Q1502",
-                      "wikidataId/Q1505",
+                      "wikidataId/Q1168",
+                      "wikidataId/Q1184",
                       "wikidataId/Q1193",
-                      "wikidataId/Q1599",
-                      "wikidataId/Q1363",
-                      "wikidataId/Q1195"
+                      "wikidataId/Q1162",
+                      "wikidataId/Q1165",
+                      "wikidataId/Q22048",
+                      "wikidataId/Q1164",
+                      "wikidataId/Q1188",
+                      "wikidataId/Q1498",
+                      "wikidataId/Q43433"
                     ],
                     "statVarKey": [
                       "Count_Person_Illiterate_Urban_multiple_place_bar_block"
@@ -245,7 +246,7 @@
     ],
     "metadata": {
       "placeDcid": [
-        "wikidataId/Q26927"
+        "wikidataId/Q1168"
       ]
     }
   },
@@ -253,41 +254,21 @@
   "debug": {},
   "pastSourceContext": "",
   "place": {
-    "dcid": "wikidataId/Q26927",
-    "name": "Lakshadweep",
+    "dcid": "wikidataId/Q1168",
+    "name": "Chhattisgarh",
     "place_type": "State"
   },
   "placeFallback": {},
   "placeSource": "CURRENT_QUERY",
   "places": [
     {
-      "dcid": "wikidataId/Q26927",
-      "name": "Lakshadweep",
+      "dcid": "wikidataId/Q1168",
+      "name": "Chhattisgarh",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q66710",
-      "name": "Daman and Diu",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1162",
-      "name": "Arunachal Pradesh",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q43433",
-      "name": "Chandigarh",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1502",
-      "name": "Mizoram",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1505",
-      "name": "Sikkim",
+      "dcid": "wikidataId/Q1184",
+      "name": "Jharkhand",
       "place_type": "State"
     },
     {
@@ -296,18 +277,38 @@
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1599",
-      "name": "Nagaland",
+      "dcid": "wikidataId/Q1162",
+      "name": "Arunachal Pradesh",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1363",
-      "name": "Tripura",
+      "dcid": "wikidataId/Q1165",
+      "name": "Bihar",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1195",
-      "name": "Meghalaya",
+      "dcid": "wikidataId/Q22048",
+      "name": "Odisha",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1164",
+      "name": "Assam",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1188",
+      "name": "Madhya Pradesh",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1498",
+      "name": "Uttar Pradesh",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q43433",
+      "name": "Chandigarh",
       "place_type": "State"
     }
   ],
@@ -315,6 +316,16 @@
     "childPlaces": {},
     "childTopics": [],
     "exploreMore": {
+      "Count_Person_Houseless_Literate": {
+        "gender": [
+          "Count_Person_Houseless_Literate_Female",
+          "Count_Person_Houseless_Literate_Male"
+        ],
+        "placeOfResidenceClassification": [
+          "Count_Person_Houseless_Literate_Rural",
+          "Count_Person_Houseless_Literate_Urban"
+        ]
+      },
       "Count_Person_Illiterate": {
         "gender": [
           "Count_Person_Illiterate_Female",
@@ -371,6 +382,10 @@
           "indianCensus/Count_Person_Religion_OtherReligionsAndPersuasions_Literate_Female",
           "indianCensus/Count_Person_Religion_ReligionNotStated_Literate_Female",
           "indianCensus/Count_Person_Religion_Sikh_Literate_Female"
+        ],
+        "socialCategory": [
+          "Count_Person_ScheduledCaste_Literate_Female",
+          "Count_Person_ScheduledTribe_Literate_Female"
         ]
       },
       "Count_Person_Literate_Rural": {

--- a/server/integration_tests/test_data/e2e_india_demo/howhasthenumberofsecondaryschoolsincreased/chart_config.json
+++ b/server/integration_tests/test_data/e2e_india_demo/howhasthenumberofsecondaryschoolsincreased/chart_config.json
@@ -8,6 +8,90 @@
               {
                 "tiles": [
                   {
+                    "placeDcidOverride": "wikidataId/Q1188",
+                    "statVarKey": [
+                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
+                    ],
+                    "title": "Madhya Pradesh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1498",
+                    "statVarKey": [
+                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
+                    ],
+                    "title": "Uttar Pradesh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1164",
+                    "statVarKey": [
+                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
+                    ],
+                    "title": "Assam",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q22048",
+                    "statVarKey": [
+                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
+                    ],
+                    "title": "Odisha",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1165",
+                    "statVarKey": [
+                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
+                    ],
+                    "title": "Bihar",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1184",
+                    "statVarKey": [
+                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
+                    ],
+                    "title": "Jharkhand",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1168",
+                    "statVarKey": [
+                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
+                    ],
+                    "title": "Chhattisgarh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
                     "placeDcidOverride": "wikidataId/Q1193",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
@@ -20,83 +104,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1363",
-                    "statVarKey": [
-                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
-                    ],
-                    "title": "Tripura",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1599",
-                    "statVarKey": [
-                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
-                    ],
-                    "title": "Nagaland",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
                     "placeDcidOverride": "wikidataId/Q1162",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
                     ],
                     "title": "Arunachal Pradesh",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1195",
-                    "statVarKey": [
-                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
-                    ],
-                    "title": "Meghalaya",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1505",
-                    "statVarKey": [
-                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
-                    ],
-                    "title": "Sikkim",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1502",
-                    "statVarKey": [
-                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
-                    ],
-                    "title": "Mizoram",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q66710",
-                    "statVarKey": [
-                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
-                    ],
-                    "title": "Daman and Diu",
                     "type": "LINE"
                   }
                 ]
@@ -112,18 +124,6 @@
                     "type": "LINE"
                   }
                 ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q26927",
-                    "statVarKey": [
-                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_abs"
-                    ],
-                    "title": "Lakshadweep",
-                    "type": "LINE"
-                  }
-                ]
               }
             ],
             "denom": "Count_Person",
@@ -134,11 +134,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1502",
+                    "placeDcidOverride": "wikidataId/Q1498",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pct"
                     ],
-                    "title": "Mizoram",
+                    "title": "Uttar Pradesh",
                     "type": "LINE"
                   }
                 ]
@@ -146,11 +146,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q26927",
+                    "placeDcidOverride": "wikidataId/Q1164",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pct"
                     ],
-                    "title": "Lakshadweep",
+                    "title": "Assam",
                     "type": "LINE"
                   }
                 ]
@@ -158,11 +158,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q66710",
+                    "placeDcidOverride": "wikidataId/Q1188",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pct"
                     ],
-                    "title": "Daman and Diu",
+                    "title": "Madhya Pradesh",
                     "type": "LINE"
                   }
                 ]
@@ -170,11 +170,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1195",
+                    "placeDcidOverride": "wikidataId/Q1165",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pct"
                     ],
-                    "title": "Meghalaya",
+                    "title": "Bihar",
                     "type": "LINE"
                   }
                 ]
@@ -182,11 +182,23 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1599",
+                    "placeDcidOverride": "wikidataId/Q22048",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pct"
                     ],
-                    "title": "Nagaland",
+                    "title": "Odisha",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1168",
+                    "statVarKey": [
+                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_pct"
+                    ],
+                    "title": "Chhattisgarh",
                     "type": "LINE"
                   }
                 ]
@@ -218,23 +230,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1363",
+                    "placeDcidOverride": "wikidataId/Q1184",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pct"
                     ],
-                    "title": "Tripura",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1505",
-                    "statVarKey": [
-                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_pct"
-                    ],
-                    "title": "Sikkim",
+                    "title": "Jharkhand",
                     "type": "LINE"
                   }
                 ]
@@ -260,11 +260,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1599",
+                    "placeDcidOverride": "wikidataId/Q1164",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pc"
                     ],
-                    "title": "Nagaland",
+                    "title": "Assam",
                     "type": "LINE"
                   }
                 ]
@@ -284,6 +284,18 @@
               {
                 "tiles": [
                   {
+                    "placeDcidOverride": "wikidataId/Q22048",
+                    "statVarKey": [
+                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_pc"
+                    ],
+                    "title": "Odisha",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
                     "placeDcidOverride": "wikidataId/Q1162",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pc"
@@ -296,11 +308,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1505",
+                    "placeDcidOverride": "wikidataId/Q1188",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pc"
                     ],
-                    "title": "Sikkim",
+                    "title": "Madhya Pradesh",
                     "type": "LINE"
                   }
                 ]
@@ -308,11 +320,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1363",
+                    "placeDcidOverride": "wikidataId/Q1184",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pc"
                     ],
-                    "title": "Tripura",
+                    "title": "Jharkhand",
                     "type": "LINE"
                   }
                 ]
@@ -320,11 +332,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q26927",
+                    "placeDcidOverride": "wikidataId/Q1165",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pc"
                     ],
-                    "title": "Lakshadweep",
+                    "title": "Bihar",
                     "type": "LINE"
                   }
                 ]
@@ -332,11 +344,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1195",
+                    "placeDcidOverride": "wikidataId/Q1168",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pc"
                     ],
-                    "title": "Meghalaya",
+                    "title": "Chhattisgarh",
                     "type": "LINE"
                   }
                 ]
@@ -344,23 +356,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q66710",
+                    "placeDcidOverride": "wikidataId/Q1498",
                     "statVarKey": [
                       "Count_School_SeniorSecondarySchool_Grade1To10_growth_pc"
                     ],
-                    "title": "Daman and Diu",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1502",
-                    "statVarKey": [
-                      "Count_School_SeniorSecondarySchool_Grade1To10_growth_pc"
-                    ],
-                    "title": "Mizoram",
+                    "title": "Uttar Pradesh",
                     "type": "LINE"
                   }
                 ]
@@ -400,7 +400,7 @@
     ],
     "metadata": {
       "placeDcid": [
-        "wikidataId/Q1193"
+        "wikidataId/Q1188"
       ]
     }
   },
@@ -408,41 +408,21 @@
   "debug": {},
   "pastSourceContext": "",
   "place": {
-    "dcid": "wikidataId/Q26927",
-    "name": "Lakshadweep",
+    "dcid": "wikidataId/Q1168",
+    "name": "Chhattisgarh",
     "place_type": "State"
   },
   "placeFallback": {},
   "placeSource": "CURRENT_QUERY",
   "places": [
     {
-      "dcid": "wikidataId/Q26927",
-      "name": "Lakshadweep",
+      "dcid": "wikidataId/Q1168",
+      "name": "Chhattisgarh",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q66710",
-      "name": "Daman and Diu",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1162",
-      "name": "Arunachal Pradesh",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q43433",
-      "name": "Chandigarh",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1502",
-      "name": "Mizoram",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1505",
-      "name": "Sikkim",
+      "dcid": "wikidataId/Q1184",
+      "name": "Jharkhand",
       "place_type": "State"
     },
     {
@@ -451,18 +431,38 @@
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1599",
-      "name": "Nagaland",
+      "dcid": "wikidataId/Q1162",
+      "name": "Arunachal Pradesh",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1363",
-      "name": "Tripura",
+      "dcid": "wikidataId/Q1165",
+      "name": "Bihar",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1195",
-      "name": "Meghalaya",
+      "dcid": "wikidataId/Q22048",
+      "name": "Odisha",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1164",
+      "name": "Assam",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1188",
+      "name": "Madhya Pradesh",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1498",
+      "name": "Uttar Pradesh",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q43433",
+      "name": "Chandigarh",
       "place_type": "State"
     }
   ],
@@ -473,9 +473,22 @@
       "Count_School_SeniorSecondarySchool_Grade1To10": {
         "schoolManagement": [
           "Count_School_SeniorSecondarySchool_Grade1To10_CentralGovernment",
+          "Count_School_SeniorSecondarySchool_Grade1To10_CentralTibetanSchool",
           "Count_School_SeniorSecondarySchool_Grade1To10_DepartmentOfEducation",
+          "Count_School_SeniorSecondarySchool_Grade1To10_GovernmentAided",
           "Count_School_SeniorSecondarySchool_Grade1To10_JawaharNavodayaVidyalaya",
-          "Count_School_SeniorSecondarySchool_Grade1To10_KendriyaVidyalaya"
+          "Count_School_SeniorSecondarySchool_Grade1To10_KendriyaVidyalaya",
+          "Count_School_SeniorSecondarySchool_Grade1To10_LocalBody",
+          "Count_School_SeniorSecondarySchool_Grade1To10_MadrasaRecognized",
+          "Count_School_SeniorSecondarySchool_Grade1To10_MadrasaUnrecognized",
+          "Count_School_SeniorSecondarySchool_Grade1To10_OtherGovernmentManaged",
+          "Count_School_SeniorSecondarySchool_Grade1To10_PrivateUnaidedButRecognized",
+          "Count_School_SeniorSecondarySchool_Grade1To10_RailwaySchool",
+          "Count_School_SeniorSecondarySchool_Grade1To10_SainikSchool",
+          "Count_School_SeniorSecondarySchool_Grade1To10_SocialWelfareDepartment",
+          "Count_School_SeniorSecondarySchool_Grade1To10_TribalWelfareDepartment",
+          "Count_School_SeniorSecondarySchool_Grade1To10_UnknownSchoolManagement",
+          "Count_School_SeniorSecondarySchool_Grade1To10_Unrecognized"
         ]
       }
     },

--- a/server/integration_tests/test_data/e2e_india_demo/howhavethewageschangedovertimeinthesestates/chart_config.json
+++ b/server/integration_tests/test_data/e2e_india_demo/howhavethewageschangedovertimeinthesestates/chart_config.json
@@ -8,59 +8,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1505",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_abs"
-                    ],
-                    "title": "Sikkim",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
                     "placeDcidOverride": "wikidataId/Q1162",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_abs"
                     ],
                     "title": "Arunachal Pradesh",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q26927",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_abs"
-                    ],
-                    "title": "Lakshadweep",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1502",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_abs"
-                    ],
-                    "title": "Mizoram",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1599",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_abs"
-                    ],
-                    "title": "Nagaland",
                     "type": "LINE"
                   }
                 ]
@@ -92,11 +44,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1363",
+                    "placeDcidOverride": "wikidataId/Q22048",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_abs"
                     ],
-                    "title": "Tripura",
+                    "title": "Odisha",
                     "type": "LINE"
                   }
                 ]
@@ -104,11 +56,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1195",
+                    "placeDcidOverride": "wikidataId/Q1165",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_abs"
                     ],
-                    "title": "Meghalaya",
+                    "title": "Bihar",
                     "type": "LINE"
                   }
                 ]
@@ -116,11 +68,59 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q66710",
+                    "placeDcidOverride": "wikidataId/Q1168",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_abs"
                     ],
-                    "title": "Daman and Diu",
+                    "title": "Chhattisgarh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1188",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_abs"
+                    ],
+                    "title": "Madhya Pradesh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1498",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_abs"
+                    ],
+                    "title": "Uttar Pradesh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1164",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_abs"
+                    ],
+                    "title": "Assam",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1184",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_abs"
+                    ],
+                    "title": "Jharkhand",
                     "type": "LINE"
                   }
                 ]
@@ -134,59 +134,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1505",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_pct"
-                    ],
-                    "title": "Sikkim",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
                     "placeDcidOverride": "wikidataId/Q1162",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_pct"
                     ],
                     "title": "Arunachal Pradesh",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q26927",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_pct"
-                    ],
-                    "title": "Lakshadweep",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1599",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_pct"
-                    ],
-                    "title": "Nagaland",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1502",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_pct"
-                    ],
-                    "title": "Mizoram",
                     "type": "LINE"
                   }
                 ]
@@ -218,11 +170,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1363",
+                    "placeDcidOverride": "wikidataId/Q22048",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_pct"
                     ],
-                    "title": "Tripura",
+                    "title": "Odisha",
                     "type": "LINE"
                   }
                 ]
@@ -230,11 +182,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1195",
+                    "placeDcidOverride": "wikidataId/Q1168",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_pct"
                     ],
-                    "title": "Meghalaya",
+                    "title": "Chhattisgarh",
                     "type": "LINE"
                   }
                 ]
@@ -242,11 +194,59 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q66710",
+                    "placeDcidOverride": "wikidataId/Q1165",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_pct"
                     ],
-                    "title": "Daman and Diu",
+                    "title": "Bihar",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1188",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_pct"
+                    ],
+                    "title": "Madhya Pradesh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1498",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_pct"
+                    ],
+                    "title": "Uttar Pradesh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1164",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_pct"
+                    ],
+                    "title": "Assam",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1184",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_pct"
+                    ],
+                    "title": "Jharkhand",
                     "type": "LINE"
                   }
                 ]
@@ -260,47 +260,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q26927",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_pc"
-                    ],
-                    "title": "Lakshadweep",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1505",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_pc"
-                    ],
-                    "title": "Sikkim",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
                     "placeDcidOverride": "wikidataId/Q1162",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_pc"
                     ],
                     "title": "Arunachal Pradesh",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "placeDcidOverride": "wikidataId/Q1502",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_pc"
-                    ],
-                    "title": "Mizoram",
                     "type": "LINE"
                   }
                 ]
@@ -320,18 +284,6 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1599",
-                    "statVarKey": [
-                      "Mean_WagesMonthly_Worker_growth_pc"
-                    ],
-                    "title": "Nagaland",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
                     "placeDcidOverride": "wikidataId/Q1193",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_pc"
@@ -344,11 +296,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1363",
+                    "placeDcidOverride": "wikidataId/Q1168",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_pc"
                     ],
-                    "title": "Tripura",
+                    "title": "Chhattisgarh",
                     "type": "LINE"
                   }
                 ]
@@ -356,11 +308,11 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q1195",
+                    "placeDcidOverride": "wikidataId/Q22048",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_pc"
                     ],
-                    "title": "Meghalaya",
+                    "title": "Odisha",
                     "type": "LINE"
                   }
                 ]
@@ -368,11 +320,59 @@
               {
                 "tiles": [
                   {
-                    "placeDcidOverride": "wikidataId/Q66710",
+                    "placeDcidOverride": "wikidataId/Q1165",
                     "statVarKey": [
                       "Mean_WagesMonthly_Worker_growth_pc"
                     ],
-                    "title": "Daman and Diu",
+                    "title": "Bihar",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1188",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_pc"
+                    ],
+                    "title": "Madhya Pradesh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1498",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_pc"
+                    ],
+                    "title": "Uttar Pradesh",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1164",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_pc"
+                    ],
+                    "title": "Assam",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "placeDcidOverride": "wikidataId/Q1184",
+                    "statVarKey": [
+                      "Mean_WagesMonthly_Worker_growth_pc"
+                    ],
+                    "title": "Jharkhand",
                     "type": "LINE"
                   }
                 ]
@@ -400,7 +400,7 @@
     ],
     "metadata": {
       "placeDcid": [
-        "wikidataId/Q1505"
+        "wikidataId/Q1162"
       ]
     }
   },
@@ -408,41 +408,21 @@
   "debug": {},
   "pastSourceContext": "",
   "place": {
-    "dcid": "wikidataId/Q26927",
-    "name": "Lakshadweep",
+    "dcid": "wikidataId/Q1168",
+    "name": "Chhattisgarh",
     "place_type": "State"
   },
   "placeFallback": {},
   "placeSource": "CURRENT_QUERY",
   "places": [
     {
-      "dcid": "wikidataId/Q26927",
-      "name": "Lakshadweep",
+      "dcid": "wikidataId/Q1168",
+      "name": "Chhattisgarh",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q66710",
-      "name": "Daman and Diu",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1162",
-      "name": "Arunachal Pradesh",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q43433",
-      "name": "Chandigarh",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1502",
-      "name": "Mizoram",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1505",
-      "name": "Sikkim",
+      "dcid": "wikidataId/Q1184",
+      "name": "Jharkhand",
       "place_type": "State"
     },
     {
@@ -451,18 +431,38 @@
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1599",
-      "name": "Nagaland",
+      "dcid": "wikidataId/Q1162",
+      "name": "Arunachal Pradesh",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1363",
-      "name": "Tripura",
+      "dcid": "wikidataId/Q1165",
+      "name": "Bihar",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1195",
-      "name": "Meghalaya",
+      "dcid": "wikidataId/Q22048",
+      "name": "Odisha",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1164",
+      "name": "Assam",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1188",
+      "name": "Madhya Pradesh",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1498",
+      "name": "Uttar Pradesh",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q43433",
+      "name": "Chandigarh",
       "place_type": "State"
     }
   ],

--- a/server/integration_tests/test_data/e2e_india_demo/howmuchhasinfantmortalityreduced/chart_config.json
+++ b/server/integration_tests/test_data/e2e_india_demo/howmuchhasinfantmortalityreduced/chart_config.json
@@ -9,16 +9,16 @@
                 "tiles": [
                   {
                     "comparisonPlaces": [
-                      "wikidataId/Q26927",
-                      "wikidataId/Q66710",
-                      "wikidataId/Q1162",
-                      "wikidataId/Q43433",
-                      "wikidataId/Q1502",
-                      "wikidataId/Q1505",
+                      "wikidataId/Q1168",
+                      "wikidataId/Q1184",
                       "wikidataId/Q1193",
-                      "wikidataId/Q1599",
-                      "wikidataId/Q1363",
-                      "wikidataId/Q1195"
+                      "wikidataId/Q1162",
+                      "wikidataId/Q1165",
+                      "wikidataId/Q22048",
+                      "wikidataId/Q1164",
+                      "wikidataId/Q1188",
+                      "wikidataId/Q1498",
+                      "wikidataId/Q43433"
                     ],
                     "statVarKey": [
                       "Count_Death_Infant_multiple_place_bar_block"
@@ -43,7 +43,7 @@
     ],
     "metadata": {
       "placeDcid": [
-        "wikidataId/Q26927"
+        "wikidataId/Q1168"
       ]
     }
   },
@@ -51,41 +51,21 @@
   "debug": {},
   "pastSourceContext": "",
   "place": {
-    "dcid": "wikidataId/Q26927",
-    "name": "Lakshadweep",
+    "dcid": "wikidataId/Q1168",
+    "name": "Chhattisgarh",
     "place_type": "State"
   },
   "placeFallback": {},
   "placeSource": "CURRENT_QUERY",
   "places": [
     {
-      "dcid": "wikidataId/Q26927",
-      "name": "Lakshadweep",
+      "dcid": "wikidataId/Q1168",
+      "name": "Chhattisgarh",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q66710",
-      "name": "Daman and Diu",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1162",
-      "name": "Arunachal Pradesh",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q43433",
-      "name": "Chandigarh",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1502",
-      "name": "Mizoram",
-      "place_type": "State"
-    },
-    {
-      "dcid": "wikidataId/Q1505",
-      "name": "Sikkim",
+      "dcid": "wikidataId/Q1184",
+      "name": "Jharkhand",
       "place_type": "State"
     },
     {
@@ -94,18 +74,38 @@
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1599",
-      "name": "Nagaland",
+      "dcid": "wikidataId/Q1162",
+      "name": "Arunachal Pradesh",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1363",
-      "name": "Tripura",
+      "dcid": "wikidataId/Q1165",
+      "name": "Bihar",
       "place_type": "State"
     },
     {
-      "dcid": "wikidataId/Q1195",
-      "name": "Meghalaya",
+      "dcid": "wikidataId/Q22048",
+      "name": "Odisha",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1164",
+      "name": "Assam",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1188",
+      "name": "Madhya Pradesh",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q1498",
+      "name": "Uttar Pradesh",
+      "place_type": "State"
+    },
+    {
+      "dcid": "wikidataId/Q43433",
+      "name": "Chandigarh",
       "place_type": "State"
     }
   ],

--- a/server/lib/nl/config_builder/builder.py
+++ b/server/lib/nl/config_builder/builder.py
@@ -79,11 +79,15 @@ def build(state: PopulateState, config: Config) -> SubjectPageConfig:
       base.place_overview_block(block.columns.add())
 
     elif cspec.chart_type == ChartType.TIMELINE_WITH_HIGHLIGHT:
-      block = builder.new_chart(cspec)
       if len(cspec.svs) > 1:
+        block = builder.new_chart(cspec)
         stat_var_spec_map = timeline.single_place_multiple_var_timeline_block(
             block.columns.add(), cspec.places[0], cspec.svs, sv2thing, cv)
+      elif len(cspec.places) > 1:
+        stat_var_spec_map = timeline.multi_place_single_var_timeline_block(
+            builder, cspec.places, cspec.svs[0], sv2thing, cspec)
       else:
+        block = builder.new_chart(cspec)
         if cspec.is_sdg:
           # Return highlight before timeline for SDG.
           stat_var_spec_map.update(

--- a/server/lib/nl/config_builder/timeline.py
+++ b/server/lib/nl/config_builder/timeline.py
@@ -128,3 +128,37 @@ def single_place_multiple_var_timeline_block(
   column.tiles.append(tile)
 
   return stat_var_spec_map
+
+
+def multi_place_single_var_timeline_block(
+    builder: base.Builder, places: List[Place], sv: str,
+    sv2thing: server.lib.nl.fulfillment.types.SV2Thing, cspec: ChartSpec):
+  """A column with two chart, all stat vars and per capita"""
+  stat_var_spec_map = {}
+  cv = cspec.chart_vars
+
+  block_title = sv2thing.name[sv]
+  block_description = sv2thing.description[sv]
+  block_footnote = sv2thing.footnote[sv]
+  block = builder.new_chart(cspec)
+  block.title = base.decorate_block_title(title=block_title,
+                                          chart_origin=cspec.chart_origin,
+                                          growth_direction=cv.growth_direction)
+  if block_description:
+    block.description = block_description
+  if block_footnote:
+    block.footnote = block_footnote
+
+  title = base.decorate_chart_title(title=sv2thing.name[sv], place=None)
+
+  # Line chart for the stat var
+  sv_key = sv + str(len(places))
+  tile = Tile(type=Tile.TileType.LINE,
+              title=title,
+              stat_var_key=[sv_key],
+              comparison_places=[p.dcid for p in places])
+  stat_var_spec_map[sv_key] = StatVarSpec(stat_var=sv,
+                                          name=sv2thing.name[sv],
+                                          unit=sv2thing.unit[sv])
+  block.columns.add().tiles.append(tile)
+  return stat_var_spec_map

--- a/server/lib/nl/fulfillment/ranking_across_places.py
+++ b/server/lib/nl/fulfillment/ranking_across_places.py
@@ -106,8 +106,7 @@ def _compute_answer_places(state: PopulateState, place: List[Place], sv: str):
       ranked_places = filter_and_rank_places_per_capita(place, state.place_type,
                                                         sv)
     else:
-      ranked_places = filter_and_rank_places_per_capita(place, state.place_type,
-                                                        sv)
+      ranked_places = filter_and_rank_places(place, state.place_type, sv)
   else:
     ranked_places = filter_and_rank_places(place, state.place_type, sv)
 

--- a/server/lib/nl/fulfillment/time_delta_across_vars.py
+++ b/server/lib/nl/fulfillment/time_delta_across_vars.py
@@ -86,6 +86,13 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
     chart_vars.svs = ranked_svs
     chart_vars.growth_direction = direction
     chart_vars.growth_ranking_type = field
+
+    # TODO: Uncomment this once we agree on look and feel.
+    # if field == 'abs':
+    #   found |= add_chart_to_utterance(ChartType.TIMELINE_WITH_HIGHLIGHT,
+    #                                   state, chart_vars, places, chart_origin)
+    #
+
     found |= add_chart_to_utterance(ChartType.RANKED_TIMELINE_COLLECTION, state,
                                     chart_vars, places, chart_origin)
 

--- a/static/js/constants/app/nl_interface_constants.ts
+++ b/static/js/constants/app/nl_interface_constants.ts
@@ -22,8 +22,9 @@ export const NL_SMALL_TILE_CLASS = "tile-sm";
 export const NL_MED_TILE_CLASS = "tile-md";
 export const NL_LARGE_TILE_CLASS = "tile-lg";
 // Number of tiles to show.
-export const NL_NUM_TILES_SHOWN = 3;
-export const NL_NUM_BLOCKS_SHOWN = 3;
+// TODO: Revert both these to 3 after fixing bugs
+export const NL_NUM_TILES_SHOWN = 12;
+export const NL_NUM_BLOCKS_SHOWN = 12;
 export const NL_SOURCE_REPLACEMENTS = {
   "https://www.datacommons.org/": "https://www.google.com",
   "https://datacommons.org/": "https://www.google.com",


### PR DESCRIPTION
1. Demo queries hack to threshold country population to 10M to ensure Kenya and Ghana show prominently ([screencast](https://screencast.googleplex.com/cast/NTMxNzk3OTM4NTM2NDQ4MHxjZjllYjJkYS00Yw)).
2. Disable the Show More feature which still apparently seems buggy.
3. Add support for multi-place timeline (see screenshot below)

![localhost_8080_explore_ (5)](https://github.com/datacommonsorg/website/assets/4375037/f2151913-5059-457d-906d-3f54b0251061)
