### PR TITLE
Add footnotes to tiles in main DC

### DIFF
--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -122,6 +122,18 @@ $box-shadow-8dp: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
   background-color: var(--light);
 }
 
+/** footnotes */
+.chart-footnote {
+  color: var(--dc-gray);
+  font-size: 0.6rem;
+  margin: 0 24px;
+
+  .chart-footnote-toggle {
+    color: var(--link-color);
+    cursor: pointer;
+  }
+}
+
 /**
  * highlight tile
  */

--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -235,6 +235,7 @@ function renderTiles(
             parentPlaces={props.parentPlaces}
             allowZoom={true}
             colors={tile.mapTileSpec?.colors}
+            footnote={props.footnote}
           />
         );
       case "LINE":
@@ -254,6 +255,7 @@ function renderTiles(
             showExploreMore={props.showExploreMore}
             showTooltipOnHover={true}
             colors={tile.lineTileSpec?.colors}
+            footnote={props.footnote}
           />
         );
       case "RANKING":
@@ -281,6 +283,7 @@ function renderTiles(
             className={className}
             comparisonPlaces={comparisonPlaces}
             enclosedPlaceType={enclosedPlaceType}
+            footnote={props.footnote}
             horizontal={tile.barTileSpec?.horizontal}
             id={id}
             key={id}
@@ -320,6 +323,7 @@ function renderTiles(
             className={className}
             scatterTileSpec={tile.scatterTileSpec}
             showExploreMore={props.showExploreMore}
+            footnote={props.footnote}
           />
         );
       case "BIVARIATE":
@@ -343,6 +347,7 @@ function renderTiles(
         return (
           <GaugeTile
             colors={tile.gaugeTileSpec?.colors}
+            footnote={props.footnote}
             id={id}
             place={place}
             range={tile.gaugeTileSpec.range}
@@ -358,6 +363,7 @@ function renderTiles(
         return (
           <DonutTile
             colors={tile.donutTileSpec?.colors}
+            footnote={props.footnote}
             id={id}
             pie={tile.donutTileSpec?.pie}
             place={place}

--- a/static/js/components/subject_page/category.tsx
+++ b/static/js/components/subject_page/category.tsx
@@ -125,7 +125,6 @@ function renderBlocks(
                 enclosedPlaceType={props.enclosedPlaceType}
                 title={block.title}
                 description={block.description}
-                footnote={block.footnote}
                 columns={block.columns}
                 eventTypeSpec={props.eventTypeSpec}
                 showExploreMore={props.showExploreMore}
@@ -141,7 +140,6 @@ function renderBlocks(
               id={id}
               title={block.title}
               description={block.description}
-              footnote={block.footnote}
               place={props.place}
               commonSVSpec={commonSVSpec}
             >

--- a/static/js/components/subject_page/disaster_event_block.tsx
+++ b/static/js/components/subject_page/disaster_event_block.tsx
@@ -73,7 +73,6 @@ interface DisasterEventBlockPropType {
   description: string;
   columns: ColumnConfig[];
   eventTypeSpec: Record<string, EventTypeSpec>;
-  footnote?: string;
   parentPlaces?: NamedNode[];
   // API root
   apiRoot?: string;

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -78,6 +78,8 @@ export interface BarTilePropType {
   // A list of specific colors to use
   colors?: string[];
   enclosedPlaceType: string;
+  // Text to show in footer
+  footnote?: string;
   horizontal?: boolean;
   id: string;
   // Maximum number of places to display
@@ -156,6 +158,7 @@ export function BarTile(props: BarTilePropType): JSX.Element {
       isInitialLoading={_.isNull(barChartData)}
       exploreLink={props.showExploreMore ? getExploreLink(props) : null}
       hasErrorMsg={barChartData && !!barChartData.errorMsg}
+      footnote={props.footnote}
     >
       <div
         id={props.id}

--- a/static/js/components/tiles/chart_footer.tsx
+++ b/static/js/components/tiles/chart_footer.tsx
@@ -18,7 +18,7 @@
  * Footer for charts in tiles.
  */
 
-import React from "react";
+import React, { useState } from "react";
 
 import {
   GA_EVENT_TILE_DOWNLOAD,
@@ -27,11 +27,16 @@ import {
   triggerGAEvent,
 } from "../../shared/ga_events";
 
+// Number of characters in footnote to show before "show more"
+const FOOTNOTE_CHAR_LIMIT = 100;
+
 interface ChartFooterPropType {
   handleEmbed?: () => void;
   // Link to explore more. Only show explore button if this object is non-empty.
   exploreLink?: { displayText: string; url: string };
   children?: React.ReactNode;
+  // Text to show above buttons
+  footnote?: string;
 }
 
 export function ChartFooter(props: ChartFooterPropType): JSX.Element {
@@ -40,7 +45,9 @@ export function ChartFooter(props: ChartFooterPropType): JSX.Element {
   }
   return (
     <>
-      <slot name="footer" {...{ part: "footer" }}></slot>
+      <slot name="footer" {...{ part: "footer" }}>
+        <Footnote text={props.footnote} />
+      </slot>
       <footer className="chart-container-footer">
         <div className="main-footer-section">
           <div className="outlinks">
@@ -84,5 +91,28 @@ export function ChartFooter(props: ChartFooterPropType): JSX.Element {
         </div>
       </footer>
     </>
+  );
+}
+
+function Footnote(props: { text: string }): JSX.Element {
+  const [showFullText, setShowFullText] = useState(false);
+
+  if (!props.text) {
+    return <></>;
+  }
+
+  const hideToggle = props.text.length < FOOTNOTE_CHAR_LIMIT;
+  const shortText = props.text.slice(0, FOOTNOTE_CHAR_LIMIT);
+
+  return (
+    <div className="chart-footnote">
+      {hideToggle || showFullText ? props.text : `${shortText}...`}
+      <span
+        className="chart-footnote-toggle"
+        onClick={() => setShowFullText(!showFullText)}
+      >
+        {!hideToggle && (showFullText ? " Show less" : " Show more")}
+      </span>
+    </div>
   );
 }

--- a/static/js/components/tiles/chart_tile.tsx
+++ b/static/js/components/tiles/chart_tile.tsx
@@ -52,6 +52,8 @@ interface ChartTileContainerProp {
   exploreLink?: { displayText: string; url: string };
   // Whether or not there is an error message in the chart.
   hasErrorMsg?: boolean;
+  // Text to show in footer
+  footnote?: string;
 }
 
 export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
@@ -92,6 +94,7 @@ export function ChartTileContainer(props: ChartTileContainerProp): JSX.Element {
       <ChartFooter
         handleEmbed={showEmbed ? handleEmbed : null}
         exploreLink={props.exploreLink}
+        footnote={props.footnote}
       >
         <NlChartFeedback id={props.id} />
       </ChartFooter>

--- a/static/js/components/tiles/donut_tile.tsx
+++ b/static/js/components/tiles/donut_tile.tsx
@@ -53,6 +53,8 @@ export interface DonutTilePropType {
   className?: string;
   // Colors to use
   colors?: string[];
+  // Text to show in footer
+  footnote?: string;
   // Id for the chart
   id: string;
   // Whether to draw as full pie chart instead
@@ -112,6 +114,7 @@ export function DonutTile(props: DonutTilePropType): JSX.Element {
       }
       isInitialLoading={_.isNull(donutChartData)}
       hasErrorMsg={donutChartData && !!donutChartData.errorMsg}
+      footnote={props.footnote}
     >
       <div
         id={props.id}

--- a/static/js/components/tiles/gauge_tile.tsx
+++ b/static/js/components/tiles/gauge_tile.tsx
@@ -42,6 +42,8 @@ export interface GaugeTilePropType {
   apiRoot?: string;
   // colors to use
   colors?: string[];
+  // Text to show in footer
+  footnote?: string;
   // ID of the tile
   id: string;
   // Place to show data for
@@ -120,6 +122,7 @@ export function GaugeTile(props: GaugeTilePropType): JSX.Element {
           : null
       }
       hasErrorMsg={gaugeData && !!gaugeData.errorMsg}
+      footnote={props.footnote}
     >
       <div
         className={`svg-container ${ASYNC_ELEMENT_HOLDER_CLASS}`}

--- a/static/js/components/tiles/line_tile.tsx
+++ b/static/js/components/tiles/line_tile.tsx
@@ -62,6 +62,8 @@ export interface LineTilePropType {
   comparisonPlaces?: string[];
   // Type of child places to plot
   enclosedPlaceType?: string;
+  // Text to show in footer
+  footnote?: string;
   id: string;
   // Whether or not to render the data version of this tile
   isDataTile?: boolean;
@@ -128,6 +130,7 @@ export function LineTile(props: LineTilePropType): JSX.Element {
       isInitialLoading={_.isNull(chartData)}
       exploreLink={props.showExploreMore ? getExploreLink(props) : null}
       hasErrorMsg={chartData && !!chartData.errorMsg}
+      footnote={props.footnote}
     >
       <div
         id={props.id}

--- a/static/js/components/tiles/map_tile.tsx
+++ b/static/js/components/tiles/map_tile.tsx
@@ -87,6 +87,8 @@ export interface MapTilePropType {
   // Extra classes to add to the container.
   className?: string;
   enclosedPlaceType: string;
+  // text to show in footer of tile
+  footnote?: string;
   id: string;
   // Parent places of the current place showing map for
   parentPlaces?: NamedPlace[];
@@ -211,6 +213,7 @@ export function MapTile(props: MapTilePropType): JSX.Element {
       isInitialLoading={_.isNull(mapChartData)}
       exploreLink={props.showExploreMore ? getExploreLink(props) : null}
       hasErrorMsg={mapChartData && !!mapChartData.errorMsg}
+      footnote={props.footnote}
     >
       {showZoomButtons && !mapChartData.errorMsg && (
         <div className="map-zoom-button-section">

--- a/static/js/components/tiles/scatter_tile.tsx
+++ b/static/js/components/tiles/scatter_tile.tsx
@@ -75,6 +75,8 @@ export interface ScatterTilePropType {
   showExploreMore?: boolean;
   // Whether or not to show a loading spinner when fetching data.
   showLoadingSpinner?: boolean;
+  // Text to show in footer
+  footnote?: string;
 }
 
 interface RawData {
@@ -161,6 +163,7 @@ export function ScatterTile(props: ScatterTilePropType): JSX.Element {
       isInitialLoading={_.isNull(scatterChartData)}
       exploreLink={props.showExploreMore ? getExploreLink(props) : null}
       hasErrorMsg={scatterChartData && !!scatterChartData.errorMsg}
+      footnote={props.footnote}
     >
       <div className="scatter-tile-content">
         <div

--- a/static/library/component_attributes.ts
+++ b/static/library/component_attributes.ts
@@ -28,6 +28,7 @@ export interface BarComponentProps
   barHeight?: number;
   childPlaceType?: string;
   colors?: string[];
+  footnote?: string;
   header: string;
   horizontal?: boolean;
   lollipop?: boolean;
@@ -49,6 +50,7 @@ export interface GaugeComponentProps
   > {
   apiRoot?: string;
   colors?: string[];
+  footnote?: string;
   header: string;
   max: number;
   min: number;
@@ -78,6 +80,7 @@ export interface LineComponentProps
   apiRoot?: string;
   childPlaceType?: string;
   colors?: string[];
+  footnote?: string;
   header: string;
   place?: string;
   places?: string[];
@@ -95,6 +98,7 @@ export interface MapComponentProps
   colors?: string[];
   date?: string;
   enclosedPlaceType?: string;
+  footnote?: string;
   header: string;
   parentPlace?: string;
   place?: string;
@@ -113,6 +117,7 @@ export interface PieComponentProps
   apiRoot?: string;
   colors?: string[];
   donut?: boolean;
+  footnote?: string;
   header: string;
   place: string;
   title?: string;


### PR DESCRIPTION
This PR:
* Displays the block footnote inline in tile footers on the explore pages.
* Removes unused footnote props from disaster event tiles (footnotes are displayed as part of the block container instead for those pages)

![Screenshot 2023-09-13 at 1 48 20 PM](https://github.com/datacommonsorg/website/assets/4034366/36ea1d9a-2ae5-4d26-87a7-71cf2f1a029b)
