### PR TITLE
[sdg] Added class names to sdg components for sanity check tests

### DIFF
--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -582,7 +582,11 @@ const ChartTile: React.FC<{ placeDcid: string; tile: ChartConfigTile }> = ({
   }
 
   return (
-    <div ref={ref} style={{ minHeight: !loaded ? height : undefined }}>
+    <div
+      className={`-dc-chart-tile -dc-chart-tile-${tile.type}`}
+      ref={ref}
+      style={{ minHeight: !loaded ? height : undefined }}
+    >
       {loaded && component}
     </div>
   );

--- a/experimental/sdg-tracker/src/components/home/GoalSection.tsx
+++ b/experimental/sdg-tracker/src/components/home/GoalSection.tsx
@@ -13,20 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import styled from "styled-components";
 import { useHistory } from "react-router-dom";
+import styled from "styled-components";
 import { RootTopic, useStoreState } from "../../state";
 import { HomeSection } from "./components";
 const HALF_TOPIC_NUM = 9;
 
 const Container = styled(HomeSection)`
   gap: 114px;
-  background-color: #F2F2F2;
-`
+  background-color: #f2f2f2;
+`;
 const HeaderContainer = styled.div`
   color: #414042;
   text-align: center;
-  
+
   .title {
     font-size: 36px;
     font-weight: 700;
@@ -36,7 +36,7 @@ const HeaderContainer = styled.div`
   .line-separator {
     height: 0;
     border-top: solid 3px #999;
-    margin: 30px 0
+    margin: 30px 0;
   }
 
   .description {
@@ -45,7 +45,7 @@ const HeaderContainer = styled.div`
     font-weight: 400;
     line-height: 36px;
   }
-`
+`;
 const GoalContainer = styled.div`
   display: flex;
   align-items: center;
@@ -81,7 +81,7 @@ const GoalContainer = styled.div`
   }
 
   .goal-number {
-    color: #FFF;
+    color: #fff;
     font-size: 24px;
     font-weight: 700;
     width: 70px;
@@ -90,7 +90,7 @@ const GoalContainer = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-  } 
+  }
 
   .goal-name {
     color: #444;
@@ -116,42 +116,67 @@ const GoalContainer = styled.div`
       height: fit-content;
     }
   }
-`
+`;
 export const GoalSection = () => {
   const history = useHistory();
   const rootTopics = useStoreState((s) => s.rootTopics);
-  const goalSections = [rootTopics.slice(0, 9), rootTopics.slice(9)]
+  const goalSections = [rootTopics.slice(0, 9), rootTopics.slice(9)];
 
   return (
     <Container>
       <HeaderContainer>
         <div className="title">Explore SDG Data by Goal</div>
         <div className="line-separator" />
-        <div className="description">Learn about SDG progress across all 17 Goals -- with data, insights and infographics in one place for a comprehensive overview.</div>
+        <div className="description">
+          Learn about SDG progress across all 17 Goals -- with data, insights
+          and infographics in one place for a comprehensive overview.
+        </div>
       </HeaderContainer>
-      <GoalContainer>{
-        goalSections.map((goalSection: RootTopic[], sectionNum) => {
-          return (<div className="goal-section" key={`section-${sectionNum}`}>
-          {
-            goalSection.map((goal: RootTopic, topicNum) => {
-              return (<div className="goal-item" key={goal.topicDcid} onClick={() => history.push(`/goals/dc/topic/sdg_1?v=${goal.topicDcid}`)}>
-                <div style={{backgroundColor: goal.color}} className="goal-number">
-                  <span>{HALF_TOPIC_NUM * sectionNum + topicNum + 1}</span>
+      <GoalContainer>
+        {goalSections.map((goalSection: RootTopic[], sectionNum) => {
+          return (
+            <div className="goal-section" key={`section-${sectionNum}`}>
+              {goalSection.map((goal: RootTopic, topicNum) => {
+                return (
+                  <div
+                    className={`goal-item -dc-goal-item-${topicNum + 1}`}
+                    key={goal.topicDcid}
+                    onClick={() =>
+                      history.push(`/goals/dc/topic/sdg_1?v=${goal.topicDcid}`)
+                    }
+                  >
+                    <div
+                      style={{ backgroundColor: goal.color }}
+                      className="goal-number"
+                    >
+                      <span>{HALF_TOPIC_NUM * sectionNum + topicNum + 1}</span>
+                    </div>
+                    <div className="goal-content">
+                      <div className="goal-name">{goal.name}</div>
+                      <div className="goal-icon">
+                        <img src={goal.homePageIcon} />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+              {sectionNum === 1 && (
+                <div
+                  className="goal-item -dc-goal-item-all"
+                  onClick={() => history.push("/goals")}
+                >
+                  <div className="goal-number">
+                    <img src={"/images/datacommons/sdg-goals-icon.svg"} />
+                  </div>
+                  <div className="goal-content">
+                    <div className="goal-name">All Goals</div>
+                  </div>
                 </div>
-                <div className="goal-content"><div className="goal-name">{goal.name}</div><div className="goal-icon"><img src={goal.homePageIcon}/></div></div>
-              </div>)
-            })
-          }
-          {sectionNum === 1 && (
-            <div className="goal-item" onClick={() => history.push("/goals")}>
-            <div className="goal-number"><img src={"/images/datacommons/sdg-goals-icon.svg"}/></div>
-            <div className="goal-content"><div className="goal-name">All Goals</div></div>
+              )}
             </div>
-          )}
-          </div>)
-        })
-      }
+          );
+        })}
       </GoalContainer>
     </Container>
-  )
-}
+  );
+};

--- a/experimental/sdg-tracker/src/components/home/PlaceSection.tsx
+++ b/experimental/sdg-tracker/src/components/home/PlaceSection.tsx
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import styled from "styled-components";
 import { AutoComplete } from "antd";
-import backgroundImg from "../../../public/images/datacommons/place-background.png";
 import React, { useState } from "react";
-import { useStoreState } from "../../state";
 import { useHistory } from "react-router-dom";
+import styled from "styled-components";
+import backgroundImg from "../../../public/images/datacommons/place-background.png";
+import { useStoreState } from "../../state";
 
 const Container = styled.div`
   font-family: Roboto;
@@ -26,7 +26,7 @@ const Container = styled.div`
   img {
     width: 100%;
   }
-`
+`;
 
 const PlaceContent = styled.div`
   background-image: url(${backgroundImg});
@@ -36,12 +36,12 @@ const PlaceContent = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-`
+`;
 
 const PlaceSearchContainer = styled.div`
   border-radius: 10px;
   border: 1px solid #414042;
-  background: rgba(255, 255, 255, 0.90);
+  background: rgba(255, 255, 255, 0.9);
   box-shadow: 4px 4px 8px 0px rgba(0, 0, 0, 0.15);
   max-width: 702px;
   width: 90%;
@@ -54,7 +54,7 @@ const PlaceSearchContainer = styled.div`
   justify-content: center;
 
   .title {
-    color: #449BD5;
+    color: #449bd5;
     font-size: 34px;
     font-weight: 700;
     line-height: 47px;
@@ -83,7 +83,7 @@ const PlaceSearchContainer = styled.div`
       align-items: center;
       font-size: 24px;
       border-radius: 30px;
-  
+
       .ant-select-selection-search {
         height: 100%;
         display: flex;
@@ -102,7 +102,7 @@ const PlaceSearchContainer = styled.div`
       }
     }
   }
-`
+`;
 
 const PlaceSearch: React.FC = () => {
   const history = useHistory();
@@ -115,13 +115,14 @@ const PlaceSearch: React.FC = () => {
   return (
     <div className="search-bar-container">
       <AutoComplete
+        className="-dc-place-search"
         value={value}
         style={{
           width: "100%",
           borderRadius: "30px",
           border: "0.5px solid #414042",
           background: "#fff",
-          height: "63px"
+          height: "63px",
         }}
         options={countries.map((c) => ({ value: c.name, dcid: c.dcid }))}
         placeholder="Select country"
@@ -146,15 +147,18 @@ const PlaceSearch: React.FC = () => {
 export const PlaceSection = () => {
   return (
     <Container>
-      <img src="/images/datacommons/sdg-color-bar.png"/>
+      <img src="/images/datacommons/sdg-color-bar.png" />
       <PlaceContent>
         <PlaceSearchContainer>
           <div className="title">Explore SDG Data by Countries</div>
           <PlaceSearch />
-          <div className="footer">Learn about country and SDG region progress through the UN Data Commons.</div>
+          <div className="footer">
+            Learn about country and SDG region progress through the UN Data
+            Commons.
+          </div>
         </PlaceSearchContainer>
       </PlaceContent>
-      <img src="/images/datacommons/sdg-color-bar.png"/>
+      <img src="/images/datacommons/sdg-color-bar.png" />
     </Container>
-  )
-}
+  );
+};

--- a/experimental/sdg-tracker/src/components/search/Search.tsx
+++ b/experimental/sdg-tracker/src/components/search/Search.tsx
@@ -321,7 +321,11 @@ const Search = () => {
                 {QUERIES.specific.map((q, i) => (
                   <StyledLinkContainer>
                     <IconSquare color={theme.sdgColors[q.goal - 1]} />
-                    <StyledLink key={i} to={`/search?q=${q.query}`}>
+                    <StyledLink
+                      className={`-dc-search-example`}
+                      key={i}
+                      to={`/search?q=${q.query}`}
+                    >
                       {q.query}
                     </StyledLink>
                   </StyledLinkContainer>

--- a/experimental/sdg-tracker/src/components/shared/AppSidebar.tsx
+++ b/experimental/sdg-tracker/src/components/shared/AppSidebar.tsx
@@ -47,13 +47,22 @@ const AppSidebar: React.FC<{
   const getMenuItem = (item: MenuItemType) => {
     if (item.children && item.children.length > 0) {
       return (
-        <SubMenu key={item.key} title={item.label} icon={item.icon}>
+        <SubMenu
+          className={`-dc-sidebar-submenu -dc-sidebar-submenu-${item.key}`}
+          key={item.key}
+          title={item.label}
+          icon={item.icon}
+        >
           {item.children.map((subItem) => getMenuItem(subItem))}
         </SubMenu>
       );
     }
     return (
-      <Menu.Item key={item.key} icon={item.icon}>
+      <Menu.Item
+        className={`-dc-sidebar-menu-item -dc-sidebar-menu-item-${item.key}`}
+        key={item.key}
+        icon={item.icon}
+      >
         {item.label}
       </Menu.Item>
     );

--- a/experimental/sdg-tracker/src/components/shared/components.tsx
+++ b/experimental/sdg-tracker/src/components/shared/components.tsx
@@ -475,7 +475,12 @@ export const TargetHeader: React.FC<{ color: string; target: string }> = ({
 
   return (
     <>
-      <TargetIdBox color={color}>{target}</TargetIdBox>
+      <TargetIdBox
+        className={`-dc-target-header -dc-target-header-${target}`}
+        color={color}
+      >
+        {target}
+      </TargetIdBox>
       <TargetText color={color}>{targetText}</TargetText>
     </>
   );

--- a/experimental/sdg-tracker/src/components/shared/components.tsx
+++ b/experimental/sdg-tracker/src/components/shared/components.tsx
@@ -116,6 +116,7 @@ export const SearchBar: React.FC<{
       <div className="info">Early Preview</div>
       <div className="search">
         <SearchInput
+          className="-dc-search-bar"
           placeholder={
             placeholder
               ? placeholder
@@ -220,6 +221,7 @@ export const CountrySelect: React.FC<{
   return (
     <CountrySelectContainer>
       <AutoComplete
+        className="-dc-place-search"
         size="large"
         value={isFocused ? value : ""}
         style={{ width: 225 }}

--- a/experimental/sdg-tracker/src/components/shared/goals/AllGoalsOverview.tsx
+++ b/experimental/sdg-tracker/src/components/shared/goals/AllGoalsOverview.tsx
@@ -28,7 +28,7 @@ const StyledContentCardHeader = styled(ContentCardHeader)`
 
 const AllGoalsOverview = () => {
   return (
-    <MainLayoutContent>
+    <MainLayoutContent className="-dc-goal-overview -dc-goal-overview-all">
       <ContentCard>
         <StyledContentCardHeader>
           <img src={SDG_ICON_URL} />

--- a/experimental/sdg-tracker/src/components/shared/goals/GoalOverview.tsx
+++ b/experimental/sdg-tracker/src/components/shared/goals/GoalOverview.tsx
@@ -67,7 +67,7 @@ const GoalOverview: React.FC<{
   const exploreUrl = location.pathname + "?" + searchParams.toString();
 
   return (
-    <ContentCard>
+    <ContentCard className={`-dc-goal-overview-${goalNumber}`}>
       <ContentCardHeader>
         <img src={rootTopic.iconUrl} />
         <h3>
@@ -77,20 +77,11 @@ const GoalOverview: React.FC<{
       <ContentCardBody>
         <Row>
           {goalSummary.image ? (
-            <StyledCol
-              md={24}
-              lg={12}
-            >
-              <GoalImage
-                src={goalSummary.image}
-                $md={breakpoint.md}
-              />
+            <StyledCol md={24} lg={12}>
+              <GoalImage src={goalSummary.image} $md={breakpoint.md} />
             </StyledCol>
           ) : null}
-          <StyledCol
-            md={24}
-            lg={goalSummary.image ? 12 : 24}
-          >
+          <StyledCol md={24} lg={goalSummary.image ? 12 : 24}>
             <GoalText>
               {goalSummary.headlines.map((headline, i) => (
                 <li key={i}>{headline}</li>

--- a/experimental/sdg-tracker/src/components/shared/goals/GoalOverview.tsx
+++ b/experimental/sdg-tracker/src/components/shared/goals/GoalOverview.tsx
@@ -67,7 +67,9 @@ const GoalOverview: React.FC<{
   const exploreUrl = location.pathname + "?" + searchParams.toString();
 
   return (
-    <ContentCard className={`-dc-goal-overview-${goalNumber}`}>
+    <ContentCard
+      className={`-dc-goal-overview -dc-goal-overview-${goalNumber}`}
+    >
       <ContentCardHeader>
         <img src={rootTopic.iconUrl} />
         <h3>


### PR DESCRIPTION
All classes start with the prefix `-dc-`

## Homepage classes
![sanity-homepage](https://github.com/datacommonsorg/website/assets/13766/4959113d-0524-4a8f-8ff1-8ee42a24fe0c)

```
-dc-place-search
-dc-goal-item-all
-dc-goal-item-1
-dc-goal-item-2
-dc-goal-item-3
...
-dc-goal-item-17
-dc-search-bar
```

## Countries / Goals page classes
![sanity-countries](https://github.com/datacommonsorg/website/assets/13766/79f3f1e7-9c21-41ea-a4ef-f329d168b57b)

### Sidebar

```
-dc-sidebar-submenu
-dc-sidebar-submenu-<dcid>
-dc-sidebar-menu-item
-dc-sidebar-menu-item-<dcid>
```

### Main content

```
-dc-place-search
-dc-goal-overview (all goal overviews tagged with this)
-dc-goal-overview-all
-dc-goal-overview-1
-dc-goal-overview-2
...
-dc-goal-overview-17
-dc-target-header
-dc-target-header-target-1.1.1
-dc-chart-tile
-dc-chart-tile-BAR
-dc-chart-tile-MAP
-dc-chart-tile-HIGHLIGHT
-dc-chart-tile-BAR
-dc-chart-tile-LINE
```

## Search
![sanity-search](https://github.com/datacommonsorg/website/assets/13766/83839847-9161-4d21-98e2-ac3540950af8)

```
-dc-search-bar
-dc-search-example
```