### PR TITLE
[UN SDG tracker] Add asterisk to maps and show disclaimer at bottom

### DIFF
--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -40,6 +40,7 @@ import {
   ContentCard,
   CountrySelect,
   Divider,
+  Footnotes,
   HeadlineTile,
   MainLayoutContent,
   PlaceHeaderCard,
@@ -409,6 +410,7 @@ const CountriesContent: React.FC<{
               selectedVariableDcids={variableDcids}
             />
           )}
+          <Footnotes />
         </MainLayoutContent>
       </Layout.Content>
     </Layout>
@@ -682,7 +684,7 @@ const ChartTile: React.FC<{
         <datacommons-map
           apiRoot={WEB_API_ENDPOINT}
           subscribe={channel}
-          header={tile.title}
+          header={`${tile.title}*`}
           variable={tileStatVars.join(" ")}
           parentPlace="Earth"
           childPlaceType="Country"

--- a/experimental/sdg-tracker/src/components/shared/components.tsx
+++ b/experimental/sdg-tracker/src/components/shared/components.tsx
@@ -506,3 +506,43 @@ export const Divider = styled.div<{ color: string }>`
   border: 1px solid ${(p) => p.color};
   margin: 40px -24px 40px -24px;
 `;
+
+// Footnotes
+const MAP_DISCLAIMER_TEXT = `
+The boundaries and names shown and the designations used on this and other maps 
+throughout this publication do not imply official endorsement or acceptance by 
+the United Nations.
+`;
+
+export const FootnotesContainer = styled.div`
+  margin: 24px 0px;
+`;
+
+export const Footnote = styled.div`
+  display: flex;
+  flex-direction: row;
+  color: grey;
+  font-size: 0.8rem;
+`;
+
+export const StyledMarker = styled.div`
+  font-size: 1rem;
+  margin: 0 4px;
+`;
+
+export const FootnoteDivider = styled.hr`
+  color: grey;
+  margin-bottom: 24px;
+`;
+
+export const Footnotes: React.FC = () => {
+  return (
+    <FootnotesContainer>
+      <FootnoteDivider></FootnoteDivider>
+      <Footnote>
+        <StyledMarker>*</StyledMarker>
+        {MAP_DISCLAIMER_TEXT}
+      </Footnote>
+    </FootnotesContainer>
+  );
+};


### PR DESCRIPTION
Adds a disclaimer to the page about map borders, and an asterisk at the end of map titles

Example of a page scrolled all the way down:
See asterisk in map chart title and disclaimer at the bottom.

<img width="1840" alt="Screenshot 2023-09-09 at 10 04 10 AM" src="https://github.com/datacommonsorg/website/assets/4034366/fd736814-3fdb-4196-9e8a-10ba2b420165">
