### PR TITLE
NL: Fix Earth title bug and don't log test queries

### DIFF
--- a/server/integration_tests/test_data/demo_climatetrace/query_1/chart_config.json
+++ b/server/integration_tests/test_data/demo_climatetrace/query_1/chart_config.json
@@ -1582,10 +1582,10 @@
   },
   "context": {},
   "debug": {},
-  "pastSourceContext": "Earth",
+  "pastSourceContext": "World",
   "place": {
     "dcid": "Earth",
-    "name": "Earth",
+    "name": "World",
     "place_type": "Place"
   },
   "placeFallback": {},
@@ -1593,7 +1593,7 @@
   "places": [
     {
       "dcid": "Earth",
-      "name": "Earth",
+      "name": "World",
       "place_type": "Place"
     }
   ],

--- a/server/integration_tests/test_data/e2e_default_place/howtoearnmoneyonlinewithoutinvestment/chart_config.json
+++ b/server/integration_tests/test_data/e2e_default_place/howtoearnmoneyonlinewithoutinvestment/chart_config.json
@@ -2,7 +2,7 @@
   "config": {},
   "context": {},
   "debug": {},
-  "pastSourceContext": "USA",
+  "pastSourceContext": "",
   "place": {
     "dcid": "",
     "name": "",

--- a/server/integration_tests/test_data/e2e_default_place/whatdoesadietfordiabeteslooklike/chart_config.json
+++ b/server/integration_tests/test_data/e2e_default_place/whatdoesadietfordiabeteslooklike/chart_config.json
@@ -2,7 +2,7 @@
   "config": {},
   "context": {},
   "debug": {},
-  "pastSourceContext": "USA",
+  "pastSourceContext": "",
   "place": {
     "dcid": "",
     "name": "",

--- a/server/integration_tests/test_data/sdg/query_2/chart_config.json
+++ b/server/integration_tests/test_data/sdg/query_2/chart_config.json
@@ -309,10 +309,10 @@
   },
   "context": {},
   "debug": {},
-  "pastSourceContext": "Earth",
+  "pastSourceContext": "World",
   "place": {
     "dcid": "Earth",
-    "name": "Earth",
+    "name": "World",
     "place_type": "Place"
   },
   "placeFallback": {},
@@ -320,7 +320,7 @@
   "places": [
     {
       "dcid": "Earth",
-      "name": "Earth",
+      "name": "World",
       "place_type": "Place"
     }
   ],

--- a/server/lib/nl/common/commentary.py
+++ b/server/lib/nl/common/commentary.py
@@ -128,7 +128,7 @@ def user_message(uttr: Utterance) -> UserMessage:
       callback = topic_from_context
     elif uttr.place_source == FulfillmentResult.PAST_QUERY and uttr.sv_source == FulfillmentResult.PAST_QUERY:
       callback = place_from_context
-    elif uttr.place_source == FulfillmentResult.DEFAULT and uttr.past_source_context != constants.EARTH_DCID:
+    elif uttr.place_source == FulfillmentResult.DEFAULT and uttr.past_source_context != constants.EARTH.name:
       callback = default_place
 
   msg = ''

--- a/server/lib/nl/common/constants.py
+++ b/server/lib/nl/common/constants.py
@@ -241,8 +241,7 @@ PAK_PLACE_TYPE_REMAP = {
 }
 
 EARTH = Place('Earth', 'World', 'Place')
-USA = Place('country/USA', 'United States of America',
-            'Country', 'country/USA')
+USA = Place('country/USA', 'United States of America', 'Country', 'country/USA')
 
 # Key is US-only map type.
 # Value is a list of corresponding parent place types.

--- a/server/lib/nl/common/constants.py
+++ b/server/lib/nl/common/constants.py
@@ -240,8 +240,9 @@ PAK_PLACE_TYPE_REMAP = {
         ContainedInPlaceType.ADMIN_AREA_3,
 }
 
-EARTH = Place('Earth', 'Earth', 'Place')
-USA = Place('country/USA', 'USA', 'Country', 'country/USA')
+EARTH = Place('Earth', 'World', 'Place')
+USA = Place('country/USA', 'United States of America',
+            'Country', 'country/USA')
 
 # Key is US-only map type.
 # Value is a list of corresponding parent place types.
@@ -260,7 +261,7 @@ USA_ONLY_MAP_TYPES = {
 # This is only for US.
 # Avoid `CITY` -> `USA` since loading maps, etc. takes a really long time.
 DEFAULT_PARENT_PLACES = {
-    ContainedInPlaceType.COUNTRY: Place('Earth', 'Earth', 'Place'),
+    ContainedInPlaceType.COUNTRY: EARTH,
     ContainedInPlaceType.COUNTY: USA,
     ContainedInPlaceType.STATE: USA,
 }

--- a/server/lib/nl/detection/context.py
+++ b/server/lib/nl/detection/context.py
@@ -284,11 +284,13 @@ def _detect_places(uttr: nl_uttr.Utterance, child_type: ContainedInPlaceType,
     if is_sdg:
       uttr.places = [constants.EARTH]
       places = [constants.EARTH_DCID]
+      uttr.place_source = nl_uttr.FulfillmentResult.DEFAULT
+      uttr.past_source_context = constants.EARTH.name
     elif use_default_place:
       uttr.places = [constants.USA]
       places = [constants.USA.dcid]
-    uttr.place_source = nl_uttr.FulfillmentResult.DEFAULT
-    uttr.past_source_context = constants.USA.name
+      uttr.place_source = nl_uttr.FulfillmentResult.DEFAULT
+      uttr.past_source_context = constants.USA.name
 
   return places, cmp_places
 

--- a/server/routes/nl/helpers.py
+++ b/server/routes/nl/helpers.py
@@ -293,7 +293,7 @@ def prepare_response_common(data_dict: Dict,
   data_dict = utils.to_dict(data_dict)
   if test:
     data_dict['test'] = test
-  if current_app.config['LOG_QUERY']:
+  if current_app.config['LOG_QUERY'] and not test:
     # Asynchronously log as bigtable write takes O(100ms)
     loop = asyncio.new_event_loop()
     session_info = futils.get_session_info(data_dict['context'], has_data)
@@ -355,7 +355,7 @@ def abort(error_message: str,
     _set_blocked(data_dict)
 
   logging.info('NL Data API: Empty Exit')
-  if current_app.config['LOG_QUERY']:
+  if current_app.config['LOG_QUERY'] and not test:
     # Asynchronously log as bigtable write takes O(100ms)
     loop = asyncio.new_event_loop()
     session_info = futils.get_session_info(context_history, False)


### PR DESCRIPTION
This fixes the issue where `Earth` would show up as the title instead of World.

Also, avoid logging test queries.