### PR TITLE
Add new text-boxes to sdg-tracker

### DIFF
--- a/experimental/sdg-tracker/src/config/goalSummaries.json
+++ b/experimental/sdg-tracker/src/config/goalSummaries.json
@@ -1,0 +1,149 @@
+[
+    {
+        "key": "1",
+        "headlines": [
+            "If current trends continue, 575 million people will still be living in extreme poverty and only one-third of countries will have halved their national poverty levels by 2030.",
+            "Despite the expansion of social protection during the COVID-19 crisis, over 4 billion people remain entirely unprotected. Many of the world\u2019s vulnerable population groups, including the young and the elderly, remain uncovered by statutory social protection programmes.",
+            "The share of government spending on essential services, such as education, health and social protection, is significantly higher in advanced economies than in emerging and developing economies.",
+            "A surge in action and investment to enhance economic opportunities, improve education and extend social protection to all, particularly the most excluded, is crucial to delivering on the central commitment to end poverty and leave no one behind."
+        ]
+    },
+    {
+        "key": "2",
+        "headlines": [
+            "The number of people facing hunger and food insecurity has been rising since 2015, with the pandemic, conflict, climate change and growing inequalities exacerbating the situation. In 2022, about 9.2 per cent of the world population was facing chronic hunger, equivalent to about 735 million people \u2013 122 million more than in 2019. An estimated 29.6 per cent of the global population \u2013 2.4 billion people \u2013 were moderately or severely food insecure, meaning they did not have access to adequate food. This figure reflects an alarming 391 million more people than in 2019.",
+            "Despite global efforts, in 2022, an estimated 45 million children under the age of 5 suffered from wasting, 148 million had stunted growth and 37 million were overweight. A fundamental shift in trajectory is needed to achieve the 2030 nutrition targets.",
+            "To achieve zero hunger by 2030, urgent coordinated action and policy solutions are imperative to address entrenched inequalities, transform food systems, invest in sustainable agricultural practices, and reduce and mitigate the impact of conflict and the pandemic on global nutrition and food security."
+        ]
+    },
+    {
+        "key": "3",
+        "headlines": [
+            "There has been some progress on improving global health in recent years. For example, 146 out of 200 countries or areas have already met or are on track to meet the SDG target on under-5 mortality. Effective HIV treatment has cut global AIDS-related deaths by 52 per cent since 2010 and at least one neglected tropical disease has been eliminated in 47 countries.",
+            "However, insufficient progress has been made in other areas, such as on reducing maternal mortality and expanding universal health coverage. Globally, approximately 800 women died every day from pregnancy or childbirth in 2020. And 381 million people were pushed or further pushed into extreme poverty in 2019 due to out-of-pocket payments for health.",
+            "The COVID-19 pandemic and ongoing crises have impeded progress towards Goal 3. Childhood vaccinations have experienced the largest decline in three decades, and tuberculosis and malaria deaths have increased compared with pre-pandemic levels.",
+            "To overcome these setbacks and address long-standing health care shortcomings, increased investment in health systems is needed to support countries in their recovery and build resilience against future health threats."
+        ]
+    },
+    {
+        "key": "4",
+        "headlines": [
+            "Progress towards quality education was already slower than required before the pandemic, but COVID-19 has had devastating impacts on education, causing learning losses in four out of five of the 104 countries studied.",
+            "Without additional measures, only one in six countries will achieve the universal secondary school completion target by 2030, an estimated 84 million children and young people will still be out of school, and approximately 300 million students will lack the basic numeracy and literacy skills necessary for success in life.",
+            "To achieve national Goal 4 benchmarks, which are reduced in ambition compared with the original Goal 4 targets, 79 low- and lower-middle- income countries still face an average annual financing gap of $97 billion.",
+            "To deliver on Goal 4, education financing must become a national investment priority. Furthermore, measures such as making education free and compulsory, increasing the number of teachers, improving basic school infrastructure and embracing digital transformation are essential."
+        ]
+    },
+    {
+        "key": "5",
+        "headlines": [
+            "With only seven years remaining, a mere 15.4 per cent of Goal 5 indicators with data are \u201con track\u201d, 61.5 per cent are at a moderate distance and 23.1 per cent are far or very far off track from 2030 targets.",
+            "In many areas, progress has been too slow. At the current rate, it will take an estimated 300 years to end child marriage, 286 years to close gaps in legal protection and remove discriminatory laws, 140 years for women to be represented equally in positions of power and leadership in the workplace, and 47 years to achieve equal representation in national parliaments.",
+            "Political leadership, investments and comprehensive policy reforms are needed to dismantle systemic barriers to achieving Goal 5. Gender equality is a cross-cutting objective and must be a key focus of national policies, budgets and institutions."
+        ]
+    },
+    {
+        "key": "6",
+        "headlines": [
+            "Despite great progress, billions of people still lack access to safe drinking water, sanitation and hygiene. Achieving universal coverage by 2030 will require a substantial increase in current global rates of progress: sixfold for drinking water, fivefold for sanitation and threefold for hygiene.",
+            "Water use efficiency has risen by 9 per cent, but water stress and water scarcity remain a concern in many parts of the world. In 2020, 2.4 billion people lived in water-stressed countries. The challenges are compounded by conflicts and climate change.",
+            "Key strategies to get Goal 6 back on track include increasing sector-wide investment and capacity-building, promoting innovation and evidence- based action, enhancing cross-sectoral coordination and cooperation among all stakeholders, and adopting a more integrated and holistic approach to water management."
+        ]
+    },
+    {
+        "key": "7",
+        "headlines": [
+            "The world continues to advance towards sustainable energy targets \u2013 but not fast enough. At the current pace, about 660 million people will still lack access to electricity and close to 2 billion people will still rely on polluting fuels and technologies for cooking by 2030.",
+            "Renewable sources power nearly 30 per cent of energy consumption in the electricity sector, but challenges remain in heating and transport sectors. Developing countries experience 9.6 per cent annual growth in renewable energy installation, but despite enormous needs, international financial flows for clean energy continue to decline.",
+            "To ensure access to energy for all by 2030, we must accelerate electrification, increase investments in renewable energy, improve energy efficiency and develop enabling policies and regulatory frameworks."
+        ]
+    },
+    {
+        "key": "8",
+        "headlines": [
+            "Multiple crises are placing the global economy under serious threat. Global real GDP per capita growth is forecast to slow down in 2023. Challenging economic conditions are pushing more workers into informal employment.",
+            "As economies start to recover, the global unemployment rate has experienced a significant decline. However, the youth unemployment rate continues to be much higher than the rate for adults, indicating ongoing challenges in securing employment opportunities for young people.",
+            "The pandemic has accelerated digital adoption and transformed access to finance. Globally, 76 per cent of adults had bank accounts or accounts with regulated institutions in 2021, up from 62 per cent in 2014.",
+            "Achieving Goal 8 will require a wholesale reform of the financial system to tackle rising debts, economic uncertainty and trade tensions, while promoting equitable pay and decent work for young people."
+        ]
+    },
+    {
+        "key": "9",
+        "headlines": [
+            "The manufacturing industry\u2019s recovery from the coronavirus disease (COVID-19) pandemic remains incomplete and uneven. Global manufacturing growth slowed down to 3.3 per cent in 2022, from 7.4 per cent in 2021. Progress in least developed countries (LDCs) is far from sufficient to reach the target of doubling the manufacturing share in gross domestic product (GDP) by 2030. However, medium-high- and high-technology industries demonstrated robust growth rates.",
+            "As of 2022, 95 per cent of the world\u2019s population was within reach of a mobile broadband network, but some areas remain underserved.",
+            "Global carbon dioxide (CO2) emissions from energy combustion and industrial processes grew by 0.9 per cent to a new all-time high of 36.8 billion metric tons, well below global GDP growth, reverting to a decade- long trend of decoupling emissions and economic growth.",
+            "To achieve Goal 9 by 2030, it is essential to support LDCs, invest in advanced technologies, lower carbon emissions and increase mobile broadband access."
+        ]
+    },
+    {
+        "key": "10",
+        "headlines": [
+            "The incomes of the poorest 40 per cent of the population had been growing faster than the national average in most countries. But emerging yet inconclusive evidence suggests that COVID-19 may have put a dent in this positive trend of falling within-country inequality. The pandemic has also caused the largest rise in between-country inequality in three decades.",
+            "One in six people worldwide has experienced discrimination in some form, with women and people with disabilities disproportionately affected.",
+            "The year 2022 witnessed the highest number of refugees (34.6 million people) ever documented. This year is also a deadly one for migrants, with nearly 7,000 deaths recorded globally.",
+            "Reducing both within- and between-country inequality requires equitable resource distribution, investing in education and skills development, implementing social protection measures, combating discrimination, supporting marginalized groups and fostering international cooperation for fair trade and financial systems."
+        ]
+    },
+    {
+        "key": "11",
+        "headlines": [
+            "Over half of the global population currently resides in urban areas, a rate projected to reach 70 per cent by 2050. Approximately 1.1 billion people currently live in slums or slum-like conditions in cities, with 2 billion more expected in the next 30 years.",
+            "In 2022, only half of the world\u2019s urban population had convenient access to public transportation. Urban sprawl, air pollution and limited open public spaces persist in cities.",
+            "Since 2015, the number of countries with national and local disaster risk reduction strategies has doubled.",
+            "To achieve Goal 11, efforts must focus on implementing inclusive, resilient and sustainable urban development policies and practices that prioritize access to basic services, affordable housing, efficient transportation and green spaces for all."
+        ]
+    },
+    {
+        "key": "12",
+        "headlines": [
+            "The material footprint per capita in high-income countries is 10 times the level of low-income countries. The world is also seriously off track in its efforts to halve per capita food waste and losses by 2030.",
+            "Global crises triggered a resurgence in fossil fuel subsidies, nearly doubling from 2020 to 2021.",
+            "Reporting has increased on corporate sustainability and on public procurement policies, but has fallen when it comes to sustainable consumption and monitoring sustainable tourism.",
+            "Responsible consumption and production must be integral to recovery from the pandemic and to acceleration plans of the Sustainable Development Goals. It is crucial to implement policies that support a shift towards sustainable practices and decouple economic growth from resource use."
+        ]
+    },
+    {
+        "key": "13",
+        "headlines": [
+            "With a climate cataclysm looming, the pace and scale of current climate action plans are wholly insufficient to effectively tackle climate change. Increasingly frequent and intense extreme weather events are already impacting every region on Earth. Rising temperatures will escalate these hazards further, posing grave risks.",
+            "The Intergovernmental Panel on Climate Change (IPCC) emphasizes that deep, rapid and sustained reductions in greenhouse gas (GHG) emissions are essential in all sectors, beginning now and continuing throughout this decade. To limit global warming to 1.5\u00b0C above pre- industrial levels, emissions must already be decreasing and need to be cut by almost half by 2030, just seven years away.",
+            "Urgent and transformative action is crucial, going beyond mere plans and promises. It requires raising ambition, covering entire economies and moving towards climate-resilient development, while outlining a clear path to achieve net-zero emissions. Time is running out, and immediate measures are necessary to avoid catastrophic consequences and secure a sustainable future for generations to come."
+        ]
+    },
+    {
+        "key": "14",
+        "headlines": [
+            "The ocean is in a state of emergency as increasing eutrophication, acidification, ocean warming and plastic pollution worsen its health. Additionally, the alarming trend of overfishing persists, leading to the depletion of over one third of global fish stocks.",
+            "While there has been some progress in expanding marine protected areas, combating illegal, unreported and unregulated fishing, banning fishing subsidies and supporting small-scale fishers, action is not advancing at the speed or scale required to meet Goal 14.",
+            "To counter these trends, swift and coordinated global action is imperative. This entails increasing funding for ocean science, intensifying conservation efforts, advancing nature- and ecosystem-based solutions, addressing the interconnections and impacts of human-induced pressures, and urgently turning the tide on climate change to safeguard the planet\u2019s largest ecosystem."
+        ]
+    },
+    {
+        "key": "15",
+        "headlines": [
+            "Terrestrial ecosystems are vital for sustaining human life, contributing to over half of global GDP and encompassing diverse cultural, spiritual, and economic values.",
+            "However, the world faces a triple crisis of climate change, pollution and biodiversity loss. Escalating trends of forest loss, land degradation and the extinction of species pose a severe threat to both the planet and people.",
+            "Despite some progress in sustainable forest management, protected areas, and the uptake of national biodiversity values and natural capital accounting, most improvements have been modest. The recently adopted Kunming-Montreal Global Biodiversity Framework provides renewed impetus for Goal 15, outlining four outcome-oriented goals to be achieved by 2050 and 23 targets to be achieved by 2030.",
+            "To fulfil Goal 15, a fundamental shift in humanity\u2019s relationship with nature is essential, along with accelerated action to address the root causes of these interconnected crises and better recognition of the tremendous value of nature."
+        ]
+    },
+    {
+        "key": "16",
+        "headlines": [
+            "Ongoing and new violent conflicts around the world are derailing the global path to peace and achievement of Goal 16. Alarmingly, the year 2022 witnessed a more than 50 per cent increase in conflict-related civilian deaths, largely due to the war in Ukraine.",
+            "As of the end of 2022, 108.4 million people were forcibly displaced worldwide \u2013 an increase of 19 million compared with the end of 2021 and two and a half times the number of a decade ago.",
+            "In 2021, the world experienced the highest number of intentional homicides in the past two decades.",
+            "Structural injustices, inequalities and emerging human rights challenges are putting peaceful and inclusive societies further out of reach. To meet Goal 16 by 2030, action is needed to restore trust and to strengthen the capacity of institutions to secure justice for all and facilitate peaceful transitions to sustainable development."
+        ]
+    },
+    {
+        "key": "17",
+        "headlines": [
+            "Developing countries are grappling with an unprecedented rise in external debt levels following the COVID-19 pandemic, compounded by challenges such as record inflation, escalating interest rates, competing priorities and constrained fiscal capacity, underscoring the urgent need for debt relief and financial assistance.",
+            "While official development assistance (ODA) flows continue to reach record peaks, the increase in 2022 is primarily attributed to spending on refugees in donor countries and aid to Ukraine.",
+            "Despite a 65 per cent improvement in Internet access since 2015, progress in bridging the digital divide has slowed down post-pandemic. Sustained efforts are required to ensure equitable access to the Internet for all.",
+            "Geopolitical tensions and the resurgence of nationalism hinder international cooperation and coordination, highlighting the importance of a collective surge in action to provide developing countries with the necessary financing and technologies to accelerate the implementation of the SDGs."
+        ]
+    }
+]

--- a/experimental/sdg-tracker/src/config/indicatorText.json
+++ b/experimental/sdg-tracker/src/config/indicatorText.json
@@ -1,0 +1,667 @@
+[
+    {
+        "key": "1.1.1",
+        "tags": {
+            "headline": "Slow and uneven progress on poverty reduction may leave hundreds of millions in extreme poverty by 2030",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-01/"
+        }
+    },
+    {
+        "key": "1.2.1",
+        "tags": {
+            "headline": "If current trends continue, only one third of countries will halve national poverty by 2030",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-01/"
+        }
+    },
+    {
+        "key": "1.3.1",
+        "tags": {
+            "headline": "Amid overlapping crises, coverage and expenditures on social protection programmes remain low",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-01/"
+        }
+    },
+    {
+        "key": "1.a.2",
+        "tags": {
+            "headline": "Advanced, emerging and developing economies alike have all increased their share of government spending on essential services",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-01/"
+        }
+    },
+    {
+        "key": "1.5.1",
+        "tags": {
+            "headline": "Globally, disasters are affecting more people but causing fewer deaths",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-01/"
+        }
+    },
+    {
+        "key": "2.1.1",
+        "tags": {
+            "headline": "In the face of a polycrisis, joint global efforts are urgently needed to address hunger and ensure food security",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-02/"
+        }
+    },
+    {
+        "key": "2.a.1",
+        "tags": {
+            "headline": "Aid and public spending on agriculture are falling despite the growing global food crisis",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-02/"
+        }
+    },
+    {
+        "key": "2.2.1",
+        "tags": {
+            "headline": "Malnutrition continues to threaten children and women worldwide, despite some progress",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-02/"
+        }
+    },
+    {
+        "key": "2.c.1",
+        "tags": {
+            "headline": "Despite dropping in 2021, the share of countries experiencing high food prices remained above the 2015\u20132019 average",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-02/"
+        }
+    },
+    {
+        "key": "3.1.1",
+        "tags": {
+            "headline": "Stagnating progress in reducing maternal mortality means a woman dies of preventable causes every two minutes",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-03/"
+        }
+    },
+    {
+        "key": "3.7.1",
+        "tags": {
+            "headline": "Progress on reproductive health continues, with falling adolescent birth rates and rising access to contraception",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-03/"
+        }
+    },
+    {
+        "key": "3.2.1",
+        "tags": {
+            "headline": "Global child mortality rates show significant decline, but challenges remain",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-03/"
+        }
+    },
+    {
+        "key": "3.b.1",
+        "tags": {
+            "headline": "The alarming decline in childhood vaccination is leaving millions of children at risk from devastating but preventable diseases",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-03/"
+        }
+    },
+    {
+        "key": "3.3.1",
+        "tags": {
+            "headline": "Intersecting crises have left the world off-kilter to achieve SDG targets on HIV, malaria and tuberculosis",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-03/"
+        }
+    },
+    {
+        "key": "3.8.1",
+        "tags": {
+            "headline": "In the wake of the pandemic, progress towards universal health coverage has slowed while financial hardship has risen",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-03/"
+        }
+    },
+    {
+        "key": "3.c.1",
+        "tags": {
+            "headline": "Despite increases in the global health workforce, numbers remain low in regions with the highest burden of disease",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-03/"
+        }
+    },
+    {
+        "key": "3.b.2",
+        "tags": {
+            "headline": "Driven by COVID-19, official development assistance for basic health has doubled since 2015",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-03/"
+        }
+    },
+    {
+        "key": "4.1.2",
+        "tags": {
+            "headline": "Primary and secondary school completion is rising, but the pace is far too slow and uneven",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-04/"
+        }
+    },
+    {
+        "key": "4.1.1",
+        "tags": {
+            "headline": "Patchy data show disappointing progress on improving primary school reading levels",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-04/"
+        }
+    },
+    {
+        "key": "4.2.2",
+        "tags": {
+            "headline": "Access to early childhood education has expanded, but progress has slowed since 2015",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-04/"
+        }
+    },
+    {
+        "key": "4.4.1",
+        "tags": {
+            "headline": "Low digital skills hamper progress towards universal and meaningful connectivity",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-04/"
+        }
+    },
+    {
+        "key": "4.a.1",
+        "tags": {
+            "headline": "Basic school infrastructure varies widely across regions and is far from universal",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-04/"
+        }
+    },
+    {
+        "key": "4.c.1",
+        "tags": {
+            "headline": "Many teachers still lack the required qualifications to teach",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-04/"
+        }
+    },
+    {
+        "key": "5.5.1",
+        "tags": {
+            "headline": "Progress has been sluggish on upping women\u2019s share in management and political representation",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-05/"
+        }
+    },
+    {
+        "key": "5.6.1",
+        "tags": {
+            "headline": "Nearly half of married women lack decision-making power over their sexual and reproductive health and rights",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-05/"
+        }
+    },
+    {
+        "key": "5.2.1",
+        "tags": {
+            "headline": "Insufficient progress has been made in reducing intimate partner violence over the past two decades",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-05/"
+        }
+    },
+    {
+        "key": "5.1.1",
+        "tags": {
+            "headline": "Discriminatory laws and gaps in legal protection persist in critical aspects, denying women their human rights worldwide",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-05/"
+        }
+    },
+    {
+        "key": "5.3.1",
+        "tags": {
+            "headline": "Recent gains are under threat in efforts to end child marriage",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-05/"
+        }
+    },
+    {
+        "key": "5.a.1",
+        "tags": {
+            "headline": "Agricultural land ownership and legal protection of women\u2019s land rights remain low",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-05/"
+        }
+    },
+    {
+        "key": "5.b.1",
+        "tags": {
+            "headline": "Mobile phone ownership can be a powerful tool for empowering women, but gender parity remains elusive in many regions",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-05/"
+        }
+    },
+    {
+        "key": "6.1.1",
+        "tags": {
+            "headline": "Access to drinking water, sanitation and hygiene improved significantly in rural areas, but stagnated or decreased in urban areas",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-06/"
+        }
+    },
+    {
+        "key": "6.3.2",
+        "tags": {
+            "headline": "Water quality is improving in countries with robust monitoring, but there are still many unknowns",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-06/"
+        }
+    },
+    {
+        "key": "6.4.1",
+        "tags": {
+            "headline": "Water-use efficiency has improved, particularly in agriculture, but rising water stress in several areas is cause for concern",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-06/"
+        }
+    },
+    {
+        "key": "6.5.1",
+        "tags": {
+            "headline": "Enhancing water management and transboundary cooperation is critical for bolstering resilience to crises",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-06/"
+        }
+    },
+    {
+        "key": "6.a.1",
+        "tags": {
+            "headline": "Decline in official development assistance to water sector raises concerns",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-06/"
+        }
+    },
+    {
+        "key": "6.6.1",
+        "tags": {
+            "headline": "As wetland ecosystems and species disappear, large-scale protection and restoration are imperative",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-06/"
+        }
+    },
+    {
+        "key": "7.1.1",
+        "tags": {
+            "headline": "More people than ever have access to electricity, but the pace is lagging for least developed countries",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-07/"
+        }
+    },
+    {
+        "key": "7.1.2",
+        "tags": {
+            "headline": "At the current pace, a quarter of the population will still be using unsafe and inefficient cooking systems by 2030",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-07/"
+        }
+    },
+    {
+        "key": "7.2.1",
+        "tags": {
+            "headline": "Renewable energy use is growing in the electricity sector, but limited in heating and transport",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-07/"
+        }
+    },
+    {
+        "key": "7.3.1",
+        "tags": {
+            "headline": "A strong rebound is needed to reach energy efficiency targets",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-07/"
+        }
+    },
+    {
+        "key": "7.a.1",
+        "tags": {
+            "headline": "International public financing for clean energy in developing countries continues to decline",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-07/"
+        }
+    },
+    {
+        "key": "7.b.1",
+        "tags": {
+            "headline": "Renewable energy is booming in developing countries, but the least developed are falling behind",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-07/"
+        }
+    },
+    {
+        "key": "8.1.1",
+        "tags": {
+            "headline": "Global economic recovery continues on a slow trajectory",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-08/"
+        }
+    },
+    {
+        "key": "8.3.1",
+        "tags": {
+            "headline": "Challenging economic conditions are pushing more workers into informal employment",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-08/"
+        }
+    },
+    {
+        "key": "8.5.2",
+        "tags": {
+            "headline": "Global unemployment is expected to decline below pre-pandemic levels, but challenges persist in low-income countries",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-08/"
+        }
+    },
+    {
+        "key": "8.6.1",
+        "tags": {
+            "headline": "Young women are more than twice as likely as young men to be out of education, employment or training",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-08/"
+        }
+    },
+    {
+        "key": "8.9.1",
+        "tags": {
+            "headline": "Tourism is on a path to recovery, but still well below pre-pandemic levels",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-08/"
+        }
+    },
+    {
+        "key": "8.10.2",
+        "tags": {
+            "headline": "COVID-19 has accelerated the adoption of digital solutions, transforming access to finance",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-08/"
+        }
+    },
+    {
+        "key": "9.2.1",
+        "tags": {
+            "headline": "Least developed countries face challenges in achieving the manufacturing target by 2030",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-09/"
+        }
+    },
+    {
+        "key": "9.4.1",
+        "tags": {
+            "headline": "Economic growth outpaced increases in CO2 emissions, aided by the use of clean technologies and reduced industrial output",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-09/"
+        }
+    },
+    {
+        "key": "9.5.1",
+        "tags": {
+            "headline": "Global research and development spending is up, particularly since the pandemic, but is still too low in least developed countries",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-09/"
+        }
+    },
+    {
+        "key": "9.b.1",
+        "tags": {
+            "headline": "Strong growth in medium-high- and high-technology industries amid global manufacturing slowdown",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-09/"
+        }
+    },
+    {
+        "key": "9.c.1",
+        "tags": {
+            "headline": "More than 95 per cent of the world has mobile broadband access of at least 3G, but connecting the final frontier is proving difficult",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-09/"
+        }
+    },
+    {
+        "key": "10.1.1",
+        "tags": {
+            "headline": "Most countries experienced increased shared prosperity, but the pandemic may have reversed some of this progress",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-10/"
+        }
+    },
+    {
+        "key": "10.2.1",
+        "tags": {
+            "headline": "The pandemic has caused the largest rise in income inequality between countries in three decades",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-10/"
+        }
+    },
+    {
+        "key": "10.3.1",
+        "tags": {
+            "headline": "Racial discrimination is one of the most common grounds for discrimination worldwide",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-10/"
+        }
+    },
+    {
+        "key": "10.7.3",
+        "tags": {
+            "headline": "With deaths along migratory routes rising globally, urgent action is needed to ensure safe migration",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-10/"
+        }
+    },
+    {
+        "key": "10.7.4",
+        "tags": {
+            "headline": "Record numbers of people are fleeing their countries in the face of mounting crises",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-10/"
+        }
+    },
+    {
+        "key": "11.1.1",
+        "tags": {
+            "headline": "Smaller cities and towns in many regions are recording faster growth in slum populations than major cities",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-11/"
+        }
+    },
+    {
+        "key": "11.2.1",
+        "tags": {
+            "headline": "The demand for urban transportation continues to grow exponentially, particularly in developing countries",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-11/"
+        }
+    },
+    {
+        "key": "11.6.2",
+        "tags": {
+            "headline": "Air pollution is not only an urban problem, but is also affecting towns and rural areas",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-11/"
+        }
+    },
+    {
+        "key": "11.7.1",
+        "tags": {
+            "headline": "Provision and access to open public spaces remains low across regions, impacting negatively on the quality of urban life",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-11/"
+        }
+    },
+    {
+        "key": "11.3.1",
+        "tags": {
+            "headline": "Urban sprawl is outpacing population growth in most cities, with detrimental effects on sustainability",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-11/"
+        }
+    },
+    {
+        "key": "11.b.1",
+        "tags": {
+            "headline": "Since 2015, many more national and local governments have reported having disaster risk reduction strategies",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-11/"
+        }
+    },
+    {
+        "key": "12.2.2",
+        "tags": {
+            "headline": "Regional inequalities in material footprints highlight consumption disparities",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-12/"
+        }
+    },
+    {
+        "key": "12.c.1",
+        "tags": {
+            "headline": "Fossil fuel subsidies rise back to 2014 levels despite calls for a phase-out",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-12/"
+        }
+    },
+    {
+        "key": "12.3.1",
+        "tags": {
+            "headline": "Despite rising global hunger, food waste and losses are staggering and uneven",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-12/"
+        }
+    },
+    {
+        "key": "12.6.1",
+        "tags": {
+            "headline": "More companies, large and small, are reporting on their efforts to improve sustainability",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-12/"
+        }
+    },
+    {
+        "key": "12.1.1",
+        "tags": {
+            "headline": "Global cooperation on sustainable consumption and production rises, while reporting dwindles",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-12/"
+        }
+    },
+    {
+        "key": "12.7.1",
+        "tags": {
+            "headline": "Despite increased public procurement reporting, sustainable tourism monitoring is down",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-12/"
+        }
+    },
+    {
+        "key": "13.2.2",
+        "tags": {
+            "headline": "Urgent global greenhouse gas emission reductions are needed to avert 1.5&deg;C tipping point",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-13/"
+        }
+    },
+    {
+        "key": "13.3.1",
+        "tags": {
+            "headline": "Global climate change education has so far not kept up with youth demand",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-13/"
+        }
+    },
+    {
+        "key": "13.2.2",
+        "tags": {
+            "headline": "Record-setting rising sea levels are a severe threat to hundreds of millions of people",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-13/"
+        }
+    },
+    {
+        "key": "13.a.1",
+        "tags": {
+            "headline": "The $100-billion-a-year climate finance goal by developed countries has yet to be met",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-13/"
+        }
+    },
+    {
+        "key": "14.1.1b",
+        "tags": {
+            "headline": "Citizen science sheds light on the magnitude of ocean plastic pollution",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-14/"
+        }
+    },
+    {
+        "key": "14.1.1a",
+        "tags": {
+            "headline": "Coastal eutrophication: a growing threat to marine ecosystems and communities",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-14/"
+        }
+    },
+    {
+        "key": "14.3.1",
+        "tags": {
+            "headline": "Expanding global ocean acidification monitoring is crucial to confront an unabating crisis",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-14/"
+        }
+    },
+    {
+        "key": "14.6.1",
+        "tags": {
+            "headline": "Despite improvements, stronger global cooperation is needed to reel in illegal fishing",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-14/"
+        }
+    },
+    {
+        "key": "14.c.1",
+        "tags": {
+            "headline": "Turning the tide: Recent marine agreements show promise for ocean protection",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-14/"
+        }
+    },
+    {
+        "key": "15.1.1",
+        "tags": {
+            "headline": "Deforestation and forest degradation remain major global threats",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-15/"
+        }
+    },
+    {
+        "key": "15.a.1",
+        "tags": {
+            "headline": "Despite efforts to mobilize financing for biodiversity conservation, a persistent funding gap remains",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-15/"
+        }
+    },
+    {
+        "key": "15.5.1",
+        "tags": {
+            "headline": "Species extinction risk has accelerated each decade since 1993",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-15/"
+        }
+    },
+    {
+        "key": "15.1.2",
+        "tags": {
+            "headline": "Growth in protected area coverage of key biodiversity areas has largely stalled",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-15/"
+        }
+    },
+    {
+        "key": "15.3.1",
+        "tags": {
+            "headline": "Alarming trends in land degradation call for urgent action to restore the Earth",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-15/"
+        }
+    },
+    {
+        "key": "16.1.1",
+        "tags": {
+            "headline": "Global homicides hit a 20-year high amid escalating gang and sociopolitical violence",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-16/"
+        }
+    },
+    {
+        "key": "16.1.2",
+        "tags": {
+            "headline": "There has been an unprecedented increase in civilian deaths in conflicts \u2013 the first since the adoption of the 2030 Agenda",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-16/"
+        }
+    },
+    {
+        "key": "16.2.2",
+        "tags": {
+            "headline": "Falling detection of victims of human trafficking during crises prompts new methods to track and combat this hidden crime",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-16/"
+        }
+    },
+    {
+        "key": "16.3.2",
+        "tags": {
+            "headline": "The global prison population keeps rising, creating overcrowding and concerns over the proportion of unsentenced detainees",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-16/"
+        }
+    },
+    {
+        "key": "16.4.1",
+        "tags": {
+            "headline": "Drug trafficking is generating illicit financial flows worth billions, fuelling corruption and diverting resources",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-16/"
+        }
+    },
+    {
+        "key": "16.7.1",
+        "tags": {
+            "headline": "The number of young parliamentarians remains low, with few holding leadership positions",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-16/"
+        }
+    },
+    {
+        "key": "17.4.1",
+        "tags": {
+            "headline": "In the wake of the pandemic, many developing countries are facing a debt crisis",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-17/"
+        }
+    },
+    {
+        "key": "17.11.1",
+        "tags": {
+            "headline": "Despite record-breaking global trade increases, the share of exports from least developed countries has stagnated and is far off target",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-17/"
+        }
+    },
+    {
+        "key": "17.2.1",
+        "tags": {
+            "headline": "Official development assistance surged in 2022 owing to spending on refugees in donor countries and aid to Ukraine",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-17/"
+        }
+    },
+    {
+        "key": "17.8.1",
+        "tags": {
+            "headline": "Internet usage reaches two-thirds of the world\u2019s population, but gender and connectivity gaps persist",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-17/"
+        }
+    },
+    {
+        "key": "17.18.3",
+        "tags": {
+            "headline": "The world needs more timely, detailed and accurate data to tackle a multitude of crises, but funding for data and statistics is ever more scarce",
+            "link": "https://unstats.un.org/sdgs/report/2023/Goal-17/"
+        }
+    }
+]

--- a/experimental/sdg-tracker/src/index.css
+++ b/experimental/sdg-tracker/src/index.css
@@ -34,3 +34,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
 }
+
+datacommons-text::part(container) {
+  background: #EEE;
+}

--- a/experimental/sdg-tracker/src/state/index.ts
+++ b/experimental/sdg-tracker/src/state/index.ts
@@ -30,6 +30,8 @@ import styled from "styled-components";
 import countries from "../config/countries.json";
 import rootTopics from "../config/rootTopics.json";
 import sidebarConfig from "../config/sidebar.json";
+import goalSummaries from "../config/goalSummaries.json";
+import indicatorHeadlines from "../config/indicatorText.json"
 import { WEB_API_ENDPOINT } from "../utils/constants";
 import DataCommonsClient from "../utils/DataCommonsClient";
 import { FulfillResponse } from "../utils/types";
@@ -51,6 +53,30 @@ export interface Place {
 }
 
 /**
+ * Summary text to accompany each goal
+ */
+export interface GoalText {
+  key: string;
+  headlines: string[];
+}
+
+/**
+ * Headlines and links for each indicator
+ */
+export interface IndicatorTags {
+  headline: string;
+  link: string;
+}
+
+/**
+ * Text to accompany each indicator
+ */
+export interface IndicatorText {
+  key: string;
+  tags: IndicatorTags;
+}
+
+/**
  * Root topic interface
  */
 export interface RootTopic {
@@ -59,8 +85,6 @@ export interface RootTopic {
   groupDcid: string;
   topicDcid: string;
   iconUrl: string;
-  storyTitle: string;
-  storyText: string;
 }
 
 /**
@@ -110,6 +134,16 @@ export interface AppModel {
   };
   sidebarMenuHierarchy: MenuItemType[];
   rootTopics: RootTopic[];
+  goalSummaries: {
+    byGoal: {
+      [key: string]: GoalText;
+    }
+  }
+  indicatorHeadlines: {
+    byIndicator: {
+      [key: string]: IndicatorTags;
+    }
+  }
 }
 
 /**
@@ -122,6 +156,8 @@ export interface AppActions {
   setSidebarMenuHierarchy: Action<AppModel, MenuItemType[]>;
   setCountries: Action<AppModel, Place[]>;
   setRegions: Action<AppModel, Place[]>;
+  setGoalSummaries: Action<AppModel, GoalText[]>
+  setIndicatorHeadlines: Action<AppModel, IndicatorText[]>;
   setFulfillment: Action<
     AppModel,
     { key: string; fulfillment: FulfillResponse }
@@ -161,6 +197,12 @@ const appModel: AppModel = {
   },
   rootTopics: [],
   sidebarMenuHierarchy: [],
+  goalSummaries: {
+    byGoal: {},
+  },
+  indicatorHeadlines: {
+    byIndicator: {},
+  },
 };
 
 /**
@@ -181,6 +223,8 @@ const appActions: AppActions = {
         }),
       }))
     );
+    actions.setGoalSummaries(goalSummaries);
+    actions.setIndicatorHeadlines(indicatorHeadlines);
     const topics: Topic[] = [];
     const traverseTopics = (item: MenuItemType) => {
       if (!item.key.startsWith("dc")) {
@@ -253,6 +297,18 @@ const appActions: AppActions = {
   setFulfillment: action((state, { key, fulfillment }) => {
     state.fulfillments.byId[key] = { ...fulfillment };
   }),
+  setGoalSummaries: action((state, goalSummaries) => {
+    state.goalSummaries.byGoal = {}
+    goalSummaries.forEach((goal) => {
+      state.goalSummaries.byGoal[goal.key] = goal;
+    })
+  }),
+  setIndicatorHeadlines: action((state, indicatorHeadlines) => {
+    state.indicatorHeadlines.byIndicator = {}
+    indicatorHeadlines.forEach((indicator) => {
+      state.indicatorHeadlines.byIndicator[indicator.key] = indicator.tags;
+    })
+  })
 };
 
 /**

--- a/experimental/sdg-tracker/src/utils/types.ts
+++ b/experimental/sdg-tracker/src/utils/types.ts
@@ -66,7 +66,7 @@ export interface RelatedThings {
   childPlaces: {
     [placeType: string]: RelatedPlace[];
   };
-  mainTopic: RelatedTopic;
+  mainTopics: RelatedTopic[];
   parentPlaces: RelatedPlace[];
   parentTopics: RelatedTopic[];
   peerTopics: RelatedTopic[];

--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -209,7 +209,7 @@ $box-shadow-8dp: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
     -webkit-mask-image: linear-gradient(180deg, rgba(250,250,250), 85%, transparent);
   }
 
-  .show-more-toggle {
+  .text-link {
     margin-left: auto;
     width: fit-content;
     font-size: 18px;

--- a/static/js/components/tiles/text_tile.tsx
+++ b/static/js/components/tiles/text_tile.tsx
@@ -18,70 +18,32 @@
  * Component for rendering a text tile.
  */
 
-import React, { useState } from "react";
+import React from "react";
 
 import { ASYNC_ELEMENT_HOLDER_CLASS } from "../../constants/css_constants";
 
 export interface TextTilePropType {
-  // number of characters of text body to show before "show more"
-  characterLimit?: number;
-  // Heading to display with the text
-  heading: string;
-  // Text body to display
-  text: string;
-  // Whether to show entire story regardless of character limit
-  showFullText?: boolean;
-}
-
-// Default number of characters of text body to show before "show more".
-const DEFAULT_STORY_CHARACTER_LIMIT = 250;
-
-/**
- * Formats text into paragraphs within <p> tags
- */
-function formatText(text: string): JSX.Element[] {
-  return text
-    .replaceAll(/\\n/g, "\n") // Catch "\n" as text instead of newline character
-    .split(/\r?\n/) // Split into paragraphs by newline character
-    .map((item, i) => <p key={i}>{item}</p>); // wrap each paragraph in a tag
+  // url to
+  link?: string;
 }
 
 export function TextTile(props: TextTilePropType): JSX.Element {
-  const [showMore, setShowMore] = useState(false);
-
-  if (!(props.heading && props.text)) {
-    return null;
-  }
-
-  const characterLimit = props.characterLimit || DEFAULT_STORY_CHARACTER_LIMIT;
-  const shouldShowFullText =
-    props.showFullText || props.text.length <= characterLimit;
-  const fullTextBody = formatText(props.text);
-  const shortTextBody = formatText(props.text.substring(0, characterLimit));
-
   return (
     <div
       className={`chart-container text-tile ${ASYNC_ELEMENT_HOLDER_CLASS}`}
       {...{ part: "container" }}
     >
       <div className="text-header" {...{ part: "heading" }}>
-        {props.heading}
+        <slot name="heading" />
       </div>
-      <div
-        className={`text-body${
-          showMore || shouldShowFullText ? "" : " fade-text"
-        }`}
-        {...{ part: "text" }}
-      >
-        {showMore || shouldShowFullText ? fullTextBody : shortTextBody}
+      <div className="text-body" {...{ part: "text" }}>
+        <slot name="text" />
       </div>
-      {!shouldShowFullText && (
-        <div
-          className="show-more-toggle"
-          onClick={() => setShowMore(!showMore)}
-          {...{ part: "show-more-toggle" }}
-        >
-          {showMore ? "Show less" : "Show more"}
+      {props.link && (
+        <div className="text-link" {...{ part: "link" }}>
+          <a href={props.link} target="_blank" rel="noreferrer">
+            See more
+          </a>
         </div>
       )}
     </div>

--- a/static/library/text_component.ts
+++ b/static/library/text_component.ts
@@ -27,11 +27,12 @@ import { createWebComponentElement } from "./utils";
  *
  * Example usage:
  *
- * <!-- Show companion text to UN SDG 1 we have in the KG -->
+ * <!-- Show some text with a link -->
  * <datacommons-text
- *      header="Title here"
- *      text="Main text goes here"
- * ></datacommons-text>
+ *   link="http://url.to/some/link"
+ * >
+ *  <div slot="text">Text here</div>
+ * </datacommons-text>
  */
 @customElement("datacommons-text")
 export class DatacommonsTextComponent extends LitElement {
@@ -39,27 +40,14 @@ export class DatacommonsTextComponent extends LitElement {
   static styles: CSSResult = css`
     ${unsafeCSS(tilesCssString)}
   `;
-  // Optional: number of characters of text body to show before "show more"
-  // defaults to 250 chars
-  characterLimit?: number;
 
-  // Header/title of the text
+  // Optional: URL to add as a "see more" link pointer
   @property()
-  header!: string;
-
-  // Optional: Whether to show entire story regardless of character limit
-  showFullText?: boolean;
-
-  // text body
-  @property()
-  text!: string;
+  link?: string;
 
   render(): HTMLElement {
     const textTileProps: TextTilePropType = {
-      characterLimit: this.characterLimit || 250,
-      heading: this.header,
-      text: this.text,
-      showFullText: this.showFullText,
+      link: this.link,
     };
     return createWebComponentElement(TextTile, textTileProps);
   }


### PR DESCRIPTION
1. Changes the datacommons-text web component to use slots for content
2. Update the interfaces in sdg-tracker site to match changes to fulfilment endpoint
3. Updates the sdg-tracker site with new summaries and headers

The following needs to come in a followup PR:
* Better layout and styling
* Determining what should happen on the "All goals" page.

Screenshots:
![Screenshot 2023-08-29 at 4 57 08 PM](https://github.com/datacommonsorg/website/assets/4034366/affdfd65-b985-49e6-9bc3-10495b12a467)
![Screenshot 2023-08-29 at 4 57 22 PM](https://github.com/datacommonsorg/website/assets/4034366/c9cbfd95-786d-453e-aa51-80165c27f7d4)
