### PR TITLE
Override descriptions for commute time variable

### DIFF
--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_3/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_3/chart_config.json
@@ -161,7 +161,7 @@
                     "statVarKey": [
                       "dc/e9gftzl2hm8h9"
                     ],
-                    "title": "Commute Time in Sunnyvale",
+                    "title": "Total Commute Time in Sunnyvale",
                     "type": "LINE"
                   }
                 ]
@@ -169,18 +169,19 @@
               {
                 "tiles": [
                   {
-                    "description": "Commute Time in Sunnyvale",
+                    "description": "Total Commute Time in Sunnyvale",
                     "statVarKey": [
                       "dc/e9gftzl2hm8h9"
                     ],
-                    "title": "Commute Time in Sunnyvale",
+                    "title": "Total Commute Time in Sunnyvale",
                     "type": "HIGHLIGHT"
                   }
                 ]
               }
             ],
             "denom": "Count_Person",
-            "title": "Commute Time"
+            "description": "Total time spent on a single commute across all workers.",
+            "title": "Total Commute Time"
           },
           {
             "columns": [
@@ -281,7 +282,7 @@
             "statVar": "dc/e27c5t4tbplg"
           },
           "dc/e9gftzl2hm8h9": {
-            "name": "Commute Time",
+            "name": "Total Commute Time",
             "statVar": "dc/e9gftzl2hm8h9"
           },
           "dc/exr9t81en1h34_multiple_place_bar_block": {

--- a/server/integration_tests/test_data/demo2_cities_feb2023/query_4/chart_config.json
+++ b/server/integration_tests/test_data/demo2_cities_feb2023/query_4/chart_config.json
@@ -175,14 +175,15 @@
                     "statVarKey": [
                       "dc/e9gftzl2hm8h9_multiple_place_bar_block"
                     ],
-                    "title": "Commute Time (${date})",
+                    "title": "Total Commute Time (${date})",
                     "type": "BAR"
                   }
                 ]
               }
             ],
             "denom": "Count_Person",
-            "title": "Commute Time"
+            "description": "Total time spent on a single commute across all workers.",
+            "title": "Total Commute Time"
           },
           {
             "columns": [
@@ -284,7 +285,7 @@
             "statVar": "dc/e27c5t4tbplg"
           },
           "dc/e9gftzl2hm8h9_multiple_place_bar_block": {
-            "name": "Commute Time",
+            "name": "Total Commute Time",
             "statVar": "dc/e9gftzl2hm8h9"
           },
           "dc/exr9t81en1h34_multiple_place_bar_block": {

--- a/server/integration_tests/test_data/fulfillment_api_basic/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_basic/chart_config.json
@@ -387,7 +387,7 @@
                     "statVarKey": [
                       "dc/e9gftzl2hm8h9"
                     ],
-                    "title": "Commute Time in Santa Clara County",
+                    "title": "Total Commute Time in Santa Clara County",
                     "type": "LINE"
                   }
                 ]
@@ -395,18 +395,19 @@
               {
                 "tiles": [
                   {
-                    "description": "Commute Time in Santa Clara County",
+                    "description": "Total Commute Time in Santa Clara County",
                     "statVarKey": [
                       "dc/e9gftzl2hm8h9"
                     ],
-                    "title": "Commute Time in Santa Clara County",
+                    "title": "Total Commute Time in Santa Clara County",
                     "type": "HIGHLIGHT"
                   }
                 ]
               }
             ],
             "denom": "Count_Person",
-            "title": "Commute Time"
+            "description": "Total time spent on a single commute across all workers.",
+            "title": "Total Commute Time"
           },
           {
             "columns": [
@@ -416,7 +417,7 @@
                     "statVarKey": [
                       "dc/e9gftzl2hm8h9"
                     ],
-                    "title": "Commute Time in Cities of Santa Clara County (${date})",
+                    "title": "Total Commute Time in Cities of Santa Clara County (${date})",
                     "type": "MAP"
                   }
                 ]
@@ -431,14 +432,15 @@
                     "statVarKey": [
                       "dc/e9gftzl2hm8h9"
                     ],
-                    "title": "Commute Time in Cities of Santa Clara County (${date})",
+                    "title": "Total Commute Time in Cities of Santa Clara County (${date})",
                     "type": "RANKING"
                   }
                 ]
               }
             ],
             "denom": "Count_Person",
-            "title": "Commute Time in Cities of Santa Clara County"
+            "description": "Total time spent on a single commute across all workers.",
+            "title": "Total Commute Time in Cities of Santa Clara County"
           },
           {
             "columns": [
@@ -615,7 +617,7 @@
             "statVar": "dc/dn2h9yfcgbkg2"
           },
           "dc/e9gftzl2hm8h9": {
-            "name": "Commute Time",
+            "name": "Total Commute Time",
             "statVar": "dc/e9gftzl2hm8h9"
           },
           "dc/exr9t81en1h34_multiple_place_bar_block": {

--- a/server/integration_tests/test_data/fulfillment_api_comparison/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_comparison/chart_config.json
@@ -144,14 +144,15 @@
                     "statVarKey": [
                       "dc/e9gftzl2hm8h9_multiple_place_bar_block"
                     ],
-                    "title": "Commute Time (${date})",
+                    "title": "Total Commute Time (${date})",
                     "type": "BAR"
                   }
                 ]
               }
             ],
             "denom": "Count_Person",
-            "title": "Commute Time"
+            "description": "Total time spent on a single commute across all workers.",
+            "title": "Total Commute Time"
           },
           {
             "columns": [
@@ -241,7 +242,7 @@
             "statVar": "dc/dn2h9yfcgbkg2"
           },
           "dc/e9gftzl2hm8h9_multiple_place_bar_block": {
-            "name": "Commute Time",
+            "name": "Total Commute Time",
             "statVar": "dc/e9gftzl2hm8h9"
           },
           "dc/exr9t81en1h34_multiple_place_bar_block": {

--- a/server/lib/nl/common/constants.py
+++ b/server/lib/nl/common/constants.py
@@ -327,6 +327,8 @@ SV_DISPLAY_NAME_OVERRIDE = {
         "Household Median Income",
     "Median_Earnings_Person":
         "Individual Median Earnings",
+    "dc/e9gftzl2hm8h9":
+        "Total Commute Time Across All Workers",
     "dc/6rltk4kf75612":
         "Work at home",
     "dc/vp8cbt6k79t94":
@@ -761,6 +763,8 @@ SV_DISPLAY_DESCRIPTION_OVERRIDE = {
         "Relative to the Average Yearly Min Temperature between 1980-2010, the Predicted Min Temperature difference with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 245 (intermediate) scenario.",
     "DiffRelativeToAvg_1980_2010_MinTemp_Daily_Hist_95PctProb_LessThan_Atleast1DayAYear_CMIP6_Ensemble_SSP585":
         "Relative to the Average Yearly Min Temperature between 1980-2010, the Predicted Min Temperature difference with 95% chance, at least once in the year, according to a CMIP6 Ensemble model as per SSP 585 (pessimistic) scenario.",
+    "dc/e9gftzl2hm8h9":
+        "Total time spent on a single commute across all workers",
 }
 
 # Have a shorter limit to avoid spamming the json.

--- a/server/lib/nl/common/constants.py
+++ b/server/lib/nl/common/constants.py
@@ -328,7 +328,7 @@ SV_DISPLAY_NAME_OVERRIDE = {
     "Median_Earnings_Person":
         "Individual Median Earnings",
     "dc/e9gftzl2hm8h9":
-        "Total Commute Time Across All Workers",
+        "Total Commute Time",
     "dc/6rltk4kf75612":
         "Work at home",
     "dc/vp8cbt6k79t94":


### PR DESCRIPTION
Add an override for the title and description for the variable `dc/e9gftzl2hm8h9` to make its meaning more clear in explore results.

Before:
![Screenshot 2023-09-05 at 10 41 28 AM](https://github.com/datacommonsorg/website/assets/4034366/e02fd6b3-401c-43a0-bbda-4227cd122e7d)


After:
![Screenshot 2023-09-05 at 10 41 00 AM](https://github.com/datacommonsorg/website/assets/4034366/2d6c3667-19ea-49d3-bc7e-c247189ba83a)
