### PR TITLE
Enable scatter webdriver tests now that mixer place info performance issue is fixed

### DIFF
--- a/server/webdriver/tests/scatter_test.py
+++ b/server/webdriver/tests/scatter_test.py
@@ -149,7 +149,6 @@ class TestScatter(WebdriverBaseTest):
     circles = chart.find_elements(By.TAG_NAME, 'circle')
     self.assertGreater(len(circles), 20)
 
-  @unittest.skip("Timeout failures.")
   def test_landing_page_link(self):
     self.driver.get(self.url_ + SCATTER_URL)
 

--- a/server/webdriver/tests/vis_scatter_test.py
+++ b/server/webdriver/tests/vis_scatter_test.py
@@ -252,7 +252,6 @@ class TestVisScatter(WebdriverBaseTest):
     circles = chart.find_elements(By.TAG_NAME, 'circle')
     self.assertGreater(len(circles), 20)
 
-  @unittest.skip("Timeout failures.")
   def test_landing_page_link(self):
     """Test one of the links on the landing page
     """


### PR DESCRIPTION
Fix is https://github.com/datacommonsorg/mixer/pull/1305