### PR TITLE
In strict mode, bail on finding temporal words

### DIFF
--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -462,6 +462,8 @@ class ExploreTest(NLWebServerTestCase):
             # This query should return empty result because we don't
             # return low-confidence results.
             'number of headless drivers in california',
+            # This should be blocked because of "december"
+            'how many day beijing snow in december?',
         ],
         mode='strict')
 

--- a/server/integration_tests/test_data/explore_strict_default_place/howmanydaybeijingsnowindecember/chart_config.json
+++ b/server/integration_tests/test_data/explore_strict_default_place/howmanydaybeijingsnowindecember/chart_config.json
@@ -1,0 +1,24 @@
+{
+  "client": "test_detect-and-fulfill",
+  "config": {},
+  "context": {},
+  "debug": {},
+  "pastSourceContext": "",
+  "place": {
+    "dcid": "",
+    "name": "",
+    "place_type": ""
+  },
+  "placeFallback": {},
+  "placeSource": "UNRECOGNIZED",
+  "places": [
+    {
+      "dcid": "",
+      "name": "",
+      "place_type": ""
+    }
+  ],
+  "relatedThings": {},
+  "svSource": "CURRENT_QUERY",
+  "userMessage": ""
+}

--- a/server/lib/nl/common/debug_utils.py
+++ b/server/lib/nl/common/debug_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, cast
+from typing import cast, Dict
 
 from server.lib.nl.detection.types import ClassificationType
 from server.lib.nl.detection.types import Detection

--- a/server/lib/nl/common/debug_utils.py
+++ b/server/lib/nl/common/debug_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
+from typing import Dict, cast
 
 from server.lib.nl.detection.types import ClassificationType
 from server.lib.nl.detection.types import Detection
@@ -86,8 +86,11 @@ def result_with_debug_info(data_dict: Dict, status: str,
         typ = 'Answer Places Reference'
       elif classification.type == ClassificationType.PER_CAPITA:
         typ = 'Per Capita'
+      elif classification.type == ClassificationType.TEMPORAL:
+        typ = 'Temporal'
+      trigger_words = ','.join(classification.attributes.trigger_words).strip()
       if typ:
-        general_parts.append(typ)
+        general_parts.append(f'{typ} ({trigger_words})')
 
   if general_parts:
     general_classification = ' | '.join(general_parts)

--- a/server/lib/nl/detection/heuristic_detector.py
+++ b/server/lib/nl/detection/heuristic_detector.py
@@ -81,6 +81,9 @@ def detect(place_detector_type: PlaceDetectorType, orig_query: str,
 
   if mode == QueryMode.STRICT:
     classifications.append(heuristic_classifiers.detailed_action(query))
+    classifications.append(
+        heuristic_classifiers.general(query, ClassificationType.TEMPORAL,
+                                      "Temporal"))
 
   # Set the Classifications list.
   classifications = [c for c in classifications if c is not None]

--- a/server/lib/nl/detection/types.py
+++ b/server/lib/nl/detection/types.py
@@ -355,6 +355,9 @@ class ClassificationType(IntEnum):
   ANSWER_PLACES_REFERENCE = 13
   PER_CAPITA = 14
   DETAILED_ACTION = 15
+  # Certain types of temporal attributes like
+  # month, day of the week, season, etc.
+  TEMPORAL = 16
   UNKNOWN = 100
 
 

--- a/server/lib/nl/fulfillment/fulfiller.py
+++ b/server/lib/nl/fulfillment/fulfiller.py
@@ -43,9 +43,7 @@ def fulfill(uttr: Utterance, explore_mode: bool = False) -> PopulateState:
   # Construct a common PopulateState
   state = PopulateState(uttr=uttr)
 
-  detailed_action = utils.get_action_verbs(uttr)
-  if detailed_action:
-    uttr.counters.info('fulfill_detailed_action_querytypes', detailed_action)
+  if not _perform_strict_mode_checks(uttr):
     return state
 
   # IMPORTANT: Do this as the very first thing before
@@ -141,6 +139,21 @@ def fulfill(uttr: Utterance, explore_mode: bool = False) -> PopulateState:
     state.uttr.sv_source = FulfillmentResult.UNKNOWN
 
   return state
+
+
+# Returns False if the checks fail (aka should not proceed).
+def _perform_strict_mode_checks(uttr: Utterance) -> bool:
+  detailed_action = utils.get_action_verbs(uttr)
+  if detailed_action:
+    uttr.counters.info('fulfill_detailed_action_querytypes', detailed_action)
+    return False
+
+  if futils.classifications_of_type(uttr.classifications,
+                                    dtypes.ClassificationType.TEMPORAL):
+    uttr.counters.info('fulfill_temporal_types_detected', [])
+    return False
+
+  return True
 
 
 def _produce_query_types(uttr: Utterance) -> List[QueryType]:

--- a/shared/lib/constants.py
+++ b/shared/lib/constants.py
@@ -342,8 +342,44 @@ QUERY_CLASSIFICATION_HEURISTICS: Dict[str, Union[List[str], Dict[
         "AnswerPlacesReference": ["these", "those"],
         "PerCapita": [
             "fraction", "percent", "percentage", "per capita", "percapita"
+        ],
+        "Temporal": [
+            # Day of week
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday",
+            # Month of year
+            "january",
+            "february",
+            "march",
+            "april",
+            "may",
+            "june",
+            "july",
+            "august",
+            "september",
+            "october",
+            "november",
+            "december",
+            # Season
+            "spring",
+            "summer",
+            "winter",
+            "autumn",
+            # Others
+            "today",
+            "yesterday",
+            "tomorrow",
         ]
     }
+
+# We do not want to strip words from events / superlatives / temporal
+# since we want those to match SVs too!
+HEURISTIC_TYPES_IN_VARIABLES = frozenset(["Event", "Superlative", "Temporal"])
 
 PLACE_TYPE_TO_PLURALS: Dict[str, str] = {
     "place": "places",

--- a/shared/lib/utils.py
+++ b/shared/lib/utils.py
@@ -38,8 +38,7 @@ def _add_classification_heuristics(set_strings: Set[str]) -> None:
         set_strings: the set of Strings to add to.
     """
   for (ctype, v) in constants.QUERY_CLASSIFICATION_HEURISTICS.items():
-    # Skip events since we want those to match SVs too!
-    if ctype == "Event" or ctype == "Superlative":
+    if ctype in constants.HEURISTIC_TYPES_IN_VARIABLES:
       continue
     if isinstance(v, list):
       # If 'v' is a list, add all the words.

--- a/shared/tests/lib/utils_test.py
+++ b/shared/tests/lib/utils_test.py
@@ -56,7 +56,7 @@ class TestUtilsAddToSet(unittest.TestCase):
     # dictionary (of lists). The strings themselves are also sentences
     # which need to be split in to words.
     for ctype, d_vals in constants.QUERY_CLASSIFICATION_HEURISTICS.items():
-      if ctype == 'Event' or ctype == 'Superlative':
+      if ctype in constants.HEURISTIC_TYPES_IN_VARIABLES:
         continue
       vals_list = []
       if type(d_vals) == list:


### PR DESCRIPTION
In strict mode, when we know we don't specially handle certain temporal words (like december), better to to not continue processing.

![image](https://github.com/datacommonsorg/website/assets/4375037/7e1f551c-b54a-407f-9742-91c282c92c02)
