### PR TITLE
Remove geoJsonCoordinateUN* properties from graph browser

### DIFF
--- a/static/js/browser/out_arc_section.tsx
+++ b/static/js/browser/out_arc_section.tsx
@@ -48,6 +48,9 @@ const IGNORED_OUT_ARC_PROPERTIES = new Set([
   "geoJsonCoordinatesDP2",
   "geoJsonCoordinatesDP3",
   "geoJsonCoordinatesUN",
+  "geoJsonCoordinatesUNDP1",
+  "geoJsonCoordinatesUNDP2",
+  "geoJsonCoordinatesUNDP3",
   "firePerimeter",
 ]);
 

--- a/static/js/browser/out_arc_section.tsx
+++ b/static/js/browser/out_arc_section.tsx
@@ -47,6 +47,7 @@ const IGNORED_OUT_ARC_PROPERTIES = new Set([
   "geoJsonCoordinatesDP1",
   "geoJsonCoordinatesDP2",
   "geoJsonCoordinatesDP3",
+  "geoJsonCoordinatesUN",
   "firePerimeter",
 ]);
 


### PR DESCRIPTION
This change hides the `geoJsonCoordinateUN` and `geoJsonCoordinateUNDP<N>` properties in the graph browser, so that their values don't overwhelm the page.

