### PR TITLE
Add prod/autopush/dev as remote screenshot target; Try to fix image corruption issue

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -143,7 +143,7 @@ function run_screenshot_test {
   export ENABLE_MODEL=true
   export MIXER_API_KEY=
   export PALM_API_KEY=
-  python3 -m pytest -n 5 --reruns 2 server/webdriver/screenshot/
+  python3 -m pytest --reruns 2 server/webdriver/screenshot/
 }
 
 # Run integration test for NL and explore interface

--- a/server/integration_tests/test_data/e2e_answer_places/whatistheemissionsinthesecounties/chart_config.json
+++ b/server/integration_tests/test_data/e2e_answer_places/whatistheemissionsinthesecounties/chart_config.json
@@ -730,6 +730,13 @@
     "childPlaces": {},
     "childTopics": [
       {
+        "dcid": "dc/topic/CO2Emissions",
+        "name": "Carbondioxide ( CO2)",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
         "dcid": "dc/topic/Emissions_Methane_EmissionsbySource",
         "name": "Methane",
         "types": [

--- a/server/webdriver/screenshot/remote/autopush.datacommons.org/page.json
+++ b/server/webdriver/screenshot/remote/autopush.datacommons.org/page.json
@@ -1,0 +1,1 @@
+../../local/page.json

--- a/server/webdriver/screenshot/remote/datacommons.org/page.json
+++ b/server/webdriver/screenshot/remote/datacommons.org/page.json
@@ -1,0 +1,1 @@
+../../local/page.json

--- a/server/webdriver/screenshot/remote/dev.datacommons.org/page.json
+++ b/server/webdriver/screenshot/remote/dev.datacommons.org/page.json
@@ -1,0 +1,1 @@
+../../local/page.json

--- a/static/js/apps/screenshot/app.tsx
+++ b/static/js/apps/screenshot/app.tsx
@@ -20,7 +20,7 @@ import React, { useEffect, useState } from "react";
 import { stringifyFn } from "../../utils/axios";
 
 // diff ratio smaller than this is regarded as no diff.
-const DIFF_RATIO_THRESHOLD = 0.001;
+const DIFF_RATIO_THRESHOLD = 0.01;
 
 export function App(props: {
   data: Record<string, { blob1: string; blob2: string }>;


### PR DESCRIPTION
All main DC site uses the same page.json as /local, Here created symbolic links.

Now there is two saving issue:

1. Some images are saved in the wrong name
2. Some images are corrupted and not fully saved.

These are very likely from the pytest parallel run. Disabling that.