### PR TITLE
[explore] mobile fixes

### DIFF
--- a/static/css/shared/_subject_page.scss
+++ b/static/css/shared/_subject_page.scss
@@ -83,7 +83,7 @@ article.category {
   display: flex;
   flex-direction: column;
   padding: 0 15px;
-  min-width: 25rem;
+  min-width: 20rem;
   flex-grow: 1;
 }
 

--- a/static/css/shared/item_list.scss
+++ b/static/css/shared/item_list.scss
@@ -23,7 +23,7 @@
     color: var(--gm-3-sys-light-primary);
     margin-left: -12px;
     .item-list-item {
-      display: inline-block;
+      display: inline-flex;
 
       &:before {
         content: "•";
@@ -33,8 +33,11 @@
       }
 
       .item-list-text {
-        margin: 10px 12px;
+        margin: 0 12px;
         line-height: 24px;
+        display: inline-block;
+        padding-left: 12px;
+        text-indent: -12px;
       }
 
       .item-list-text:hover {


### PR DESCRIPTION
- fix left/right nudging by decreasing the min width of tiles
- fix list items being cut off by using a combination of padding + text-indent

regular desktop:
<img width="1771" alt="Screenshot 2023-09-05 at 4 58 07 PM" src="https://github.com/datacommonsorg/website/assets/69875368/c39a292d-c72c-45e6-a4fb-4fe7f0d203f6">

mobile:
[screen-recording - 2023-09-05T170005.795.webm](https://github.com/datacommonsorg/website/assets/69875368/4dfd2802-2a51-47bb-bb03-4f7ff9229767)
