### PR TITLE
Enable PaLM on dev and unsdg

### DIFF
--- a/server/app_env/dev.py
+++ b/server/app_env/dev.py
@@ -20,3 +20,4 @@ class Config(_base.Config):
   LOG_QUERY = True
   SHOW_TOPIC = True
   GA_ACCOUNT = 'G-P9M91VX1T3'
+  USE_PALM = True

--- a/server/app_env/unsdg.py
+++ b/server/app_env/unsdg.py
@@ -23,6 +23,7 @@ class Config(_base.Config):
   LOGO_PATH = "/custom_dc/unsdg/logo.png"
   OVERRIDE_CSS_PATH = '/custom_dc/unsdg/overrides.css'
   SHOW_DISASTER = False
+  USE_PALM = True
 
 
 class LocalConfig(Config, local.Config):


### PR DESCRIPTION
The SecretManager setups for palm-api-key exist in both:
* https://pantheon.corp.google.com/security/secret-manager/secret/palm-api-key/versions?mods=-monitoring_api_staging&project=datcom-recon-autopush
* https://pantheon.corp.google.com/security/secret-manager/secret/palm-api-key/versions?mods=-monitoring_api_staging&project=datcom-website-dev