### PR TITLE
NL: Fix a few bugs

### DIFF
--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_3/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_3/chart_config.json
@@ -147,6 +147,70 @@
             ],
             "denom": "Count_Person",
             "title": "Production Transportation and Material Moving Occupations"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/e9gftzl2hm8h9"
+                    ],
+                    "title": "Commute Time in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Commute Time in Sunnyvale",
+                    "statVarKey": [
+                      "dc/e9gftzl2hm8h9"
+                    ],
+                    "title": "Commute Time in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Commute Time"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "dc/fyc3yvjy0xw6g_multiple_place_bar_block",
+                      "dc/dbe0drezxrpv6_multiple_place_bar_block",
+                      "dc/1fw0t5m6459gb_multiple_place_bar_block",
+                      "dc/vgwx3kjjzz8wf_multiple_place_bar_block",
+                      "dc/7ykp70f9rtck9_multiple_place_bar_block",
+                      "dc/exr9t81en1h34_multiple_place_bar_block",
+                      "dc/62gn48xpbqew9_multiple_place_bar_block",
+                      "dc/vfs5dgtzhp4j4_multiple_place_bar_block",
+                      "dc/pplpj0y0mzd3g_multiple_place_bar_block",
+                      "dc/t0hh9jhx104k7_multiple_place_bar_block",
+                      "dc/kfr6chpkw90e3_multiple_place_bar_block",
+                      "dc/h7ft916g93ys2_multiple_place_bar_block"
+                    ],
+                    "title": "Commuters by Commute Time in Sunnyvale (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Commuters by Commute Time"
           }
         ],
         "statVarSpec": {
@@ -154,9 +218,17 @@
             "name": "Drive alone",
             "statVar": "dc/0gettc3bc60cb"
           },
+          "dc/1fw0t5m6459gb_multiple_place_bar_block": {
+            "name": "Population: 10 - 14 Minute",
+            "statVar": "dc/1fw0t5m6459gb"
+          },
           "dc/4xklqxfc27w1f_multiple_place_bar_block": {
             "name": "Population: Public Transportation Excluding Taxicab, Management, Business, Science, And Arts Occupations",
             "statVar": "dc/4xklqxfc27w1f"
+          },
+          "dc/62gn48xpbqew9_multiple_place_bar_block": {
+            "name": "Population: 30 - 34 Minute",
+            "statVar": "dc/62gn48xpbqew9"
           },
           "dc/6rltk4kf75612_multiple_place_bar_block": {
             "name": "Work at home",
@@ -170,6 +242,10 @@
             "name": "Population: Worked At Home, Sales And Office Occupations",
             "statVar": "dc/7wt44yv38rew"
           },
+          "dc/7ykp70f9rtck9_multiple_place_bar_block": {
+            "name": "Population: 20 - 24 Minute",
+            "statVar": "dc/7ykp70f9rtck9"
+          },
           "dc/80q8jrnkvwtt3_multiple_place_bar_block": {
             "name": "Population: Car Truck or Van Carpooled, Management, Business, Science, And Arts Occupations",
             "statVar": "dc/80q8jrnkvwtt3"
@@ -181,6 +257,10 @@
           "dc/cs8fvwkmpmlpg_multiple_place_bar_block": {
             "name": "Population: Worked At Home, Production, Transportation, And Material Moving Occupations",
             "statVar": "dc/cs8fvwkmpmlpg"
+          },
+          "dc/dbe0drezxrpv6_multiple_place_bar_block": {
+            "name": "Population: 5 - 9 Minute",
+            "statVar": "dc/dbe0drezxrpv6"
           },
           "dc/dj7khl7q78412_multiple_place_bar_block": {
             "name": "Population: Car Truck or Van Carpooled, Production, Transportation, And Material Moving Occupations",
@@ -194,9 +274,25 @@
             "name": "Population: Taxicab Motorcycle Bicycle or Other Means, Production, Transportation, And Material Moving Occupations",
             "statVar": "dc/e27c5t4tbplg"
           },
+          "dc/e9gftzl2hm8h9": {
+            "name": "Commute Time",
+            "statVar": "dc/e9gftzl2hm8h9"
+          },
+          "dc/exr9t81en1h34_multiple_place_bar_block": {
+            "name": "Population: 25 - 29 Minute",
+            "statVar": "dc/exr9t81en1h34"
+          },
           "dc/fgt7thnws9vx9_multiple_place_bar_block": {
             "name": "Population: Walked, Production, Transportation, And Material Moving Occupations",
             "statVar": "dc/fgt7thnws9vx9"
+          },
+          "dc/fyc3yvjy0xw6g_multiple_place_bar_block": {
+            "name": "Population: 5 Minute or Less",
+            "statVar": "dc/fyc3yvjy0xw6g"
+          },
+          "dc/h7ft916g93ys2_multiple_place_bar_block": {
+            "name": "Population: 90 Minute or More",
+            "statVar": "dc/h7ft916g93ys2"
           },
           "dc/hbkh95kc7pkb6_multiple_place_bar_block": {
             "name": "Public Transit",
@@ -218,6 +314,10 @@
             "name": "Population: Car Truck or Van Drove Alone, Service Occupations",
             "statVar": "dc/k33ngtzpqxql6"
           },
+          "dc/kfr6chpkw90e3_multiple_place_bar_block": {
+            "name": "Population: 60 - 89 Minute",
+            "statVar": "dc/kfr6chpkw90e3"
+          },
           "dc/kt900ezddrf79_multiple_place_bar_block": {
             "name": "Population: Car Truck or Van Drove Alone, Sales And Office Occupations",
             "statVar": "dc/kt900ezddrf79"
@@ -238,6 +338,10 @@
             "name": "Population: Public Transportation Excluding Taxicab, Sales And Office Occupations",
             "statVar": "dc/nvrxn11yxlen2"
           },
+          "dc/pplpj0y0mzd3g_multiple_place_bar_block": {
+            "name": "Population: 40 - 44 Minute",
+            "statVar": "dc/pplpj0y0mzd3g"
+          },
           "dc/r0delcsw86kc6_multiple_place_bar_block": {
             "name": "Population: Car Truck or Van Drove Alone, Production, Transportation, And Material Moving Occupations",
             "statVar": "dc/r0delcsw86kc6"
@@ -246,9 +350,21 @@
             "name": "Population: Taxicab Motorcycle Bicycle or Other Means, Sales And Office Occupations",
             "statVar": "dc/slp5hywj7b9c1"
           },
+          "dc/t0hh9jhx104k7_multiple_place_bar_block": {
+            "name": "Population: 45 - 59 Minute",
+            "statVar": "dc/t0hh9jhx104k7"
+          },
           "dc/v33p7mwnpe9vb_multiple_place_bar_block": {
             "name": "Population: Walked, Management, Business, Science, And Arts Occupations",
             "statVar": "dc/v33p7mwnpe9vb"
+          },
+          "dc/vfs5dgtzhp4j4_multiple_place_bar_block": {
+            "name": "Population: 35 - 39 Minute",
+            "statVar": "dc/vfs5dgtzhp4j4"
+          },
+          "dc/vgwx3kjjzz8wf_multiple_place_bar_block": {
+            "name": "Population: 15 - 19 Minute",
+            "statVar": "dc/vgwx3kjjzz8wf"
           },
           "dc/vp8cbt6k79t94_multiple_place_bar_block": {
             "name": "Walk to work",

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_4/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_4/chart_config.json
@@ -152,6 +152,67 @@
             ],
             "denom": "Count_Person",
             "title": "Production Transportation and Material Moving Occupations"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/0665028",
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "dc/e9gftzl2hm8h9_multiple_place_bar_block"
+                    ],
+                    "title": "Commute Time (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Commute Time"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/0665028",
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "dc/fyc3yvjy0xw6g_multiple_place_bar_block",
+                      "dc/dbe0drezxrpv6_multiple_place_bar_block",
+                      "dc/1fw0t5m6459gb_multiple_place_bar_block",
+                      "dc/vgwx3kjjzz8wf_multiple_place_bar_block",
+                      "dc/7ykp70f9rtck9_multiple_place_bar_block",
+                      "dc/exr9t81en1h34_multiple_place_bar_block",
+                      "dc/62gn48xpbqew9_multiple_place_bar_block",
+                      "dc/vfs5dgtzhp4j4_multiple_place_bar_block",
+                      "dc/pplpj0y0mzd3g_multiple_place_bar_block",
+                      "dc/t0hh9jhx104k7_multiple_place_bar_block",
+                      "dc/kfr6chpkw90e3_multiple_place_bar_block",
+                      "dc/h7ft916g93ys2_multiple_place_bar_block"
+                    ],
+                    "title": "Commuters by Commute Time (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Commuters by Commute Time"
           }
         ],
         "statVarSpec": {
@@ -159,9 +220,17 @@
             "name": "Drive alone",
             "statVar": "dc/0gettc3bc60cb"
           },
+          "dc/1fw0t5m6459gb_multiple_place_bar_block": {
+            "name": "Population: 10 - 14 Minute",
+            "statVar": "dc/1fw0t5m6459gb"
+          },
           "dc/4xklqxfc27w1f_multiple_place_bar_block": {
             "name": "Population: Public Transportation Excluding Taxicab, Management, Business, Science, And Arts Occupations",
             "statVar": "dc/4xklqxfc27w1f"
+          },
+          "dc/62gn48xpbqew9_multiple_place_bar_block": {
+            "name": "Population: 30 - 34 Minute",
+            "statVar": "dc/62gn48xpbqew9"
           },
           "dc/6rltk4kf75612_multiple_place_bar_block": {
             "name": "Work at home",
@@ -175,6 +244,10 @@
             "name": "Population: Worked At Home, Sales And Office Occupations",
             "statVar": "dc/7wt44yv38rew"
           },
+          "dc/7ykp70f9rtck9_multiple_place_bar_block": {
+            "name": "Population: 20 - 24 Minute",
+            "statVar": "dc/7ykp70f9rtck9"
+          },
           "dc/80q8jrnkvwtt3_multiple_place_bar_block": {
             "name": "Population: Car Truck or Van Carpooled, Management, Business, Science, And Arts Occupations",
             "statVar": "dc/80q8jrnkvwtt3"
@@ -186,6 +259,10 @@
           "dc/cs8fvwkmpmlpg_multiple_place_bar_block": {
             "name": "Population: Worked At Home, Production, Transportation, And Material Moving Occupations",
             "statVar": "dc/cs8fvwkmpmlpg"
+          },
+          "dc/dbe0drezxrpv6_multiple_place_bar_block": {
+            "name": "Population: 5 - 9 Minute",
+            "statVar": "dc/dbe0drezxrpv6"
           },
           "dc/dj7khl7q78412_multiple_place_bar_block": {
             "name": "Population: Car Truck or Van Carpooled, Production, Transportation, And Material Moving Occupations",
@@ -199,9 +276,25 @@
             "name": "Population: Taxicab Motorcycle Bicycle or Other Means, Production, Transportation, And Material Moving Occupations",
             "statVar": "dc/e27c5t4tbplg"
           },
+          "dc/e9gftzl2hm8h9_multiple_place_bar_block": {
+            "name": "Commute Time",
+            "statVar": "dc/e9gftzl2hm8h9"
+          },
+          "dc/exr9t81en1h34_multiple_place_bar_block": {
+            "name": "Population: 25 - 29 Minute",
+            "statVar": "dc/exr9t81en1h34"
+          },
           "dc/fgt7thnws9vx9_multiple_place_bar_block": {
             "name": "Population: Walked, Production, Transportation, And Material Moving Occupations",
             "statVar": "dc/fgt7thnws9vx9"
+          },
+          "dc/fyc3yvjy0xw6g_multiple_place_bar_block": {
+            "name": "Population: 5 Minute or Less",
+            "statVar": "dc/fyc3yvjy0xw6g"
+          },
+          "dc/h7ft916g93ys2_multiple_place_bar_block": {
+            "name": "Population: 90 Minute or More",
+            "statVar": "dc/h7ft916g93ys2"
           },
           "dc/hbkh95kc7pkb6_multiple_place_bar_block": {
             "name": "Public Transit",
@@ -223,6 +316,10 @@
             "name": "Population: Car Truck or Van Drove Alone, Service Occupations",
             "statVar": "dc/k33ngtzpqxql6"
           },
+          "dc/kfr6chpkw90e3_multiple_place_bar_block": {
+            "name": "Population: 60 - 89 Minute",
+            "statVar": "dc/kfr6chpkw90e3"
+          },
           "dc/kt900ezddrf79_multiple_place_bar_block": {
             "name": "Population: Car Truck or Van Drove Alone, Sales And Office Occupations",
             "statVar": "dc/kt900ezddrf79"
@@ -243,6 +340,10 @@
             "name": "Population: Public Transportation Excluding Taxicab, Sales And Office Occupations",
             "statVar": "dc/nvrxn11yxlen2"
           },
+          "dc/pplpj0y0mzd3g_multiple_place_bar_block": {
+            "name": "Population: 40 - 44 Minute",
+            "statVar": "dc/pplpj0y0mzd3g"
+          },
           "dc/r0delcsw86kc6_multiple_place_bar_block": {
             "name": "Population: Car Truck or Van Drove Alone, Production, Transportation, And Material Moving Occupations",
             "statVar": "dc/r0delcsw86kc6"
@@ -251,9 +352,21 @@
             "name": "Population: Taxicab Motorcycle Bicycle or Other Means, Sales And Office Occupations",
             "statVar": "dc/slp5hywj7b9c1"
           },
+          "dc/t0hh9jhx104k7_multiple_place_bar_block": {
+            "name": "Population: 45 - 59 Minute",
+            "statVar": "dc/t0hh9jhx104k7"
+          },
           "dc/v33p7mwnpe9vb_multiple_place_bar_block": {
             "name": "Population: Walked, Management, Business, Science, And Arts Occupations",
             "statVar": "dc/v33p7mwnpe9vb"
+          },
+          "dc/vfs5dgtzhp4j4_multiple_place_bar_block": {
+            "name": "Population: 35 - 39 Minute",
+            "statVar": "dc/vfs5dgtzhp4j4"
+          },
+          "dc/vgwx3kjjzz8wf_multiple_place_bar_block": {
+            "name": "Population: 15 - 19 Minute",
+            "statVar": "dc/vgwx3kjjzz8wf"
           },
           "dc/vp8cbt6k79t94_multiple_place_bar_block": {
             "name": "Walk to work",

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_8/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_8/chart_config.json
@@ -99,28 +99,102 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "Count_Person_DetailedHighSchool"
+                      "Count_Person_EnrolledInKindergarten",
+                      "Count_Person_DetailedPrimarySchool",
+                      "Count_Person_DetailedMiddleSchool",
+                      "Count_Person_DetailedHighSchool",
+                      "Count_Person_EnrolledInCollegeUndergraduateYears"
                     ],
-                    "title": "High School Students in Sunnyvale",
+                    "title": "Student Population by Enrollment Level in Sunnyvale",
                     "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "High School Students in Sunnyvale",
-                    "statVarKey": [
-                      "Count_Person_DetailedHighSchool"
-                    ],
-                    "title": "High School Students in Sunnyvale",
-                    "type": "HIGHLIGHT"
                   }
                 ]
               }
             ],
             "denom": "Count_Person",
-            "title": "High School Students"
+            "title": "Student Population by Enrollment Level"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/g8kg52zcxzw9f",
+                      "dc/p34mhcpgtth76"
+                    ],
+                    "title": "Students in Kindergarten by Gender in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Students in Kindergarten by Gender"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "dc/1c4zcyw02n71g_multiple_place_bar_block",
+                      "dc/3n8g9we5yv7th_multiple_place_bar_block",
+                      "dc/556pqlh586bmc_multiple_place_bar_block",
+                      "dc/7g77dy8hfb1rg_multiple_place_bar_block",
+                      "dc/c6n2z7vh9sy31_multiple_place_bar_block",
+                      "dc/gr3zem8shyhbf_multiple_place_bar_block",
+                      "dc/ns1rqx6wy9909_multiple_place_bar_block",
+                      "dc/nt9cq96phw6nf_multiple_place_bar_block",
+                      "dc/qnphlls92tvs9_multiple_place_bar_block"
+                    ],
+                    "title": "Students in Kindergarten by Race in Sunnyvale (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Students in Kindergarten by Race"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/0677000"
+                    ],
+                    "statVarKey": [
+                      "dc/68cg2z97cpl7d_multiple_place_bar_block",
+                      "dc/b6h698m2vmdcc_multiple_place_bar_block",
+                      "dc/bf85zc6wypd2h_multiple_place_bar_block",
+                      "dc/e4y4hqq6mjfsh_multiple_place_bar_block",
+                      "dc/env3140jqssg8_multiple_place_bar_block",
+                      "dc/jhjdplbeg26k1_multiple_place_bar_block",
+                      "dc/p4jzvj8q1lnmd_multiple_place_bar_block",
+                      "dc/wk2vjrzfgyq5d_multiple_place_bar_block",
+                      "dc/x9e7150515yt7_multiple_place_bar_block"
+                    ],
+                    "title": "Students in Primary School by Race in Sunnyvale (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Students in Primary School by Race"
           },
           {
             "columns": [
@@ -150,35 +224,6 @@
             ],
             "denom": "Count_Person",
             "title": "Population Currently Enrolled in School"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "dc/jhjdplbeg26k1"
-                    ],
-                    "title": "Population: Primary School, Two or More Races in Sunnyvale",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Population: Primary School, Two or More Races in Sunnyvale",
-                    "statVarKey": [
-                      "dc/jhjdplbeg26k1"
-                    ],
-                    "title": "Population: Primary School, Two or More Races in Sunnyvale",
-                    "type": "HIGHLIGHT"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Population: Primary School, Two or More Races"
           },
           {
             "columns": [
@@ -256,6 +301,14 @@
             "name": "Population: 11th Grade",
             "statVar": "Count_Person_EducationalAttainment11ThGrade"
           },
+          "Count_Person_EnrolledInCollegeUndergraduateYears": {
+            "name": "Population: Enrolled in College Undergraduate Years",
+            "statVar": "Count_Person_EnrolledInCollegeUndergraduateYears"
+          },
+          "Count_Person_EnrolledInKindergarten": {
+            "name": "Population: Enrolled in Kindergarten",
+            "statVar": "Count_Person_EnrolledInKindergarten"
+          },
           "Count_Person_EnrolledInSchool": {
             "name": "Population Currently Enrolled in School",
             "statVar": "Count_Person_EnrolledInSchool"
@@ -264,17 +317,49 @@
             "name": "Population: 7th And 8th Grade",
             "statVar": "Count_Person_Years25Onwards_EducationalAttainment_7ThAnd8ThGrade"
           },
+          "dc/1c4zcyw02n71g_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten, Asian Alone",
+            "statVar": "dc/1c4zcyw02n71g"
+          },
+          "dc/3n8g9we5yv7th_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten, Two or More Races",
+            "statVar": "dc/3n8g9we5yv7th"
+          },
+          "dc/556pqlh586bmc_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten, Native Hawaiian or Other Pacific Islander Alone",
+            "statVar": "dc/556pqlh586bmc"
+          },
+          "dc/68cg2z97cpl7d_multiple_place_bar_block": {
+            "name": "Population: Primary School, Hispanic or Latino",
+            "statVar": "dc/68cg2z97cpl7d"
+          },
           "dc/6zbb7s5nx6rxb_multiple_place_bar_block": {
             "name": "Population: Middle School, Some Other Race Alone",
             "statVar": "dc/6zbb7s5nx6rxb"
+          },
+          "dc/7g77dy8hfb1rg_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten, Hispanic or Latino",
+            "statVar": "dc/7g77dy8hfb1rg"
           },
           "dc/b3nmcj3w1lhed_multiple_place_bar_block": {
             "name": "Population: Middle School, Two or More Races",
             "statVar": "dc/b3nmcj3w1lhed"
           },
+          "dc/b6h698m2vmdcc_multiple_place_bar_block": {
+            "name": "Population: Primary School, White Alone Not Hispanic or Latino",
+            "statVar": "dc/b6h698m2vmdcc"
+          },
+          "dc/bf85zc6wypd2h_multiple_place_bar_block": {
+            "name": "Population: Primary School, White Alone",
+            "statVar": "dc/bf85zc6wypd2h"
+          },
           "dc/c57vzg7l74577_multiple_place_bar_block": {
             "name": "Population: Middle School, Native Hawaiian or Other Pacific Islander Alone",
             "statVar": "dc/c57vzg7l74577"
+          },
+          "dc/c6n2z7vh9sy31_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten, Some Other Race Alone",
+            "statVar": "dc/c6n2z7vh9sy31"
           },
           "dc/c75qlm98pmcb2_multiple_place_bar_block": {
             "name": "Population: Middle School, White Alone Not Hispanic or Latino",
@@ -284,11 +369,27 @@
             "name": "Population: Middle School, Black or African American Alone",
             "statVar": "dc/e2szvml8jkld8"
           },
+          "dc/e4y4hqq6mjfsh_multiple_place_bar_block": {
+            "name": "Population: Primary School, Black or African American Alone",
+            "statVar": "dc/e4y4hqq6mjfsh"
+          },
+          "dc/env3140jqssg8_multiple_place_bar_block": {
+            "name": "Population: Primary School, Some Other Race Alone",
+            "statVar": "dc/env3140jqssg8"
+          },
           "dc/g4fthg3t3y5td_multiple_place_bar_block": {
             "name": "Population: Middle School, Asian Alone",
             "statVar": "dc/g4fthg3t3y5td"
           },
-          "dc/jhjdplbeg26k1": {
+          "dc/g8kg52zcxzw9f": {
+            "name": "Population: Female, Enrolled in Kindergarten",
+            "statVar": "dc/g8kg52zcxzw9f"
+          },
+          "dc/gr3zem8shyhbf_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten, White Alone",
+            "statVar": "dc/gr3zem8shyhbf"
+          },
+          "dc/jhjdplbeg26k1_multiple_place_bar_block": {
             "name": "Population: Primary School, Two or More Races",
             "statVar": "dc/jhjdplbeg26k1"
           },
@@ -296,9 +397,37 @@
             "name": "Population: Middle School, American Indian or Alaska Native Alone",
             "statVar": "dc/njgzb8knf11n8"
           },
+          "dc/ns1rqx6wy9909_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten, Black or African American Alone",
+            "statVar": "dc/ns1rqx6wy9909"
+          },
+          "dc/nt9cq96phw6nf_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten, White Alone Not Hispanic or Latino",
+            "statVar": "dc/nt9cq96phw6nf"
+          },
+          "dc/p34mhcpgtth76": {
+            "name": "Population: Male, Enrolled in Kindergarten",
+            "statVar": "dc/p34mhcpgtth76"
+          },
+          "dc/p4jzvj8q1lnmd_multiple_place_bar_block": {
+            "name": "Population: Primary School, American Indian or Alaska Native Alone",
+            "statVar": "dc/p4jzvj8q1lnmd"
+          },
+          "dc/qnphlls92tvs9_multiple_place_bar_block": {
+            "name": "Population: Enrolled in Kindergarten, American Indian or Alaska Native Alone",
+            "statVar": "dc/qnphlls92tvs9"
+          },
           "dc/qvf1yrhwzp8rd_multiple_place_bar_block": {
             "name": "Population: Middle School, White Alone",
             "statVar": "dc/qvf1yrhwzp8rd"
+          },
+          "dc/wk2vjrzfgyq5d_multiple_place_bar_block": {
+            "name": "Population: Primary School, Native Hawaiian or Other Pacific Islander Alone",
+            "statVar": "dc/wk2vjrzfgyq5d"
+          },
+          "dc/x9e7150515yt7_multiple_place_bar_block": {
+            "name": "Population: Primary School, Asian Alone",
+            "statVar": "dc/x9e7150515yt7"
           },
           "dc/zvr6djt1p9gj3_multiple_place_bar_block": {
             "name": "Population: Middle School, Hispanic or Latino",

--- a/server/integration_tests/test_data/demo_climatetrace/query_1/chart_config.json
+++ b/server/integration_tests/test_data/demo_climatetrace/query_1/chart_config.json
@@ -1180,6 +1180,102 @@
                       "showHighest": true
                     },
                     "statVarKey": [
+                      "Annual_Emissions_NitrousOxide_Power"
+                    ],
+                    "title": "Annual Amount of Emissions: Power, Nitrous Oxide in the World (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Annual_Emissions_NitrousOxide_Power"
+                    ],
+                    "title": "Annual Amount of Emissions: Power, Nitrous Oxide in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Annual Amount of Emissions: Power, Nitrous Oxide in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "Annual_Emissions_CarbonDioxideEquivalent100YearGlobalWarmingPotential_Power"
+                    ],
+                    "title": "Annual Amount of Emissions: Power, Carbon Dioxide Equivalent 100 Year Global Warming Potential in the World (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Annual_Emissions_CarbonDioxideEquivalent100YearGlobalWarmingPotential_Power"
+                    ],
+                    "title": "Annual Amount of Emissions: Power, Carbon Dioxide Equivalent 100 Year Global Warming Potential in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Annual Amount of Emissions: Power, Carbon Dioxide Equivalent 100 Year Global Warming Potential in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "Annual_Emissions_CarbonDioxideEquivalent20YearGlobalWarmingPotential_Power"
+                    ],
+                    "title": "Annual Amount of Emissions: Power, Carbon Dioxide Equivalent 20 Year Global Warming Potential in the World (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Annual_Emissions_CarbonDioxideEquivalent20YearGlobalWarmingPotential_Power"
+                    ],
+                    "title": "Annual Amount of Emissions: Power, Carbon Dioxide Equivalent 20 Year Global Warming Potential in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Annual Amount of Emissions: Power, Carbon Dioxide Equivalent 20 Year Global Warming Potential in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
                       "Annual_Emissions_Methane_ClimateTrace_OtherEnergyUse"
                     ],
                     "title": "Annual Amount of Emissions: Other Energy Use, Methane in the World (${date})",
@@ -1303,6 +1399,14 @@
           "Amount_Emissions_CarbonDioxide_PerCapita": {
             "name": "CO2 Emissions Per Capita",
             "statVar": "Amount_Emissions_CarbonDioxide_PerCapita"
+          },
+          "Annual_Emissions_CarbonDioxideEquivalent100YearGlobalWarmingPotential_Power": {
+            "name": "Annual Amount of Emissions: Power, Carbon Dioxide Equivalent 100 Year Global Warming Potential",
+            "statVar": "Annual_Emissions_CarbonDioxideEquivalent100YearGlobalWarmingPotential_Power"
+          },
+          "Annual_Emissions_CarbonDioxideEquivalent20YearGlobalWarmingPotential_Power": {
+            "name": "Annual Amount of Emissions: Power, Carbon Dioxide Equivalent 20 Year Global Warming Potential",
+            "statVar": "Annual_Emissions_CarbonDioxideEquivalent20YearGlobalWarmingPotential_Power"
           },
           "Annual_Emissions_CarbonDioxide_Agriculture": {
             "name": "CO\u2082 Emissions from Agriculture",
@@ -1443,6 +1547,10 @@
           "Annual_Emissions_NitrousOxide_Manufacturing": {
             "name": "Annual Amount of Emissions: Manufacturing, Nitrous Oxide",
             "statVar": "Annual_Emissions_NitrousOxide_Manufacturing"
+          },
+          "Annual_Emissions_NitrousOxide_Power": {
+            "name": "Annual Amount of Emissions: Power, Nitrous Oxide",
+            "statVar": "Annual_Emissions_NitrousOxide_Power"
           },
           "Annual_Emissions_NitrousOxide_Transportation": {
             "name": "Annual Amount of Emissions: Transportation, Nitrous Oxide",

--- a/server/integration_tests/test_data/demo_feb2023/query_1/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_1/chart_config.json
@@ -113,6 +113,402 @@
                       "showHighest": true
                     },
                     "statVarKey": [
+                      "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Max Temperature (\u00b0C) Once in Decade With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Max Temperature (\u00b0C) Once in Decade With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Predicted Max Temperature with 95% chance, at least once in the decade, according to a CMIP6 Ensemble model as per SSP 245 (intermediate) scenario.",
+            "footnote": "SSP245 is a medium pathway. It is an update to RCP 4.5 with an additional radiative forcing of 4.5 W/m\u00b2. RCP 4.5 is more likely than not to result in global temperature rise between 2 \u00b0C and 3 \u00b0C by 2100.,",
+            "title": "Max Temperature (\u00b0C) Once in Decade With 95% Chance: SSP245 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Max Temperature (\u00b0C) Once in Decade With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Max Temperature (\u00b0C) Once in Decade With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Predicted Max Temperature with 95% chance, at least once in the decade, according to a CMIP6 Ensemble model as per SSP 585 (pessimistic) scenario.",
+            "footnote": "SSP585 is a pessimistic pathway. It is an update to RCP 8.5 with an additional radiative forcing of 8.5 W/m\u00b2. RCP 8.5 is more likely than not to result in global temperature rise between 3 \u00b0C and 12.6 \u00b0C by 2100.",
+            "title": "Max Temperature (\u00b0C) Once in Decade With 95% Chance: SP585 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showLowest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Min Temperature (\u00b0C) Once in Decade With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Min Temperature (\u00b0C) Once in Decade With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Predicted Min Temperature with 95% chance, at least once in the decade, according to a CMIP6 Ensemble model as per SSP 245 (intermediate) scenario.",
+            "footnote": "SSP245 is a medium pathway. It is an update to RCP 4.5 with an additional radiative forcing of 4.5 W/m\u00b2. RCP 4.5 is more likely than not to result in global temperature rise between 2 \u00b0C and 3 \u00b0C by 2100.,",
+            "title": "Min Temperature (\u00b0C) Once in Decade With 95% Chance: SSP245 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showLowest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Min Temperature (\u00b0C) Once in Decade With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Min Temperature (\u00b0C) Once in Decade With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Predicted Min Temperature with 95% chance, at least once in the decade, according to a CMIP6 Ensemble model as per SSP 585 (pessimistic) scenario.",
+            "footnote": "SSP585 is a pessimistic pathway. It is an update to RCP 8.5 with an additional radiative forcing of 8.5 W/m\u00b2. RCP 8.5 is more likely than not to result in global temperature rise between 3 \u00b0C and 12.6 \u00b0C by 2100.",
+            "title": "Min Temperature (\u00b0C) Once in Decade With 95% Chance: SP585 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "DiffRelativeToAvg_1980_2010_MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Relative Max Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "DiffRelativeToAvg_1980_2010_MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Relative Max Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Relative to the Average Yearly Max Temperature between 1980-2010, the Predicted Max Temperature difference with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 245 (intermediate) scenario.",
+            "footnote": "SSP245 is a medium pathway. It is an update to RCP 4.5 with an additional radiative forcing of 4.5 W/m\u00b2. RCP 4.5 is more likely than not to result in global temperature rise between 2 \u00b0C and 3 \u00b0C by 2100.,",
+            "title": "Relative Max Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "DiffRelativeToAvg_1980_2010_MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Relative Max Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "DiffRelativeToAvg_1980_2010_MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Relative Max Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Relative to the Average Yearly Max Temperature between 1980-2010, the Predicted Max Temperature difference with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 585 (pessimistic) scenario.",
+            "footnote": "SSP585 is a pessimistic pathway. It is an update to RCP 8.5 with an additional radiative forcing of 8.5 W/m\u00b2. RCP 8.5 is more likely than not to result in global temperature rise between 3 \u00b0C and 12.6 \u00b0C by 2100.",
+            "title": "Relative Max Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Max Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Max Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Predicted Max Temperature with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 245 (intermediate) scenario.",
+            "footnote": "SSP245 is a medium pathway. It is an update to RCP 4.5 with an additional radiative forcing of 4.5 W/m\u00b2. RCP 4.5 is more likely than not to result in global temperature rise between 2 \u00b0C and 3 \u00b0C by 2100.,",
+            "title": "Max Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
+                      "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Max Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Max Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Predicted Max Temperature with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 585 (pessimistic) scenario.",
+            "footnote": "SSP585 is a pessimistic pathway. It is an update to RCP 8.5 with an additional radiative forcing of 8.5 W/m\u00b2. RCP 8.5 is more likely than not to result in global temperature rise between 3 \u00b0C and 12.6 \u00b0C by 2100.",
+            "title": "Max Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showLowest": true
+                    },
+                    "statVarKey": [
+                      "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Relative Min Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Relative Min Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Relative to the Average Yearly Min Temperature between 1980-2010, the Predicted Min Temperature difference with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 245 (intermediate) scenario.",
+            "footnote": "SSP245 is a medium pathway. It is an update to RCP 4.5 with an additional radiative forcing of 4.5 W/m\u00b2. RCP 4.5 is more likely than not to result in global temperature rise between 2 \u00b0C and 3 \u00b0C by 2100.,",
+            "title": "Relative Min Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showLowest": true
+                    },
+                    "statVarKey": [
+                      "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Relative Min Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Relative Min Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Relative to the Average Yearly Min Temperature between 1980-2010, the Predicted Min Temperature difference with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 585 (pessimistic) scenario.",
+            "footnote": "SSP585 is a pessimistic pathway. It is an update to RCP 8.5 with an additional radiative forcing of 8.5 W/m\u00b2. RCP 8.5 is more likely than not to result in global temperature rise between 3 \u00b0C and 12.6 \u00b0C by 2100.",
+            "title": "Relative Min Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showLowest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Min Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+                    ],
+                    "title": "Min Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Predicted Min Temperature with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 245 (intermediate) scenario.",
+            "footnote": "SSP245 is a medium pathway. It is an update to RCP 4.5 with an additional radiative forcing of 4.5 W/m\u00b2. RCP 4.5 is more likely than not to result in global temperature rise between 2 \u00b0C and 3 \u00b0C by 2100.,",
+            "title": "Min Temperature (\u00b0C) Once in Year With 95% Chance: SSP245 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showLowest": true
+                    },
+                    "statVarKey": [
+                      "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Min Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+                    ],
+                    "title": "Min Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "description": "Predicted Min Temperature with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 585 (pessimistic) scenario.",
+            "footnote": "SSP585 is a pessimistic pathway. It is an update to RCP 8.5 with an additional radiative forcing of 8.5 W/m\u00b2. RCP 8.5 is more likely than not to result in global temperature rise between 3 \u00b0C and 12.6 \u00b0C by 2100.",
+            "title": "Min Temperature (\u00b0C) Once in Year With 95% Chance: SP585 in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 10,
+                      "showHighest": true
+                    },
+                    "statVarKey": [
                       "Temperature"
                     ],
                     "title": "Temperature in a Location in Counties of California (${date})",
@@ -303,6 +699,14 @@
             "name": "Relative Max Temperature (\u00b0C) Once In Decade With 95% Chance: SP585",
             "statVar": "DiffRelativeToAvg_1980_2010_MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
           },
+          "DiffRelativeToAvg_1980_2010_MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP245": {
+            "name": "Relative Max Temperature (\u00b0C) Once In Year With 95% Chance: SSP245",
+            "statVar": "DiffRelativeToAvg_1980_2010_MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+          },
+          "DiffRelativeToAvg_1980_2010_MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP585": {
+            "name": "Relative Max Temperature (\u00b0C) Once In Year With 95% Chance: SP585",
+            "statVar": "DiffRelativeToAvg_1980_2010_MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+          },
           "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245": {
             "name": "Relative Min Temperature (\u00b0C) Once In Decade With 95% Chance: SSP245",
             "statVar": "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
@@ -310,6 +714,30 @@
           "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585": {
             "name": "Relative Min Temperature (\u00b0C) Once In Decade With 95% Chance: SP585",
             "statVar": "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
+          "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP245": {
+            "name": "Relative Min Temperature (\u00b0C) Once In Year With 95% Chance: SSP245",
+            "statVar": "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+          },
+          "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP585": {
+            "name": "Relative Min Temperature (\u00b0C) Once In Year With 95% Chance: SP585",
+            "statVar": "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
+          },
+          "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245": {
+            "name": "Max Temperature (\u00b0C) Once In Decade With 95% Chance: SSP245",
+            "statVar": "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585": {
+            "name": "Max Temperature (\u00b0C) Once In Decade With 95% Chance: SP585",
+            "statVar": "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
+          "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP245": {
+            "name": "Max Temperature (\u00b0C) Once In Year With 95% Chance: SSP245",
+            "statVar": "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+          },
+          "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP585": {
+            "name": "Max Temperature (\u00b0C) Once In Year With 95% Chance: SP585",
+            "statVar": "MaxTemp_Daily_Hist_95PctProb_Greater_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
           },
           "Max_Temperature": {
             "name": "Maximum Temperature",
@@ -322,6 +750,22 @@
           "Mean_Temperature": {
             "name": "Mean Temperature",
             "statVar": "Mean_Temperature"
+          },
+          "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245": {
+            "name": "Min Temperature (\u00b0C) Once In Decade With 95% Chance: SSP245",
+            "statVar": "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP245"
+          },
+          "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585": {
+            "name": "Min Temperature (\u00b0C) Once In Decade With 95% Chance: SP585",
+            "statVar": "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayADecade_CMIP6_Ensemble_SSP585"
+          },
+          "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP245": {
+            "name": "Min Temperature (\u00b0C) Once In Year With 95% Chance: SSP245",
+            "statVar": "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP245"
+          },
+          "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP585": {
+            "name": "Min Temperature (\u00b0C) Once In Year With 95% Chance: SP585",
+            "statVar": "MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP585"
           },
           "Min_Temperature": {
             "name": "Min Temperature",

--- a/server/integration_tests/test_data/demo_feb2023/query_4/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_4/chart_config.json
@@ -341,6 +341,63 @@
                 "tiles": [
                   {
                     "statVarKey": [
+                      "UnemploymentRate_Person"
+                    ],
+                    "title": "Unemployment Rate in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Unemployment Rate in Placer County",
+                    "statVarKey": [
+                      "UnemploymentRate_Person"
+                    ],
+                    "title": "Unemployment Rate in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Unemployment Rate"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_16OrMoreYears_PrivatelyOwnedEstablishment_NoHealthInsurance_UnpaidFamilyWorker_Worker"
+                    ],
+                    "title": "Population: 16 Years or More, Civilian, Privately Owned, No Health Insurance, Non Institutionalized, Unpaid Family Worker, Worker in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: 16 Years or More, Civilian, Privately Owned, No Health Insurance, Non Institutionalized, Unpaid Family Worker, Worker in Placer County",
+                    "statVarKey": [
+                      "Count_Person_16OrMoreYears_PrivatelyOwnedEstablishment_NoHealthInsurance_UnpaidFamilyWorker_Worker"
+                    ],
+                    "title": "Population: 16 Years or More, Civilian, Privately Owned, No Health Insurance, Non Institutionalized, Unpaid Family Worker, Worker in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: 16 Years or More, Civilian, Privately Owned, No Health Insurance, Non Institutionalized, Unpaid Family Worker, Worker"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
                       "dc/m615rq99fwf2c"
                     ],
                     "title": "Population: Car Truck or Van Carpooled, Service Occupations in Placer County",
@@ -402,6 +459,10 @@
           "Count_Household_MarriedCoupleFamilyHousehold_With2Worker": {
             "name": "Count of Household: Married Couple Family Household, Worker 2",
             "statVar": "Count_Household_MarriedCoupleFamilyHousehold_With2Worker"
+          },
+          "Count_Person_16OrMoreYears_PrivatelyOwnedEstablishment_NoHealthInsurance_UnpaidFamilyWorker_Worker": {
+            "name": "Population: 16 Years or More, Civilian, Privately Owned, No Health Insurance, Non Institutionalized, Unpaid Family Worker, Worker",
+            "statVar": "Count_Person_16OrMoreYears_PrivatelyOwnedEstablishment_NoHealthInsurance_UnpaidFamilyWorker_Worker"
           },
           "Count_Person_Employed": {
             "name": "Population With Current Employment",
@@ -478,6 +539,10 @@
           "Count_Worker_NAICSWholesaleTrade_multiple_place_bar_block": {
             "name": "Wholesale Trade",
             "statVar": "Count_Worker_NAICSWholesaleTrade"
+          },
+          "UnemploymentRate_Person": {
+            "name": "Unemployment Rate",
+            "statVar": "UnemploymentRate_Person"
           },
           "dc/7wt44yv38rew": {
             "name": "Population: Worked At Home, Sales And Office Occupations",

--- a/server/integration_tests/test_data/demo_feb2023/query_6/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_6/chart_config.json
@@ -421,28 +421,106 @@
               {
                 "tiles": [
                   {
-                    "statVarKey": [
-                      "Percent_Person_18To64Years_ReceivedNoHealthInsurance"
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/06061"
                     ],
-                    "title": "Percentage of Population Aged 18-64 With No Health Insurance in Placer County",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Percentage of Population Aged 18-64 With No Health Insurance in Placer County",
                     "statVarKey": [
-                      "Percent_Person_18To64Years_ReceivedNoHealthInsurance"
+                      "Count_Person_WithDisability_Female_multiple_place_bar_block",
+                      "Count_Person_WithDisability_Male_multiple_place_bar_block"
                     ],
-                    "title": "Percentage of Population Aged 18-64 With No Health Insurance in Placer County",
-                    "type": "HIGHLIGHT"
+                    "title": "Disabled Population by Gender in Placer County (${date})",
+                    "type": "BAR"
                   }
                 ]
               }
             ],
-            "title": "Percentage of Population Aged 18-64 With No Health Insurance"
+            "denom": "Count_Person",
+            "title": "Disabled Population by Gender"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/06061"
+                    ],
+                    "statVarKey": [
+                      "Count_Person_WithDisability_AmericanIndianOrAlaskaNativeAlone_multiple_place_bar_block",
+                      "Count_Person_WithDisability_BlackOrAfricanAmericanAlone_multiple_place_bar_block",
+                      "Count_Person_WithDisability_HispanicOrLatino_multiple_place_bar_block",
+                      "Count_Person_WithDisability_OneRace_multiple_place_bar_block",
+                      "Count_Person_WithDisability_SomeOtherRaceAlone_multiple_place_bar_block",
+                      "Count_Person_WithDisability_TwoOrMoreRaces_multiple_place_bar_block",
+                      "Count_Person_WithDisability_WhiteAlone_multiple_place_bar_block",
+                      "Count_Person_WithDisability_WhiteAloneNotHispanicOrLatino_multiple_place_bar_block"
+                    ],
+                    "title": "Disabled Population by Race in Placer County (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Disabled Population by Race"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/06061"
+                    ],
+                    "statVarKey": [
+                      "Count_Person_Female_NoHealthInsurance_multiple_place_bar_block",
+                      "Count_Person_Male_NoHealthInsurance_multiple_place_bar_block"
+                    ],
+                    "title": "Uninsured by Gender in Placer County (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Uninsured by Gender"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/06061"
+                    ],
+                    "statVarKey": [
+                      "Count_Person_Female_WithHealthInsurance_multiple_place_bar_block",
+                      "Count_Person_Male_WithHealthInsurance_multiple_place_bar_block"
+                    ],
+                    "title": "With Health Insurance by Gender in Placer County (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "With Health Insurance by Gender"
           },
           {
             "columns": [
@@ -450,9 +528,9 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "Count_Person_WithVAHealthCare"
+                      "Count_Person_NoHealthInsurance"
                     ],
-                    "title": "People With VA Health Care in Placer County",
+                    "title": "Population Without Health Insurance in Placer County",
                     "type": "LINE"
                   }
                 ]
@@ -460,18 +538,74 @@
               {
                 "tiles": [
                   {
-                    "description": "People With VA Health Care in Placer County",
+                    "description": "Population Without Health Insurance in Placer County",
                     "statVarKey": [
-                      "Count_Person_WithVAHealthCare"
+                      "Count_Person_NoHealthInsurance"
                     ],
-                    "title": "People With VA Health Care in Placer County",
+                    "title": "Population Without Health Insurance in Placer County",
                     "type": "HIGHLIGHT"
                   }
                 ]
               }
             ],
             "denom": "Count_Person",
-            "title": "People With VA Health Care"
+            "title": "Population Without Health Insurance"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_WithHealthInsurance"
+                    ],
+                    "title": "Population With Health Insurance in Placer County",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population With Health Insurance in Placer County",
+                    "statVarKey": [
+                      "Count_Person_WithHealthInsurance"
+                    ],
+                    "title": "Population With Health Insurance in Placer County",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population With Health Insurance"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "geoId/06061"
+                    ],
+                    "statVarKey": [
+                      "Count_Person_WithPrivateHealthInsurance_multiple_place_bar_block",
+                      "Count_Person_WithPrivateHealthInsuranceOnly_multiple_place_bar_block",
+                      "Count_Person_WithPublicHealthInsurance_multiple_place_bar_block",
+                      "Count_Person_WithPublicHealthInsuranceOnly_multiple_place_bar_block"
+                    ],
+                    "title": "Type of Health Insurance Coverage in Placer County (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Type of Health Insurance Coverage"
           }
         ],
         "statVarSpec": {
@@ -519,9 +653,85 @@
             "name": "Deaths From Neoplasms (Tumors or Abnormal Growths)",
             "statVar": "Count_Death_Neoplasms"
           },
-          "Count_Person_WithVAHealthCare": {
-            "name": "People With VA Health Care",
-            "statVar": "Count_Person_WithVAHealthCare"
+          "Count_Person_Female_NoHealthInsurance_multiple_place_bar_block": {
+            "name": "Women With No Health Insurance",
+            "statVar": "Count_Person_Female_NoHealthInsurance"
+          },
+          "Count_Person_Female_WithHealthInsurance_multiple_place_bar_block": {
+            "name": "Women With Health Insurance",
+            "statVar": "Count_Person_Female_WithHealthInsurance"
+          },
+          "Count_Person_Male_NoHealthInsurance_multiple_place_bar_block": {
+            "name": "Men With No Health Insurance",
+            "statVar": "Count_Person_Male_NoHealthInsurance"
+          },
+          "Count_Person_Male_WithHealthInsurance_multiple_place_bar_block": {
+            "name": "Men With Health Insurance",
+            "statVar": "Count_Person_Male_WithHealthInsurance"
+          },
+          "Count_Person_NoHealthInsurance": {
+            "name": "Population Without Health Insurance",
+            "statVar": "Count_Person_NoHealthInsurance"
+          },
+          "Count_Person_WithDisability_AmericanIndianOrAlaskaNativeAlone_multiple_place_bar_block": {
+            "name": "American Indian/Alaska Native Population With Disabilities",
+            "statVar": "Count_Person_WithDisability_AmericanIndianOrAlaskaNativeAlone"
+          },
+          "Count_Person_WithDisability_BlackOrAfricanAmericanAlone_multiple_place_bar_block": {
+            "name": "Black/African American Population With Disabilities",
+            "statVar": "Count_Person_WithDisability_BlackOrAfricanAmericanAlone"
+          },
+          "Count_Person_WithDisability_Female_multiple_place_bar_block": {
+            "name": "Women With Disabilities",
+            "statVar": "Count_Person_WithDisability_Female"
+          },
+          "Count_Person_WithDisability_HispanicOrLatino_multiple_place_bar_block": {
+            "name": "Hispanic/Latino Population With Disabilities",
+            "statVar": "Count_Person_WithDisability_HispanicOrLatino"
+          },
+          "Count_Person_WithDisability_Male_multiple_place_bar_block": {
+            "name": "Men With Disabilities",
+            "statVar": "Count_Person_WithDisability_Male"
+          },
+          "Count_Person_WithDisability_OneRace_multiple_place_bar_block": {
+            "name": "Single-Race Population With Disabilities",
+            "statVar": "Count_Person_WithDisability_OneRace"
+          },
+          "Count_Person_WithDisability_SomeOtherRaceAlone_multiple_place_bar_block": {
+            "name": "Disabled Population of Some Other Race",
+            "statVar": "Count_Person_WithDisability_SomeOtherRaceAlone"
+          },
+          "Count_Person_WithDisability_TwoOrMoreRaces_multiple_place_bar_block": {
+            "name": "Disabled Population of Two or More Races",
+            "statVar": "Count_Person_WithDisability_TwoOrMoreRaces"
+          },
+          "Count_Person_WithDisability_WhiteAloneNotHispanicOrLatino_multiple_place_bar_block": {
+            "name": "Non Hispanic or Latino White Population With Disabilities",
+            "statVar": "Count_Person_WithDisability_WhiteAloneNotHispanicOrLatino"
+          },
+          "Count_Person_WithDisability_WhiteAlone_multiple_place_bar_block": {
+            "name": "White Disbabled Population",
+            "statVar": "Count_Person_WithDisability_WhiteAlone"
+          },
+          "Count_Person_WithHealthInsurance": {
+            "name": "Population With Health Insurance",
+            "statVar": "Count_Person_WithHealthInsurance"
+          },
+          "Count_Person_WithPrivateHealthInsuranceOnly_multiple_place_bar_block": {
+            "name": "People With Only Private Health Insurance",
+            "statVar": "Count_Person_WithPrivateHealthInsuranceOnly"
+          },
+          "Count_Person_WithPrivateHealthInsurance_multiple_place_bar_block": {
+            "name": "People With Private Health Insurance",
+            "statVar": "Count_Person_WithPrivateHealthInsurance"
+          },
+          "Count_Person_WithPublicHealthInsuranceOnly_multiple_place_bar_block": {
+            "name": "People With Only Public Health Insurance",
+            "statVar": "Count_Person_WithPublicHealthInsuranceOnly"
+          },
+          "Count_Person_WithPublicHealthInsurance_multiple_place_bar_block": {
+            "name": "People With Public Health Insurance",
+            "statVar": "Count_Person_WithPublicHealthInsurance"
           },
           "Percent_Person_18OrMoreYears_WithDepression": {
             "name": "Depression",
@@ -531,11 +741,6 @@
           "Percent_Person_18OrMoreYears_WithHighBloodPressure_ReceivedTakingBloodPressureMedication": {
             "name": "Percent of Adults with Blood Pressure Who Take Medication",
             "statVar": "Percent_Person_18OrMoreYears_WithHighBloodPressure_ReceivedTakingBloodPressureMedication",
-            "unit": "%"
-          },
-          "Percent_Person_18To64Years_ReceivedNoHealthInsurance": {
-            "name": "Percentage of Population Aged 18-64 With No Health Insurance",
-            "statVar": "Percent_Person_18To64Years_ReceivedNoHealthInsurance",
             "unit": "%"
           },
           "Percent_Person_21To65Years_Female_ReceivedCervicalCancerScreening_multiple_place_bar_block": {

--- a/server/integration_tests/test_data/e2e_edge_cases/povertyincaliforniaandcalifornia/chart_config.json
+++ b/server/integration_tests/test_data/e2e_edge_cases/povertyincaliforniaandcalifornia/chart_config.json
@@ -658,6 +658,67 @@
             ],
             "denom": "Count_Person",
             "title": "Population With Poverty Status Determined"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_OnlyEnglishSpokenAtHome_AbovePovertyLevelInThePast12Months"
+                    ],
+                    "title": "English Spoken at Home, Above Poverty Line in California",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "English Spoken at Home, Above Poverty Line in California",
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_OnlyEnglishSpokenAtHome_AbovePovertyLevelInThePast12Months"
+                    ],
+                    "title": "English Spoken at Home, Above Poverty Line in California",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "English Spoken at Home, Above Poverty Line"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_OnlyEnglishSpokenAtHome_AbovePovertyLevelInThePast12Months"
+                    ],
+                    "title": "English Spoken at Home, Above Poverty Line in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_OnlyEnglishSpokenAtHome_AbovePovertyLevelInThePast12Months"
+                    ],
+                    "title": "English Spoken at Home, Above Poverty Line in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "English Spoken at Home, Above Poverty Line in Counties of California"
           }
         ],
         "statVarSpec": {
@@ -680,6 +741,10 @@
           "Count_Person_5OrMoreYears_LanguageOtherThanEnglishSpokenAtHome_BelowPovertyLevelInThePast12Months": {
             "name": "Some language other than English spoken at home & below poverty line",
             "statVar": "Count_Person_5OrMoreYears_LanguageOtherThanEnglishSpokenAtHome_BelowPovertyLevelInThePast12Months"
+          },
+          "Count_Person_5OrMoreYears_OnlyEnglishSpokenAtHome_AbovePovertyLevelInThePast12Months": {
+            "name": "English Spoken At Home, Above Poverty Line",
+            "statVar": "Count_Person_5OrMoreYears_OnlyEnglishSpokenAtHome_AbovePovertyLevelInThePast12Months"
           },
           "Count_Person_5OrMoreYears_OnlyEnglishSpokenAtHome_BelowPovertyLevelInThePast12Months": {
             "name": "Population 5 Years or More, Only English, Below Poverty Level in Past 12 Months",

--- a/server/integration_tests/test_data/e2e_electrification_demo/howdothesecountriescomparewiththeusandgermany/chart_config.json
+++ b/server/integration_tests/test_data/e2e_electrification_demo/howdothesecountriescomparewiththeusandgermany/chart_config.json
@@ -126,50 +126,22 @@
                       "country/UGA"
                     ],
                     "statVarKey": [
-                      "Annual_Consumption_Electricity_multiple_place_bar_block"
+                      "Annual_Consumption_Electricity_multiple_place_bar_block",
+                      "Annual_Consumption_Electricity_Agriculture_multiple_place_bar_block",
+                      "Annual_Consumption_Electricity_CommerceAndPublicServices_multiple_place_bar_block",
+                      "Annual_Consumption_Electricity_ConstructionIndustry_multiple_place_bar_block",
+                      "Annual_Consumption_Electricity_Households_multiple_place_bar_block",
+                      "Annual_Consumption_Electricity_Manufacturing_multiple_place_bar_block",
+                      "Annual_Consumption_Electricity_TransportIndustry_multiple_place_bar_block"
                     ],
-                    "title": "Annual Electricity Consumption (${date})",
+                    "title": "Electricity Consumption by Sector (${date})",
                     "type": "BAR"
                   }
                 ]
               }
             ],
             "denom": "Count_Person",
-            "title": "Annual Electricity Consumption"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "barTileSpec": {
-                      "maxVariables": 15,
-                      "sort": "DESCENDING"
-                    },
-                    "comparisonPlaces": [
-                      "country/USA",
-                      "country/DEU",
-                      "country/KEN",
-                      "country/GHA",
-                      "country/ETH",
-                      "country/MLI",
-                      "country/MAR",
-                      "country/RWA",
-                      "country/SEN",
-                      "country/GIN",
-                      "country/UGA"
-                    ],
-                    "statVarKey": [
-                      "Annual_Consumption_Electricity_Households_multiple_place_bar_block"
-                    ],
-                    "title": "Annual Consumption of Electricity: for Households (${date})",
-                    "type": "BAR"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Annual Consumption of Electricity: for Households"
+            "title": "Electricity Consumption by Sector"
           },
           {
             "columns": [
@@ -318,6 +290,18 @@
             "name": "Per Capita Electricity Use",
             "statVar": "Amount_Consumption_Electricity_PerCapita"
           },
+          "Annual_Consumption_Electricity_Agriculture_multiple_place_bar_block": {
+            "name": "Annual Consumption of Electricity: for Agriculture",
+            "statVar": "Annual_Consumption_Electricity_Agriculture"
+          },
+          "Annual_Consumption_Electricity_CommerceAndPublicServices_multiple_place_bar_block": {
+            "name": "Annual Consumption of Electricity: for Commerce And Public Services",
+            "statVar": "Annual_Consumption_Electricity_CommerceAndPublicServices"
+          },
+          "Annual_Consumption_Electricity_ConstructionIndustry_multiple_place_bar_block": {
+            "name": "Annual Consumption of Electricity: for Construction Industry",
+            "statVar": "Annual_Consumption_Electricity_ConstructionIndustry"
+          },
           "Annual_Consumption_Electricity_ElectricityGeneration_EnergyIndustryOwnUse_multiple_place_bar_block": {
             "name": "Annual Consumption of Electricity: for Electricity Generation, Energy Industry Own Use",
             "statVar": "Annual_Consumption_Electricity_ElectricityGeneration_EnergyIndustryOwnUse"
@@ -326,9 +310,17 @@
             "name": "Annual Consumption of Electricity: for Households",
             "statVar": "Annual_Consumption_Electricity_Households"
           },
+          "Annual_Consumption_Electricity_Manufacturing_multiple_place_bar_block": {
+            "name": "Annual Consumption of Electricity: for Manufacturing",
+            "statVar": "Annual_Consumption_Electricity_Manufacturing"
+          },
           "Annual_Consumption_Electricity_OtherSector_multiple_place_bar_block": {
             "name": "Annual Consumption of Electricity: for UN_Other Sector",
             "statVar": "Annual_Consumption_Electricity_OtherSector"
+          },
+          "Annual_Consumption_Electricity_TransportIndustry_multiple_place_bar_block": {
+            "name": "Annual Consumption of Electricity: for Transport Industry",
+            "statVar": "Annual_Consumption_Electricity_TransportIndustry"
           },
           "Annual_Consumption_Electricity_multiple_place_bar_block": {
             "name": "Annual Electricity Consumption",

--- a/server/integration_tests/test_data/e2e_india_demo/whichstatesinindiahavethehighestpovertylevelspercapita/chart_config.json
+++ b/server/integration_tests/test_data/e2e_india_demo/whichstatesinindiahavethehighestpovertylevelspercapita/chart_config.json
@@ -197,22 +197,11 @@
                 "tiles": [
                   {
                     "statVarKey": [
+                      "Count_Person_Rural_BelowPovertyLevelInThePast12Months",
                       "Count_Person_Urban_BelowPovertyLevelInThePast12Months"
                     ],
-                    "title": "Urban Residents, Below Poverty Level in the Past 12 Months in India",
+                    "title": "Impoverished Population by Residency in India",
                     "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Urban Residents, Below Poverty Level in the Past 12 Months in India",
-                    "statVarKey": [
-                      "Count_Person_Urban_BelowPovertyLevelInThePast12Months"
-                    ],
-                    "title": "Urban Residents, Below Poverty Level in the Past 12 Months in India",
-                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -255,22 +244,12 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "sdg/SI_POV_DAY1.AGE--Y15T64"
+                      "sdg/SI_POV_DAY1.AGE--Y0T14",
+                      "sdg/SI_POV_DAY1.AGE--Y15T64",
+                      "sdg/SI_POV_DAY1.AGE--Y_GE65"
                     ],
-                    "title": "Population Age 15 to 64 Below International Poverty Line in India",
+                    "title": "Population Below International Poverty Line by Age in India",
                     "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Population Age 15 to 64 Below International Poverty Line in India",
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1.AGE--Y15T64"
-                    ],
-                    "title": "Population Age 15 to 64 Below International Poverty Line in India",
-                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -283,22 +262,11 @@
                 "tiles": [
                   {
                     "statVarKey": [
+                      "sdg/SI_POV_DAY1.SEX--F",
                       "sdg/SI_POV_DAY1.SEX--M"
                     ],
-                    "title": "Men Below International Poverty Line in India",
+                    "title": "Population Below International Poverty Line by Gender in India",
                     "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Men Below International Poverty Line in India",
-                    "statVarKey": [
-                      "sdg/SI_POV_DAY1.SEX--M"
-                    ],
-                    "title": "Men Below International Poverty Line in India",
-                    "type": "HIGHLIGHT"
                   }
                 ]
               }
@@ -311,9 +279,26 @@
                 "tiles": [
                   {
                     "statVarKey": [
+                      "sdg/SI_POV_DAY1.URBANISATION--U",
                       "sdg/SI_POV_DAY1.URBANISATION--R"
                     ],
-                    "title": "Rural Population Below International Poverty Line in India",
+                    "title": "Population Below International Poverty Line in Rural Vs. Urban Areas in India",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "title": "Population Below International Poverty Line in Rural Vs. Urban Areas"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SP_ACS_BSRVH2O"
+                    ],
+                    "title": "Population Using Basic Drinking Water Services in India",
                     "type": "LINE"
                   }
                 ]
@@ -321,17 +306,90 @@
               {
                 "tiles": [
                   {
-                    "description": "Rural Population Below International Poverty Line in India",
+                    "description": "Population Using Basic Drinking Water Services in India",
                     "statVarKey": [
-                      "sdg/SI_POV_DAY1.URBANISATION--R"
+                      "sdg/SP_ACS_BSRVH2O"
                     ],
-                    "title": "Rural Population Below International Poverty Line in India",
+                    "title": "Population Using Basic Drinking Water Services in India",
                     "type": "HIGHLIGHT"
                   }
                 ]
               }
             ],
-            "title": "Population Below International Poverty Line in Rural Vs. Urban Areas"
+            "title": "Population Using Basic Drinking Water Services"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SP_ACS_BSRVSAN"
+                    ],
+                    "title": "Population Using Basic Sanitation Services in India",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population Using Basic Sanitation Services in India",
+                    "statVarKey": [
+                      "sdg/SP_ACS_BSRVSAN"
+                    ],
+                    "title": "Population Using Basic Sanitation Services in India",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Population Using Basic Sanitation Services"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_EMP1.AGE--Y_GE15"
+                    ],
+                    "title": "Employed Population Aged 15 or Over Below International Poverty Line in India",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Employed Population Aged 15 or Over Below International Poverty Line in India",
+                    "statVarKey": [
+                      "sdg/SI_POV_EMP1.AGE--Y_GE15"
+                    ],
+                    "title": "Employed Population Aged 15 or Over Below International Poverty Line in India",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Employed Population Aged 15 or Over Below International Poverty Line"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--F",
+                      "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--M"
+                    ],
+                    "title": "Employed Population Below International Poverty Line by Gender in India",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "title": "Employed Population Below International Poverty Line by Gender"
           }
         ],
         "statVarSpec": {
@@ -355,9 +413,21 @@
             "name": "Population Below International Poverty Line",
             "statVar": "sdg/SI_POV_DAY1"
           },
+          "sdg/SI_POV_DAY1.AGE--Y0T14": {
+            "name": "Population Age Under 15 Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.AGE--Y0T14"
+          },
           "sdg/SI_POV_DAY1.AGE--Y15T64": {
             "name": "Population Age 15 to 64 Below International Poverty Line",
             "statVar": "sdg/SI_POV_DAY1.AGE--Y15T64"
+          },
+          "sdg/SI_POV_DAY1.AGE--Y_GE65": {
+            "name": "Population Age 65 or Older Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.AGE--Y_GE65"
+          },
+          "sdg/SI_POV_DAY1.SEX--F": {
+            "name": "Women Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.SEX--F"
           },
           "sdg/SI_POV_DAY1.SEX--M": {
             "name": "Men Below International Poverty Line",
@@ -366,6 +436,30 @@
           "sdg/SI_POV_DAY1.URBANISATION--R": {
             "name": "Rural Population Below International Poverty Line",
             "statVar": "sdg/SI_POV_DAY1.URBANISATION--R"
+          },
+          "sdg/SI_POV_DAY1.URBANISATION--U": {
+            "name": "Urban Population Below International Poverty Line",
+            "statVar": "sdg/SI_POV_DAY1.URBANISATION--U"
+          },
+          "sdg/SI_POV_EMP1.AGE--Y_GE15": {
+            "name": "Employed Population Aged 15 or Over Below International Poverty Line",
+            "statVar": "sdg/SI_POV_EMP1.AGE--Y_GE15"
+          },
+          "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--F": {
+            "name": "Employed Women Aged 15 or Over Below International Poverty Line",
+            "statVar": "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--F"
+          },
+          "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--M": {
+            "name": "Employed Men Aged 15 or Over Below International Poverty Line",
+            "statVar": "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--M"
+          },
+          "sdg/SP_ACS_BSRVH2O": {
+            "name": "Population Using Basic Drinking Water Services",
+            "statVar": "sdg/SP_ACS_BSRVH2O"
+          },
+          "sdg/SP_ACS_BSRVSAN": {
+            "name": "Population Using Basic Sanitation Services",
+            "statVar": "sdg/SP_ACS_BSRVSAN"
           }
         }
       }
@@ -723,6 +817,24 @@
         "sdg_urbanisation": [
           "sdg/SI_POV_DAY1.URBANISATION--R",
           "sdg/SI_POV_DAY1.URBANISATION--U"
+        ]
+      },
+      "sdg/SI_POV_EMP1.AGE--Y_GE15": {
+        "gender": [
+          "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--F",
+          "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--M"
+        ]
+      },
+      "sdg/SP_ACS_BSRVH2O": {
+        "sdg_urbanisation": [
+          "sdg/SP_ACS_BSRVH2O.URBANISATION--R",
+          "sdg/SP_ACS_BSRVH2O.URBANISATION--U"
+        ]
+      },
+      "sdg/SP_ACS_BSRVSAN": {
+        "sdg_urbanisation": [
+          "sdg/SP_ACS_BSRVSAN.URBANISATION--R",
+          "sdg/SP_ACS_BSRVSAN.URBANISATION--U"
         ]
       }
     },

--- a/server/integration_tests/test_data/international/query_3/chart_config.json
+++ b/server/integration_tests/test_data/international/query_3/chart_config.json
@@ -82,6 +82,62 @@
                 "tiles": [
                   {
                     "statVarKey": [
+                      "UnemploymentRate_Person"
+                    ],
+                    "title": "Unemployment Rate in United Kingdom",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Unemployment Rate in United Kingdom",
+                    "statVarKey": [
+                      "UnemploymentRate_Person"
+                    ],
+                    "title": "Unemployment Rate in United Kingdom",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Unemployment Rate"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "UnemploymentRate_Person_Female"
+                    ],
+                    "title": "Unemployment Rate of Females in United Kingdom",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Unemployment Rate of Females in United Kingdom",
+                    "statVarKey": [
+                      "UnemploymentRate_Person_Female"
+                    ],
+                    "title": "Unemployment Rate of Females in United Kingdom",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Unemployment Rate of Females"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
                       "Amount_EconomicActivity_GrossDomesticProduction_Nominal_AsAFractionOf_Count_Person"
                     ],
                     "title": "Amount of Economic Activity (Nominal): Gross Domestic Production (Per Capita) in Eurostat Nuts 3 Places of United Kingdom (${date})",
@@ -109,6 +165,14 @@
           "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction": {
             "name": "Growth Rate of GDP",
             "statVar": "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
+          },
+          "UnemploymentRate_Person": {
+            "name": "Unemployment Rate",
+            "statVar": "UnemploymentRate_Person"
+          },
+          "UnemploymentRate_Person_Female": {
+            "name": "Unemployment Rate of Females",
+            "statVar": "UnemploymentRate_Person_Female"
           }
         }
       }

--- a/server/integration_tests/test_data/international/query_5/chart_config.json
+++ b/server/integration_tests/test_data/international/query_5/chart_config.json
@@ -77,12 +77,235 @@
               }
             ],
             "title": "Floods"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Area_DroughtEvent"
+                    ],
+                    "title": "Area of Drought Event in Brazil",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Area of Drought Event in Brazil",
+                    "statVarKey": [
+                      "Area_DroughtEvent"
+                    ],
+                    "title": "Area of Drought Event in Brazil",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Area of Drought Event"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_DroughtEvent"
+                    ],
+                    "title": "Droughts in Brazil",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Droughts in Brazil",
+                    "statVarKey": [
+                      "Count_DroughtEvent"
+                    ],
+                    "title": "Droughts in Brazil",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Droughts"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_FireEvent"
+                    ],
+                    "title": "Count of Fire Event in Brazil",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Count of Fire Event in Brazil",
+                    "statVarKey": [
+                      "Count_FireEvent"
+                    ],
+                    "title": "Count of Fire Event in Brazil",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Count of Fire Event"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_CycloneEvent"
+                    ],
+                    "title": "Cyclones in Brazil",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Cyclones in Brazil",
+                    "statVarKey": [
+                      "Count_CycloneEvent"
+                    ],
+                    "title": "Cyclones in Brazil",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Cyclones"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxVariables": 15,
+                      "sort": "DESCENDING"
+                    },
+                    "comparisonPlaces": [
+                      "country/BRA"
+                    ],
+                    "statVarKey": [
+                      "Count_CycloneEvent_TropicalDisturbance_multiple_place_bar_block",
+                      "Count_CycloneEvent_TropicalStorm_multiple_place_bar_block"
+                    ],
+                    "title": "Cyclones by Type in Brazil (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "title": "Cyclones by Type"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_EarthquakeEvent"
+                    ],
+                    "title": "Earthquakes in Brazil",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Earthquakes in Brazil",
+                    "statVarKey": [
+                      "Count_EarthquakeEvent"
+                    ],
+                    "title": "Earthquakes in Brazil",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Earthquakes"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_EarthquakeEvent_M5To6",
+                      "Count_EarthquakeEvent_M6To7",
+                      "Count_EarthquakeEvent_M7To8"
+                    ],
+                    "title": "Earthquakes by Intensity in Brazil",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Earthquakes by Intensity"
           }
         ],
         "statVarSpec": {
+          "Area_DroughtEvent": {
+            "name": "Area of Drought Event",
+            "statVar": "Area_DroughtEvent"
+          },
           "Area_FloodEvent": {
             "name": "Area of Flood Event",
             "statVar": "Area_FloodEvent"
+          },
+          "Count_CycloneEvent": {
+            "name": "Cyclones",
+            "statVar": "Count_CycloneEvent"
+          },
+          "Count_CycloneEvent_TropicalDisturbance_multiple_place_bar_block": {
+            "name": "Count of Cyclone Event: Tropical Disturbance",
+            "statVar": "Count_CycloneEvent_TropicalDisturbance"
+          },
+          "Count_CycloneEvent_TropicalStorm_multiple_place_bar_block": {
+            "name": "Count of Cyclone Event: Tropical Storm",
+            "statVar": "Count_CycloneEvent_TropicalStorm"
+          },
+          "Count_DroughtEvent": {
+            "name": "Droughts",
+            "statVar": "Count_DroughtEvent"
+          },
+          "Count_EarthquakeEvent": {
+            "name": "Earthquakes",
+            "statVar": "Count_EarthquakeEvent"
+          },
+          "Count_EarthquakeEvent_M5To6": {
+            "name": "Count of Earthquake Event: 5 - 6 Magnitude",
+            "statVar": "Count_EarthquakeEvent_M5To6"
+          },
+          "Count_EarthquakeEvent_M6To7": {
+            "name": "Count of Earthquake Event: 6 - 7 Magnitude",
+            "statVar": "Count_EarthquakeEvent_M6To7"
+          },
+          "Count_EarthquakeEvent_M7To8": {
+            "name": "Count of Earthquake Event: 7 - 8 Magnitude",
+            "statVar": "Count_EarthquakeEvent_M7To8"
+          },
+          "Count_FireEvent": {
+            "name": "Count of Fire Event",
+            "statVar": "Count_FireEvent"
           },
           "Count_FloodEvent": {
             "name": "Floods",

--- a/server/integration_tests/test_data/sdg/query_1/chart_config.json
+++ b/server/integration_tests/test_data/sdg/query_1/chart_config.json
@@ -110,6 +110,71 @@
               }
             ],
             "title": "Population Below International Poverty Line in Rural Vs. Urban Areas in Countries of Africa"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SP_ACS_BSRVH2O"
+                    ],
+                    "title": "Population Using Basic Drinking Water Services in Countries of Africa (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SP_ACS_BSRVSAN"
+                    ],
+                    "title": "Population Using Basic Sanitation Services in Countries of Africa (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_EMP1.AGE--Y_GE15"
+                    ],
+                    "title": "Employed Population Aged 15 or Over Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Population Below International Poverty Line and More in Countries of Africa"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--F"
+                    ],
+                    "title": "Employed Women Aged 15 or Over Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--M"
+                    ],
+                    "title": "Employed Men Aged 15 or Over Below International Poverty Line in Countries of Africa (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Employed Population Below International Poverty Line by Gender in Countries of Africa"
           }
         ],
         "statVarSpec": {
@@ -144,6 +209,26 @@
           "sdg/SI_POV_DAY1.URBANISATION--U": {
             "name": "Urban Population Below International Poverty Line",
             "statVar": "sdg/SI_POV_DAY1.URBANISATION--U"
+          },
+          "sdg/SI_POV_EMP1.AGE--Y_GE15": {
+            "name": "Employed Population Aged 15 or Over Below International Poverty Line",
+            "statVar": "sdg/SI_POV_EMP1.AGE--Y_GE15"
+          },
+          "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--F": {
+            "name": "Employed Women Aged 15 or Over Below International Poverty Line",
+            "statVar": "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--F"
+          },
+          "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--M": {
+            "name": "Employed Men Aged 15 or Over Below International Poverty Line",
+            "statVar": "sdg/SI_POV_EMP1.AGE--Y_GE15__SEX--M"
+          },
+          "sdg/SP_ACS_BSRVH2O": {
+            "name": "Population Using Basic Drinking Water Services",
+            "statVar": "sdg/SP_ACS_BSRVH2O"
+          },
+          "sdg/SP_ACS_BSRVSAN": {
+            "name": "Population Using Basic Sanitation Services",
+            "statVar": "sdg/SP_ACS_BSRVSAN"
           }
         }
       }

--- a/server/integration_tests/test_data/sdg/query_3/chart_config.json
+++ b/server/integration_tests/test_data/sdg/query_3/chart_config.json
@@ -150,6 +150,498 @@
             ],
             "denom": "Count_Person",
             "title": "Health Behaviors in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/WHS4_543"
+                    ],
+                    "title": "Bcg Immunization Coverage Among 1-Year-Olds (%) in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Hepatitis B (Hepb3) Immunization Coverage Among 1-Year-Olds (%) and More in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/MORT_MATERNALNUM"
+                    ],
+                    "title": "Number of Maternal Deaths in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "sdg/SH_STA_MORT.SEX--F"
+                    ],
+                    "title": "Maternal Mortality Ratio in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "title": "Number of Maternal Deaths and More in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/CM_01"
+                    ],
+                    "title": "Number of Under-Five Deaths in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/CM_02"
+                    ],
+                    "title": "Number of Infant Deaths in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/CM_03"
+                    ],
+                    "title": "Number of Neonatal Deaths in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Child Mortality in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001418"
+                    ],
+                    "title": "Alcohol Use Disorders, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001419"
+                    ],
+                    "title": "Breast Cancer, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001420"
+                    ],
+                    "title": "Colon and Rectum Cancers, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001421"
+                    ],
+                    "title": "Diabetes Mellitus, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001422"
+                    ],
+                    "title": "Drownings, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001423"
+                    ],
+                    "title": "Falls, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001424"
+                    ],
+                    "title": "Fires, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001425"
+                    ],
+                    "title": "Ischaemic Heart Disease, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001426"
+                    ],
+                    "title": "Liver Cancer, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001427"
+                    ],
+                    "title": "Liver Cirrhosis, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001429"
+                    ],
+                    "title": "Mouth and Oropharynx Cancer, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001430"
+                    ],
+                    "title": "Oesophagus Cancer, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001431"
+                    ],
+                    "title": "Poisoning, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001432"
+                    ],
+                    "title": "Prematurity and Low Birth Rate, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001433"
+                    ],
+                    "title": "Road Traffic Accidents, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001434"
+                    ],
+                    "title": "Self-Inflicted Injury, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001435"
+                    ],
+                    "title": "Other Unintentional Injuries, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001436"
+                    ],
+                    "title": "Violence, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SA_0000001689"
+                    ],
+                    "title": "Cerebrovascular Disease, Per 100,000 in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Disability-Adjusted Life-Years in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NTD_4"
+                    ],
+                    "title": "New Cases of Human African Trypanosomiasis in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NTD_LEISHCNUM"
+                    ],
+                    "title": "Cases of Cutaneous Leishmaniasis in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NTD_LEISHVNUM"
+                    ],
+                    "title": "Cases of Visceral Leishmaniasis in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NTD_LEPR5"
+                    ],
+                    "title": "New G2D Leprosy Cases in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Cases of Neglected Troplical Diseases in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/LBW_PREVALENCE"
+                    ],
+                    "title": "% Low Birth Weight in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NUTOVERWEIGHTPREV"
+                    ],
+                    "title": "% Overweight, Children Under 5 Years in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NUTRITION_ANAEMIA_CHILDREN_PREV"
+                    ],
+                    "title": "% Anaemia, Children Aged 6-59 Months in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NUTRITION_WA_2"
+                    ],
+                    "title": "% Underweight, Children Under 5 Years in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NUTRITION_WH_2"
+                    ],
+                    "title": "% Wasted, Children Under 5 Years in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NUTRITION_WH_3"
+                    ],
+                    "title": "% Severely Wasted, Children Under 5 Years in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NUTSTUNTINGPREV"
+                    ],
+                    "title": "% Stunting, Children Under 5 Years in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Non-communicable Diseases Among Children in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/GDO_q35"
+                    ],
+                    "title": "Estimated Population-Based Prevalence of Depression in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SDG_SH_DTH_RNCOM_ChronicRespiratoryDiseases"
+                    ],
+                    "title": "Non-Communicable Disease Deaths, by Disease & Sex, Chronic Respiratory Diseases in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SDG_SH_DTH_RNCOM_DiabetesMellitus"
+                    ],
+                    "title": "Non-Communicable Disease Deaths, by Disease & Sex, Diabetes Mellitus in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SDG_SH_DTH_RNCOM_MajorCardiovascularDiseases"
+                    ],
+                    "title": "Non-Communicable Diseases Deaths, by Disease & Sex, Major Cardiovascular Diseases in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/SDG_SH_DTH_RNCOM_MalignantNeoplasms"
+                    ],
+                    "title": "Non-Communicable Diseases Deaths, by Disease & Sex, Malignant Neoplasms in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Deaths Due to Non-communicable Diseases in the World"
           }
         ],
         "statVarSpec": {
@@ -169,6 +661,30 @@
             "name": "Male Life Expectancy",
             "statVar": "LifeExpectancy_Person_Male"
           },
+          "WHO/CM_01": {
+            "name": "Number Of Under-Five Deaths",
+            "statVar": "WHO/CM_01"
+          },
+          "WHO/CM_02": {
+            "name": "Number Of Infant Deaths",
+            "statVar": "WHO/CM_02"
+          },
+          "WHO/CM_03": {
+            "name": "Number Of Neonatal Deaths",
+            "statVar": "WHO/CM_03"
+          },
+          "WHO/GDO_q35": {
+            "name": "Estimated Population-Based Prevalence Of Depression",
+            "statVar": "WHO/GDO_q35"
+          },
+          "WHO/LBW_PREVALENCE": {
+            "name": "% Low Birth Weight",
+            "statVar": "WHO/LBW_PREVALENCE"
+          },
+          "WHO/MORT_MATERNALNUM": {
+            "name": "Number Of Maternal Deaths",
+            "statVar": "WHO/MORT_MATERNALNUM"
+          },
           "WHO/M_Est_smk_daily": {
             "name": "% Daily Tobacco Smokers (Estimate)",
             "statVar": "WHO/M_Est_smk_daily"
@@ -185,6 +701,138 @@
             "name": "% Insufficient Physical Activity Among Adults Aged 18+ Years (Crude Estimate)",
             "statVar": "WHO/NCD_PAC"
           },
+          "WHO/NTD_4": {
+            "name": "New Cases Of Human African Trypanosomiasis",
+            "statVar": "WHO/NTD_4"
+          },
+          "WHO/NTD_LEISHCNUM": {
+            "name": "Cases Of Cutaneous Leishmaniasis",
+            "statVar": "WHO/NTD_LEISHCNUM"
+          },
+          "WHO/NTD_LEISHVNUM": {
+            "name": "Cases Of Visceral Leishmaniasis",
+            "statVar": "WHO/NTD_LEISHVNUM"
+          },
+          "WHO/NTD_LEPR5": {
+            "name": "New G2D Leprosy Cases",
+            "statVar": "WHO/NTD_LEPR5"
+          },
+          "WHO/NUTOVERWEIGHTPREV": {
+            "name": "% Overweight, Children Under 5 Years",
+            "statVar": "WHO/NUTOVERWEIGHTPREV"
+          },
+          "WHO/NUTRITION_ANAEMIA_CHILDREN_PREV": {
+            "name": "% Anaemia, Children Aged 6-59 Months",
+            "statVar": "WHO/NUTRITION_ANAEMIA_CHILDREN_PREV"
+          },
+          "WHO/NUTRITION_WA_2": {
+            "name": "% Underweight, Children Under 5 Years",
+            "statVar": "WHO/NUTRITION_WA_2"
+          },
+          "WHO/NUTRITION_WH_2": {
+            "name": "% Wasted, Children Under 5 Years",
+            "statVar": "WHO/NUTRITION_WH_2"
+          },
+          "WHO/NUTRITION_WH_3": {
+            "name": "% Severely Wasted, Children Under 5 Years",
+            "statVar": "WHO/NUTRITION_WH_3"
+          },
+          "WHO/NUTSTUNTINGPREV": {
+            "name": "% Stunting, Children Under 5 Years",
+            "statVar": "WHO/NUTSTUNTINGPREV"
+          },
+          "WHO/SA_0000001418": {
+            "name": "Alcohol Use Disorders, Per 100,000",
+            "statVar": "WHO/SA_0000001418"
+          },
+          "WHO/SA_0000001419": {
+            "name": "Breast Cancer, Per 100,000",
+            "statVar": "WHO/SA_0000001419"
+          },
+          "WHO/SA_0000001420": {
+            "name": "Colon And Rectum Cancers, Per 100,000",
+            "statVar": "WHO/SA_0000001420"
+          },
+          "WHO/SA_0000001421": {
+            "name": "Diabetes Mellitus, Per 100,000",
+            "statVar": "WHO/SA_0000001421"
+          },
+          "WHO/SA_0000001422": {
+            "name": "Drownings, Per 100,000",
+            "statVar": "WHO/SA_0000001422"
+          },
+          "WHO/SA_0000001423": {
+            "name": "Falls, Per 100,000",
+            "statVar": "WHO/SA_0000001423"
+          },
+          "WHO/SA_0000001424": {
+            "name": "Fires, Per 100,000",
+            "statVar": "WHO/SA_0000001424"
+          },
+          "WHO/SA_0000001425": {
+            "name": "Ischaemic Heart Disease, Per 100,000",
+            "statVar": "WHO/SA_0000001425"
+          },
+          "WHO/SA_0000001426": {
+            "name": "Liver Cancer, Per 100,000",
+            "statVar": "WHO/SA_0000001426"
+          },
+          "WHO/SA_0000001427": {
+            "name": "Liver Cirrhosis, Per 100,000",
+            "statVar": "WHO/SA_0000001427"
+          },
+          "WHO/SA_0000001429": {
+            "name": "Mouth And Oropharynx Cancer, Per 100,000",
+            "statVar": "WHO/SA_0000001429"
+          },
+          "WHO/SA_0000001430": {
+            "name": "Oesophagus Cancer, Per 100,000",
+            "statVar": "WHO/SA_0000001430"
+          },
+          "WHO/SA_0000001431": {
+            "name": "Poisoning, Per 100,000",
+            "statVar": "WHO/SA_0000001431"
+          },
+          "WHO/SA_0000001432": {
+            "name": "Prematurity And Low Birth Rate, Per 100,000",
+            "statVar": "WHO/SA_0000001432"
+          },
+          "WHO/SA_0000001433": {
+            "name": "Road Traffic Accidents, Per 100,000",
+            "statVar": "WHO/SA_0000001433"
+          },
+          "WHO/SA_0000001434": {
+            "name": "Self-Inflicted Injury, Per 100,000",
+            "statVar": "WHO/SA_0000001434"
+          },
+          "WHO/SA_0000001435": {
+            "name": "Other Unintentional Injuries, Per 100,000",
+            "statVar": "WHO/SA_0000001435"
+          },
+          "WHO/SA_0000001436": {
+            "name": "Violence, Per 100,000",
+            "statVar": "WHO/SA_0000001436"
+          },
+          "WHO/SA_0000001689": {
+            "name": "Cerebrovascular Disease, Per 100,000",
+            "statVar": "WHO/SA_0000001689"
+          },
+          "WHO/SDG_SH_DTH_RNCOM_ChronicRespiratoryDiseases": {
+            "name": "Non-Communicable Disease Deaths, By Disease & Sex, Chronic Respiratory Diseases",
+            "statVar": "WHO/SDG_SH_DTH_RNCOM_ChronicRespiratoryDiseases"
+          },
+          "WHO/SDG_SH_DTH_RNCOM_DiabetesMellitus": {
+            "name": "Non-Communicable Disease Deaths, By Disease & Sex, Diabetes Mellitus",
+            "statVar": "WHO/SDG_SH_DTH_RNCOM_DiabetesMellitus"
+          },
+          "WHO/SDG_SH_DTH_RNCOM_MajorCardiovascularDiseases": {
+            "name": "Non-Communicable Diseases Deaths, By Disease & Sex, Major Cardiovascular Diseases",
+            "statVar": "WHO/SDG_SH_DTH_RNCOM_MajorCardiovascularDiseases"
+          },
+          "WHO/SDG_SH_DTH_RNCOM_MalignantNeoplasms": {
+            "name": "Non-Communicable Diseases Deaths, By Disease & Sex, Malignant Neoplasms",
+            "statVar": "WHO/SDG_SH_DTH_RNCOM_MalignantNeoplasms"
+          },
           "WHO/WHS4_117": {
             "name": "Hepatitis B (Hepb3) Immunization Coverage Among 1-Year-Olds (%)",
             "statVar": "WHO/WHS4_117"
@@ -196,6 +844,14 @@
           "WHO/WHS4_129": {
             "name": "Hib (Hib3) Immunization Coverage Among 1-Year-Olds (%)",
             "statVar": "WHO/WHS4_129"
+          },
+          "WHO/WHS4_543": {
+            "name": "Bcg Immunization Coverage Among 1-Year-Olds (%)",
+            "statVar": "WHO/WHS4_543"
+          },
+          "sdg/SH_STA_MORT.SEX--F": {
+            "name": "Maternal mortality ratio",
+            "statVar": "sdg/SH_STA_MORT.SEX--F"
           }
         }
       }

--- a/server/lib/explore/topic.py
+++ b/server/lib/explore/topic.py
@@ -43,9 +43,9 @@ class TopicMembers:
 def compute_chart_vars(
     state: ftypes.PopulateState) -> OrderedDict[str, List[ftypes.ChartVars]]:
   # Have a slightly higher limit for non-US places since there are fewer vars.
-  num_topics_limit = 2
+  num_topics_limit = 3
   if state.uttr.places and cutils.is_us_place(state.uttr.places[0]):
-    num_topics_limit = 1
+    num_topics_limit = 2
 
   dc = state.uttr.insight_ctx.get(Params.DC.value, DCNames.MAIN_DC.value)
   chart_vars_map = OrderedDict()
@@ -62,7 +62,8 @@ def compute_chart_vars(
                              orig_sv=sv,
                              dc=dc)
       state.uttr.counters.timeit('topic_calls', start)
-      num_topics_opened += 1
+      if cv:
+        num_topics_opened += 1
     if cv:
       chart_vars_map[sv] = cv
   return chart_vars_map

--- a/server/lib/nl/detection/detector.py
+++ b/server/lib/nl/detection/detector.py
@@ -16,7 +16,6 @@
 from typing import Dict, List
 
 from flask import current_app
-from markupsafe import escape
 
 from server.lib.nl.common import serialize
 from server.lib.nl.common import utils
@@ -73,12 +72,9 @@ def detect(detector_type: str, place_detector_type: PlaceDetectorType,
   #
   # Heuristic detection.
   #
-  heuristic_detection = heuristic_detector.detect(place_detector_type,
-                                                  str(escape(original_query)),
-                                                  no_punct_query,
-                                                  embeddings_index_type,
-                                                  query_detection_debug_logs,
-                                                  counters)
+  heuristic_detection = heuristic_detector.detect(
+      place_detector_type, original_query, no_punct_query,
+      embeddings_index_type, query_detection_debug_logs, counters)
   if detector_type == RequestedDetectorType.Heuristic.value:
     return heuristic_detection
 

--- a/server/lib/nl/fulfillment/containedin.py
+++ b/server/lib/nl/fulfillment/containedin.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import logging
 from typing import List
 
@@ -50,6 +51,7 @@ def populate(state: PopulateState, chart_vars: ChartVars,
     state.uttr.counters.err('containedin_failed_cb_toomanyplaces',
                             contained_places)
     return False
+  chart_vars = copy.deepcopy(chart_vars)
 
   exist_svs = ext.svs4children(state, contained_places[0],
                                chart_vars.svs).exist_svs

--- a/server/lib/nl/fulfillment/ranking_across_places.py
+++ b/server/lib/nl/fulfillment/ranking_across_places.py
@@ -67,6 +67,8 @@ def populate(state: PopulateState,
     })
     return False
 
+  chart_vars = copy.deepcopy(chart_vars)
+
   if chart_vars.event:
     return add_chart_to_utterance(ChartType.EVENT_CHART, state, chart_vars,
                                   places, chart_origin)

--- a/server/lib/nl/fulfillment/simple.py
+++ b/server/lib/nl/fulfillment/simple.py
@@ -35,6 +35,8 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
     # [meaning of life]
     state.uttr.counters.err('simple_failed_noplaceandsv', 1)
     return False
+  # Do not mutate the original.
+  chart_vars = copy.deepcopy(chart_vars)
 
   if chart_vars.event:
     # This can happen if an event is part of a topic and it can be triggered


### PR DESCRIPTION
1. Prefer to show timeline/bar before ranking/map even if query had ranking, and only when the user asks for place-type show ranking+map on top.  That way, [top jobs in Nevada] will show the top jobs bar chart and [top jobs in Nevada Counties] will show per-county SVs on top.
2.  Fix a few deepcopy bugs causing [top jobs in Placer County] to regress.
3. Open more topics.  I saw that often for poverty stuff dc/topic/SDG_x and others come on top, so opening more topics should help with richer results.
4. Avoid escaping query before passing into embeddings index.  This was found while triaging [Ratio of people in Denver who have an associate's degree] which doesn't match the right SV on top.