### PR TITLE
[nodejs] update query response

### DIFF
--- a/static/nodejs_server/bar_tile.ts
+++ b/static/nodejs_server/bar_tile.ts
@@ -114,6 +114,7 @@ export async function getBarTileResult(
       legend,
       title: getChartTitle(tileConfig.title, getReplacementStrings(chartData)),
       type: "BAR",
+      unit: chartData.unit,
     };
     if (useChartUrl) {
       result.chartUrl = getChartUrl(

--- a/static/nodejs_server/line_tile.ts
+++ b/static/nodejs_server/line_tile.ts
@@ -18,6 +18,8 @@
  * Functions for getting results for the line tile
  */
 
+import _ from "lodash";
+
 import {
   draw,
   fetchData,
@@ -90,7 +92,23 @@ export async function getLineTileResult(
       legend: chartData.dataGroup.map((dg) => dg.label || "A"),
       title: getChartTitle(tileConfig.title, getReplacementStrings(tileProp)),
       type: "LINE",
+      unit: chartData.unit,
     };
+    // If it is a single line chart, add highlight information.
+    if (chartData.dataGroup && chartData.dataGroup.length === 1) {
+      const dataPoints = _.cloneDeep(chartData.dataGroup[0].value);
+      if (!_.isEmpty(dataPoints)) {
+        dataPoints.sort((a, b) => {
+          const fieldToCompare =
+            a.time && b.time ? "time" : a.date && b.date ? "date" : "label";
+          return a[fieldToCompare] > b[fieldToCompare] ? -1 : 1;
+        });
+        result.highlight = {
+          date: dataPoints[0].label,
+          value: dataPoints[0].value,
+        };
+      }
+    }
     if (useChartUrl) {
       result.chartUrl = getChartUrl(
         tileConfig,

--- a/static/nodejs_server/map_tile.ts
+++ b/static/nodejs_server/map_tile.ts
@@ -144,6 +144,7 @@ export async function getMapTileResult(
         getReplacementStrings(tileProp, chartData)
       ),
       type: "MAP",
+      unit: !_.isEmpty(chartData.layerData) ? chartData.layerData[0].unit : "",
     };
     if (useChartUrl) {
       result.chartUrl = getChartUrl(

--- a/static/nodejs_server/ranking_tile.ts
+++ b/static/nodejs_server/ranking_tile.ts
@@ -117,6 +117,10 @@ function getRankingUnitResult(
       sv
     ),
     type: "TABLE",
+    unit:
+      !_.isEmpty(rankingGroup.unit) && rankingGroup.unit.length == 1
+        ? rankingGroup.unit[0]
+        : "",
   };
 
   if (useChartUrl) {

--- a/static/nodejs_server/types.ts
+++ b/static/nodejs_server/types.ts
@@ -34,4 +34,11 @@ export interface TileResult {
   chartUrl?: string;
   // The svg for the chart in the tile as an xml string. One of chartUrl or svg should be set.
   svg?: string;
+  // The unit of the data in the chart if it's a single unit.
+  unit?: string;
+  // The data point to highlight. Only returned for single line line charts.
+  highlight?: {
+    value: number;
+    date: string;
+  };
 }

--- a/static/src/server.ts
+++ b/static/src/server.ts
@@ -93,6 +93,10 @@ const NS_TO_MS_SCALE_FACTOR = BigInt(1000000);
 const MS_TO_S_SCALE_FACTOR = 1000;
 // The param value for the chartUrl param which indicates using svg
 const CHART_URL_PARAM_SVG = "0";
+// The param value if we should return all charts in /nodejs/query. Otherwise,
+// return QUERY_MAX_RESULTS.
+const SHOW_ALL_URL_PARAM = "1";
+const QUERY_MAX_RESULTS = 3;
 
 const dom = new JSDOM(
   `<html><body><div id="dom-id" style="width:500px"></div></body></html>`,
@@ -457,6 +461,7 @@ app.get("/nodejs/query", (req: Request, res: Response) => {
   const startTime = process.hrtime.bigint();
   const query = req.query.q;
   const useChartUrl = req.query.chartUrl !== CHART_URL_PARAM_SVG;
+  const allResults = req.query.all === SHOW_ALL_URL_PARAM;
   const urlRoot = `${req.protocol}://${req.get("host")}`;
   res.setHeader("Content-Type", "application/json");
   axios
@@ -495,11 +500,17 @@ app.get("/nodejs/query", (req: Request, res: Response) => {
       const tilePromises: Array<Promise<TileResult[] | TileResult>> = [];
       const categories = config["categories"] || [];
       categories.forEach((category, catIdx) => {
+        if (!allResults && tilePromises.length >= QUERY_MAX_RESULTS) {
+          return;
+        }
         const svSpec = {};
         for (const sv in category["statVarSpec"]) {
           svSpec[sv] = category["statVarSpec"][sv];
         }
         category.blocks.forEach((block, blkIdx) => {
+          if (!allResults && tilePromises.length >= QUERY_MAX_RESULTS) {
+            return;
+          }
           const blockId = `cat${catIdx}-blk${blkIdx}`;
           let blockTilePromises = [];
           switch (block.type) {

--- a/static/src/server.ts
+++ b/static/src/server.ts
@@ -93,9 +93,9 @@ const NS_TO_MS_SCALE_FACTOR = BigInt(1000000);
 const MS_TO_S_SCALE_FACTOR = 1000;
 // The param value for the chartUrl param which indicates using svg
 const CHART_URL_PARAM_SVG = "0";
-// The param value if we should return all charts in /nodejs/query. Otherwise,
-// return QUERY_MAX_RESULTS.
-const SHOW_ALL_URL_PARAM = "1";
+// The param value for the allCharts param if we should return all charts in
+// /nodejs/query. Otherwise, return QUERY_MAX_RESULTS number of charts.
+const ALL_CHARTS_URL_PARAM = "1";
 const QUERY_MAX_RESULTS = 3;
 
 const dom = new JSDOM(
@@ -461,7 +461,7 @@ app.get("/nodejs/query", (req: Request, res: Response) => {
   const startTime = process.hrtime.bigint();
   const query = req.query.q;
   const useChartUrl = req.query.chartUrl !== CHART_URL_PARAM_SVG;
-  const allResults = req.query.all === SHOW_ALL_URL_PARAM;
+  const allResults = req.query.allCharts === ALL_CHARTS_URL_PARAM;
   const urlRoot = `${req.protocol}://${req.get("host")}`;
   res.setHeader("Content-Type", "application/json");
   axios


### PR DESCRIPTION
- add `unit` field for all charts
- add `highlight` field for single line line charts
- only return first 3 charts (use `&allCharts=1` to show all charts)

updated response:
https://paste.googleplex.com/5876459951357952

updated response w/ `&all=1`:
https://paste.googleplex.com/5318110008573952