### PR TITLE
[GA] Add GA4 timing event around detec/fulfill endpoints

### DIFF
--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -30,7 +30,7 @@ import {
   URL_DELIM,
   URL_HASH_PARAMS,
 } from "../../constants/app/explore_constants";
-import { GA_EVENT_PAGE_VIEW, triggerGAEvent } from "../../shared/ga_events";
+import { GA_EVENT_NL_DETECT_FULFILL, GA_EVENT_NL_FULFILL, GA_EVENT_PAGE_VIEW, triggerGAEvent } from "../../shared/ga_events";
 import {
   QueryResult,
   UserMessageInfo,
@@ -319,6 +319,7 @@ const fetchFulfillData = async (
   disableExploreMore: string
 ) => {
   try {
+    let startTime = window.performance ? window.performance.now() : undefined;
     const resp = await axios.post(`/api/explore/fulfill`, {
       dc,
       entities: places,
@@ -330,6 +331,15 @@ const fetchFulfillData = async (
       classifications: classificationsJson,
       disableExploreMore,
     });
+    if (startTime) {
+      let endTime = window.performance ? window.performance.now() - startTime : undefined;
+      if (endTime) {
+        triggerGAEvent(GA_EVENT_NL_FULFILL, {
+          GA_PARAM_TOPIC: topics,
+          GA_VALUE_TIMING_MS: Math.round(endTime).toString()
+        });
+      }
+    }
     return resp.data;
   } catch (error) {
     console.log(error);
@@ -348,6 +358,7 @@ const fetchDetectAndFufillData = async (
   const detectorTypeArg = detector ? `&detector=${detector}` : "";
   const llmApiArg = llmApi ? `&llm_api=${llmApi}` : "";
   try {
+    let startTime = window.performance ? window.performance.now() : undefined;
     const resp = await axios.post(
       `/api/explore/detect-and-fulfill?q=${query}${detectorTypeArg}${llmApiArg}`,
       {
@@ -356,6 +367,15 @@ const fetchDetectAndFufillData = async (
         disableExploreMore,
       }
     );
+    if (startTime) {
+      let endTime = window.performance ? window.performance.now() - startTime : undefined;
+      if (endTime) {
+        triggerGAEvent(GA_EVENT_NL_DETECT_FULFILL, {
+          GA_PARAM_QUERY: query,
+          GA_VALUE_TIMING_MS: Math.round(endTime).toString()
+        });
+      }
+    }
     return resp.data;
   } catch (error) {
     console.log(error);

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -30,7 +30,12 @@ import {
   URL_DELIM,
   URL_HASH_PARAMS,
 } from "../../constants/app/explore_constants";
-import { GA_EVENT_NL_DETECT_FULFILL, GA_EVENT_NL_FULFILL, GA_EVENT_PAGE_VIEW, triggerGAEvent } from "../../shared/ga_events";
+import {
+  GA_EVENT_NL_DETECT_FULFILL,
+  GA_EVENT_NL_FULFILL,
+  GA_EVENT_PAGE_VIEW,
+  triggerGAEvent,
+} from "../../shared/ga_events";
 import {
   QueryResult,
   UserMessageInfo,
@@ -319,7 +324,7 @@ const fetchFulfillData = async (
   disableExploreMore: string
 ) => {
   try {
-    let startTime = window.performance ? window.performance.now() : undefined;
+    const startTime = window.performance ? window.performance.now() : undefined;
     const resp = await axios.post(`/api/explore/fulfill`, {
       dc,
       entities: places,
@@ -332,11 +337,13 @@ const fetchFulfillData = async (
       disableExploreMore,
     });
     if (startTime) {
-      let endTime = window.performance ? window.performance.now() - startTime : undefined;
+      const endTime = window.performance
+        ? window.performance.now() - startTime
+        : undefined;
       if (endTime) {
         triggerGAEvent(GA_EVENT_NL_FULFILL, {
           GA_PARAM_TOPIC: topics,
-          GA_VALUE_TIMING_MS: Math.round(endTime).toString()
+          GA_VALUE_TIMING_MS: Math.round(endTime).toString(),
         });
       }
     }
@@ -358,7 +365,7 @@ const fetchDetectAndFufillData = async (
   const detectorTypeArg = detector ? `&detector=${detector}` : "";
   const llmApiArg = llmApi ? `&llm_api=${llmApi}` : "";
   try {
-    let startTime = window.performance ? window.performance.now() : undefined;
+    const startTime = window.performance ? window.performance.now() : undefined;
     const resp = await axios.post(
       `/api/explore/detect-and-fulfill?q=${query}${detectorTypeArg}${llmApiArg}`,
       {
@@ -368,11 +375,13 @@ const fetchDetectAndFufillData = async (
       }
     );
     if (startTime) {
-      let endTime = window.performance ? window.performance.now() - startTime : undefined;
+      const endTime = window.performance
+        ? window.performance.now() - startTime
+        : undefined;
       if (endTime) {
         triggerGAEvent(GA_EVENT_NL_DETECT_FULFILL, {
           GA_PARAM_QUERY: query,
-          GA_VALUE_TIMING_MS: Math.round(endTime).toString()
+          GA_VALUE_TIMING_MS: Math.round(endTime).toString(),
         });
       }
     }

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -34,6 +34,10 @@ import {
   GA_EVENT_NL_DETECT_FULFILL,
   GA_EVENT_NL_FULFILL,
   GA_EVENT_PAGE_VIEW,
+  GA_PARAM_PLACE,
+  GA_PARAM_QUERY,
+  GA_PARAM_TIMING_MS,
+  GA_PARAM_TOPIC,
   triggerGAEvent,
 } from "../../shared/ga_events";
 import {
@@ -337,13 +341,14 @@ const fetchFulfillData = async (
       disableExploreMore,
     });
     if (startTime) {
-      const endTime = window.performance
+      const elapsedTime = window.performance
         ? window.performance.now() - startTime
         : undefined;
-      if (endTime) {
+      if (elapsedTime) {
         triggerGAEvent(GA_EVENT_NL_FULFILL, {
-          GA_PARAM_TOPIC: topics,
-          GA_VALUE_TIMING_MS: Math.round(endTime).toString(),
+          [GA_PARAM_TOPIC]: topics,
+          [GA_PARAM_PLACE]: places,
+          [GA_PARAM_TIMING_MS]: Math.round(elapsedTime).toString(),
         });
       }
     }
@@ -375,13 +380,14 @@ const fetchDetectAndFufillData = async (
       }
     );
     if (startTime) {
-      const endTime = window.performance
+      const elapsedTime = window.performance
         ? window.performance.now() - startTime
         : undefined;
-      if (endTime) {
+      if (elapsedTime) {
+        // TODO(beets): Add past queries from context.
         triggerGAEvent(GA_EVENT_NL_DETECT_FULFILL, {
-          GA_PARAM_QUERY: query,
-          GA_VALUE_TIMING_MS: Math.round(endTime).toString(),
+          [GA_PARAM_QUERY]: query,
+          [GA_PARAM_TIMING_MS]: Math.round(elapsedTime).toString(),
         });
       }
     }

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -26,7 +26,7 @@ export function triggerGAEvent(
   if (window.gtag) {
     window.gtag("event", eventName, parameter);
   }
-  console.log(eventName, parameter);
+  console.log(parameter);
 }
 
 /**
@@ -161,6 +161,8 @@ export const GA_PARAM_QUERY = "query";
 export const GA_PARAM_URL = "url";
 export const GA_PARAM_SOURCE = "source";
 export const GA_PARAM_TOPIC = "topic";
+export const GA_PARAM_PLACE = "place";
+export const GA_PARAM_TIMING_MS = "time_ms";
 
 //GA event parameter values
 export const GA_VALUE_PLACE_CHART_CLICK_STAT_VAR_CHIP = "stat var chip";
@@ -190,4 +192,3 @@ export const GA_VALUE_TOOL_CHART_OPTION_FILTER_BY_POPULATION =
 export const GA_VALUE_SEARCH_SOURCE_EXPLORE = "explore";
 export const GA_VALUE_SEARCH_SOURCE_EXPLORE_LANDING = "explore_landing";
 export const GA_VALUE_SEARCH_SOURCE_HOMEPAGE = "homepage";
-export const GA_VALUE_TIMING_MS = "time_ms";

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -147,7 +147,6 @@ export const GA_EVENT_TILE_EXPLORE_MORE = "tile_explore_more";
  */
 export const GA_EVENT_TILE_SOURCE = "tile_source";
 
-
 // GA event parameters
 export const GA_PARAM_PLACE_CATEGORY_CLICK_SOURCE =
   "place_category_click_source";

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -26,6 +26,7 @@ export function triggerGAEvent(
   if (window.gtag) {
     window.gtag("event", eventName, parameter);
   }
+  console.log(eventName, parameter);
 }
 
 /**
@@ -98,6 +99,22 @@ export const GA_EVENT_TOOL_CHART_OPTION_CLICK = "tool_chart_option_click";
 export const GA_EVENT_NL_SEARCH = "explore_search_q";
 
 /**
+ * Triggered when detection results are returned in NL search.
+ * Parameters:
+ *   "query": search query
+ *   "time_ms": e2e request/response timing in ms.
+ */
+export const GA_EVENT_NL_DETECT_FULFILL = "explore_detect_fulfill";
+
+/**
+ * Triggered when detection results are returned in NL search.
+ * Parameters:
+ *   "topic": array of topics
+ *   "time_ms": e2e request/response timing in ms.
+ */
+export const GA_EVENT_NL_FULFILL = "explore_fulfill";
+
+/**
  * Triggered when "download" button is clicked on a tile.
  * Parameters:
  *    "type": "Timeline Tool" | "Scatter Tool" | "Map Tool" | ""
@@ -130,6 +147,7 @@ export const GA_EVENT_TILE_EXPLORE_MORE = "tile_explore_more";
  */
 export const GA_EVENT_TILE_SOURCE = "tile_source";
 
+
 // GA event parameters
 export const GA_PARAM_PLACE_CATEGORY_CLICK_SOURCE =
   "place_category_click_source";
@@ -143,6 +161,7 @@ export const GA_PARAM_TILE_TYPE = "type";
 export const GA_PARAM_QUERY = "query";
 export const GA_PARAM_URL = "url";
 export const GA_PARAM_SOURCE = "source";
+export const GA_PARAM_TOPIC = "topic";
 
 //GA event parameter values
 export const GA_VALUE_PLACE_CHART_CLICK_STAT_VAR_CHIP = "stat var chip";
@@ -172,3 +191,4 @@ export const GA_VALUE_TOOL_CHART_OPTION_FILTER_BY_POPULATION =
 export const GA_VALUE_SEARCH_SOURCE_EXPLORE = "explore";
 export const GA_VALUE_SEARCH_SOURCE_EXPLORE_LANDING = "explore_landing";
 export const GA_VALUE_SEARCH_SOURCE_HOMEPAGE = "homepage";
+export const GA_VALUE_TIMING_MS = "time_ms";


### PR DESCRIPTION
This is still somewhat experimental, since GA4 removed native support for page timing events:
https://support.google.com/analytics/answer/9964640#settings-with-no-GA4-equivalent&zippy=%2Cin-this-article

@pradh Adding minimal information first that we can continue to augment if this works, though please let me know if any of the other parameters would be useful to track.