### PR TITLE
[Place Page] Add nl search bar to place page

### DIFF
--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -28,6 +28,7 @@ limitations under the License.
 
 {% block content %}
 <div id="body" class="container-fluid">
+  <div id="nl-search-bar"></div>
   <div id="body-row" class="row">
     <div id="sidebar-outer" class="col-md-3x col-lg-2 order-last order-lg-0">
       <div id="sidebar-top-spacer" class="d-none d-lg-block"></div>
@@ -53,9 +54,6 @@ limitations under the License.
                 placeholder="{% trans %}Enter a country, state, county or city{% endtrans %}" type="text" />
             </div>
           </div>
-          <!-- <h4>Graph browser</h4> -->
-          <h4 id="place-dcid" class="mt-3 mt-m-0"><span><a href="/browser/{{place_dcid}}">{% trans %}Graph Browser{%
-                endtrans %} ›</a></span></h4>
         </div>
       </div>
       <div id="place-summary" class="row-col" data-summary="{{ place_summary or '' }}"></div>

--- a/static/css/place/place.scss
+++ b/static/css/place/place.scss
@@ -23,6 +23,7 @@
 @import "../shared/story_block.scss";
 @import "../shared/story_chart.scss";
 @import "../shared/modal.scss";
+@import "../nl_search_bar";
 
 $vertical-section-border: 1px solid var(--dc-gray-lite);
 $vertical-section-margin: 2rem;
@@ -40,6 +41,7 @@ $chart-border: 0.5px solid #dee2e6;
 #dc-places {
   margin-left: 1.5rem;
   margin-right: 1.5rem;
+  margin-top: 20px;
 
   @include media-breakpoint-up(md) {
     margin-left: 3rem;

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -20,7 +20,15 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { PageData } from "../chart/types";
+import { NlSearchBar } from "../components/nl_search_bar";
 import { loadLocaleData } from "../i18n/i18n";
+import {
+  GA_EVENT_NL_SEARCH,
+  GA_PARAM_QUERY,
+  GA_PARAM_SOURCE,
+  GA_VALUE_SEARCH_SOURCE_EXPLORE_LANDING,
+  triggerGAEvent,
+} from "../shared/ga_events";
 import { initSearchAutocomplete } from "../shared/place_autocomplete";
 import { ChildPlace } from "./child_places_menu";
 import { MainPane, showOverview } from "./main_pane";
@@ -123,6 +131,18 @@ async function getLandingPageData(
     });
 }
 
+/**
+ * Handler for NL search bar
+ * @param q search query entered by user
+ */
+function onSearch(q: string): void {
+  triggerGAEvent(GA_EVENT_NL_SEARCH, {
+    [GA_PARAM_QUERY]: q,
+    [GA_PARAM_SOURCE]: GA_VALUE_SEARCH_SOURCE_EXPLORE_LANDING,
+  });
+  window.location.href = `/explore#q=${encodeURIComponent(q)}&dc=main`;
+}
+
 function renderPage(): void {
   const urlParams = new URLSearchParams(window.location.search);
   const urlHash = window.location.hash;
@@ -155,6 +175,17 @@ function renderPage(): void {
       loadingElem.style.display = "none";
       const data: PageData = landingPageData;
       const isUsaPlace = isPlaceInUsa(dcid, data.parentPlaces);
+      ReactDOM.render(
+        React.createElement(NlSearchBar, {
+          inputId: "query-search-input",
+          onSearch,
+          placeholder: `Enter a question about ${placeName} to explore`,
+          initialValue: "",
+          shouldAutoFocus: false,
+        }),
+        document.getElementById("nl-search-bar")
+      );
+
       ReactDOM.render(
         React.createElement(Menu, {
           pageChart: data.pageChart,

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -177,10 +177,10 @@ function renderPage(): void {
       const isUsaPlace = isPlaceInUsa(dcid, data.parentPlaces);
       ReactDOM.render(
         React.createElement(NlSearchBar, {
+          initialValue: "",
           inputId: "query-search-input",
           onSearch,
           placeholder: `Enter a question about ${placeName} to explore`,
-          initialValue: "",
           shouldAutoFocus: false,
         }),
         document.getElementById("nl-search-bar")

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -140,7 +140,7 @@ function onSearch(q: string): void {
     [GA_PARAM_QUERY]: q,
     [GA_PARAM_SOURCE]: GA_VALUE_SEARCH_SOURCE_EXPLORE_LANDING,
   });
-  window.location.href = `/explore#q=${encodeURIComponent(q)}&dc=main`;
+  window.location.href = `/explore#q=${encodeURIComponent(q)}`;
 }
 
 function renderPage(): void {

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -26,7 +26,7 @@ import {
   GA_EVENT_NL_SEARCH,
   GA_PARAM_QUERY,
   GA_PARAM_SOURCE,
-  GA_VALUE_SEARCH_SOURCE_EXPLORE_LANDING,
+  GA_VALUE_SEARCH_SOURCE_PLACE_PAGE,
   triggerGAEvent,
 } from "../shared/ga_events";
 import { initSearchAutocomplete } from "../shared/place_autocomplete";
@@ -138,7 +138,7 @@ async function getLandingPageData(
 function onSearch(q: string): void {
   triggerGAEvent(GA_EVENT_NL_SEARCH, {
     [GA_PARAM_QUERY]: q,
-    [GA_PARAM_SOURCE]: GA_VALUE_SEARCH_SOURCE_EXPLORE_LANDING,
+    [GA_PARAM_SOURCE]: GA_VALUE_SEARCH_SOURCE_PLACE_PAGE,
   });
   window.location.href = `/explore#q=${encodeURIComponent(q)}`;
 }

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -191,3 +191,4 @@ export const GA_VALUE_TOOL_CHART_OPTION_FILTER_BY_POPULATION =
 export const GA_VALUE_SEARCH_SOURCE_EXPLORE = "explore";
 export const GA_VALUE_SEARCH_SOURCE_EXPLORE_LANDING = "explore_landing";
 export const GA_VALUE_SEARCH_SOURCE_HOMEPAGE = "homepage";
+export const GA_VALUE_SEARCH_SOURCE_PLACE_PAGE = "place";


### PR DESCRIPTION
As followup to https://github.com/datacommonsorg/website/pull/3825, this PR replaces the tiny "Graph Browser" link on the place pages with the NL search bar on top of the page, following the design set in our figma mocks.

Updating the UI treatment for switching places, tabbing sections, and chart styling will come in future PRs.

Before:
![Screenshot 2023-12-13 at 12 57 29 PM](https://github.com/datacommonsorg/website/assets/4034366/4cf43abc-63b2-436e-b279-2a10deeb46e1)

After:
![Screenshot 2023-12-13 at 12 57 49 PM](https://github.com/datacommonsorg/website/assets/4034366/2711d0d9-3a9b-4705-9cc1-3db2325ddd48)
