### PR TITLE
Quick fix: cut off breadcrumbs that are too long with overflow: hidden

### DIFF
--- a/experimental/sdg-tracker/src/components/shared/components.tsx
+++ b/experimental/sdg-tracker/src/components/shared/components.tsx
@@ -266,6 +266,7 @@ const PlaceCardContent = styled.div`
   flex-direction: column;
   gap: 24px;
   margin: 24px;
+  overflow: hidden;
 `;
 
 const PlaceTitle = styled.div`


### PR DESCRIPTION
Quick fix for breadcrumbs overflowing the headers on mobile. We should go back and clean this up after demos are done.

Screenshot:
![Screenshot 2023-09-07 at 1 03 53 AM](https://github.com/datacommonsorg/website/assets/4034366/a6249c8c-87ab-4f28-8416-bbc88ca806e1)
