### PR TITLE
[UN SDG] Fix missing charts in search results

### DIFF
--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -275,6 +275,8 @@ function buildTileHierarchy(
   topicDcids.sort();
   if (mainTopics.length == 2) {
     topicNameStr = `${mainTopics[0].name} vs. ${mainTopics[1].name}`;
+  } else if (mainTopics.length == 1) {
+    topicNameStr = mainTopics[0].name;
   }
   return {hierarchy, orderedTiles, topicNameStr};
 }

--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -275,7 +275,7 @@ function buildTileHierarchy(
   topicDcids.sort();
   if (mainTopics.length == 2) {
     topicNameStr = `${mainTopics[0].name} vs. ${mainTopics[1].name}`;
-  } else if (mainTopics.length == 1) {
+  } else {
     topicNameStr = mainTopics[0].name;
   }
   return {hierarchy, orderedTiles, topicNameStr};

--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -35,7 +35,6 @@ import {
   ChartConfigTile,
   FulfillResponse,
   StatVarSpec,
-  VarToTopicMapping,
 } from "../../utils/types";
 
 import {
@@ -438,7 +437,8 @@ const ChartContent: React.FC<{
   selectedVariableDcids: string[];
   isSearch: boolean;
 }> = (props) => {
-  const { fulfillResponse, placeDcids, selectedVariableDcids, isSearch } = props;
+  const { fulfillResponse, placeDcids, selectedVariableDcids, isSearch } =
+    props;
   if (!fulfillResponse || fulfillResponse.failure) {
     return null;
   }
@@ -477,7 +477,13 @@ const ChartCategoryContent: React.FC<{
   placeDcids: string[];
   selectedTopics: string[];
   isSearch: boolean;
-}> = ({ chartConfigCategory, fulfillResponse, placeDcids, selectedTopics, isSearch }) => {
+}> = ({
+  chartConfigCategory,
+  fulfillResponse,
+  placeDcids,
+  selectedTopics,
+  isSearch,
+}) => {
   const varToTopics = fulfillResponse.relatedThings.varToTopics;
   // stores hierarchy of Goals -> Target -> Indicator -> Tiles
   const allGoals: Goals = {};

--- a/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
+++ b/experimental/sdg-tracker/src/components/countries/CountriesContent.tsx
@@ -272,12 +272,14 @@ function buildTileHierarchy(
   });
 
   let topicNameStr = "";
-  topicDcids.sort();
-  if (mainTopics.length == 2) {
-    topicNameStr = `${mainTopics[0].name} vs. ${mainTopics[1].name}`;
-  } else {
-    topicNameStr = mainTopics[0].name;
+  if (!_.isEmpty(mainTopics)) {
+    if (mainTopics.length == 2) {
+      topicNameStr = `${mainTopics[0].name} vs. ${mainTopics[1].name}`;
+    } else {
+      topicNameStr = mainTopics[0].name;
+    }
   }
+
   return {hierarchy, orderedTiles, topicNameStr};
 }
 

--- a/experimental/sdg-tracker/src/components/shared/components.tsx
+++ b/experimental/sdg-tracker/src/components/shared/components.tsx
@@ -24,6 +24,7 @@ import styled from "styled-components";
 import { useStoreState } from "../../state";
 import { QUERY_PARAM_VARIABLE, ROOT_TOPIC } from "../../utils/constants";
 import "./components.css";
+import { RelatedTopic } from "../../utils/types";
 
 const SearchInputContainer = styled.div`
   display: flex;
@@ -310,16 +311,20 @@ export const PlaceHeaderCard: React.FC<{
   placeNames: string[];
   hideBreadcrumbs?: boolean;
   hidePlaceSearch?: boolean;
+  isSearch: boolean;
   setSelectedPlaceDcid: (selectedPlaceDcid: string) => void;
   userMessage?: string;
   variableDcids: string[];
+  topicNames?: string;
 }> = ({
   placeNames,
   hideBreadcrumbs,
   hidePlaceSearch,
+  isSearch,
   setSelectedPlaceDcid,
   userMessage,
   variableDcids,
+  topicNames,
 }) => {
   // get breadcrumbs from current location
   const location = useLocation();
@@ -356,8 +361,11 @@ export const PlaceHeaderCard: React.FC<{
     <PlaceCard>
       <PlaceCardContent>
         {userMessage && <UserMessage>{userMessage}</UserMessage>}
-        {hidePlaceSearch ? (
-          <PlaceTitle>{placeNames.join(", ")}</PlaceTitle>
+        {hidePlaceSearch || isSearch ? (
+          <PlaceTitle>
+            {placeNames.join(", ")}
+            {isSearch && topicNames ? ` • ${topicNames}`: ""}
+          </PlaceTitle>
         ) : (
           <CountrySelect
             setSelectedPlaceDcid={setSelectedPlaceDcid}


### PR DESCRIPTION
Some charts were not showing up in search results because of filtering by `mainTopic`.

This PR changes the search results pages:
* results are all in one card with all tiles displayed
* tiles are no longer ordered by goal/target/indicator
* target headings have been taken out
* Adds topic name to the header behind the place name using mainTopics (this approach matches what's currently used on our explore pages)

<img width="1203" alt="Screenshot 2023-09-11 at 1 36 16 PM" src="https://github.com/datacommonsorg/website/assets/4034366/8565cae4-abfa-43f6-9fa2-7c059a4fd3fa">

<img width="1211" alt="Screenshot 2023-09-11 at 1 36 32 PM" src="https://github.com/datacommonsorg/website/assets/4034366/c8c616e6-e467-4eae-a4ad-2eee1a5a3905">

