### PR TITLE
[nodejs] Update multi-cluster setup

### DIFF
--- a/docs/iap.md
+++ b/docs/iap.md
@@ -48,12 +48,15 @@ Deploy backend config and service
 ```bash
 # In <REPO_ROOT>/gke
 kubectl apply -f backendconfig_iap.yaml
-kubectl apply -f mcs.yaml
+kubectl apply -f website_mcs.yaml
+# [OPTIONAL] run this to deploy the nodejs service
+kubectl apply -f website_nodejs_mcs.yaml
 
 cp mci.yaml.tpl mci.yaml
 # Update <IP> to be the static IP of the website, which can be found in
 # <REPO_ROOT>/deploy/gke/<ENV>.yaml,
 # [Optional] change the certificate to match the current SSL certificate
+# [Optional] remove the nodejs path if not deploying nodejs service
 kubectl apply -f mci.yaml
 ```
 

--- a/gke/README.md
+++ b/gke/README.md
@@ -74,11 +74,14 @@ the file to describe the environment the clusters are being used for.
     ```
 
 1. (Optional) If you're using multiple clusters, run the following script to
-   setup multi-cluster ingress and services.
+   setup multi-cluster ingress and services. Use the "-n" flag to include the nodejs server in the setup.
 
     ```bash
-    # Set up multi-cluster ingress and service
+    # Set up multi-cluster ingress and service WITHOUT nodejs
     ./setup_config_cluster.sh
+
+    # Set up multi-cluster ingress and service WITH nodejså
+    ./setup_config_cluster.sh -n
     ```
 
 ### DNS setup
@@ -113,11 +116,11 @@ where `<ENV>` refers to the name of the instance and `<REGION>` is the region of
 
 ## Update cluster config
 
-If multi-cluster ingress and service needs to be updated, then for each region that needs to be updated, run:
+If multi-cluster ingress and service needs to be updated, then for each region that needs to be updated, run the following commands. The "-n" flag determines whether or not to set up a nodejs server (include "-n" to setup nodejs).
 
 ```bash
 gcloud config set project <PROJECT>
-./update_config_cluster.sh -e <ENV> -l <REGION>
+./update_config_cluster.sh -e <ENV> -l <REGION> -n
 ```
 
 where `<ENV>` refers to the name of the instance and `<REGION>` is the region of the cluster.

--- a/gke/README.md
+++ b/gke/README.md
@@ -80,7 +80,7 @@ the file to describe the environment the clusters are being used for.
     # Set up multi-cluster ingress and service WITHOUT nodejs
     ./setup_config_cluster.sh
 
-    # Set up multi-cluster ingress and service WITH nodejså
+    # Set up multi-cluster ingress and service WITH nodejs
     ./setup_config_cluster.sh -n
     ```
 

--- a/gke/update_config_cluster.sh
+++ b/gke/update_config_cluster.sh
@@ -16,19 +16,23 @@
 set -e
 
 function help {
-  echo "Usage: $0 -el"
+  echo "Usage: $0 -eln"
   echo "-e       Instance environment as defined under ../deploy/gke"
   echo "-l       GKE region Default: us-central1"
+  echo "-n       Setup nodejs service"
   exit 1
 }
 
-while getopts ":e:l:" OPTION; do
+while getopts ":e:l:n?" OPTION; do
   case $OPTION in
     e)
       ENV=$OPTARG
       ;;
     l)
       LOCATION=$OPTARG
+      ;;
+    n)
+      export SETUP_NODEJS=true
       ;;
     *)
       help
@@ -57,10 +61,19 @@ gcloud container clusters get-credentials $CLUSTER_NAME \
 cp mci.yaml.tpl mci.yaml
 export IP=$(gcloud compute addresses list --global --filter='name:dc-website-ip' --format='value(ADDRESS)')
 yq eval -i '.metadata.annotations."networking.gke.io/static-ip" = env(IP)' mci.yaml
+# If not setting up nodejs service, remove the nodejs path from the mci.yaml
+if [[ -z $SETUP_NODEJS ]]; then
+  yq eval -i 'del(.spec.template.spec.rules.[].http.paths[] | select(.backend.serviceName == "website-nodejs-mcs"))' mci.yaml
+fi
 
 # Apply configs
 kubectl apply -f backendconfig.yaml
 kubectl apply -f mci.yaml
-kubectl apply -f mcs.yaml
+kubectl apply -f website_mcs.yaml
+# If setting up nodejs service, apply the mcs yaml definition for nodejs
+if [[ $SETUP_NODEJS ]]; then
+  kubectl apply -f website_nodejs_mcs.yaml
+fi
+
 
 # Check the status: `kubectl describe mci website -n website`

--- a/gke/website_mcs.yaml
+++ b/gke/website_mcs.yaml
@@ -1,0 +1,33 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: networking.gke.io/v1
+kind: MultiClusterService
+metadata:
+  name: website-mcs
+  namespace: website
+  annotations:
+    # Refers to the backend config from backendconfig.yaml.
+    # This is to get 60s timeout for the Cloud Load Balancer.
+    cloud.google.com/backend-config: '{"ports": {"8080":"backendconfig"}}'
+spec:
+  template:
+    spec:
+      selector:
+        app: website-app
+      ports:
+        - name: web
+          protocol: TCP
+          port: 8080
+          targetPort: 8080
+

--- a/gke/website_nodejs_mcs.yaml
+++ b/gke/website_nodejs_mcs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,29 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: networking.gke.io/v1
-kind: MultiClusterService
-metadata:
-  name: website-mcs
-  namespace: website
-  annotations:
-    # Refers to the backend config from backendconfig.yaml.
-    # This is to get 60s timeout for the Cloud Load Balancer.
-    cloud.google.com/backend-config: '{"ports": {"8080":"backendconfig"}}'
-spec:
-  template:
-    spec:
-      selector:
-        app: website-app
-      ports:
-        - name: web
-          protocol: TCP
-          port: 8080
-          targetPort: 8080
-
----
-
 apiVersion: networking.gke.io/v1
 kind: MultiClusterService
 metadata:


### PR DESCRIPTION
Update multi cluster setup scripts to have control over whether or not nodejs service gets added in the setup
- new "-n" flag to denote whether or not to set up the nodejs service
- split the yaml definitions for the nodejs service and website service into their own separate yaml files