### PR TITLE
fix search animation cut off on ios

### DIFF
--- a/static/css/homepage.scss
+++ b/static/css/homepage.scss
@@ -267,7 +267,6 @@ $search-answer-bottom: 48px;
       font-family: $headings-font-family;
       font-size: 16px;
       size: 30px;
-      line-height: 52px;
       z-index: 100;
       position: relative;
     }


### PR DESCRIPTION
It was a bug that manifests in safari. No changes in Chrome on macs.

Before:
![image](https://github.com/datacommonsorg/website/assets/6052978/e0a4993a-abac-4f22-8d00-c20e533c4a07)


After:
![image](https://github.com/datacommonsorg/website/assets/6052978/8bc97c35-d9e3-45a0-a9ef-5419470f92f5)
