### PR TITLE
Add setting to prevent per-capita toggle from affecting some variables

### DIFF
--- a/server/config/subject_page.proto
+++ b/server/config/subject_page.proto
@@ -96,6 +96,8 @@ message StatVarSpec {
   // [Optional] The date to use when getting data for the stat var. Will use the
   // latest date if not set. Only enabled in map, ranking, and scatter tiles.
   string date = 7;
+  // [Optional] Whether to prevent this variable from being shown per capita. 
+  string no_per_capita = 8;
 }
 
 // This ranks across child places for a single stat var.

--- a/server/config/subject_page.proto
+++ b/server/config/subject_page.proto
@@ -97,7 +97,7 @@ message StatVarSpec {
   // latest date if not set. Only enabled in map, ranking, and scatter tiles.
   string date = 7;
   // [Optional] Whether to prevent this variable from being shown per capita. 
-  string no_per_capita = 8;
+  bool no_per_capita = 8;
 }
 
 // This ranks across child places for a single stat var.

--- a/static/js/components/subject_page/stat_var_provider.ts
+++ b/static/js/components/subject_page/stat_var_provider.ts
@@ -38,7 +38,7 @@ export class StatVarProvider {
       return null;
     }
     const spec = _.cloneDeep(this._statVarSpecMap[key]);
-    if (blockDenom) {
+    if (blockDenom && !spec.noPerCapita) {
       spec.denom = blockDenom;
       spec.scaling = PER_CAPITA_SCALING;
       spec.unit = PER_CAPITA_UNIT;

--- a/static/js/shared/types.ts
+++ b/static/js/shared/types.ts
@@ -201,6 +201,11 @@ export interface StatVarSpec {
   log: boolean;
   name?: string;
   date?: string;
+  // Whether to block setting the denominator to "per capita".
+  // Used in subject pages for variables where dividing by population does
+  // not make sense.
+  // Set to "true" to block toggling per capita in subject pages.
+  noPerCapita?: boolean;
 }
 
 export interface SampleDates {


### PR DESCRIPTION
Adds a `noPerCapita` attribute to statVarSpecs, which when set, will prevent the per capita toggle on subject pages from dividing their value by population. This is helpful for (1) allowing the per capita toggle to only change one of the axes on a scatter plot (by preventing the change on an axis that doesn't need it) and (2) preventing per capita on variables that are already per capita.

Note, this still needs the following backend changes to show up in explore results:
(1) We should enable the per capita toggle on comparison pages with scatter plots
(2) Fulfillment needs to emit "noPerCapita = true" in the statVarSpecs we wish to prevent from toggling per capita for.