### PR TITLE
Fixed ranking component rendering bug. Updated web components package-lock version

### DIFF
--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datacommonsorg/web-components",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@datacommonsorg/web-components",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@rollup/plugin-typescript": "^11.1.3",
         "bootstrap": "^4.5.2",

--- a/static/library/ranking_component.ts
+++ b/static/library/ranking_component.ts
@@ -166,7 +166,7 @@ export class DatacommonsRankingComponent extends LitElement {
         highestTitle: this.highestTitle,
         lowestTitle: this.lowestTitle,
         rankingCount: this.rankingCount || 5,
-        showHighest: this.showHighest,
+        showHighest: !this.showLowest && !this.showHighestLowest,
         showHighestLowest: this.showHighestLowest,
         showLowest: this.showLowest,
         showMultiColumn: this.showMultiColumn,

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -102,7 +102,7 @@
     },
     "../packages/web-components": {
       "name": "@datacommonsorg/web-components",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@rollup/plugin-typescript": "^11.1.3",
         "bootstrap": "^4.5.2",


### PR DESCRIPTION
Reverted change from https://github.com/datacommonsorg/website/pull/3712/files#diff-c2a36ba6cf48741c18a3d860061b77d19b8245d55643936f5dc778c210b573daL164

that was preventing ranking component from rendering

Fixes: <img width="1249" alt="Screenshot 2023-11-08 at 7 46 30 AM" src="https://github.com/datacommonsorg/website/assets/13766/7dde47d7-d308-4b67-9b90-f88b0bd72311">