### PR TITLE
[nl] Use facetId in timeline config

### DIFF
--- a/server/integration_tests/test_data/demo_feb2023/query_2/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_2/chart_config.json
@@ -71,7 +71,7 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "Count_FireIncidentComplex_2022"
+                      "Count_FireIncidentComplex_2022_2791262687"
                     ],
                     "title": "Count of Fire Incident Complex Event in California",
                     "type": "LINE"
@@ -99,7 +99,7 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "Count_WildfireEvent_2022"
+                      "Count_WildfireEvent_2022_3627417845"
                     ],
                     "title": "Wildfires in California",
                     "type": "LINE"
@@ -160,6 +160,12 @@
             "name": "Count of Fire Incident Complex Event",
             "statVar": "Count_FireIncidentComplex"
           },
+          "Count_FireIncidentComplex_2022_2791262687": {
+            "date": "2022",
+            "facetId": "2791262687",
+            "name": "Count of Fire Incident Complex Event",
+            "statVar": "Count_FireIncidentComplex"
+          },
           "Count_PrescribedFireEvent_2022": {
             "date": "2022",
             "name": "Count of Prescribed Fire Event",
@@ -167,6 +173,12 @@
           },
           "Count_WildfireEvent_2022": {
             "date": "2022",
+            "name": "Wildfires",
+            "statVar": "Count_WildfireEvent"
+          },
+          "Count_WildfireEvent_2022_3627417845": {
+            "date": "2022",
+            "facetId": "3627417845",
             "name": "Wildfires",
             "statVar": "Count_WildfireEvent"
           },

--- a/server/integration_tests/test_data/e2e_single_date/lifeexpectancyinusstatesin2018/chart_config.json
+++ b/server/integration_tests/test_data/e2e_single_date/lifeexpectancyinusstatesin2018/chart_config.json
@@ -41,7 +41,7 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "LifeExpectancy_Person_2018"
+                      "LifeExpectancy_Person_2018_3397709707"
                     ],
                     "title": "Life Expectancy in United States",
                     "type": "LINE"
@@ -131,8 +131,8 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "LifeExpectancy_Person_Female_2018",
-                      "LifeExpectancy_Person_Male_2018"
+                      "LifeExpectancy_Person_Female_2018_3397709707",
+                      "LifeExpectancy_Person_Male_2018_3397709707"
                     ],
                     "title": "Life Expectancy by Gender in United States",
                     "type": "LINE"
@@ -149,13 +149,31 @@
             "name": "Life Expectancy",
             "statVar": "LifeExpectancy_Person"
           },
+          "LifeExpectancy_Person_2018_3397709707": {
+            "date": "2018",
+            "facetId": "3397709707",
+            "name": "Life Expectancy",
+            "statVar": "LifeExpectancy_Person"
+          },
           "LifeExpectancy_Person_Female_2018": {
             "date": "2018",
             "name": "Female Life Expectancy",
             "statVar": "LifeExpectancy_Person_Female"
           },
+          "LifeExpectancy_Person_Female_2018_3397709707": {
+            "date": "2018",
+            "facetId": "3397709707",
+            "name": "Female Life Expectancy",
+            "statVar": "LifeExpectancy_Person_Female"
+          },
           "LifeExpectancy_Person_Male_2018": {
             "date": "2018",
+            "name": "Male Life Expectancy",
+            "statVar": "LifeExpectancy_Person_Male"
+          },
+          "LifeExpectancy_Person_Male_2018_3397709707": {
+            "date": "2018",
+            "facetId": "3397709707",
             "name": "Male Life Expectancy",
             "statVar": "LifeExpectancy_Person_Male"
           }

--- a/server/integration_tests/test_data/e2e_single_date/populationintheusinthelastyear/chart_config.json
+++ b/server/integration_tests/test_data/e2e_single_date/populationintheusinthelastyear/chart_config.json
@@ -10,7 +10,7 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "Count_Person_2022"
+                      "Count_Person_2022_2176550201"
                     ],
                     "title": "Population in United States",
                     "type": "LINE"
@@ -69,7 +69,7 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "Count_Person_PerArea_2022"
+                      "Count_Person_PerArea_2022_1151455814"
                     ],
                     "title": "Population Density in United States",
                     "type": "LINE"
@@ -131,8 +131,20 @@
             "name": "Population",
             "statVar": "Count_Person"
           },
+          "Count_Person_2022_2176550201": {
+            "date": "2022",
+            "facetId": "2176550201",
+            "name": "Population",
+            "statVar": "Count_Person"
+          },
           "Count_Person_PerArea_2022": {
             "date": "2022",
+            "name": "Population Density",
+            "statVar": "Count_Person_PerArea"
+          },
+          "Count_Person_PerArea_2022_1151455814": {
+            "date": "2022",
+            "facetId": "1151455814",
             "name": "Population Density",
             "statVar": "Count_Person_PerArea"
           }

--- a/server/lib/nl/config_builder/builder.py
+++ b/server/lib/nl/config_builder/builder.py
@@ -108,7 +108,7 @@ def build(state: PopulateState, config: Config) -> SubjectPageConfig:
                                         cspec.single_date))
         stat_var_spec_map = timeline.single_place_single_var_timeline_block(
             block.columns.add(), cspec.places[0], cspec.svs[0], sv2thing,
-            cspec.single_date)
+            cspec.single_date, cv)
         if not cspec.is_sdg:
           stat_var_spec_map.update(
               highlight.highlight_block(block.columns.add(), cspec.places[0],

--- a/server/lib/nl/fulfillment/existence.py
+++ b/server/lib/nl/fulfillment/existence.py
@@ -34,6 +34,8 @@ class ChartVarsExistenceCheckState:
   # Existing svs from among chart_vars.svs
   # Note that `chart_vars` is not mutated to point to existing SVs.
   exist_svs: List[str]
+  # Map of existing svs to id of facet that exists for that SV.
+  exist_sv_facet_ids: Dict[str, str]
   # Set only if chart_vars.event is true, to indicate event existence.
   exist_event: bool = False
 
@@ -56,8 +58,8 @@ class ExistenceCheckTracker:
     self.places = sorted(place2keys.keys())
     self.all_svs = set()
     self.exist_sv_states: List[SVExistenceCheckState] = []
-    # Map of existing SVs with key as SV DCID and value as
-    # whether the SV has single-data point.
+    # Map of existing SVs with key as SV DCID and value as an ID to a facet that
+    # has data for that SV.
     self.existing_svs = {}
 
   def _run(self):
@@ -96,6 +98,7 @@ class ExistenceCheckTracker:
         for sv in ecv.chart_vars.svs:
           if sv in self.existing_svs:
             ecv.exist_svs.append(sv)
+            ecv.exist_sv_facet_ids = self.existing_svs
 
   # Get chart-vars for addition to charts
   def get_chart_vars(self,
@@ -103,6 +106,7 @@ class ExistenceCheckTracker:
     cv = cv_existence.chart_vars
     # Set existing SVs.
     cv.svs = cv_existence.exist_svs
+    cv.sv_exist_facet_id = cv_existence.exist_sv_facet_ids
     return cv
 
 
@@ -121,7 +125,8 @@ class MainExistenceCheckTracker(ExistenceCheckTracker):
       exist_state = SVExistenceCheckState(sv=sv, chart_vars_list=[])
       for chart_vars in chart_vars_list:
         exist_cv = ChartVarsExistenceCheckState(chart_vars=chart_vars,
-                                                exist_svs=[])
+                                                exist_svs=[],
+                                                exist_sv_facet_ids={})
         if chart_vars.event:
           exist_cv.exist_event = utils.event_existence_for_place(
               places[0], chart_vars.event, self.state.uttr.counters)
@@ -176,7 +181,8 @@ class ExtensionExistenceCheckTracker(ExistenceCheckTracker):
                 svs=extended_svs,
                 orig_sv_map={sv: extended_svs},
                 is_topic_peer_group=True),
-                                         exist_svs=[]))
+                                         exist_svs=[],
+                                         exist_sv_facet_ids={}))
         self.all_svs.update(extended_svs)
 
       # If we have the main chart-vars or extended-svs, add.

--- a/server/lib/nl/fulfillment/types.py
+++ b/server/lib/nl/fulfillment/types.py
@@ -71,6 +71,10 @@ class ChartVars:
   # Set if is_topic_peer_group is set.
   svpg_id: str = ''
 
+  # Map of sv to id of facet that has data for this sv. Only used by LINE tiles
+  # when there is a date specified.
+  sv_exist_facet_id = Dict[str, str]
+
 
 @dataclass
 class SV2Thing:


### PR DESCRIPTION
Fix a problem with date handling where only a specific series has data for specified date, but the LINE tile may use a different series. This fix makes NL pass the facet id of the series that we want used (if it matters) to the config.

before: https://screenshot.googleplex.com/4LGnpRH3x9FsULs (notice that the line chart starts after 2001)
after: https://screenshot.googleplex.com/9cgjkFrcUCEEtcN