### PR TITLE
[UN SDG Tracker] Only show goal overviews and indicator blurbs for the world + make infographic backgrounds white

### DIFF
--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -403,7 +403,12 @@ const ChartGoalBlock: React.FC<{
 }> = ({ placeDcid, goal, targetData }) => {
   return (
     <>
-      { placeDcid === EARTH_PLACE_DCID && <GoalOverview goalNumber={Number(goal)} showExploreLink={false} />}
+      {placeDcid === EARTH_PLACE_DCID && (
+        <GoalOverview
+          goalNumber={Number(goal)}
+          showExploreLink={false}
+        />
+      )}
       {Object.keys(targetData).map((target, i) => {
         return (
           <ChartTargetBlock
@@ -428,7 +433,10 @@ const ChartTargetBlock: React.FC<{
   const color = theme.sdgColors[goalNumber - 1];
   return (
     <ContentCard>
-     <TargetHeader color={color} target={target} />
+      <TargetHeader
+        color={color}
+        target={target}
+      />
       <Divider color={color} />
       {Object.keys(indicatorData).map((indicator, i) => {
         return (
@@ -454,7 +462,12 @@ const ChartIndicatorBlock: React.FC<{
   const color = theme.sdgColors[goalNumber - 1];
   return (
     <ChartContentBody>
-      {placeDcid === EARTH_PLACE_DCID && <HeadlineTile backgroundColor={color} indicator={indicator} />}
+      {placeDcid === EARTH_PLACE_DCID && (
+        <HeadlineTile
+          backgroundColor={color}
+          indicator={indicator}
+        />
+      )}
       {tiles.map((tile, i) => (
         <ChartTile
           key={`${indicator}-${i}`}

--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -403,7 +403,7 @@ const ChartGoalBlock: React.FC<{
 }> = ({ placeDcid, goal, targetData }) => {
   return (
     <>
-      <GoalOverview goalNumber={Number(goal)} showExploreLink={false} />
+      { placeDcid === EARTH_PLACE_DCID && <GoalOverview goalNumber={Number(goal)} showExploreLink={false} />}
       {Object.keys(targetData).map((target, i) => {
         return (
           <ChartTargetBlock
@@ -428,7 +428,7 @@ const ChartTargetBlock: React.FC<{
   const color = theme.sdgColors[goalNumber - 1];
   return (
     <ContentCard>
-      <TargetHeader color={color} target={target} />
+     <TargetHeader color={color} target={target} />
       <Divider color={color} />
       {Object.keys(indicatorData).map((indicator, i) => {
         return (
@@ -454,7 +454,7 @@ const ChartIndicatorBlock: React.FC<{
   const color = theme.sdgColors[goalNumber - 1];
   return (
     <ChartContentBody>
-      <HeadlineTile backgroundColor={color} indicator={indicator} />
+      {placeDcid === EARTH_PLACE_DCID && <HeadlineTile backgroundColor={color} indicator={indicator} />}
       {tiles.map((tile, i) => (
         <ChartTile
           key={`${indicator}-${i}`}

--- a/experimental/sdg-tracker/src/components/shared/components.tsx
+++ b/experimental/sdg-tracker/src/components/shared/components.tsx
@@ -401,6 +401,7 @@ const HeadlineImage = styled.img`
     0px 1px 14px rgba(3, 7, 18, 0.05);
   padding: 1rem;
   margin-bottom: 2rem;
+  background-color: white;
 `;
 
 const HeadlineLink = styled.div`


### PR DESCRIPTION
This PR:
1. Only show goal overviews and indicator blurbs/infographics if the page has the World as the place. The content of those overviews/blurbs is written only for the world, so showing them on country pages/search results does not make sense.
2. Makes the background color of infographics white

With this change...

### Blurbs are hidden when searching for a particular country/region
![Screenshot 2023-09-08 at 1 01 39 PM](https://github.com/datacommonsorg/website/assets/4034366/ae42bc96-255a-46ee-b3fd-ba276af856f8)


### But searching globally retains the blurbs
![Screenshot 2023-09-08 at 1 20 08 PM](https://github.com/datacommonsorg/website/assets/4034366/3641daaf-1ed4-413b-a661-792cd29a0659)

### Blurbs show up in the "Goals" pages

![Screenshot 2023-09-08 at 1 19 39 PM](https://github.com/datacommonsorg/website/assets/4034366/7e77c125-ee64-4ef2-abe8-0887c372fcc9)

### But not in "Country/Region" pages
![Screenshot 2023-09-08 at 1 02 14 PM](https://github.com/datacommonsorg/website/assets/4034366/7f2e1581-4abc-4ba3-a256-7662933552f3)
