### PR TITLE
Add metadata for Google Search Console access

### DIFF
--- a/server/templates/static/homepage.html
+++ b/server/templates/static/homepage.html
@@ -27,6 +27,8 @@
  {% block head %}
  <link rel="stylesheet" href={{url_for('static', filename='css/homepage.min.css', t=config['VERSION'])}}>
  <script src={{url_for('static', filename='homepage.js', t=config['VERSION'])}} async></script>
+ <!-- required for Google Search Console access -->
+ <meta name="google-site-verification" content="63gGTTtkTwcSjEijMIuCq5VeaOmz_u0wsvB_bpRubZI" />
  {% endblock %}
 
  {% block content %}


### PR DESCRIPTION
Adds a meta tag to the <head> tags of the homepage, that are required for access to the [Google Search Console](https://search.google.com/search-console/about) tool. The tool will allow us to measure how well datacommons.org is performing in search rankings.

Tag was generated following the steps at https://search.google.com/search-console/welcome and using the "HTML tag" verification method for URL prefix https://datacommons.org

