### PR TITLE
Fix maps of Europe being cut-off

### DIFF
--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -511,18 +511,14 @@ export function drawD3Map(
           )
           .on("mouseover", onMouseOver(canClickRegion, containerElement));
       });
-    console.log(zoom);
     svg.call(zoom).call(zoom.transform, STARTING_ZOOM_TRANSFORMATION);
     if (zoomParams.zoomInButtonId) {
-      console.log(d3.select(`#${zoomParams.zoomInButtonId}`));
       d3.select(`#${zoomParams.zoomInButtonId}`).on("click", () => {
-        console.log("clicked zoom in");
         svg.call(zoom.scaleBy, 2);
       });
     }
     if (zoomParams.zoomOutButtonId) {
       d3.select(`#${zoomParams.zoomOutButtonId}`).on("click", () => {
-        console.log("clicked zoom out");
         svg.call(zoom.scaleBy, 0.5);
       });
     }

--- a/static/js/chart/draw_d3_map.ts
+++ b/static/js/chart/draw_d3_map.ts
@@ -275,7 +275,7 @@ export function getProjection(
         .geoAzimuthalEqualArea()
         .rotate([-20.0, -52.0])
         .translate([mapWidth / 2, mapHeight / 2])
-        .scale(mapWidth / 1.5)
+        .scale(Math.min(mapWidth / 1.5, mapHeight / 0.75))
         .precision(0.1);
       isMapFitted = true;
       break;
@@ -511,14 +511,18 @@ export function drawD3Map(
           )
           .on("mouseover", onMouseOver(canClickRegion, containerElement));
       });
+    console.log(zoom);
     svg.call(zoom).call(zoom.transform, STARTING_ZOOM_TRANSFORMATION);
     if (zoomParams.zoomInButtonId) {
+      console.log(d3.select(`#${zoomParams.zoomInButtonId}`));
       d3.select(`#${zoomParams.zoomInButtonId}`).on("click", () => {
+        console.log("clicked zoom in");
         svg.call(zoom.scaleBy, 2);
       });
     }
     if (zoomParams.zoomOutButtonId) {
       d3.select(`#${zoomParams.zoomOutButtonId}`).on("click", () => {
+        console.log("clicked zoom out");
         svg.call(zoom.scaleBy, 0.5);
       });
     }


### PR DESCRIPTION
Updates the projection scaling for maps of Europe so that the borders are no longer cut off when the chart is much wider than its height.

 Before:
![Screenshot 2023-09-10 at 2 15 48 PM](https://github.com/datacommonsorg/website/assets/4034366/a306b67f-1ba1-4817-af5b-005e0d1eb6da)

After:
![Screenshot 2023-09-10 at 2 15 21 PM](https://github.com/datacommonsorg/website/assets/4034366/2e3985be-9f98-4c19-8fcf-f4aa5668997b)

What Map tool now looks like:
![Screenshot 2023-09-10 at 2 18 01 PM](https://github.com/datacommonsorg/website/assets/4034366/0350cbce-461d-40f6-b580-d2083196f599)

What explore tiles now look like:
![Screenshot 2023-09-10 at 2 18 33 PM](https://github.com/datacommonsorg/website/assets/4034366/4c6bb14c-5fe6-4713-adb4-b4f05a4f2e58)
