### PR TITLE
[UN SDG] Bug fix: show target cards in order

### DIFF
--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -489,9 +489,10 @@ const ChartCategoryContent: React.FC<{
       });
     });
   });
+  
   return (
     <>
-      {Object.keys(allGoals).map((goal, i) => {
+      {Object.keys(allGoals).sort().map((goal, i) => {
         return (
           <ChartGoalBlock
             fulfillResponse={fulfillResponse}
@@ -521,7 +522,7 @@ const ChartGoalBlock: React.FC<{
       {placeDcids[0] === EARTH_PLACE_DCID && (
         <GoalOverview goalNumber={Number(goal)} showExploreLink={false} />
       )}
-      {Object.keys(targetData).map((target, i) => {
+      {Object.keys(targetData).sort().map((target, i) => {
         return (
           <ChartTargetBlock
             key={`${goal}-${i}`}
@@ -551,7 +552,7 @@ const ChartTargetBlock: React.FC<{
     <ContentCard>
       <TargetHeader color={color} target={target} />
       <Divider color={color} />
-      {Object.keys(indicatorData).map((indicator, i) => {
+      {Object.keys(indicatorData).sort().map((indicator, i) => {
         return (
           <ChartIndicatorBlock
             fulfillResponse={fulfillResponse}

--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -489,7 +489,6 @@ const ChartCategoryContent: React.FC<{
       });
     });
   });
-  
   return (
     <>
       {Object.keys(allGoals).sort().map((goal, i) => {


### PR DESCRIPTION
Sorts the goals/targets/indicators so that the goals, cards, and tiles show up in lexical order by indicator number.

Before:
![Screenshot 2023-09-09 at 7 42 13 PM](https://github.com/datacommonsorg/website/assets/4034366/46c5a9c2-f1c2-44cb-ba93-5e3f7754e480)

After:
![Screenshot 2023-09-09 at 7 41 52 PM](https://github.com/datacommonsorg/website/assets/4034366/a7d2e036-4308-4fe0-823c-4900d99173fe)
