### PR TITLE
[sdg] Use text in [ ] for line chart legend labels 

### DIFF
--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -531,6 +531,7 @@ const ChartTile: React.FC<{ placeDcid: string; tile: ChartConfigTile }> = ({
           header={tile.title}
           variables={tile.statVarKey.join(" ")}
           places={placeDcid}
+          variableNameRegex={"(?<=\\[)(.*?)(?=\\])"}
         />
       </>
     );

--- a/packages/web-components/docs/components/line.md
+++ b/packages/web-components/docs/components/line.md
@@ -1,4 +1,4 @@
-# Data Commons Gauge Chart Web Component
+# Data Commons Line Chart Web Component
 
 [Data Commons Web Component](../../README.md) for visualizing one or more statistical variables about a single place.
 
@@ -37,3 +37,7 @@ Optional:
   Optionally specify a custom chart color for each variable. Pass colors in the same order as variables.
 
   Values should follow CSS specification (keywords, rgb, rgba, hsl, #hex). Separate multiple values with spaces, e.g., `"#ff0000 #00ff00 #0000ff"`. Make sure individual colors have no spaces. For example, use `rgba(255,0,0,0.3)` instead of `rgba(255, 0, 0, 0.3)`.
+
+- `variableNameRegex` _string_
+
+  Optionally specify regex to use to extract out variable name. e.g., if the variableNameRegex is "(.*?)(?=:)", only the part before a ":" will be used for variable names. So "variable 1: test" will become "variable 1".

--- a/packages/web-components/examples/all-charts.html
+++ b/packages/web-components/examples/all-charts.html
@@ -261,6 +261,12 @@
       variables="DifferenceRelativeToBaseDate1990_Max_Temperature DifferenceRelativeToBaseDate1990_Min_Temperature"
     ></datacommons-line>
     <datacommons-line
+      header="Max and Min Temperature (Difference Relative To Base Date): Relative To 1990 (With Regex Matching)"
+      place="country/USA"
+      variables="DifferenceRelativeToBaseDate1990_Max_Temperature DifferenceRelativeToBaseDate1990_Min_Temperature"
+      variableNameRegex="(.*?)(?=:)"
+      ></datacommons-line>
+    <datacommons-line
       header="Mean Palmer Drought Severity Index (PDSI) in the US"
       place="country/USA"
       variables="Mean_PalmerDroughtSeverityIndex"

--- a/static/js/components/tiles/line_tile.tsx
+++ b/static/js/components/tiles/line_tile.tsx
@@ -78,6 +78,9 @@ export interface LineTilePropType {
   showLoadingSpinner?: boolean;
   // Whether to show tooltip on hover
   showTooltipOnHover?: boolean;
+  // If provided, only the first case of the stat var name that matches
+  // this regex will be used as the stat var name.
+  statVarNameRegex?: string;
 }
 
 export interface LineChartData {
@@ -178,7 +181,7 @@ export const fetchData = async (props: LineTilePropType) => {
   const resp = await dataPromise;
   // get place names from dcids
   const placeDcids = Object.keys(resp.data[statVars[0]]);
-  const statVarNames = await getStatVarNames(props.statVarSpec, props.apiRoot);
+  const statVarNames = await getStatVarNames(props.statVarSpec, props.apiRoot, props.statVarNameRegex);
   const placeNames = await getPlaceNames(placeDcids, props.apiRoot);
   // How legend labels should be set
   // If neither options are set, default to showing stat vars in legend labels

--- a/static/library/line_chart_component.ts
+++ b/static/library/line_chart_component.ts
@@ -86,6 +86,12 @@ export class DatacommonsLineComponent extends LitElement {
   // Statistical variable DCIDs
   @property({ type: Array<string>, converter: convertArrayAttribute })
   variables!: Array<string>;
+  
+  // Optional: Regex used to process variable names
+  // If provided, will only use the first case of the variable name that matches
+  // this regex.
+  @property()
+  variableNameRegex!: string;
 
   render(): HTMLElement {
     const lineTileProps: LineTilePropType = {
@@ -110,6 +116,7 @@ export class DatacommonsLineComponent extends LitElement {
       })),
       svgChartHeight: 200,
       title: this.header || this.title,
+      statVarNameRegex: this.variableNameRegex
     };
     return createWebComponentElement(LineTile, lineTileProps);
   }

--- a/static/library/line_chart_component.ts
+++ b/static/library/line_chart_component.ts
@@ -90,6 +90,9 @@ export class DatacommonsLineComponent extends LitElement {
   // Optional: Regex used to process variable names
   // If provided, will only use the first case of the variable name that matches
   // this regex.
+  // For example, if the variableNameRegex is "(.*?)(?=:)", only the part before
+  // a ":" will be used for variable names. So "variable 1: test" will become
+  // "variable 1".
   @property()
   variableNameRegex!: string;
 


### PR DESCRIPTION
- do this by adding a new regex property to the line web component that allows processing of stat var names using regex.

<img width="1466" alt="Screenshot 2023-09-07 at 4 14 55 PM" src="https://github.com/datacommonsorg/website/assets/69875368/642bd248-ba06-4df3-a650-17b8efff64bd">
