### PR TITLE
NL: Improve bad-words matching

### DIFF
--- a/server/integration_tests/test_data/e2e_electrification_demo/whichcountriesinafricahavehadthegreatestincreaseinelectricityaccess/chart_config.json
+++ b/server/integration_tests/test_data/e2e_electrification_demo/whichcountriesinafricahavehadthegreatestincreaseinelectricityaccess/chart_config.json
@@ -503,13 +503,6 @@
           ]
         },
         {
-          "dcid": "country/IOT",
-          "name": "British Indian Ocean Territory",
-          "types": [
-            "Country"
-          ]
-        },
-        {
           "dcid": "country/KEN",
           "name": "Kenya",
           "types": [
@@ -673,6 +666,13 @@
         {
           "dcid": "country/STP",
           "name": "S\u00e3o Tom\u00e9 and Pr\u00edncipe",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/SWZ",
+          "name": "Eswatini",
           "types": [
             "Country"
           ]

--- a/server/lib/nl/common/bad_words.py
+++ b/server/lib/nl/common/bad_words.py
@@ -49,10 +49,9 @@ class Entry:
 
 @dataclass
 class BadWords:
-  # The key is a word.  If the value is empty, then
-  # its a single word.  If it is non-empty then it is
-  # part of a multi-word filter where every other word
-  # must match!
+  # The key is a word.  It is either a singleton word,
+  # or the first word in a phrase, or the first sorted
+  # word in a multi-word (aka colon-delimited) entry.
   words: Dict[str, Entry]
 
 

--- a/server/lib/nl/common/bad_words.py
+++ b/server/lib/nl/common/bad_words.py
@@ -25,18 +25,21 @@ _DELIM = ':'
 
 @dataclass
 class Entry:
-  # Set to true if this is a single word!
+  # Set to true if the key of the Entry is a single word.
   is_singleton: bool
 
-  # This entry has phrases.
+  # This entry has phrases beginning with the key of Entry.
+  # NOTE: These are full phrases including the word in the key,
+  # for convenience of matching.
   #
   # In case of "very bad dog", "very bad cow"
   # We will have: ["very bad dog", "very bad cow"]
   #
   phrases: List[str] = field(default_factory=list)
 
-  # This is a multi-word entry, with the other words.
-  # Each string is a word.
+  # This is a multi-word entry, where we must match every
+  # word (in any order) in the query.  When sorted, the first
+  # word is the key of Entry, and the remaining words are here.
   #
   # In case of "idiot:cat:bat", only if idiot, bat and cat
   # appear in the query (regardless of ordering),
@@ -76,7 +79,6 @@ def load_bad_words_file(local_file: str, validate: bool = False) -> BadWords:
 
       # Generally, be resilient to duplicates.  Only assert when `validate` is set.
       if _DELIM in line:
-        # NOTE: in this case words should not have spaces in them!
         words = sorted([w.strip() for w in line.split(_DELIM) if w.strip()])
         if words[0] not in bad_words.words:
           bad_words.words[words[0]] = Entry(is_singleton=False)
@@ -94,7 +96,7 @@ def load_bad_words_file(local_file: str, validate: bool = False) -> BadWords:
         parts = line.split(' ', 1)
         if parts[0] not in bad_words.words:
           bad_words.words[parts[0]] = Entry(is_singleton=False)
-        bad_words.words[parts[0]].phrases.append(parts[1])
+        bad_words.words[parts[0]].phrases.append(line)
 
         if validate:
           for w in line.split():

--- a/server/lib/nl/common/bad_words.py
+++ b/server/lib/nl/common/bad_words.py
@@ -12,40 +12,137 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from typing import Set
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Dict, List
 
 from server.lib.config import GLOBAL_CONFIG_BUCKET
 from shared.lib import gcs
 
 BAD_WORDS_FILE = 'nl_bad_words.txt'
+_DELIM = ':'
+
+
+@dataclass
+class Entry:
+  # Set to true if this is a single word!
+  is_singleton: bool
+
+  # This entry has phrases.
+  #
+  # In case of "very bad dog", "very bad cow"
+  # We will have: ["very bad dog", "very bad cow"]
+  #
+  phrases: List[str] = field(default_factory=list)
+
+  # This is a multi-word entry, with the other words.
+  # Each string is a word.
+  #
+  # In case of "idiot:cat:bat", only if idiot, bat and cat
+  # appear in the query (regardless of ordering),
+  # will we match.  We will have: ["cat", "idiot"]
+  other_words: List[str] = field(default_factory=list)
+
+
+@dataclass
+class BadWords:
+  # The key is a word.  If the value is empty, then
+  # its a single word.  If it is non-empty then it is
+  # part of a multi-word filter where every other word
+  # must match!
+  words: Dict[str, Entry]
 
 
 #
 # Loads a list of bad words from a text file.
 #
-def load_bad_words() -> Set[str]:
+def load_bad_words() -> BadWords:
   local_file = gcs.download_file(bucket=GLOBAL_CONFIG_BUCKET,
                                  filename=BAD_WORDS_FILE)
-  bad_words = set()
+  return load_bad_words_file(local_file)
+
+
+def load_bad_words_file(local_file: str, validate: bool = False) -> BadWords:
+  bad_words = BadWords(words={})
 
   with open(local_file) as fp:
     for line in fp:
-      line = line.strip()
+      line = line.strip().lower()
+      # Remove extra spaces between words
+      line = ' '.join(line.split())
       # Ignore comments
       if line.startswith('#') or line.startswith('//'):
         continue
 
-      bad_words.add(line.lower())
+      # Generally, be resilient to duplicates.  Only assert when `validate` is set.
+      if _DELIM in line:
+        # NOTE: in this case words should not have spaces in them!
+        words = sorted([w.strip() for w in line.split(_DELIM) if w.strip()])
+        if words[0] not in bad_words.words:
+          bad_words.words[words[0]] = Entry(is_singleton=False)
+        bad_words.words[words[0]].other_words = words[1:]
+
+        if validate:
+          assert ' ' not in line, f'Line {line} has a ":" and a phrase!'
+          for w in words:
+            if w in bad_words.words:
+              assert not bad_words.words[
+                  w].is_singleton, f'{line} is redundant because {w} already exists!'
+
+      elif ' ' in line:
+        # This is the case of a phrase.
+        parts = line.split(' ', 1)
+        if parts[0] not in bad_words.words:
+          bad_words.words[parts[0]] = Entry(is_singleton=False)
+        bad_words.words[parts[0]].phrases.append(parts[1])
+
+        if validate:
+          for w in line.split():
+            if w in bad_words.words:
+              assert not bad_words.words[
+                  w].is_singleton, f'{line} is redundant because {w} already exists!'
+      else:
+        # Singleton case.
+        if line not in bad_words.words:
+          bad_words.words[line] = Entry(is_singleton=True)
+        else:
+          bad_words.words[line].is_singleton = True
+
+        if validate:
+          ow = bad_words.words[line].other_words
+          assert not ow, f'{line} makes redundant {ow}'
+          ph = bad_words.words[line].phrases
+          assert not ph, f'{line} makes redundant {ph}'
 
   return bad_words
+
+
+def validate_bad_words():
+  local_file = gcs.download_file(bucket=GLOBAL_CONFIG_BUCKET,
+                                 filename=BAD_WORDS_FILE)
+  load_bad_words_file(local_file, validate=True)
 
 
 #
 # Returns false if the query contains any bad word.
 #
-def is_safe(query: str, bad_words: Set[str]) -> bool:
-  for w in query.split():
-    if w.strip() in bad_words:
-      return False
+def is_safe(query: str, bad_words: BadWords) -> bool:
+  qwords = [w.strip() for w in query.split() if w.strip()]
+  qwset = set(qwords)
+  for word in qwords:
+    entry = bad_words.words.get(word)
+    if entry:
+      if entry.is_singleton:
+        # Single-word badword!
+        return False
+
+      for ph in entry.phrases:
+        if ph in query:
+          # The entire phrase matches!
+          return False
+
+      if entry.other_words and all([bw in qwset for bw in entry.other_words]):
+        # Every other bad-word also exists in the query.
+        return False
+
   return True

--- a/server/tests/lib/nl/bad_words_test.py
+++ b/server/tests/lib/nl/bad_words_test.py
@@ -32,6 +32,7 @@ class TestBadWords(unittest.TestCase):
 
     # Phrase: "very bad word"
     self.assertFalse(bad_words.is_safe('is that a very bad word really', bw))
+    # Phrase: "very good sentence"
     self.assertFalse(
         bad_words.is_safe('is that a very good sentence really', bw))
     # Another ordering of the words is fine.
@@ -45,8 +46,12 @@ class TestBadWords(unittest.TestCase):
 
     # Multi words: cat and holy
     self.assertFalse(bad_words.is_safe('oh that cat is real holy', bw))
+    # Multi words: cat, moly and doly
+    self.assertFalse(bad_words.is_safe('doly is cat that has moly', bw))
     # Any single word is fine.
     self.assertTrue(bad_words.is_safe('is that cow holy too', bw))
+    self.assertTrue(bad_words.is_safe('is doly having moly holy', bw))
+    self.assertTrue(bad_words.is_safe('my cat is named doly', bw))
     self.assertTrue(bad_words.is_safe('cat on the wall', bw))
 
   def test_validate_prod(self):

--- a/server/tests/lib/nl/bad_words_test.py
+++ b/server/tests/lib/nl/bad_words_test.py
@@ -34,6 +34,10 @@ class TestBadWords(unittest.TestCase):
     self.assertFalse(bad_words.is_safe('is that a very bad word really', bw))
     self.assertFalse(
         bad_words.is_safe('is that a very good sentence really', bw))
+    # Another ordering of the words is fine.
+    self.assertTrue(bad_words.is_safe('bad word very', bw))
+    self.assertTrue(bad_words.is_safe('word bad very', bw))
+    self.assertTrue(bad_words.is_safe('very word bad', bw))
     # Subset of phrases should be fine
     self.assertTrue(bad_words.is_safe('that very bad story', bw))
     self.assertTrue(bad_words.is_safe('that bad word was epic', bw))

--- a/server/tests/lib/nl/bad_words_test.py
+++ b/server/tests/lib/nl/bad_words_test.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for bad_words functions."""
+
+import unittest
+
+import server.lib.nl.common.bad_words as bad_words
+
+
+class TestBadWords(unittest.TestCase):
+
+  def test_sample(self):
+    bw = bad_words.load_bad_words_file('server/tests/test_data/bad_words.txt')
+
+    # Non-existent words
+    self.assertTrue(bad_words.is_safe('number of people', bw))
+
+    # Single-word: "stupid"
+    self.assertFalse(bad_words.is_safe('is it that stupid', bw))
+    self.assertFalse(bad_words.is_safe('who said stupid is as stupid does', bw))
+
+    # Phrase: "very bad word"
+    self.assertFalse(bad_words.is_safe('is that a very bad word really', bw))
+    self.assertFalse(
+        bad_words.is_safe('is that a very good sentence really', bw))
+    # Subset of phrases should be fine
+    self.assertTrue(bad_words.is_safe('that very bad story', bw))
+    self.assertTrue(bad_words.is_safe('that bad word was epic', bw))
+    self.assertTrue(bad_words.is_safe('that bad sentence was legendary', bw))
+
+    # Multi words: cat and holy
+    self.assertFalse(bad_words.is_safe('oh that cat is real holy', bw))
+    # Any single word is fine.
+    self.assertTrue(bad_words.is_safe('is that cow holy too', bw))
+    self.assertTrue(bad_words.is_safe('cat on the wall', bw))
+
+  def test_validate_prod(self):
+    bad_words.validate_bad_words()

--- a/server/tests/test_data/bad_words.txt
+++ b/server/tests/test_data/bad_words.txt
@@ -3,3 +3,4 @@ holy:cat
 this is:a bad:thing to do
 very  bad  word
 very good sentence
+cat:moly:doly

--- a/server/tests/test_data/bad_words.txt
+++ b/server/tests/test_data/bad_words.txt
@@ -1,0 +1,5 @@
+stupid
+holy:cat
+this is:a bad:thing to do
+very  bad  word
+very good sentence


### PR DESCRIPTION
1.  Support phrases
2. Support multi-word matching, where every word has to appear in the query (in any order), with `:` separation.
3. Add tests and prod file validation

Note: Using regex as input might be very flexible but since it is easy to get wrong or eye-ball, I chose this simpler config of just `:` separated values.