### PR TITLE
NL: Improve logging, etc

### DIFF
--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -28,15 +28,17 @@ _TEST_DATA = 'test_data'
 
 class ExploreTest(NLWebServerTestCase):
 
-  def run_fulfillment(self, test_dir, req_json, failure=''):
-    resp = requests.post(self.get_server_url() + '/api/explore/fulfill',
+  def run_fulfillment(self, test_dir, req_json, failure='', test=''):
+    resp = requests.post(self.get_server_url() +
+                         f'/api/explore/fulfill?test={test}',
                          json=req_json).json()
     self.handle_response(json.dumps(req_json), resp, test_dir, '', failure)
 
-  def run_detection(self, test_dir, queries, dc='', failure=''):
+  def run_detection(self, test_dir, queries, dc='', failure='', test=''):
     ctx = {}
     for q in queries:
-      resp = requests.post(self.get_server_url() + f'/api/explore/detect?q={q}',
+      resp = requests.post(self.get_server_url() +
+                           f'/api/explore/detect?q={q}&test={test}',
                            json={
                                'contextHistory': ctx,
                                'dc': dc,
@@ -48,11 +50,16 @@ class ExploreTest(NLWebServerTestCase):
         d = q.replace(' ', '').replace('?', '').lower()
       self.handle_response(q, resp, test_dir, d, failure)
 
-  def run_detect_and_fulfill(self, test_dir, queries, dc='', failure=''):
+  def run_detect_and_fulfill(self,
+                             test_dir,
+                             queries,
+                             dc='',
+                             failure='',
+                             test=''):
     ctx = {}
     for q in queries:
       resp = requests.post(self.get_server_url() +
-                           f'/api/explore/detect-and-fulfill?q={q}',
+                           f'/api/explore/detect-and-fulfill?q={q}&test={test}',
                            json={
                                'contextHistory': ctx,
                                'dc': dc,
@@ -127,7 +134,8 @@ class ExploreTest(NLWebServerTestCase):
           self.assertEqual(dbg["main_place_name"], expected["main_place_name"])
 
   def test_detection_basic(self):
-    self.run_detection('detection_api_basic', ['Commute in California'])
+    self.run_detection('detection_api_basic', ['Commute in California'],
+                       test='unittest')
 
   def test_detection_sdg(self):
     self.run_detection('detection_api_sdg', ['Health in USA'], dc='sdg')
@@ -153,7 +161,7 @@ class ExploreTest(NLWebServerTestCase):
         'dc': '',
         'disableExploreMore': '1',
     }
-    self.run_fulfillment('fulfillment_api_basic', req)
+    self.run_fulfillment('fulfillment_api_basic', req, test='unittest')
 
   def test_fulfillment_explore_more(self):
     req = {
@@ -312,7 +320,8 @@ class ExploreTest(NLWebServerTestCase):
     self.run_detect_and_fulfill('e2e_superlatives', [
         'Richest counties in california',
         'List schools in Sunnyvale',
-    ])
+    ],
+                                test='unittest')
 
   def test_e2e_sdg(self):
     self.run_detect_and_fulfill('e2e_sdg', [

--- a/server/integration_tests/nl_test.py
+++ b/server/integration_tests/nl_test.py
@@ -37,7 +37,8 @@ class NLTest(NLWebServerTestCase):
                    check_place_detection=False,
                    expected_detectors=[],
                    place_detector='dc',
-                   failure=''):
+                   failure='',
+                   test=''):
     if detector == 'heuristic':
       detection_method = 'Heuristic Based'
     elif detector == 'llm':
@@ -49,7 +50,7 @@ class NLTest(NLWebServerTestCase):
       print('Issuing ', test_dir, f'query[{i}]', q)
       resp = requests.post(
           self.get_server_url() +
-          f'/api/nl/data?q={q}&idx={idx}&detector={detector}&place_detector={place_detector}',
+          f'/api/nl/data?q={q}&idx={idx}&detector={detector}&place_detector={place_detector}&test={test}',
           json={
               'contextHistory': ctx
           }).json()
@@ -209,7 +210,8 @@ class NLTest(NLWebServerTestCase):
 
   def test_demo_climatetrace(self):
     self.run_sequence('demo_climatetrace',
-                      ['Which countries emit the most greenhouse gases?'])
+                      ['Which countries emit the most greenhouse gases?'],
+                      test='unittest')
 
   # This test uses DC's Recognize Places API.
   def test_place_detection_e2e_dc(self):

--- a/server/integration_tests/test_data/demo_climatetrace/query_1/chart_config.json
+++ b/server/integration_tests/test_data/demo_climatetrace/query_1/chart_config.json
@@ -1599,5 +1599,6 @@
   ],
   "relatedThings": {},
   "svSource": "CURRENT_QUERY",
+  "test": "unittest",
   "userMessage": ""
 }

--- a/server/integration_tests/test_data/detection_api_basic/chart_config.json
+++ b/server/integration_tests/test_data/detection_api_basic/chart_config.json
@@ -13,6 +13,7 @@
     "geoId/06"
   ],
   "sessionId": "007_999999999",
+  "test": "unittest",
   "variables": [
     "dc/topic/CommuteTime",
     "dc/topic/WorkCommute",

--- a/server/integration_tests/test_data/e2e_superlatives/listschoolsinsunnyvale/chart_config.json
+++ b/server/integration_tests/test_data/e2e_superlatives/listschoolsinsunnyvale/chart_config.json
@@ -699,5 +699,6 @@
     ]
   },
   "svSource": "UNKNOWN",
+  "test": "unittest",
   "userMessage": ""
 }

--- a/server/integration_tests/test_data/e2e_superlatives/richestcountiesincalifornia/chart_config.json
+++ b/server/integration_tests/test_data/e2e_superlatives/richestcountiesincalifornia/chart_config.json
@@ -1836,5 +1836,6 @@
     ]
   },
   "svSource": "UNKNOWN",
+  "test": "unittest",
   "userMessage": ""
 }

--- a/server/integration_tests/test_data/fulfillment_api_basic/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_basic/chart_config.json
@@ -1214,5 +1214,6 @@
     ]
   },
   "svSource": "UNKNOWN",
+  "test": "unittest",
   "userMessage": ""
 }

--- a/server/lib/explore/params.py
+++ b/server/lib/explore/params.py
@@ -28,6 +28,7 @@ class Params(str, Enum):
   DC = 'dc'
   EXT_SVGS = 'extensionGroups'
   EXP_MORE_DISABLED = 'disableExploreMore'
+  TEST = 'test'
 
 
 class DCNames(str, Enum):

--- a/server/lib/nl/common/utterance.py
+++ b/server/lib/nl/common/utterance.py
@@ -173,3 +173,5 @@ class Utterance:
   place_fallback: PlaceFallback = None
   # Past complete context for insight flow.
   insight_ctx: Dict = field(default_factory=dict)
+  # Test param.
+  test: str = ''

--- a/server/lib/nl/detection/palm_api.py
+++ b/server/lib/nl/detection/palm_api.py
@@ -189,7 +189,7 @@ _UNSAFE_SIGNAL_WORDS = [
     'adult',
     'biased',
     'discriminatory',
-    'harmful'
+    'harmful',
     'hate',
     'offensive',
     'problem',

--- a/server/lib/nl/detection/palm_api.py
+++ b/server/lib/nl/detection/palm_api.py
@@ -188,7 +188,6 @@ def parse_response(query: str, resp: Dict, field: str,
 _UNSAFE_SIGNAL_WORDS = [
     'adult',
     'biased',
-    'cannot',
     'discriminatory',
     'harmful'
     'hate',
@@ -198,9 +197,7 @@ _UNSAFE_SIGNAL_WORDS = [
     'respectful',
     'sexist',
     'stereotype',
-    'unsafe',
     'violence',
-    'will not',
 ]
 
 

--- a/server/lib/nl/detection/utils.py
+++ b/server/lib/nl/detection/utils.py
@@ -150,8 +150,11 @@ def empty_place_detection() -> PlaceDetection:
                         main_place=None)
 
 
-def create_utterance(query_detection: Detection, currentUtterance: Utterance,
-                     counters: ctr.Counters, session_id: str) -> Utterance:
+def create_utterance(query_detection: Detection,
+                     currentUtterance: Utterance,
+                     counters: ctr.Counters,
+                     session_id: str,
+                     test: str = '') -> Utterance:
   filtered_svs = filter_svs(query_detection.svs_detected.single_sv, counters)
 
   # Construct Utterance datastructure.
@@ -168,7 +171,8 @@ def create_utterance(query_detection: Detection, currentUtterance: Utterance,
                    counters=counters,
                    session_id=session_id,
                    multi_svs=query_detection.svs_detected.multi_sv,
-                   llm_resp=query_detection.llm_resp)
+                   llm_resp=query_detection.llm_resp,
+                   test=test)
   uttr.counters.info('filtered_svs', filtered_svs)
 
   # Add detected places.

--- a/server/routes/explore/api.py
+++ b/server/routes/explore/api.py
@@ -52,8 +52,6 @@ def detect():
       request, 'explore', debug_logs)
   if error_json:
     return error_json
-  if not utterance:
-    return helpers.abort('Sorry could not answer your query.', '', [])
 
   data_dict = copy.deepcopy(utterance.insight_ctx)
   utterance.prev_utterance = None
@@ -68,7 +66,8 @@ def detect():
                                          utterance.detection,
                                          dbg_counters,
                                          debug_logs,
-                                         has_data=True)
+                                         has_data=True,
+                                         test=utterance.test)
 
 
 #
@@ -84,10 +83,9 @@ def fulfill():
   """Data handler."""
   logging.info('NL Chart API: Enter')
 
-  req_json = request.get_json()
   debug_logs = {}
   counters = ctr.Counters()
-  return _fulfill_with_insight_ctx(req_json, debug_logs, counters)
+  return _fulfill_with_insight_ctx(request, debug_logs, counters)
 
 
 #
@@ -97,19 +95,20 @@ def fulfill():
 def detect_and_fulfill():
   debug_logs = {}
 
+  test = request.args.get(Params.TEST.value, '')
   # First sanity DC name, if any.
   dc_name = request.get_json().get(Params.DC.value)
   if not dc_name:
     dc_name = DCNames.MAIN_DC.value
   if dc_name not in set([it.value for it in DCNames]):
-    return helpers.abort(f'Invalid Custom Data Commons Name {dc_name}', '', [])
+    return helpers.abort(f'Invalid Custom Data Commons Name {dc_name}',
+                         '', [],
+                         test=test)
 
   utterance, error_json = helpers.parse_query_and_detect(
       request, 'explore', debug_logs)
   if error_json:
     return error_json
-  if not utterance:
-    return helpers.abort('Sorry, could not answer your query.', '', [])
 
   # Set some params used downstream in explore flow.
   utterance.insight_ctx[
@@ -157,12 +156,18 @@ def _fulfill_with_chart_config(utterance: nl_utterance.Utterance,
 #
 # Given an insight context, fulfills it into charts.
 #
-def _fulfill_with_insight_ctx(insight_ctx: Dict, debug_logs: Dict,
+def _fulfill_with_insight_ctx(request: Dict, debug_logs: Dict,
                               counters: ctr.Counters) -> Dict:
+  insight_ctx = request.get_json()
+  test = request.args.get(Params.TEST.value, '')
   if not insight_ctx:
-    return helpers.abort('Sorry, could not answer your query.', '', [])
+    return helpers.abort('Sorry, could not answer your query.',
+                         '', [],
+                         test=test)
   if not insight_ctx.get('entities'):
-    return helpers.abort('Could not recognize any places in the query.', '', [])
+    return helpers.abort('Could not recognize any places in the query.',
+                         '', [],
+                         test=test)
 
   entities = insight_ctx.get(Params.ENTITIES.value, [])
   cmp_entities = insight_ctx.get(Params.CMP_ENTITIES.value, [])
@@ -176,7 +181,9 @@ def _fulfill_with_insight_ctx(insight_ctx: Dict, debug_logs: Dict,
   if not dc_name:
     dc_name = DCNames.MAIN_DC.value
   if dc_name not in set([it.value for it in DCNames]):
-    return helpers.abort(f'Invalid Custom Data Commons Name {dc_name}', '', [])
+    return helpers.abort(f'Invalid Custom Data Commons Name {dc_name}',
+                         '', [],
+                         test=test)
 
   if not session_id:
     if current_app.config['LOG_QUERY']:
@@ -194,9 +201,10 @@ def _fulfill_with_insight_ctx(insight_ctx: Dict, debug_logs: Dict,
       debug_logs, counters)
   counters.timeit('construct_for_explore', start)
   if not query_detection:
-    return helpers.abort(error_msg, '', [])
+    return helpers.abort(error_msg, '', [], test=test)
 
-  utterance = create_utterance(query_detection, None, counters, session_id)
+  utterance = create_utterance(query_detection, None, counters, session_id,
+                               test)
   utterance.insight_ctx = insight_ctx
   utterance.insight_ctx[Params.DC.value] = dc_name
   return _fulfill_with_chart_config(utterance, debug_logs)

--- a/server/routes/nl/api.py
+++ b/server/routes/nl/api.py
@@ -42,8 +42,6 @@ def data():
       request, 'nl', debug_logs)
   if error_json:
     return error_json
-  if not utterance:
-    return helpers.abort('Failed to process!', '', [])
   return helpers.fulfill_with_chart_config(utterance, debug_logs)
 
 

--- a/server/routes/nl/helpers.py
+++ b/server/routes/nl/helpers.py
@@ -17,7 +17,7 @@ import json
 import logging
 import os
 import time
-from typing import Dict
+from typing import Dict, List
 
 import flask
 from flask import current_app
@@ -25,6 +25,7 @@ from google.protobuf.json_format import MessageToJson
 from markupsafe import escape
 
 from server.config.subject_page_pb2 import SubjectPageConfig
+from server.lib.explore import params
 from server.lib.nl.common import bad_words
 from server.lib.nl.common import commentary
 from server.lib.nl.common import serialize
@@ -62,12 +63,16 @@ def parse_query_and_detect(request: Dict, app: str, debug_logs: Dict):
     flask.abort(404)
   nl_bad_words = current_app.config['NL_BAD_WORDS']
 
+  test = request.args.get(params.Params.TEST.value, '')
+
   # Index-type default is in nl_server.
   embeddings_index_type = request.args.get('idx', '')
   original_query = request.args.get('q')
   if not original_query:
     err_json = helpers.abort(
-        'Received an empty query, please type a few words :)', '', [])
+        'Received an empty query, please type a few words :)',
+        '', [],
+        test=test)
     return None, err_json
   context_history = []
   if request.get_json():
@@ -102,8 +107,10 @@ def parse_query_and_detect(request: Dict, app: str, debug_logs: Dict):
   query = str(escape(shared_utils.remove_punctuations(original_query)))
   if not query:
     err_json = helpers.abort(
-        'Received an empty query, please type a few words :)', original_query,
-        context_history)
+        'Received an empty query, please type a few words :)',
+        original_query,
+        context_history,
+        test=test)
     return None, err_json
 
   #
@@ -112,8 +119,10 @@ def parse_query_and_detect(request: Dict, app: str, debug_logs: Dict):
   if (not bad_words.is_safe(original_query, nl_bad_words) or
       not bad_words.is_safe(query, nl_bad_words)):
     err_json = helpers.abort('Sorry, could not complete your request.',
-                             original_query, context_history)
-    _set_blocked(err_json)
+                             original_query,
+                             context_history,
+                             test=test,
+                             blocked=True)
     return None, err_json
 
   counters = ctr.Counters()
@@ -138,14 +147,17 @@ def parse_query_and_detect(request: Dict, app: str, debug_logs: Dict):
                                     debug_logs, counters)
   if not query_detection:
     err_json = helpers.abort('Sorry, could not complete your request.',
-                             original_query, context_history, debug_logs,
-                             counters)
-    _set_blocked(err_json)
+                             original_query,
+                             context_history,
+                             debug_logs,
+                             counters,
+                             test=test,
+                             blocked=True)
     return None, err_json
   counters.timeit('query_detection', start)
 
   utterance = create_utterance(query_detection, prev_utterance, counters,
-                               session_id)
+                               session_id, test)
 
   if utterance:
     context.merge_with_context(utterance, is_sdg)
@@ -255,16 +267,22 @@ def prepare_response(utterance: nl_utterance.Utterance,
 
   has_charts = True if page_config else False
   return prepare_response_common(data_dict, status_str, detection, dbg_counters,
-                                 debug_logs, has_charts)
+                                 debug_logs, has_charts, utterance.test)
 
 
-def prepare_response_common(data_dict: Dict, status_str: str,
-                            detection: Detection, dbg_counters: Dict,
-                            debug_logs: Dict, has_data: bool) -> Dict:
+def prepare_response_common(data_dict: Dict,
+                            status_str: str,
+                            detection: Detection,
+                            dbg_counters: Dict,
+                            debug_logs: Dict,
+                            has_data: bool,
+                            test: str = '') -> Dict:
   data_dict = dbg.result_with_debug_info(data_dict, status_str, detection,
                                          dbg_counters, debug_logs)
   # Convert data_dict to pure json.
   data_dict = utils.to_dict(data_dict)
+  if test:
+    data_dict['test'] = test
   if current_app.config['LOG_QUERY']:
     # Asynchronously log as bigtable write takes O(100ms)
     loop = asyncio.new_event_loop()
@@ -280,9 +298,11 @@ def prepare_response_common(data_dict: Dict, status_str: str,
 #
 def abort(error_message: str,
           original_query: str,
-          context_history: Dict,
+          context_history: List[Dict],
           debug_logs: Dict = None,
-          counters: ctr.Counters = None) -> Dict:
+          counters: ctr.Counters = None,
+          blocked: bool = False,
+          test: str = '') -> Dict:
   query = str(escape(shared_utils.remove_punctuations(original_query)))
   escaped_context_history = []
   for ch in context_history:
@@ -318,7 +338,20 @@ def abort(error_message: str,
                                          query_detection=query_detection,
                                          debug_counters=counters.get(),
                                          query_detection_debug_logs=debug_logs)
+
+  if test:
+    data_dict['test'] = test
+  if blocked:
+    _set_blocked(data_dict)
+
   logging.info('NL Data API: Empty Exit')
+  if current_app.config['LOG_QUERY']:
+    # Asynchronously log as bigtable write takes O(100ms)
+    loop = asyncio.new_event_loop()
+    session_info = futils.get_session_info(context_history, False)
+    data_dict['session'] = session_info
+    loop.run_until_complete(bt.write_row(session_info, data_dict, debug_logs))
+
   return data_dict
 
 

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -259,6 +259,7 @@ export function App(props: { isDemo: boolean }): JSX.Element {
     );
     const detector = getSingleParam(hashParams[URL_HASH_PARAMS.DETECTOR]);
     const llmApi = getSingleParam(hashParams[URL_HASH_PARAMS.LLM_API]);
+    const testMode = getSingleParam(hashParams[URL_HASH_PARAMS.TEST_MODE]);
 
     let fulfillmentPromise: Promise<any>;
     const gaTitle = query
@@ -278,7 +279,8 @@ export function App(props: { isDemo: boolean }): JSX.Element {
         dc,
         disableExploreMore,
         detector,
-        llmApi
+        llmApi,
+        testMode
       )
         .then((resp) => {
           processFulfillData(resp, false);
@@ -297,7 +299,8 @@ export function App(props: { isDemo: boolean }): JSX.Element {
         dc,
         [],
         [],
-        disableExploreMore
+        disableExploreMore,
+        testMode
       )
         .then((resp) => {
           processFulfillData(resp, true);
@@ -325,11 +328,13 @@ const fetchFulfillData = async (
   dc: string,
   svgs: string[],
   classificationsJson: any,
-  disableExploreMore: string
+  disableExploreMore: string,
+  testMode: string
 ) => {
   try {
+    const testModeArg = testMode ? `?test=${testMode}` : "";
     const startTime = window.performance ? window.performance.now() : undefined;
-    const resp = await axios.post(`/api/explore/fulfill`, {
+    const resp = await axios.post(`/api/explore/fulfill${testModeArg}`, {
       dc,
       entities: places,
       variables: topics,
@@ -365,14 +370,16 @@ const fetchDetectAndFufillData = async (
   dc: string,
   disableExploreMore: string,
   detector: string,
-  llmApi: string
+  llmApi: string,
+  testMode: string
 ) => {
   const detectorTypeArg = detector ? `&detector=${detector}` : "";
   const llmApiArg = llmApi ? `&llm_api=${llmApi}` : "";
+  const testModeArg = testMode ? `&test=${testMode}` : "";
   try {
     const startTime = window.performance ? window.performance.now() : undefined;
     const resp = await axios.post(
-      `/api/explore/detect-and-fulfill?q=${query}${detectorTypeArg}${llmApiArg}`,
+      `/api/explore/detect-and-fulfill?q=${query}${detectorTypeArg}${llmApiArg}${testModeArg}`,
       {
         contextHistory: savedContext,
         dc,

--- a/static/js/constants/app/explore_constants.ts
+++ b/static/js/constants/app/explore_constants.ts
@@ -35,6 +35,7 @@ export const URL_HASH_PARAMS = {
   AUTO_PLAY_DISABLE_TYPING: "at",
   AUTO_PLAY_MANUAL_ENTER: "ae",
   MAXIMUM_BLOCK: "mb",
+  TEST_MODE: "test",
 };
 // Dcid of the default topic to use
 export const DEFAULT_TOPIC = "dc/topic/Root";


### PR DESCRIPTION
This PR makes 3 fixes:

1. Logs to BT when we abort a query (for bad-words or otherwise).
2. Supports `explore` to specify a url param `test=<type>`, which gets plumbed into the response which is logged.
3. Drops a few signal words in LLM response to avoid false positive blocks.

To validate (1), I ran tests locally and was able to find it in BT (see screenshot)

![image](https://github.com/datacommonsorg/website/assets/4375037/d42bb52a-3629-42c7-87b2-46a45374961e)

![image](https://github.com/datacommonsorg/website/assets/4375037/e2b9d44b-b10c-449d-8596-7659c379fc87)

![image](https://github.com/datacommonsorg/website/assets/4375037/bc31221e-08fa-4723-a435-9c38bad4da08)
