### PR TITLE
add veterans topic to index

### DIFF
--- a/deploy/nl/embeddings.yaml
+++ b/deploy/nl/embeddings.yaml
@@ -1,4 +1,4 @@
 small: embeddings_small_2023_05_24_23_17_03.csv
-medium_ft: embeddings_medium_2023_09_19_18_35_14.ft_final_v20230717230459.all-MiniLM-L6-v2.csv
+medium_ft: embeddings_medium_2023_10_04_13_55_01.ft_final_v20230717230459.all-MiniLM-L6-v2.csv
 sdg_ft: embeddings_sdg_2023_09_12_16_38_04.ft_final_v20230717230459.all-MiniLM-L6-v2.csv
 

--- a/deploy/nl/embeddings.yaml
+++ b/deploy/nl/embeddings.yaml
@@ -1,4 +1,4 @@
 small: embeddings_small_2023_05_24_23_17_03.csv
-medium_ft: embeddings_medium_2023_10_04_13_55_01.ft_final_v20230717230459.all-MiniLM-L6-v2.csv
+medium_ft: embeddings_medium_2023_10_04_22_47_16.ft_final_v20230717230459.all-MiniLM-L6-v2.csv
 sdg_ft: embeddings_sdg_2023_09_12_16_38_04.ft_final_v20230717230459.all-MiniLM-L6-v2.csv
 

--- a/tools/nl/embeddings/data/curated_input/sheets_svs.csv
+++ b/tools/nl/embeddings/data/curated_input/sheets_svs.csv
@@ -1571,8 +1571,8 @@ Exports_EconomicActivity_ElectronicComponents,Electronics Components Exports,,,e
 Imports_EconomicActivity_ElectronicComponents,Electronics Components Imports,,,import of electronics;electronic components import; imports of electronic components;
 Exports_EconomicActivity_Pharmaceutical,Pharmaceutical Exports,,,export of pharmaceuicals;pharmaceutical export; exports of pharmaceuticals;
 Imports_EconomicActivity_Pharmaceutical,Pharmaceutical Imports,,,import of pharmaceuicals;pharmaceutical import; imports of pharmaceuticals;
-dc/topic/Veterans,Veterans,Veterans,,
-dc/topic/VeteransByGender,Veterans By Gender,Veterans By Gender,,
-dc/topic/VeteransByGroupQuartersResidence,Veterans By Group Quarters Residence,Veterans By Group Quarters Residence,,
-dc/topic/VeteransByWar,Veterans By War,Veterans By War,,
-dc/topic/VeteransIncome,Veterans Income,Veterans Income,,
+dc/topic/Veterans,Veterans,Veterans,,veteran;
+dc/topic/VeteransByGender,Veterans By Gender,Veterans By Gender,,gender of veterans;gender breakdown of veterans;veterans gender breakdown;
+dc/topic/VeteransByGroupQuartersResidence,Veterans By Group Quarters Residence,Veterans By Group Quarters Residence,,residence of veterans;
+dc/topic/VeteransByWar,Veterans By War,Veterans By War,,veterans by wars fought;wars veterans fought in;
+dc/topic/VeteransIncome,Veterans Income,Veterans Income,,income of veterans;veterans earnings;earnings of veterans;

--- a/tools/nl/embeddings/data/curated_input/sheets_svs.csv
+++ b/tools/nl/embeddings/data/curated_input/sheets_svs.csv
@@ -1571,3 +1571,8 @@ Exports_EconomicActivity_ElectronicComponents,Electronics Components Exports,,,e
 Imports_EconomicActivity_ElectronicComponents,Electronics Components Imports,,,import of electronics;electronic components import; imports of electronic components;
 Exports_EconomicActivity_Pharmaceutical,Pharmaceutical Exports,,,export of pharmaceuicals;pharmaceutical export; exports of pharmaceuticals;
 Imports_EconomicActivity_Pharmaceutical,Pharmaceutical Imports,,,import of pharmaceuicals;pharmaceutical import; imports of pharmaceuticals;
+dc/topic/Veterans,Veterans,Veterans,,
+dc/topic/VeteransByGender,Veterans By Gender,Veterans By Gender,,
+dc/topic/VeteransByGroupQuartersResidence,Veterans By Group Quarters Residence,Veterans By Group Quarters Residence,,
+dc/topic/VeteransByWar,Veterans By War,Veterans By War,,
+dc/topic/VeteransIncome,Veterans Income,Veterans Income,,

--- a/tools/nl/embeddings/data/preindex/medium/sv_descriptions.csv
+++ b/tools/nl/embeddings/data/preindex/medium/sv_descriptions.csv
@@ -6257,11 +6257,11 @@ dc/topic/UrbanMalePopulationByAge,Urban Male Population By Age
 dc/topic/UrbanPopulationByAge,Urban Population By Age
 dc/topic/Vaccines,Vaccines
 dc/topic/VeryOldAndVeryYoungPopulation,Very Old and Very Young Population;very old and very young;young children and old people
-dc/topic/Veterans,Veterans
-dc/topic/VeteransByGender,Veterans By Gender
-dc/topic/VeteransByGroupQuartersResidence,Veterans By Group Quarters Residence
-dc/topic/VeteransByWar,Veterans By War
-dc/topic/VeteransIncome,Veterans Income
+dc/topic/Veterans,Veterans;veteran
+dc/topic/VeteransByGender,Veterans By Gender;gender breakdown of veterans;gender of veterans;veterans gender breakdown
+dc/topic/VeteransByGroupQuartersResidence,Veterans By Group Quarters Residence;residence of veterans
+dc/topic/VeteransByWar,Veterans By War;veterans by wars fought;wars veterans fought in
+dc/topic/VeteransIncome,Veterans Income;earnings of veterans;income of veterans;veterans earnings
 dc/topic/Visibility,Visibility
 dc/topic/Volcano,Volcano
 dc/topic/Voting,Voting

--- a/tools/nl/embeddings/data/preindex/medium/sv_descriptions.csv
+++ b/tools/nl/embeddings/data/preindex/medium/sv_descriptions.csv
@@ -6257,6 +6257,11 @@ dc/topic/UrbanMalePopulationByAge,Urban Male Population By Age
 dc/topic/UrbanPopulationByAge,Urban Population By Age
 dc/topic/Vaccines,Vaccines
 dc/topic/VeryOldAndVeryYoungPopulation,Very Old and Very Young Population;very old and very young;young children and old people
+dc/topic/Veterans,Veterans
+dc/topic/VeteransByGender,Veterans By Gender
+dc/topic/VeteransByGroupQuartersResidence,Veterans By Group Quarters Residence
+dc/topic/VeteransByWar,Veterans By War
+dc/topic/VeteransIncome,Veterans Income
 dc/topic/Visibility,Visibility
 dc/topic/Volcano,Volcano
 dc/topic/Voting,Voting


### PR DESCRIPTION
diff_report: https://gist.githubusercontent.com/chejennifer/46aba5cb393e634774afff3e8829349c/raw/c6c89983c3a346df32ea587953c52294f01c3068/diff_report.html

Note: not sure if we want ALL the veterans topics to be showing up under veteran unemployment ..?
<img width="1500" alt="Screenshot 2023-10-04 at 2 24 26 PM" src="https://github.com/datacommonsorg/website/assets/69875368/7fbf16db-917b-4176-b4fd-9f5c461fce93">
