### PR TITLE
[tiles] fix per capita scaling bug

### DIFF
--- a/static/js/utils/tile_utils.tsx
+++ b/static/js/utils/tile_utils.tsx
@@ -403,7 +403,7 @@ export function getStatFormat(
 ): { unit: string; scaling: number; numFractionDigits: number } {
   const result = {
     unit: svSpec.unit,
-    scaling: svSpec.scaling,
+    scaling: svSpec.scaling || 1,
     numFractionDigits: NUM_FRACTION_DIGITS,
   };
   // If unit was specified in the svSpec, use that unit


### PR DESCRIPTION
- fix bug when svSpec.scaling was undefined, we were trying to multiply undefined by 100 for per capita

![Screenshot 2023-09-26 at 1 23 24 PM](https://github.com/datacommonsorg/website/assets/69875368/673a6f05-c7c6-4667-a2fa-8449e1a1ba98)
