### PR TITLE
[sdg] added rounded corners back to search bar

### DIFF
--- a/experimental/sdg-tracker-un/frontend-tester/UNSD-Website-skeleton/UNSD.Website/ClientApp/src/templates/DataCommons/components/shared/components.tsx
+++ b/experimental/sdg-tracker-un/frontend-tester/UNSD-Website-skeleton/UNSD.Website/ClientApp/src/templates/DataCommons/components/shared/components.tsx
@@ -58,6 +58,7 @@ const SearchInputContainer = styled.div`
     position: relative;
 
     input {
+      border-radius: 2rem !important;
       padding-right: 2.25rem;
     }
 


### PR DESCRIPTION
## Before
<img width="850" alt="Screenshot 2023-09-13 at 8 31 04 PM" src="https://github.com/datacommonsorg/website/assets/13766/7229d017-cc9b-4541-8b9f-6592dcad002e">
<img width="811" alt="Screenshot 2023-09-13 at 8 30 56 PM" src="https://github.com/datacommonsorg/website/assets/13766/5dc52030-b1af-49a6-9a77-6199399149d4">




## After
<img width="831" alt="Screenshot 2023-09-13 at 8 31 18 PM" src="https://github.com/datacommonsorg/website/assets/13766/7f89b913-54c8-490f-be70-1e942bdca663">
<img width="848" alt="Screenshot 2023-09-13 at 8 31 09 PM" src="https://github.com/datacommonsorg/website/assets/13766/a5dc1c00-5006-416a-afe6-12b18cf5e6f2">
