### PR TITLE
Show search box for SDG on DC site

### DIFF
--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -146,13 +146,11 @@ export function SuccessResult(props: SuccessResultPropType): JSX.Element {
             debugData={props.debugData}
             queryResult={props.queryResult}
           ></DebugInfo>
-          {props.exploreContext.dc !== "sdg" && (
-            <SearchSection
-              query={props.query}
-              debugData={props.debugData}
-              exploreContext={props.exploreContext}
-            />
-          )}
+          <SearchSection
+            query={props.query}
+            debugData={props.debugData}
+            exploreContext={props.exploreContext}
+          />
         </div>
       </div>
       <div className="col-12" ref={chartSectionRef}>


### PR DESCRIPTION
This is so that we can test SDG index independently on our site with context.