### PR TITLE
PR1:  Improve messaging on place-type fallbacks

### DIFF
--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -312,3 +312,20 @@ class ExploreTest(NLWebServerTestCase):
         'Compare progress on poverty in Mexico, Nigeria and Pakistan'
     ],
                                 dc='sdg')
+
+  def test_e2e_fallbacks(self):
+    self.run_detect_and_fulfill(
+        'e2e_fallbacks',
+        [
+            # There is NO county-level data at all, so this
+            # should fallback to US states.
+            'Life expectancy in US counties',
+            # There is county-level data further down in the
+            # chart list, so it should also fallback to states.
+            'Tamil speakers in US counties',
+            # This should fallback from tract to city.
+            'auto thefts in tracts of sunnyvale',
+            # This should fallback from child-type (tract)
+            # to the place (SC county) to its state (CA).
+            'auto thefts in tracts of santa clara county'
+        ])

--- a/server/integration_tests/test_data/demo_fallback/query_3/chart_config.json
+++ b/server/integration_tests/test_data/demo_fallback/query_3/chart_config.json
@@ -119,7 +119,23 @@
     "name": "California",
     "place_type": "State"
   },
-  "placeFallback": {},
+  "placeFallback": {
+    "newPlace": {
+      "country": "country/USA",
+      "dcid": "geoId/06",
+      "name": "California",
+      "place_type": "State"
+    },
+    "newStr": "California",
+    "origPlace": {
+      "country": "country/USA",
+      "dcid": "geoId/06",
+      "name": "California",
+      "place_type": "State"
+    },
+    "origStr": "counties in California",
+    "origType": "County"
+  },
   "placeSource": "CURRENT_QUERY",
   "places": [
     {
@@ -130,5 +146,5 @@
   ],
   "relatedThings": {},
   "svSource": "CURRENT_QUERY",
-  "userMessage": ""
+  "userMessage": "Sorry, there were no relevant statistics for counties in California. See results for California."
 }

--- a/server/integration_tests/test_data/e2e_fallbacks/autotheftsintractsofsantaclaracounty/chart_config.json
+++ b/server/integration_tests/test_data/e2e_fallbacks/autotheftsintractsofsantaclaracounty/chart_config.json
@@ -1,0 +1,297 @@
+{
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "type": "PLACE_OVERVIEW"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "metadata": {
+      "placeDcid": [
+        "geoId/06085"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "pastSourceContext": "",
+  "place": {
+    "dcid": "geoId/06085",
+    "name": "Santa Clara County",
+    "place_type": "County"
+  },
+  "placeFallback": {},
+  "placeSource": "CURRENT_QUERY",
+  "places": [
+    {
+      "dcid": "geoId/06085",
+      "name": "Santa Clara County",
+      "place_type": "County"
+    }
+  ],
+  "relatedThings": {
+    "childPlaces": {},
+    "childTopics": [
+      {
+        "dcid": "dc/topic/Demographics",
+        "name": "Demographics",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/Health",
+        "name": "Health",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/Economy",
+        "name": "Economy",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/EducationHousingAndCommute",
+        "name": "Education, Housing and Commute",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/Equity",
+        "name": "Equity",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/Sustainability",
+        "name": "Sustainability",
+        "types": [
+          "Topic"
+        ]
+      }
+    ],
+    "exploreMore": {},
+    "mainTopics": [
+      {
+        "dcid": "dc/topic/Root",
+        "name": "Statistics",
+        "types": [
+          "Topic"
+        ]
+      }
+    ],
+    "parentPlaces": [],
+    "parentTopics": [],
+    "peerPlaces": [
+      {
+        "dcid": "geoId/06001",
+        "name": "Alameda",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/36005",
+        "name": "Bronx",
+        "types": [
+          "County"
+        ]
+      },
+      {
+        "dcid": "geoId/06013",
+        "name": "Contra Costa",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/17031",
+        "name": "Cook",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/39035",
+        "name": "Cuyahoga",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/48113",
+        "name": "Dallas",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/12031",
+        "name": "Duval",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/08041",
+        "name": "El Paso",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/51059",
+        "name": "Fairfax",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/13121",
+        "name": "Fulton",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/48201",
+        "name": "Harris",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/12057",
+        "name": "Hillsborough",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/15003",
+        "name": "Honolulu",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/08059",
+        "name": "Jefferson",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/06029",
+        "name": "Kern",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/53033",
+        "name": "King",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/06037",
+        "name": "Los Angeles",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/04013",
+        "name": "Maricopa",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/37119",
+        "name": "Mecklenburg",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/12086",
+        "name": "Miami-Dade",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/06059",
+        "name": "Orange",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/36081",
+        "name": "Queens",
+        "types": [
+          "County"
+        ]
+      },
+      {
+        "dcid": "geoId/06065",
+        "name": "Riverside",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/06071",
+        "name": "San Bernardino",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/06073",
+        "name": "San Diego",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/06075",
+        "name": "San Francisco",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      },
+      {
+        "dcid": "geoId/24047",
+        "name": "Worcester",
+        "types": [
+          "AdministrativeArea2"
+        ]
+      }
+    ],
+    "peerTopics": []
+  },
+  "showForm": true,
+  "svSource": "UNFULFILLED",
+  "userMessage": "Sorry, there were no relevant statistics about the topic for Santa Clara County. See available topic categories with statistics for Santa Clara County."
+}

--- a/server/integration_tests/test_data/e2e_fallbacks/autotheftsintractsofsunnyvale/chart_config.json
+++ b/server/integration_tests/test_data/e2e_fallbacks/autotheftsintractsofsunnyvale/chart_config.json
@@ -1,0 +1,202 @@
+{
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_CriminalActivities_MotorVehicleTheft"
+                    ],
+                    "title": "Motor Vehicle Thefts in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Motor Vehicle Thefts in Sunnyvale",
+                    "statVarKey": [
+                      "Count_CriminalActivities_MotorVehicleTheft"
+                    ],
+                    "title": "Motor Vehicle Thefts in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Motor Vehicle Thefts"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_CriminalActivities_Robbery"
+                    ],
+                    "title": "Robberies in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Robberies in Sunnyvale",
+                    "statVarKey": [
+                      "Count_CriminalActivities_Robbery"
+                    ],
+                    "title": "Robberies in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Robberies"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_CriminalActivities_PropertyCrime"
+                    ],
+                    "title": "Property Related Crimes in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Property Related Crimes in Sunnyvale",
+                    "statVarKey": [
+                      "Count_CriminalActivities_PropertyCrime"
+                    ],
+                    "title": "Property Related Crimes in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Property Related Crimes"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_CriminalActivities_LarcenyTheft"
+                    ],
+                    "title": "Larceny Theft Cases in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Larceny Theft Cases in Sunnyvale",
+                    "statVarKey": [
+                      "Count_CriminalActivities_LarcenyTheft"
+                    ],
+                    "title": "Larceny Theft Cases in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Larceny Theft Cases"
+          }
+        ],
+        "statVarSpec": {
+          "Count_CriminalActivities_LarcenyTheft": {
+            "name": "Larceny Theft Cases",
+            "statVar": "Count_CriminalActivities_LarcenyTheft"
+          },
+          "Count_CriminalActivities_MotorVehicleTheft": {
+            "name": "Motor Vehicle Thefts",
+            "statVar": "Count_CriminalActivities_MotorVehicleTheft"
+          },
+          "Count_CriminalActivities_PropertyCrime": {
+            "name": "Property Related Crimes",
+            "statVar": "Count_CriminalActivities_PropertyCrime"
+          },
+          "Count_CriminalActivities_Robbery": {
+            "name": "Robberies",
+            "statVar": "Count_CriminalActivities_Robbery"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "placeDcid": [
+        "geoId/0677000"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "pastSourceContext": "",
+  "place": {
+    "dcid": "geoId/0677000",
+    "name": "Sunnyvale",
+    "place_type": "City"
+  },
+  "placeFallback": {
+    "newPlace": {
+      "country": "country/USA",
+      "dcid": "geoId/0677000",
+      "name": "Sunnyvale",
+      "place_type": "City"
+    },
+    "newStr": "Sunnyvale",
+    "origPlace": {
+      "country": "country/USA",
+      "dcid": "geoId/0677000",
+      "name": "Sunnyvale",
+      "place_type": "City"
+    },
+    "origStr": "census tracts in Sunnyvale",
+    "origType": "CensusTract"
+  },
+  "placeSource": "CURRENT_QUERY",
+  "places": [
+    {
+      "dcid": "geoId/0677000",
+      "name": "Sunnyvale",
+      "place_type": "City"
+    }
+  ],
+  "relatedThings": {
+    "childPlaces": {},
+    "childTopics": [],
+    "exploreMore": {},
+    "mainTopics": [
+      {
+        "dcid": "dc/topic/Crime",
+        "name": "Crime",
+        "types": [
+          "Topic"
+        ]
+      }
+    ],
+    "parentPlaces": [],
+    "parentTopics": [],
+    "peerPlaces": [],
+    "peerTopics": []
+  },
+  "svSource": "CURRENT_QUERY",
+  "userMessage": "Sorry, there were no relevant statistics for census tracts in Sunnyvale. See results for Sunnyvale."
+}

--- a/server/integration_tests/test_data/e2e_fallbacks/lifeexpectancyinuscounties/chart_config.json
+++ b/server/integration_tests/test_data/e2e_fallbacks/lifeexpectancyinuscounties/chart_config.json
@@ -1,0 +1,164 @@
+{
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "LifeExpectancy_Person"
+                    ],
+                    "title": "Life Expectancy in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Life Expectancy in United States",
+                    "statVarKey": [
+                      "LifeExpectancy_Person"
+                    ],
+                    "title": "Life Expectancy in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Life Expectancy"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "LifeExpectancy_Person_Female",
+                      "LifeExpectancy_Person_Male"
+                    ],
+                    "title": "Life Expectancy by Gender in United States",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "title": "Life Expectancy by Gender"
+          }
+        ],
+        "statVarSpec": {
+          "LifeExpectancy_Person": {
+            "name": "Life Expectancy",
+            "statVar": "LifeExpectancy_Person"
+          },
+          "LifeExpectancy_Person_Female": {
+            "name": "Female Life Expectancy",
+            "statVar": "LifeExpectancy_Person_Female"
+          },
+          "LifeExpectancy_Person_Male": {
+            "name": "Male Life Expectancy",
+            "statVar": "LifeExpectancy_Person_Male"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "placeDcid": [
+        "country/USA"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "pastSourceContext": "",
+  "place": {
+    "dcid": "country/USA",
+    "name": "United States",
+    "place_type": "Country"
+  },
+  "placeFallback": {
+    "newPlace": {
+      "country": "country/USA",
+      "dcid": "country/USA",
+      "name": "United States",
+      "place_type": "Country"
+    },
+    "newStr": "United States",
+    "origPlace": {
+      "country": "country/USA",
+      "dcid": "country/USA",
+      "name": "United States",
+      "place_type": "Country"
+    },
+    "origStr": "counties in United States",
+    "origType": "County"
+  },
+  "placeSource": "CURRENT_QUERY",
+  "places": [
+    {
+      "dcid": "country/USA",
+      "name": "United States",
+      "place_type": "Country"
+    }
+  ],
+  "relatedThings": {
+    "childPlaces": {},
+    "childTopics": [],
+    "exploreMore": {
+      "LifeExpectancy_Person": {
+        "gender": [
+          "LifeExpectancy_Person_Female",
+          "LifeExpectancy_Person_Male"
+        ]
+      }
+    },
+    "mainTopics": [
+      {
+        "dcid": "dc/topic/LifeExpectancy",
+        "name": "Life Expectancy",
+        "types": [
+          "Topic"
+        ]
+      }
+    ],
+    "parentPlaces": [],
+    "parentTopics": [
+      {
+        "dcid": "dc/topic/Mortality",
+        "name": "Mortality",
+        "types": [
+          "Topic"
+        ]
+      }
+    ],
+    "peerPlaces": [],
+    "peerTopics": [
+      {
+        "dcid": "dc/topic/CausesOfDeath",
+        "name": "Causes of Death",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/FemaleMortality",
+        "name": "Female Mortality",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/InfantMortality",
+        "name": "Infant Mortality",
+        "types": [
+          "Topic"
+        ]
+      }
+    ]
+  },
+  "svSource": "CURRENT_QUERY",
+  "userMessage": "Sorry, there were no relevant statistics for counties in United States. See results for United States."
+}

--- a/server/integration_tests/test_data/e2e_fallbacks/tamilspeakersinuscounties/chart_config.json
+++ b/server/integration_tests/test_data/e2e_fallbacks/tamilspeakersinuscounties/chart_config.json
@@ -1,0 +1,476 @@
+{
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_TamilSpokenAtHome"
+                    ],
+                    "title": "Population: Tamil Spoken at Home in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Tamil Spoken at Home in United States",
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_TamilSpokenAtHome"
+                    ],
+                    "title": "Population: Tamil Spoken at Home in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Tamil Spoken at Home"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TamilSpokenAtHome"
+                    ],
+                    "title": "Tamil Speakers at Home Who Speak English Very Well in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Tamil Speakers at Home Who Speak English Very Well in United States",
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TamilSpokenAtHome"
+                    ],
+                    "title": "Tamil Speakers at Home Who Speak English Very Well in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Tamil Speakers at Home Who Speak English Very Well"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TamilSpokenAtHome"
+                    ],
+                    "title": "Tamil Speakers at Home Who Speak English Less Than Very Well in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Tamil Speakers at Home Who Speak English Less Than Very Well in United States",
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TamilSpokenAtHome"
+                    ],
+                    "title": "Tamil Speakers at Home Who Speak English Less Than Very Well in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Tamil Speakers at Home Who Speak English Less Than Very Well"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TeluguSpokenAtHome"
+                    ],
+                    "title": "Telugu Speakers at Home Who Speak English Less Than Very Well in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Telugu Speakers at Home Who Speak English Less Than Very Well in United States",
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TeluguSpokenAtHome"
+                    ],
+                    "title": "Telugu Speakers at Home Who Speak English Less Than Very Well in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Telugu Speakers at Home Who Speak English Less Than Very Well"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TeluguSpokenAtHome"
+                    ],
+                    "title": "Telugu Speakers at Home Who Speak English Very Well in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Telugu Speakers at Home Who Speak English Very Well in United States",
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TeluguSpokenAtHome"
+                    ],
+                    "title": "Telugu Speakers at Home Who Speak English Very Well in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Telugu Speakers at Home Who Speak English Very Well"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_TeluguSpokenAtHome"
+                    ],
+                    "title": "Population: Telugu Spoken at Home in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Telugu Spoken at Home in United States",
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_TeluguSpokenAtHome"
+                    ],
+                    "title": "Population: Telugu Spoken at Home in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Telugu Spoken at Home"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+                    ],
+                    "title": "Population: Malayalam Kannada or Other Dravidian Languages Spoken at Home in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Malayalam Kannada or Other Dravidian Languages Spoken at Home in United States",
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+                    ],
+                    "title": "Population: Malayalam Kannada or Other Dravidian Languages Spoken at Home in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Malayalam Kannada or Other Dravidian Languages Spoken at Home"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_HindiSpokenAtHome"
+                    ],
+                    "title": "Population: Hindi Spoken at Home in Counties of United States (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_HindiSpokenAtHome"
+                    ],
+                    "title": "Population: Hindi Spoken at Home in Counties of United States (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Hindi Spoken at Home in Counties of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_HindiSpokenAtHome"
+                    ],
+                    "title": "Population: Hindi Spoken at Home in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Hindi Spoken at Home in United States",
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_HindiSpokenAtHome"
+                    ],
+                    "title": "Population: Hindi Spoken at Home in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Hindi Spoken at Home"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+                    ],
+                    "title": "Population: Speak English Very Well, Malayalam Kannada or Other Dravidian Languages in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Speak English Very Well, Malayalam Kannada or Other Dravidian Languages in United States",
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+                    ],
+                    "title": "Population: Speak English Very Well, Malayalam Kannada or Other Dravidian Languages in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Speak English Very Well, Malayalam Kannada or Other Dravidian Languages"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+                    ],
+                    "title": "Population: Speak English Less Than Very Well, Malayalam Kannada or Other Dravidian Languages in United States",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Speak English Less Than Very Well, Malayalam Kannada or Other Dravidian Languages in United States",
+                    "statVarKey": [
+                      "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+                    ],
+                    "title": "Population: Speak English Less Than Very Well, Malayalam Kannada or Other Dravidian Languages in United States",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Speak English Less Than Very Well, Malayalam Kannada or Other Dravidian Languages"
+          }
+        ],
+        "statVarSpec": {
+          "Count_Person_5OrMoreYears_HindiSpokenAtHome": {
+            "name": "Population: Hindi spoken at home",
+            "statVar": "Count_Person_5OrMoreYears_HindiSpokenAtHome"
+          },
+          "Count_Person_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome": {
+            "name": "Population: Malayalam Kannada Or Other Dravidian Languages Spoken At Home",
+            "statVar": "Count_Person_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+          },
+          "Count_Person_5OrMoreYears_TamilSpokenAtHome": {
+            "name": "Population: Tamil Spoken At Home",
+            "statVar": "Count_Person_5OrMoreYears_TamilSpokenAtHome"
+          },
+          "Count_Person_5OrMoreYears_TeluguSpokenAtHome": {
+            "name": "Population: Telugu Spoken At Home",
+            "statVar": "Count_Person_5OrMoreYears_TeluguSpokenAtHome"
+          },
+          "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome": {
+            "name": "Population: Speak English Less Than Very Well, Malayalam Kannada or Other Dravidian Languages",
+            "statVar": "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+          },
+          "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TamilSpokenAtHome": {
+            "name": "Tamil Speakers At Home Who Speak English Less Than Very Well",
+            "statVar": "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TamilSpokenAtHome"
+          },
+          "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TeluguSpokenAtHome": {
+            "name": "Telugu Speakers At Home Who Speak English Less Than Very Well",
+            "statVar": "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TeluguSpokenAtHome"
+          },
+          "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome": {
+            "name": "Population: Speak English Very Well, Malayalam Kannada or Other Dravidian Languages",
+            "statVar": "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+          },
+          "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TamilSpokenAtHome": {
+            "name": "Tamil Speakers At Home Who Speak English Very Well",
+            "statVar": "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TamilSpokenAtHome"
+          },
+          "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TeluguSpokenAtHome": {
+            "name": "Telugu Speakers At Home Who Speak English Very Well",
+            "statVar": "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TeluguSpokenAtHome"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "containedPlaceTypes": {
+        "Country": "County"
+      },
+      "placeDcid": [
+        "country/USA"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "pastSourceContext": "",
+  "place": {
+    "dcid": "country/USA",
+    "name": "United States",
+    "place_type": "Country"
+  },
+  "placeFallback": {
+    "newPlace": {
+      "country": "country/USA",
+      "dcid": "country/USA",
+      "name": "United States",
+      "place_type": "Country"
+    },
+    "newStr": "United States",
+    "origPlace": {
+      "country": "country/USA",
+      "dcid": "country/USA",
+      "name": "United States",
+      "place_type": "Country"
+    },
+    "origStr": "counties in United States",
+    "origType": "County"
+  },
+  "placeSource": "CURRENT_QUERY",
+  "places": [
+    {
+      "dcid": "country/USA",
+      "name": "United States",
+      "place_type": "Country"
+    }
+  ],
+  "relatedThings": {
+    "childPlaces": {},
+    "childTopics": [],
+    "exploreMore": {
+      "Count_Person_5OrMoreYears_HindiSpokenAtHome": {
+        "abilityToSpeakEnglish": [
+          "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_HindiSpokenAtHome",
+          "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_HindiSpokenAtHome"
+        ]
+      },
+      "Count_Person_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome": {
+        "abilityToSpeakEnglish": [
+          "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome",
+          "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_MalayalamKannadaOrOtherDravidianLanguagesSpokenAtHome"
+        ]
+      },
+      "Count_Person_5OrMoreYears_TamilSpokenAtHome": {
+        "abilityToSpeakEnglish": [
+          "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TamilSpokenAtHome",
+          "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TamilSpokenAtHome"
+        ]
+      },
+      "Count_Person_5OrMoreYears_TeluguSpokenAtHome": {
+        "abilityToSpeakEnglish": [
+          "Count_Person_SpeakEnglishLessThanVeryWell_5OrMoreYears_TeluguSpokenAtHome",
+          "Count_Person_SpeakEnglishVeryWell_5OrMoreYears_TeluguSpokenAtHome"
+        ]
+      }
+    },
+    "mainTopics": [
+      {
+        "dcid": "dc/topic/NonEnglishLanguageAtHome",
+        "name": "Non-English Languages",
+        "types": [
+          "Topic"
+        ]
+      }
+    ],
+    "parentPlaces": [],
+    "parentTopics": [
+      {
+        "dcid": "dc/topic/Language",
+        "name": "Language Spoken At Home",
+        "types": [
+          "Topic"
+        ]
+      }
+    ],
+    "peerPlaces": [],
+    "peerTopics": [
+      {
+        "dcid": "dc/topic/EnglishLanguageAtHome",
+        "name": "English Language",
+        "types": [
+          "Topic"
+        ]
+      }
+    ]
+  },
+  "svSource": "CURRENT_QUERY",
+  "userMessage": "Sorry, there were no relevant statistics for counties in United States. See results for United States."
+}

--- a/server/lib/explore/related.py
+++ b/server/lib/explore/related.py
@@ -63,7 +63,7 @@ def compute_related_things(state: ftypes.PopulateState,
   # If we did a place-fallback, do not bother setting these!
   had_place_fallback = bool(fallback and fallback.newPlace and
                             fallback.origPlace and
-                            fallback.newPlace.dcid != fallback.origPlace.dcid)
+                            fallback.newStr != fallback.origStr)
   if not had_place_fallback:
     related_things['parentPlaces'] = _get_json_places(pd.parent_places)
     if state.place_type and pd.child_places:

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -221,7 +221,7 @@ def _add_charts_with_existence_check(state: PopulateState,
 
       # If we have found enough charts, return success
       if num_charts >= _MAX_NUM_CHARTS:
-        return True
+        break
 
     # Handle extended/comparable SVs only for simple query since
     # for those we would construct a single bar chart comparing the differe
@@ -229,7 +229,8 @@ def _add_charts_with_existence_check(state: PopulateState,
     # individual "related" charts, and those don't look good.
     #
     # TODO: Optimize and enable in Explore mode.
-    if qt == QueryType.BASIC and existing_svs and not state.place_type and not state.ranking_types:
+    if (qt == QueryType.BASIC and existing_svs and not state.place_type and
+        not state.ranking_types and num_charts < _MAX_NUM_CHARTS):
       # Note that we want to expand on existing_svs only, and in the
       # order of `svs`
       ordered_existing_svs = [v for v in svs if v in existing_svs]
@@ -240,6 +241,11 @@ def _add_charts_with_existence_check(state: PopulateState,
 
     # For a given handler, if we found any charts at all, we're good.
     if found:
+      if (qt == QueryType.BASIC and state.place_type and
+          not state.had_default_place_type and
+          not state.has_child_type_in_top_basic_charts):
+        state.place_type = None
+        _maybe_set_fallback(state, places)
       break
 
   if not found:

--- a/server/lib/nl/fulfillment/types.py
+++ b/server/lib/nl/fulfillment/types.py
@@ -115,8 +115,12 @@ class PopulateState:
   # Whether this is explore mode of fulfillment.
   explore_mode: bool = False
   # Set to true if utterance has overwritten SVs.  So they should
-  # be cleared and not propagated into context.
+  # be cleared and not be propagated into context.
   has_overwritten_svs: bool = False
+  # Set to true if TOP charts include requested child-type for
+  # BASIC.  This is a hack around the fact that BASIC type combines
+  # contained-in, ranking and simple.
+  has_child_type_in_top_basic_charts: bool = False
 
 
 @dataclass


### PR DESCRIPTION
Today, we do not have any message for queries with place-types like:
- [life expectancy in US counties]
- [tamil speakers in US counties]
- [auto thefts in tracts of sunnyvale]

When we don't have any data at the requested place-type.  Because, post Explore-style rewrite, contained-in and simple were clubbed into a single "query handler".  That is, this `basic` query handler produces some charts (at US/sunnyvale level but not maps), so fallback, which works at query-handler granularity, does not kick in.  And unless fallback kicks in, we don't report fallback message.

Address this by having a custom child-type fulfillment tracker for `basic`.  And when that tells us, report fallback message.

Upcoming PR will actually do further place-type fallback.

**Screenshots**

![image](https://github.com/datacommonsorg/website/assets/4375037/acab5b7a-47fe-4820-9ed8-8147e837c0ed)

![image](https://github.com/datacommonsorg/website/assets/4375037/fc037ec1-1117-43be-aa37-b0c535e04bcb)
