### PR TITLE
Update map tool geo json ready hook

### DIFF
--- a/static/js/tools/map/compute/geojson.ts
+++ b/static/js/tools/map/compute/geojson.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import { Dispatch, useContext, useEffect } from "react";
 import { GeoJsonData } from "../../../chart/types";
 import { ChartDataType, ChartStore, ChartStoreAction } from "../chart_store";
 import { Context } from "../context";
-import { useDefaultStatReady, useGeoJsonReady } from "../ready_hooks";
+import { useDefaultStatReady } from "../ready_hooks";
 import { getGeoJsonDataFeatures, MANUAL_GEOJSON_DISTANCES } from "../util";
 
 // For IPCC grid data, geoJson features is calculated based on the grid
@@ -32,14 +32,13 @@ export function useUpdateGeoJson(
   dispatch: Dispatch<ChartStoreAction>
 ) {
   const { placeInfo } = useContext(Context);
-  const geoJsonReady = useGeoJsonReady(chartStore);
   const defaultStatReady = useDefaultStatReady(chartStore);
 
   useEffect(() => {
     if (
       placeInfo.value.enclosedPlaceType in MANUAL_GEOJSON_DISTANCES &&
-      geoJsonReady() &&
       defaultStatReady() &&
+      !_.isEmpty(chartStore.geoJson.data) &&
       _.isEmpty(chartStore.geoJson.data.features)
     ) {
       console.log("update geo json data features");
@@ -50,6 +49,7 @@ export function useUpdateGeoJson(
       dispatch({
         type: ChartDataType.GEO_JSON,
         error: null,
+        context: chartStore.geoJson.context,
         payload: {
           type: "FeatureCollection",
           properties: { currentGeo: placeInfo.value.enclosingPlace.dcid },
@@ -62,7 +62,6 @@ export function useUpdateGeoJson(
     chartStore.defaultStat,
     placeInfo.value.enclosedPlaceType,
     placeInfo.value.enclosingPlace.dcid,
-    geoJsonReady,
     defaultStatReady,
     dispatch,
   ]);

--- a/static/js/tools/map/fetcher/default_stat.ts
+++ b/static/js/tools/map/fetcher/default_stat.ts
@@ -18,15 +18,10 @@
  * Fetch the default (best available) stat data
  */
 
-import axios from "axios";
 import _ from "lodash";
 import { Dispatch, useContext, useEffect } from "react";
 
-import {
-  EntityObservationWrapper,
-  PointApiResponse,
-} from "../../../shared/stat_types";
-import { stringifyFn } from "../../../utils/axios";
+import { EntityObservationWrapper } from "../../../shared/stat_types";
 import { getPointWithin } from "../../../utils/data_fetch_utils";
 import { ChartDataType, ChartStoreAction } from "../chart_store";
 import { Context } from "../context";

--- a/static/js/tools/map/ready_hooks.ts
+++ b/static/js/tools/map/ready_hooks.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,12 +38,15 @@ export function useGeoJsonReady(chartStore: ChartStore) {
     return (
       !chartStore.geoJson.error &&
       !_.isEmpty(c) &&
+      !_.isEmpty(chartStore.geoJson.data) &&
+      !_.isEmpty(chartStore.geoJson.data.features) &&
       placeInfo.value.enclosingPlace.dcid === c.placeInfo.enclosingPlace.dcid &&
       placeInfo.value.enclosedPlaceType === c.placeInfo.enclosedPlaceType &&
       borderIsReady
     );
   }, [
     chartStore.geoJson.context,
+    chartStore.geoJson.data,
     chartStore.geoJson.error,
     placeInfo.value.enclosingPlace.dcid,
     placeInfo.value.enclosedPlaceType,


### PR DESCRIPTION
Current logic treat geoJson is "ready" even though the data features is empty. This poses an issue when the geoJson is computed for 1deg grid. The render function is entered once, but as geoJson is not ready, it's unmounted, making the later render fail. Not clear why this works for the ipcc_grid, but local testing shows the fix works for existing charts.