### PR TITLE
Fix Lint Tests

### DIFF
--- a/build/ci/cloudbuild.npm.yaml
+++ b/build/ci/cloudbuild.npm.yaml
@@ -27,6 +27,7 @@ steps:
         cp -r /resources/node_modules -d static/
 
         # ./run_test.sh -lbc will run lint test, build client packages, and run client tests.
+        set -e
         ./run_test.sh -l
         ./run_test.sh -b
         ./run_test.sh -c

--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -18,6 +18,9 @@
  * Component for rendering a default block (block with no type).
  */
 
+// Import web components
+import "../../../library";
+
 import axios from "axios";
 import React, { useEffect, useRef, useState } from "react";
 import { Input } from "reactstrap";
@@ -55,9 +58,6 @@ import { RankingTile } from "../tiles/ranking_tile";
 import { ScatterTile } from "../tiles/scatter_tile";
 import { Column } from "./column";
 import { StatVarProvider } from "./stat_var_provider";
-
-// Import web components
-import "../../../library";
 
 /**
  * Translates the line tile's timeScale enum to the TimeScaleOption type

--- a/static/js/components/subject_page/category.tsx
+++ b/static/js/components/subject_page/category.tsx
@@ -27,7 +27,7 @@ import {
   EventTypeSpec,
 } from "../../types/subject_page_proto_types";
 import { getId } from "../../utils/subject_page_utils";
-import { ReplacementStrings, formatString } from "../../utils/tile_utils";
+import { formatString, ReplacementStrings } from "../../utils/tile_utils";
 import { ErrorBoundary } from "../error_boundary";
 import { Block } from "./block";
 import { BlockContainer } from "./block_container";

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -18,22 +18,6 @@
  * Component for rendering a bar tile.
  */
 
-import { getPlaceNames, getPlaceType } from "../../utils/place_utils";
-import { getDateRange } from "../../utils/string_utils";
-import {
-  getDenomInfo,
-  getNoDataErrorMsg,
-  getStatFormat,
-  getStatVarNames,
-  ReplacementStrings,
-  showError,
-} from "../../utils/tile_utils";
-import { ChartTileContainer } from "./chart_tile";
-import {
-  ChartOptions,
-  MultiOrContainedInPlaceMultiVariableTileType,
-} from "./tile_types";
-import { useDrawOnResize } from "./use_draw_on_resize";
 import { ChartSortOption } from "@datacommonsorg/web-components";
 import _ from "lodash";
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -60,6 +44,22 @@ import {
   getSeries,
   getSeriesWithin,
 } from "../../utils/data_fetch_utils";
+import { getPlaceNames, getPlaceType } from "../../utils/place_utils";
+import { getDateRange } from "../../utils/string_utils";
+import {
+  getDenomInfo,
+  getNoDataErrorMsg,
+  getStatFormat,
+  getStatVarNames,
+  ReplacementStrings,
+  showError,
+} from "../../utils/tile_utils";
+import { ChartTileContainer } from "./chart_tile";
+import {
+  ChartOptions,
+  MultiOrContainedInPlaceMultiVariableTileType,
+} from "./tile_types";
+import { useDrawOnResize } from "./use_draw_on_resize";
 
 const NUM_PLACES = 7;
 

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -18,10 +18,26 @@
  * Component for rendering a bar tile.
  */
 
+import { getPlaceNames, getPlaceType } from "../../utils/place_utils";
+import { getDateRange } from "../../utils/string_utils";
+import {
+  getDenomInfo,
+  getNoDataErrorMsg,
+  getStatFormat,
+  getStatVarNames,
+  ReplacementStrings,
+  showError,
+} from "../../utils/tile_utils";
+import { ChartTileContainer } from "./chart_tile";
+import {
+  ChartOptions,
+  MultiOrContainedInPlaceMultiVariableTileType,
+} from "./tile_types";
+import { useDrawOnResize } from "./use_draw_on_resize";
+import { ChartSortOption } from "@datacommonsorg/web-components";
 import _ from "lodash";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
-import { ChartSortOption } from "@datacommonsorg/web-components";
 import { VisType } from "../../apps/visualization/vis_type_configs";
 import { DataGroup, DataPoint } from "../../chart/base";
 import {
@@ -44,22 +60,6 @@ import {
   getSeries,
   getSeriesWithin,
 } from "../../utils/data_fetch_utils";
-import { getPlaceNames, getPlaceType } from "../../utils/place_utils";
-import { getDateRange } from "../../utils/string_utils";
-import {
-  ReplacementStrings,
-  getDenomInfo,
-  getNoDataErrorMsg,
-  getStatFormat,
-  getStatVarNames,
-  showError,
-} from "../../utils/tile_utils";
-import { ChartTileContainer } from "./chart_tile";
-import {
-  ChartOptions,
-  MultiOrContainedInPlaceMultiVariableTileType,
-} from "./tile_types";
-import { useDrawOnResize } from "./use_draw_on_resize";
 
 const NUM_PLACES = 7;
 

--- a/static/js/components/tiles/donut_tile.tsx
+++ b/static/js/components/tiles/donut_tile.tsx
@@ -31,11 +31,11 @@ import { getPoint, getSeries } from "../../utils/data_fetch_utils";
 import { getPlaceNames } from "../../utils/place_utils";
 import { getDateRange } from "../../utils/string_utils";
 import {
-  ReplacementStrings,
   getDenomInfo,
   getNoDataErrorMsg,
   getStatFormat,
   getStatVarNames,
+  ReplacementStrings,
   showError,
 } from "../../utils/tile_utils";
 import { ChartTileContainer } from "./chart_tile";

--- a/static/js/components/tiles/line_tile.tsx
+++ b/static/js/components/tiles/line_tile.tsx
@@ -43,10 +43,10 @@ import {
 import { getPlaceNames } from "../../utils/place_utils";
 import { getUnit } from "../../utils/stat_metadata_utils";
 import {
-  ReplacementStrings,
   getNoDataErrorMsg,
   getStatFormat,
   getStatVarNames,
+  ReplacementStrings,
   showError,
 } from "../../utils/tile_utils";
 import { ChartTileContainer } from "./chart_tile";

--- a/static/js/utils/subject_page_utils.ts
+++ b/static/js/utils/subject_page_utils.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ChartSortOption } from "@datacommonsorg/web-components";
 import axios from "axios";
 import _ from "lodash";
 
-import { ChartSortOption } from "@datacommonsorg/web-components";
 import { GeoJsonData } from "../chart/types";
 import {
   NL_LARGE_TILE_CLASS,

--- a/static/library/bar_component.ts
+++ b/static/library/bar_component.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import { ChartSortOption } from "@datacommonsorg/web-components";
 import { css, CSSResult, LitElement, unsafeCSS } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import _ from "lodash";
 
 import tilesCssString from "!!raw-loader!sass-loader!../css/tiles.scss";
 
-import { ChartSortOption } from "@datacommonsorg/web-components";
 import { BarTile, BarTilePropType } from "../js/components/tiles/bar_tile";
 import {
   convertArrayAttribute,

--- a/static/library/slider_component.ts
+++ b/static/library/slider_component.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import { ChartEventDetail } from "@datacommonsorg/web-components";
 import { css, CSSResult, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
-import { ChartEventDetail } from "@datacommonsorg/web-components";
 import { convertArrayAttribute, getApiRoot } from "./utils";
 
 const MOST_RECENT_TEXT = "Most recent";

--- a/static/library/text_component.ts
+++ b/static/library/text_component.ts
@@ -18,7 +18,6 @@ import { css, CSSResult, LitElement, unsafeCSS } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import tilesCssString from "../css/tiles.scss";
-
 import { TextTile, TextTilePropType } from "../js/components/tiles/text_tile";
 import { createWebComponentElement } from "./utils";
 


### PR DESCRIPTION
The `website-pull-request-npm` can pass even when lint tests fail, causing some badly formatted code to be successfully merged. This PR fixes the test, and corrects the files with lint issues.

Root cause was that `website-pull-request-npm` did not exit when the lint test fails and instead silently proceeded, passing if client tests passed. Added `set -e` so that bash exits on a test failure.