### PR TITLE
Update highlight tile unit display for large per-capita percentages.

### DIFF
--- a/static/js/components/tiles/highlight_tile.tsx
+++ b/static/js/components/tiles/highlight_tile.tsx
@@ -121,6 +121,7 @@ export function HighlightTile(props: HighlightTilePropType): JSX.Element {
   const [highlightData, setHighlightData] = useState<HighlightData | undefined>(
     null
   );
+
   useEffect(() => {
     fetchData(props).then((data) => {
       setHighlightData(data);

--- a/static/js/components/tiles/highlight_tile.tsx
+++ b/static/js/components/tiles/highlight_tile.tsx
@@ -151,10 +151,13 @@ export function HighlightTile(props: HighlightTilePropType): JSX.Element {
       ? metadataUnit.slice(numberUnit.length).trimStart()
       : metadataUnit;
   }
+  // Find percentages that are too big, and adjust back to non-percentage value
+  // This avoids cases like "1.3K%" being displayed instead of "13" when showing
+  // a per capita value.
   if (
     numberUnit === "%" &&
     highlightData.value >= 100 &&
-    props.statVarSpec.scaling == 100
+    props.statVarSpec.denom === "Count_Person"
   ) {
     numberUnit = "";
     metadataUnit = highlightData.unitDisplayName;

--- a/static/js/components/tiles/highlight_tile.tsx
+++ b/static/js/components/tiles/highlight_tile.tsx
@@ -121,7 +121,6 @@ export function HighlightTile(props: HighlightTilePropType): JSX.Element {
   const [highlightData, setHighlightData] = useState<HighlightData | undefined>(
     null
   );
-
   useEffect(() => {
     fetchData(props).then((data) => {
       setHighlightData(data);
@@ -151,6 +150,15 @@ export function HighlightTile(props: HighlightTilePropType): JSX.Element {
     metadataUnit = numberUnit
       ? metadataUnit.slice(numberUnit.length).trimStart()
       : metadataUnit;
+  }
+  if (
+    numberUnit === "%" &&
+    highlightData.value >= 100 &&
+    props.statVarSpec.scaling == 100
+  ) {
+    numberUnit = "";
+    metadataUnit = highlightData.unitDisplayName;
+    highlightData.value /= props.statVarSpec.scaling;
   }
   return (
     <div


### PR DESCRIPTION
Updates the styling of the units on the highlight tile, so that when per-capita results in a large percentage, we show the raw value instead of a percentage. This prevents us from showing something like "1.3K%" to the user instead of the actual value "13".

Before:
![Screenshot 2023-08-31 at 1 40 05 PM](https://github.com/datacommonsorg/website/assets/4034366/87084bb7-f0f7-4bfd-8c3c-8c4aada08be3)

After:
![Screenshot 2023-08-31 at 1 39 08 PM](https://github.com/datacommonsorg/website/assets/4034366/c42af2f9-ac07-4e82-bea3-b1f5d9ad35a3)
