### PR TITLE
[testing cronjob] increase history limit

### DIFF
--- a/gke/cron_testing_job.yaml.tpl
+++ b/gke/cron_testing_job.yaml.tpl
@@ -21,8 +21,8 @@ metadata:
 spec:
   # Run every 4 hours
   schedule: "0 */4 * * *"
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 100
+  failedJobsHistoryLimit: 100
   jobTemplate:
     spec:
       backoffLimit: 0


### PR DESCRIPTION
- increase history limit to save the logs of more runs