### PR TITLE
[UN SDG] Add "open-in-new" icon to read more link in blurbs

### DIFF
--- a/experimental/sdg-tracker-un/frontend-tester/UNSD-Website-skeleton/UNSD.Website/ClientApp/src/templates/DataCommons/components/shared/components.tsx
+++ b/experimental/sdg-tracker-un/frontend-tester/UNSD-Website-skeleton/UNSD.Website/ClientApp/src/templates/DataCommons/components/shared/components.tsx
@@ -469,8 +469,21 @@ const HeadlineImage = styled.img`
 `;
 
 const HeadlineLink = styled.div`
+  cursor: pointer; 
   margin-left: auto;
   width: fit-content;
+
+  a {
+    font-size: 1rem;
+    line-height: 1rem;
+  }
+
+  .material-icons-outlined {
+    color: #5B92E5;
+    font-size: 1rem;
+    line-height: 1rem;
+    vertical-align: middle;
+  }
 `;
 
 export const HeadlineTile: React.FC<{
@@ -500,7 +513,8 @@ export const HeadlineTile: React.FC<{
         ))}
       </Row>
       <HeadlineLink>
-        <a href={headlineData.link}>Read more</a>
+        <a href={headlineData.link}>Read more </a>
+        <span className="material-icons-outlined">open_in_new</span>
       </HeadlineLink>
     </HeadlineContainer>
   );

--- a/experimental/sdg-tracker-un/frontend-tester/UNSD-Website-skeleton/UNSD.Website/ClientApp/src/templates/DataCommons/components/shared/components.tsx
+++ b/experimental/sdg-tracker-un/frontend-tester/UNSD-Website-skeleton/UNSD.Website/ClientApp/src/templates/DataCommons/components/shared/components.tsx
@@ -513,8 +513,10 @@ export const HeadlineTile: React.FC<{
         ))}
       </Row>
       <HeadlineLink>
-        <a href={headlineData.link}>Read more </a>
-        <span className="material-icons-outlined">open_in_new</span>
+        <a href={headlineData.link} target="_blank" rel="noreferrer">
+          Read more{" "}
+          <span className="material-icons-outlined">open_in_new</span>
+        </a>
       </HeadlineLink>
     </HeadlineContainer>
   );


### PR DESCRIPTION
Updates the "Read More" links in infographic blurbs:
* Links open in a new tab
* Adds the "open-in-new" icon to tell users link will take them to a new tab

<img width="648" alt="Screenshot 2023-09-14 at 10 32 51 AM" src="https://github.com/datacommonsorg/website/assets/4034366/8c3fd9bf-bb64-4a8a-b145-d88c53be4f6c">
