### PR TITLE
Increase element wait timeout for screenshot tests

### DIFF
--- a/server/webdriver/screenshot/runner.py
+++ b/server/webdriver/screenshot/runner.py
@@ -29,7 +29,7 @@ from server.webdriver import shared
 WIDTH = 1280
 SCREENSHOTS_FOLDER = 'screenshots'
 
-timeout = 20
+WAIT_TIMEOUT = 40
 
 
 def prepare(page_config_dir):
@@ -65,13 +65,13 @@ def run(driver, page_base_url, page_config):
   if page_config['async']:
     shared.wait_for_loading(driver)
     try:
-      WebDriverWait(driver, timeout).until(shared.charts_rendered)
+      WebDriverWait(driver, WAIT_TIMEOUT).until(shared.charts_rendered)
     except (TimeoutException, UnexpectedAlertPresentException) as e:
       logging.error("Exception for url: %s\n%s", url, e)
       raise e
   else:
     element_present = EC.presence_of_element_located((By.TAG_NAME, 'main'))
-    WebDriverWait(driver, timeout).until(element_present)
+    WebDriverWait(driver, WAIT_TIMEOUT).until(element_present)
   # Extra sleep to make sure page element settles. For example, stat var
   # hierarchy widget expands via animation.
   time.sleep(1)

--- a/static/js/components/tiles/sv_ranking_units.tsx
+++ b/static/js/components/tiles/sv_ranking_units.tsx
@@ -21,7 +21,6 @@ import React, { RefObject, useRef } from "react";
 
 import { VisType } from "../../apps/visualization/vis_type_configs";
 import { URL_PATH } from "../../constants/app/visualization_constants";
-import { ASYNC_ELEMENT_CLASS } from "../../constants/css_constants";
 import {
   RankingData,
   RankingGroup,
@@ -100,9 +99,7 @@ export function SvRankingUnits(props: SvRankingUnitsProps): JSX.Element {
   return (
     <React.Fragment>
       {rankingMetadata.showHighestLowest || props.errorMsg ? (
-        <div
-          className={`ranking-unit-container ${ASYNC_ELEMENT_CLASS} highest-ranking-container`}
-        >
+        <div className="ranking-unit-container highest-ranking-container">
           {getRankingUnit(
             title,
             statVar,
@@ -131,9 +128,7 @@ export function SvRankingUnits(props: SvRankingUnitsProps): JSX.Element {
       ) : (
         <>
           {rankingMetadata.showHighest && (
-            <div
-              className={`ranking-unit-container ${ASYNC_ELEMENT_CLASS} highest-ranking-container`}
-            >
+            <div className="ranking-unit-container highest-ranking-container">
               {getRankingUnit(
                 title,
                 statVar,
@@ -158,9 +153,7 @@ export function SvRankingUnits(props: SvRankingUnitsProps): JSX.Element {
             </div>
           )}
           {rankingMetadata.showLowest && (
-            <div
-              className={`ranking-unit-container ${ASYNC_ELEMENT_CLASS} lowest-ranking-container`}
-            >
+            <div className="ranking-unit-container lowest-ranking-container">
               {getRankingUnit(
                 title,
                 statVar,


### PR DESCRIPTION
Removed duplicated ASYNC_ELEMENT_CLASS tagging, which exist twice in ranking tile.