### PR TITLE
Add support for fetching descendant names for non-place entities.

### DIFF
--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -436,10 +436,15 @@ def triples(nodes, out=True):
 
 
 def descendent_places(nodes, descendent_type):
-  return property_values(nodes,
-                         'containedInPlace+',
-                         out=False,
-                         constraints='{{typeOf:{}}}'.format(descendent_type))
+  # When the only node being requested is also the descendent_type, fetch all nodes of that type.
+  if nodes and len(nodes) == 1 and nodes[0] == descendent_type:
+    return property_values(nodes, "typeOf", out=False)
+  return property_values(
+      nodes,
+      "containedInPlace+",
+      out=False,
+      constraints="{{typeOf:{}}}".format(descendent_type),
+  )
 
 
 def raw_descendent_places(nodes, descendent_type):


### PR DESCRIPTION
API results:

[non-place-descendants.webm](https://github.com/datacommonsorg/website/assets/1221814/03d54559-00aa-45b8-b97e-9ba040a11446)

With this change, we can now do scatter plots for non-place entities:

![image](https://github.com/datacommonsorg/website/assets/1221814/3bf02c9c-49ed-4283-a4b5-78eb72d77015)

