### PR TITLE
Bug quick fix: Fix per-capita toggle for US counties scatter plots

### DIFF
--- a/static/js/components/tiles/scatter_tile.tsx
+++ b/static/js/components/tiles/scatter_tile.tsx
@@ -230,16 +230,21 @@ function getPopulationPromise(
   statVarSpec: StatVarSpec[],
   apiRoot?: string
 ): Promise<SeriesApiResponse> {
-  const statVars = [];
+  const statVars = new Set<string>();
   for (const sv of statVarSpec) {
     if (sv.denom) {
-      statVars.push(sv.denom);
+      statVars.add(sv.denom);
     }
   }
   if (_.isEmpty(statVars)) {
     return Promise.resolve(null);
   } else {
-    return getSeriesWithin(apiRoot, placeDcid, enclosedPlaceType, statVars);
+    return getSeriesWithin(
+      apiRoot,
+      placeDcid,
+      enclosedPlaceType,
+      Array.from(statVars)
+    );
   }
 }
 


### PR DESCRIPTION
**Problem:** The "See per-capita" toggle fails on some scatter plots because the scatter tile sends out a duplicate API call for "Count_Person", one for each axis, which can overwhelm mixer when making concurrent fetches because there are too many places to fetch data for.

**Fix:** Remove duplicate denom dcids in the data fetch.

**Testing:** Verified changes locally on explore pages and scatter plot explorer.

| Per Capita Off | Per Capita On |
--- | --- |
| ![Screenshot 2023-10-31 at 11 20 35 AM](https://github.com/datacommonsorg/website/assets/4034366/ae964ff5-5a20-4f9c-a5f4-a3cf155968f6) |  ![Screenshot 2023-10-31 at 11 29 00 AM](https://github.com/datacommonsorg/website/assets/4034366/47c344c2-c63e-4540-95fd-c412d57c87ff) |
