### PR TITLE
Update dev and magiceye replicas

### DIFF
--- a/deploy/helm_charts/envs/dev.yaml
+++ b/deploy/helm_charts/envs/dev.yaml
@@ -21,7 +21,7 @@ namespace:
 
 website:
   flaskEnv: dev
-  replicas: 20
+  replicas: 10
   redis:
     enabled: true
     configFile: |
@@ -40,15 +40,15 @@ serviceGroups:
   svg:
     replicas: 5
   observation:
-    replicas: 20
+    replicas: 10
   node:
-    replicas: 10
+    replicas: 5
   default:
-    replicas: 10
+    replicas: 5
 
 nl:
   enabled: true
 
 nodejs:
   enabled: true
-  replicas: 6
+  replicas: 50

--- a/deploy/helm_charts/envs/magic_eye.yaml
+++ b/deploy/helm_charts/envs/magic_eye.yaml
@@ -41,11 +41,14 @@ nl:
 serviceGroups:
   recon: null
   svg:
-    replicas: 6
+    replicas: 3
+    resources:
+      memoryRequest: "12G"
+      memoryLimit: "12G"
   observation:
-    replicas: 6
+    replicas: 10
   node:
-    replicas: 6
+    replicas: 10
   default:
     replicas: 6
 
@@ -54,7 +57,7 @@ kgStoreConfig:
     project: datcom-magiceye-dev
     instance: dc-graph
     tables:
-      - magic_eye_2023_02_18_16_57_52
+      - magic_eye_2023_09_28_15_15_11
 
 svg:
   blocklistFile: ["dc/g/Uncategorized", "oecd/g/OECD"]


### PR DESCRIPTION
DEV: Reduce web server replicas as launch as complete; Increase NodeJs replicas for large scale offline charts generation.

MagicEye: Reduce SVG replicas as it's the least needed. Update Bigtable version. Note this cache substantially increased the SVG in-memory cache built time due to the large amount of stat vars added.