### PR TITLE
[library] scatter plot improvements

### DIFF
--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -175,6 +175,29 @@ $box-shadow-8dp: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
   right: 0;
 }
 
+#scatter-tooltip {
+  background-color: var(--dc-gray-lite);
+  box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.2);
+  font-size: 10pt;
+  padding: 10px;
+  border-radius: 8px;
+  opacity: 0.9;
+  z-index: 2;
+  border: 0.5px solid var(--dc-gray-lite);
+  word-break: break-word;  
+  white-space: normal;
+  position: relative;
+}
+
+#scatter-tooltip header {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+#scatter-tooltip footer {
+  margin-top: 0.5rem;
+}
+
 /**
  * text tile
  */

--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -200,7 +200,7 @@ $box-shadow-8dp: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
   border: 0.5px solid var(--dc-gray-lite);
   word-break: break-word;  
   white-space: normal;
-  position: relative;
+  position: absolute;
 }
 
 #scatter-tooltip header {

--- a/static/js/components/tiles/scatter_tile.tsx
+++ b/static/js/components/tiles/scatter_tile.tsx
@@ -46,7 +46,7 @@ import { scatterDataToCsv } from "../../utils/chart_csv_utils";
 import { getStringOrNA } from "../../utils/number_utils";
 import { getPlaceScatterData } from "../../utils/scatter_data_utils";
 import { getDateRange } from "../../utils/string_utils";
-import { getStatVarName, ReplacementStrings } from "../../utils/tile_utils";
+import { getStatVarNames, ReplacementStrings } from "../../utils/tile_utils";
 import { ChartTileContainer } from "./chart_tile";
 import { useDrawOnResize } from "./use_draw_on_resize";
 
@@ -73,6 +73,7 @@ interface RawData {
   placeStats: PointApiResponse;
   population: SeriesApiResponse;
   placeNames: { [placeDcid: string]: string };
+  statVarNames: { [statVarDcid: string]: string };
 }
 
 interface ScatterChartData {
@@ -87,6 +88,9 @@ interface ScatterChartData {
   errorMsg: string;
   // props used when fetching this data
   props: ScatterTilePropType;
+  // Names of stat vars to use for labels
+  xStatVarName: string;
+  yStatVarName: string;
 }
 
 export function ScatterTile(props: ScatterTilePropType): JSX.Element {
@@ -282,7 +286,11 @@ export const fetchData = async (props: ScatterTilePropType) => {
       populationPromise,
       placeNamesPromise,
     ]);
-    const rawData = { placeStats, population, placeNames };
+    const statVarNames = await getStatVarNames(
+      props.statVarSpec,
+      props.apiRoot
+    );
+    const rawData = { placeStats, population, placeNames, statVarNames };
     return rawToChart(rawData, props);
   } catch (error) {
     return null;
@@ -297,6 +305,8 @@ function rawToChart(
   const xStatVar = props.statVarSpec[1];
   const yPlacePointStat = rawData.placeStats.data[yStatVar.statVar];
   const xPlacePointStat = rawData.placeStats.data[xStatVar.statVar];
+  const xStatVarName = rawData.statVarNames[xStatVar.statVar];
+  const yStatVarName = rawData.statVarNames[yStatVar.statVar];
   if (!xPlacePointStat || !yPlacePointStat) {
     return;
   }
@@ -354,6 +364,8 @@ function rawToChart(
     yDate: getDateRange(Array.from(yDates)),
     errorMsg,
     props,
+    xStatVarName,
+    yStatVarName,
   };
 }
 
@@ -411,21 +423,11 @@ export function draw(
     showRegression: false,
     highlightPoints,
   };
-  const yLabel = getStatVarName(
-    chartData.yStatVar.statVar,
-    [chartData.yStatVar],
-    !_.isEmpty(chartData.yStatVar.denom)
-  );
-  const xLabel = getStatVarName(
-    chartData.xStatVar.statVar,
-    [chartData.xStatVar],
-    !_.isEmpty(chartData.xStatVar.denom)
-  );
   const plotProperties: ScatterPlotProperties = {
     width,
     height: svgChartHeight,
-    xLabel,
-    yLabel,
+    xLabel: chartData.xStatVarName,
+    yLabel: chartData.yStatVarName,
     xUnit: chartData.xStatVar.unit,
     yUnit: chartData.yStatVar.unit,
   };

--- a/static/library/scatter_component.ts
+++ b/static/library/scatter_component.ts
@@ -96,6 +96,9 @@ export class DatacommonsScatterComponent extends LitElement {
   @property({ type: Boolean })
   showQuadrants?: boolean;
 
+  @property({ type: Array<string>, converter: convertArrayAttribute })
+  usePerCapita?: string[];
+
   render(): HTMLElement {
     const scatterTileProps: ScatterTilePropType = {
       apiRoot: this.apiRoot || DEFAULT_API_ENDPOINT,
@@ -115,7 +118,7 @@ export class DatacommonsScatterComponent extends LitElement {
         showQuadrants: this.showQuadrants,
       },
       statVarSpec: this.variables.map((variable) => ({
-        denom: "",
+        denom: this.usePerCapita?.includes(variable) ? "Count_Person" : "",
         log: false,
         name: "",
         scaling: 1,

--- a/static/library/scatter_component.ts
+++ b/static/library/scatter_component.ts
@@ -96,6 +96,7 @@ export class DatacommonsScatterComponent extends LitElement {
   @property({ type: Boolean })
   showQuadrants?: boolean;
 
+  // Optional: list of statvars to plot in per capita instead of raw value
   @property({ type: Array<string>, converter: convertArrayAttribute })
   usePerCapita?: string[];
 


### PR DESCRIPTION
This PR updates the scatter plot web components to match behavior and styling of scatter plots on our website. This will improve behavior of scatter plots for files in our experimental folder (like the UN sdg tracking page).

Changes:
1. Fetches the stat var names if one is not provided in StatVarSpec. This fixes the axes labels in the scatter plot web component, and brings behavior in line with the other tiles/web components.
Before:
![Screenshot 2023-08-28 at 1 13 53 PM](https://github.com/datacommonsorg/website/assets/4034366/8b480e73-c044-42d1-b857-12f6cf7e58eb)

After:
![Screenshot 2023-08-28 at 12 18 26 PM](https://github.com/datacommonsorg/website/assets/4034366/fc49fce5-df6f-47b6-950e-3659e80a6a55)


2. Fix tooltip styling in web components
Before:
![Screenshot 2023-08-28 at 1 13 35 PM](https://github.com/datacommonsorg/website/assets/4034366/e1efffe8-bf2b-4321-bd33-d1c4e7264bd5)

After:
![Screenshot 2023-08-28 at 12 33 16 PM](https://github.com/datacommonsorg/website/assets/4034366/0d428248-12c6-40d7-b7a4-1f682ad9f7aa)


3. Allows the user to optionally set some variables as "per capita" by providing the list of variables to make per capita. Note that this does not yet add an indication this is per capita. We should discuss how we want to show this on the chart.
Ex:
```
<datacommons-scatter
  header="Population vs Median Household Income for US States"
  variables="Annual_Generation_Electricity Median_Income_Household"
  parentPlace="country/USA"
  childPlaceType="State"
  usePerCapita="Annual_Generation_Electricity"
></datacommons-scatter>
```
![Screenshot 2023-08-28 at 12 18 32 PM](https://github.com/datacommonsorg/website/assets/4034366/3cd300f3-afba-44c4-b1b5-9fceb355a551)
