### PR TITLE
Added support for web components in screenshot test

### DIFF
--- a/packages/web-components/src/main.ts
+++ b/packages/web-components/src/main.ts
@@ -32,6 +32,10 @@ import {
 
 export type { ChartEventDetail, ChartSortOption } from "./main.d";
 
+/**
+ * Keep in sync with the web component definitions at static/library/*component.ts
+ * and integration tests at server/webdriver/shared.py
+ */
 declare global {
   namespace JSX {
     interface IntrinsicElements {

--- a/server/webdriver/shared.py
+++ b/server/webdriver/shared.py
@@ -23,7 +23,8 @@ MAX_NUM_SPINNERS = 3
 ASYNC_ELEMENT_HOLDER_CLASS = 'dc-async-element-holder'
 ASYNC_ELEMENT_CLASS = 'dc-async-element'
 TIMEOUT = 60
-# Keep in sync with packages/web-components/src/main.ts
+# Keep in sync with the web component definitions at static/library/*component.ts
+# and packages/web-components/src/main.ts
 WEB_COMPONENT_TAG_NAMES = [
     'datacommons-bar', 'datacommons-gauge', 'datacommons-highlight',
     'datacommons-line', 'datacommons-map', 'datacommons-pie',

--- a/server/webdriver/shared.py
+++ b/server/webdriver/shared.py
@@ -23,10 +23,12 @@ MAX_NUM_SPINNERS = 3
 ASYNC_ELEMENT_HOLDER_CLASS = 'dc-async-element-holder'
 ASYNC_ELEMENT_CLASS = 'dc-async-element'
 TIMEOUT = 60
+# Keep in sync with packages/web-components/src/main.ts
 WEB_COMPONENT_TAG_NAMES = [
-    'datacommons-bar', 'datacommons-map', 'datacommons-line',
-    'datacommons-highlight', 'datacommons-gauge', 'datacommons-pie',
-    'datacommons-highlight', 'datacommons-scatter'
+    'datacommons-bar', 'datacommons-gauge', 'datacommons-highlight',
+    'datacommons-line', 'datacommons-map', 'datacommons-pie',
+    'datacommons-ranking', 'datacommons-slider', 'datacommons-text',
+    'datacommons-scatter'
 ]
 
 

--- a/server/webdriver/shared.py
+++ b/server/webdriver/shared.py
@@ -23,15 +23,10 @@ MAX_NUM_SPINNERS = 3
 ASYNC_ELEMENT_HOLDER_CLASS = 'dc-async-element-holder'
 ASYNC_ELEMENT_CLASS = 'dc-async-element'
 TIMEOUT = 60
-WEB_COMPONENT_TAG_NAMES=[
-  'datacommons-bar',
-  'datacommons-map',
-  'datacommons-line',
-  'datacommons-highlight',
-  'datacommons-gauge',
-  'datacommons-pie',
-  'datacommons-highlight',
-  'datacommons-scatter'
+WEB_COMPONENT_TAG_NAMES = [
+    'datacommons-bar', 'datacommons-map', 'datacommons-line',
+    'datacommons-highlight', 'datacommons-gauge', 'datacommons-pie',
+    'datacommons-highlight', 'datacommons-scatter'
 ]
 
 
@@ -67,22 +62,27 @@ def charts_rendered(driver):
   """
   Wait asynchronously for charts or web components to show up
   """
-  web_component_element_present = EC.any_of(*[ EC.presence_of_element_located((By.TAG_NAME, tag_name)) for tag_name in WEB_COMPONENT_TAG_NAMES])
+  web_component_element_present = EC.any_of(*[
+      EC.presence_of_element_located((By.TAG_NAME, tag_name))
+      for tag_name in WEB_COMPONENT_TAG_NAMES
+  ])
   chart_element_present = EC.presence_of_element_located(
       (By.CLASS_NAME, ASYNC_ELEMENT_HOLDER_CLASS))
-  WebDriverWait(driver, TIMEOUT).until(EC.any_of(chart_element_present, web_component_element_present))
+  WebDriverWait(driver, TIMEOUT).until(
+      EC.any_of(chart_element_present, web_component_element_present))
   chart_containers = driver.find_elements(By.CLASS_NAME,
                                           ASYNC_ELEMENT_HOLDER_CLASS)
-  web_component_containers = driver.find_elements(By.CSS_SELECTOR, ", ".join(WEB_COMPONENT_TAG_NAMES))
+  web_component_containers = driver.find_elements(
+      By.CSS_SELECTOR, ", ".join(WEB_COMPONENT_TAG_NAMES))
   for c in chart_containers:
     try:
       c.find_element(By.CLASS_NAME, ASYNC_ELEMENT_CLASS)
     except NoSuchElementException:
       return False
-  
+
   for wc in web_component_containers:
-      header = wc.get_attribute("header")
-      description = wc.get_attribute("description")
-      if not header and not description:
-        return False
+    header = wc.get_attribute("header")
+    description = wc.get_attribute("description")
+    if not header and not description:
+      return False
   return True

--- a/server/webdriver/shared.py
+++ b/server/webdriver/shared.py
@@ -23,6 +23,16 @@ MAX_NUM_SPINNERS = 3
 ASYNC_ELEMENT_HOLDER_CLASS = 'dc-async-element-holder'
 ASYNC_ELEMENT_CLASS = 'dc-async-element'
 TIMEOUT = 60
+WEB_COMPONENT_TAG_NAMES=[
+  'datacommons-bar',
+  'datacommons-map',
+  'datacommons-line',
+  'datacommons-highlight',
+  'datacommons-gauge',
+  'datacommons-pie',
+  'datacommons-highlight',
+  'datacommons-scatter'
+]
 
 
 def wait_for_loading(driver):
@@ -54,16 +64,25 @@ def click_sv_group(driver, svg_name):
 
 
 def charts_rendered(driver):
-  """Wait for asyncronously charts to show up.
   """
-  element_present = EC.presence_of_element_located(
+  Wait asynchronously for charts or web components to show up
+  """
+  web_component_element_present = EC.any_of(*[ EC.presence_of_element_located((By.TAG_NAME, tag_name)) for tag_name in WEB_COMPONENT_TAG_NAMES])
+  chart_element_present = EC.presence_of_element_located(
       (By.CLASS_NAME, ASYNC_ELEMENT_HOLDER_CLASS))
-  WebDriverWait(driver, TIMEOUT).until(element_present)
+  WebDriverWait(driver, TIMEOUT).until(EC.any_of(chart_element_present, web_component_element_present))
   chart_containers = driver.find_elements(By.CLASS_NAME,
                                           ASYNC_ELEMENT_HOLDER_CLASS)
+  web_component_containers = driver.find_elements(By.CSS_SELECTOR, ", ".join(WEB_COMPONENT_TAG_NAMES))
   for c in chart_containers:
     try:
       c.find_element(By.CLASS_NAME, ASYNC_ELEMENT_CLASS)
     except NoSuchElementException:
       return False
+  
+  for wc in web_component_containers:
+      header = wc.get_attribute("header")
+      description = wc.get_attribute("description")
+      if not header and not description:
+        return False
   return True

--- a/static/library/index.ts
+++ b/static/library/index.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * Keep web component definitions in sync with typings at
+ * packages/web-components/src/main.ts and integration tests at
+ * server/webdriver/shared.py
+ */
 import { renderRankingComponent } from "../js/ranking/component";
 import { DatacommonsBarComponent } from "./bar_component";
 import {


### PR DESCRIPTION
Updated `charts_rendered` helper to wait for the web components as well as charts. The original check wasn't working for web components because selenium's element selectors can't reach into the web component shadow root