### PR TITLE
Fix repo tests

### DIFF
--- a/server/routes/event/html.py
+++ b/server/routes/event/html.py
@@ -128,6 +128,8 @@ def find_best_place_for_config(places: Dict[str, List[str]]) -> str:
     Returns a single place dcid to use for the subject page config (preferring
     the lowest granularity for topic).
     """
+  if not places:
+    return None
   for container in DEFAULT_CONTAINED_PLACE_TYPES.keys():
     for place_dcid, type_list in reversed(list(places.items())):
       if container in type_list:
@@ -143,9 +145,9 @@ def event_node(dcid=DEFAULT_EVENT_DCID):
   node_name = escape(dcid)
   properties = {}
   try:
-    name_results = shared_api.names([dcid])
-    if dcid in name_results.keys():
-      node_name = name_results.get(dcid)
+    name_result = shared_api.names([dcid]).get(dcid, '')
+    if name_result:
+      node_name = name_result
     properties = fetch.triples([dcid]).get(dcid, {})
   except Exception as e:
     logging.info(e)
@@ -161,7 +163,6 @@ def event_node(dcid=DEFAULT_EVENT_DCID):
   subject_config = copy.deepcopy(raw_subject_config)
   places = get_places(properties)
   place_dcid = find_best_place_for_config(places)
-
   subject_page_args = EMPTY_SUBJECT_PAGE_ARGS
   if place_dcid:
     place_metadata = lib_subject_page_config.place_metadata(

--- a/server/tests/nodejs_e2e_test.py
+++ b/server/tests/nodejs_e2e_test.py
@@ -64,3 +64,5 @@ class IntegrationTest(unittest.TestCase):
     self.run_test('scatter_non_bard',
                   'obesity vs. poverty in counties of california', "", "dc")
     self.run_test('disaster', 'fires in california')
+    self.run_test('rank_top_only',
+                  'California counties with the highest female population')

--- a/server/tests/test_data/nodejs_query/disaster/screenshot.json
+++ b/server/tests/test_data/nodejs_query/disaster/screenshot.json
@@ -22,7 +22,7 @@
       "dcUrl": "https://datacommons.org/explore#q=fires%20in%20california"
     },
     {
-      "data_csv": "rank,place,Count of Wildland Fire Event\r\n1,Riverside County,13\r\n2,San Bernardino County,10\r\n3,El Dorado County,10\r\n4,Tehama County,8\r\n5,Plumas County,7\r\n6,Fresno County,7\r\n7,Ventura County,6\r\n8,Sonoma County,6\r\n9,Shasta County,5\r\n10,Nevada County,5",
+      "data_csv": "rank,place,Count of Wildland Fire Event\r\n1,Riverside County,13\r\n2,San Bernardino County,10\r\n3,El Dorado County,10\r\n4,Tehama County,8\r\n5,Plumas County,7\r\n54,Kings County,1\r\n55,Kern County,1\r\n56,Inyo County,1\r\n57,Del Norte County,1\r\n58,Contra Costa County,1",
       "srcs": [
         {
           "name": "data-nifc.opendata.arcgis.com",

--- a/server/tests/test_data/nodejs_query/rank_top_only/screenshot.json
+++ b/server/tests/test_data/nodejs_query/rank_top_only/screenshot.json
@@ -1,0 +1,51 @@
+{
+  "charts": [
+    {
+      "data_csv": "rank,place,Women\r\n1,Los Angeles County,5055907\r\n2,San Diego County,1628153\r\n3,Orange County,1604231\r\n4,Riverside County,1201934\r\n5,San Bernardino County,1085470\r\n6,Santa Clara County,948198\r\n7,Alameda County,845577\r\n8,Sacramento County,798959\r\n9,Contra Costa County,590637\r\n10,Fresno County,500456",
+      "srcs": [
+        {
+          "name": "census.gov",
+          "url": "https://www.census.gov/programs-surveys/acs/data/data-via-ftp.html"
+        }
+      ],
+      "title": "Women in Counties of California (2021)",
+      "type": "TABLE",
+      "unit": "",
+      "dcUrl": "https://datacommons.org/explore#q=California%20counties%20with%20the%20highest%20female%20population"
+    },
+    {
+      "data_csv": "label,Women\r\n2021,19741309\r\n2020,19783141\r\n2019,19757199\r\n2018,19694991\r\n2017,19616268\r\n2016,19453236\r\n2015,19334329\r\n2014,19155401\r\n2013,18932713\r\n2012,18764048\r\n2011,18581482",
+      "srcs": [
+        {
+          "name": "census.gov",
+          "url": "https://www.census.gov/programs-surveys/acs/data/data-via-ftp.html"
+        }
+      ],
+      "legend": [
+        "Women"
+      ],
+      "title": "Women in California",
+      "type": "LINE",
+      "unit": "",
+      "highlight": {
+        "date": "2021",
+        "value": 19741309
+      },
+      "chartUrl": "",
+      "dcUrl": "https://datacommons.org/explore#q=California%20counties%20with%20the%20highest%20female%20population"
+    },
+    {
+      "data_csv": "rank,place,Women over 85\r\n1,Los Angeles County,118481\r\n2,Orange County,39726\r\n3,San Diego County,36521\r\n4,Riverside County,23571\r\n5,Santa Clara County,22817\r\n6,Alameda County,18943\r\n7,Sacramento County,17587\r\n8,San Bernardino County,17092\r\n9,San Francisco County,13962\r\n10,Contra Costa County,13826",
+      "srcs": [
+        {
+          "name": "census.gov",
+          "url": "https://www.census.gov/programs-surveys/acs/data/data-via-ftp.html"
+        }
+      ],
+      "title": "Women Over 85 in Counties of California (2021)",
+      "type": "TABLE",
+      "unit": "",
+      "dcUrl": "https://datacommons.org/explore#q=California%20counties%20with%20the%20highest%20female%20population"
+    }
+  ]
+}

--- a/server/tests/test_data/nodejs_query/scatter/screenshot.json
+++ b/server/tests/test_data/nodejs_query/scatter/screenshot.json
@@ -1,7 +1,24 @@
 {
   "charts": [
     {
-      "data_csv": "rank,place,Prevalence of Obesity\r\n1,San Bernardino County,38.1\r\n2,Imperial County,38\r\n3,Fresno County,36.8\r\n4,Kern County,36.6\r\n5,Riverside County,36.2\r\n6,Madera County,35.9\r\n7,Tulare County,35.5\r\n8,Kings County,35.1\r\n9,Stanislaus County,34.8\r\n10,Tehama County,34.2",
+      "data_csv": "placeName,placeDcid,xDate,xValue-Count_Person_BelowPovertyLevelInThePast12Months,yDate,yValue-Percent_Person_Obesity\r\n\"Alameda County, CA\",geoId/06001,2021,146763,2021,24.8\r\n\"Alpine County, CA\",geoId/06003,2021,174,2021,29.1\r\n\"Amador County, CA\",geoId/06005,2021,2891,2021,29.6\r\n\"Butte County, CA\",geoId/06007,2021,37731,2021,31\r\n\"Calaveras County, CA\",geoId/06009,2021,6346,2021,30.6\r\n\"Colusa County, CA\",geoId/06011,2021,2807,2021,33.4\r\n\"Contra Costa County, CA\",geoId/06013,2021,94523,2021,24.3\r\n\"Del Norte County, CA\",geoId/06015,2021,4284,2021,32.7\r\n\"El Dorado County, CA\",geoId/06017,2021,16394,2021,28.1\r\n\"Fresno County, CA\",geoId/06019,2021,198793,2021,36.8\r\n\"Glenn County, CA\",geoId/06021,2021,4272,2021,31.8\r\n\"Humboldt County, CA\",geoId/06023,2021,27116,2021,33.2\r\n\"Imperial County, CA\",geoId/06025,2021,35711,2021,38\r\n\"Inyo County, CA\",geoId/06027,2021,1989,2021,29.4\r\n\"Kern County, CA\",geoId/06029,2021,169289,2021,36.6\r\n\"Kings County, CA\",geoId/06031,2021,22449,2021,35.1\r\n\"Lake County, CA\",geoId/06033,2021,11173,2021,33.7\r\n\"Lassen County, CA\",geoId/06035,2021,3196,2021,32.1\r\n\"Los Angeles County, CA\",geoId/06037,2021,1366544,2021,28.5\r\n\"Madera County, CA\",geoId/06039,2021,28921,2021,35.9\r\n\"Marin County, CA\",geoId/06041,2021,17840,2021,22.9\r\n\"Mariposa County, CA\",geoId/06043,2021,2236,2021,30\r\n\"Mendocino County, CA\",geoId/06045,2021,14246,2021,31.5\r\n\"Merced County, CA\",geoId/06047,2021,52771,2021,33\r\n\"Modoc County, CA\",geoId/06049,2021,1664,2021,33.1\r\n\"Mono County, CA\",geoId/06051,2021,1312,2021,29.6\r\n\"Monterey County, CA\",geoId/06053,2021,51288,2021,27.5\r\n\"Napa County, CA\",geoId/06055,2021,10394,2021,28\r\n\"Nevada County, CA\",geoId/06057,2021,10567,2021,27.5\r\n\"Orange County, CA\",geoId/06059,2021,311294,2021,25.3\r\n\"Placer County, CA\",geoId/06061,2021,27629,2021,26.3\r\n\"Plumas County, CA\",geoId/06063,2021,2287,2021,29.5\r\n\"Riverside County, CA\",geoId/06065,2021,283249,2021,36.2\r\n\"Sacramento County, CA\",geoId/06067,2021,205590,2021,31.7\r\n\"San Benito County, CA\",geoId/06069,2021,4875,2021,31\r\n\"San Bernardino County, CA\",geoId/06071,2021,302798,2021,38.1\r\n\"San Diego County, CA\",geoId/06073,2021,344458,2021,23.9\r\n\"San Francisco County, CA\",geoId/06075,2021,87874,2021,18.7\r\n\"San Joaquin County, CA\",geoId/06077,2021,101951,2021,33.3\r\n\"San Luis Obispo County, CA\",geoId/06079,2021,32077,2021,30.5\r\n\"San Mateo County, CA\",geoId/06081,2021,46644,2021,21\r\n\"Santa Barbara County, CA\",geoId/06083,2021,57269,2021,30.1\r\n\"Santa Clara County, CA\",geoId/06085,2021,126551,2021,18.5\r\n\"Santa Cruz County, CA\",geoId/06087,2021,28396,2021,25.2\r\n\"Shasta County, CA\",geoId/06089,2021,25365,2021,30.9\r\n\"Sierra County, CA\",geoId/06091,2021,249,2021,29.8\r\n\"Siskiyou County, CA\",geoId/06093,2021,7309,2021,32.8\r\n\"Solano County, CA\",geoId/06095,2021,39020,2021,29.9\r\n\"Sonoma County, CA\",geoId/06097,2021,42142,2021,28.6\r\n\"Stanislaus County, CA\",geoId/06099,2021,74272,2021,34.8\r\n\"Sutter County, CA\",geoId/06101,2021,12383,2021,31.6\r\n\"Tehama County, CA\",geoId/06103,2021,11597,2021,34.2\r\n\"Trinity County, CA\",geoId/06105,2021,3512,2021,33\r\n\"Tulare County, CA\",geoId/06107,2021,91866,2021,35.5\r\n\"Tuolumne County, CA\",geoId/06109,2021,5119,2021,29.5\r\n\"Ventura County, CA\",geoId/06111,2021,73740,2021,27\r\n\"Yolo County, CA\",geoId/06113,2021,36036,2021,27.8\r\n\"Yuba County, CA\",geoId/06115,2021,11939,2021,33.9",
+      "srcs": [
+        {
+          "name": "census.gov",
+          "url": "https://www.census.gov/programs-surveys/acs/data/data-via-ftp.html"
+        },
+        {
+          "name": "cdc.gov",
+          "url": "https://www.cdc.gov/places/index.html"
+        }
+      ],
+      "title": "Prevalence of Obesity (2021) Vs. Population Below Poverty Line (2021) in Counties of California",
+      "type": "SCATTER",
+      "chartUrl": "",
+      "dcUrl": "https://datacommons.org/explore#q=obesity%20vs.%20poverty%20in%20counties%20of%20california"
+    },
+    {
+      "data_csv": "rank,place,Prevalence of Obesity\r\n1,San Bernardino County,38.1\r\n2,Imperial County,38\r\n3,Fresno County,36.8\r\n4,Kern County,36.6\r\n5,Riverside County,36.2\r\n54,San Diego County,23.9\r\n55,Marin County,22.9\r\n56,San Mateo County,21\r\n57,San Francisco County,18.7\r\n58,Santa Clara County,18.5",
       "srcs": [
         {
           "name": "cdc.gov",
@@ -14,7 +31,7 @@
       "dcUrl": "https://datacommons.org/explore#q=obesity%20vs.%20poverty%20in%20counties%20of%20california"
     },
     {
-      "data_csv": "rank,place,Population Below poverty line\r\n1,Los Angeles County,1366544\r\n2,San Diego County,344458\r\n3,Orange County,311294\r\n4,San Bernardino County,302798\r\n5,Riverside County,283249\r\n6,Sacramento County,205590\r\n7,Fresno County,198793\r\n8,Kern County,169289\r\n9,Alameda County,146763\r\n10,Santa Clara County,126551",
+      "data_csv": "rank,place,Population Below poverty line\r\n1,Los Angeles County,1366544\r\n2,San Diego County,344458\r\n3,Orange County,311294\r\n4,San Bernardino County,302798\r\n5,Riverside County,283249\r\n54,Inyo County,1989\r\n55,Modoc County,1664\r\n56,Mono County,1312\r\n57,Sierra County,249\r\n58,Alpine County,174",
       "srcs": [
         {
           "name": "census.gov",
@@ -22,19 +39,6 @@
         }
       ],
       "title": "Population Below Poverty Line in Counties of California (2021)",
-      "type": "TABLE",
-      "unit": "",
-      "dcUrl": "https://datacommons.org/explore#q=obesity%20vs.%20poverty%20in%20counties%20of%20california"
-    },
-    {
-      "data_csv": "rank,place,Women below Poverty Line\r\n1,Los Angeles County,748361\r\n2,San Diego County,188480\r\n3,Orange County,173060\r\n4,San Bernardino County,166608\r\n5,Riverside County,156263\r\n6,Sacramento County,109243\r\n7,Fresno County,107496\r\n8,Kern County,93511\r\n9,Alameda County,80874\r\n10,Santa Clara County,69556",
-      "srcs": [
-        {
-          "name": "census.gov",
-          "url": "https://www.census.gov/programs-surveys/acs/data/data-via-ftp.html"
-        }
-      ],
-      "title": "Women Below Poverty Line in Counties of California (2021)",
       "type": "TABLE",
       "unit": "",
       "dcUrl": "https://datacommons.org/explore#q=obesity%20vs.%20poverty%20in%20counties%20of%20california"

--- a/server/tests/test_data/nodejs_query/scatter_non_bard/screenshot.json
+++ b/server/tests/test_data/nodejs_query/scatter_non_bard/screenshot.json
@@ -32,7 +32,7 @@
       "dcUrl": "https://datacommons.org/explore#q=obesity%20vs.%20poverty%20in%20counties%20of%20california"
     },
     {
-      "data_csv": "rank,place,Prevalence of Obesity\r\n1,San Bernardino County,38.1\r\n2,Imperial County,38\r\n3,Fresno County,36.8\r\n4,Kern County,36.6\r\n5,Riverside County,36.2\r\n6,Madera County,35.9\r\n7,Tulare County,35.5\r\n8,Kings County,35.1\r\n9,Stanislaus County,34.8\r\n10,Tehama County,34.2",
+      "data_csv": "rank,place,Prevalence of Obesity\r\n1,San Bernardino County,38.1\r\n2,Imperial County,38\r\n3,Fresno County,36.8\r\n4,Kern County,36.6\r\n5,Riverside County,36.2\r\n54,San Diego County,23.9\r\n55,Marin County,22.9\r\n56,San Mateo County,21\r\n57,San Francisco County,18.7\r\n58,Santa Clara County,18.5",
       "srcs": [
         {
           "name": "cdc.gov",

--- a/server/tests/test_data/nodejs_query/timeline/screenshot.json
+++ b/server/tests/test_data/nodejs_query/timeline/screenshot.json
@@ -22,7 +22,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Average Income for Family Households\r\n1,Williams County,126095\r\n2,Dunn County,122699\r\n3,Divide County,118649\r\n4,Mountrail County,118316\r\n5,McKenzie County,117604\r\n6,Stark County,116735\r\n7,Burleigh County,115103\r\n8,Cass County,114000\r\n9,Burke County,113710\r\n10,Morton County,111901",
+      "data_csv": "rank,place,Average Income for Family Households\r\n1,Williams County,126095\r\n2,Dunn County,122699\r\n3,Divide County,118649\r\n4,Mountrail County,118316\r\n5,McKenzie County,117604\r\n49,Pierce County,76245\r\n50,McIntosh County,75949\r\n51,Rolette County,72908\r\n52,Benson County,69206\r\n53,Sioux County,56872",
       "srcs": [
         {
           "name": "data.census.gov",

--- a/server/tests/test_data/nodejs_query/timeline_all/screenshot.json
+++ b/server/tests/test_data/nodejs_query/timeline_all/screenshot.json
@@ -22,7 +22,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Average Income for Family Households\r\n1,Williams County,126095\r\n2,Dunn County,122699\r\n3,Divide County,118649\r\n4,Mountrail County,118316\r\n5,McKenzie County,117604\r\n6,Stark County,116735\r\n7,Burleigh County,115103\r\n8,Cass County,114000\r\n9,Burke County,113710\r\n10,Morton County,111901",
+      "data_csv": "rank,place,Average Income for Family Households\r\n1,Williams County,126095\r\n2,Dunn County,122699\r\n3,Divide County,118649\r\n4,Mountrail County,118316\r\n5,McKenzie County,117604\r\n49,Pierce County,76245\r\n50,McIntosh County,75949\r\n51,Rolette County,72908\r\n52,Benson County,69206\r\n53,Sioux County,56872",
       "srcs": [
         {
           "name": "data.census.gov",
@@ -56,7 +56,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Median Family Household Income\r\n1,Dunn County,107625\r\n2,Williams County,100650\r\n3,Mercer County,97866\r\n4,Stark County,96087\r\n5,Burleigh County,95104\r\n6,Burke County,94028\r\n7,Morton County,93092\r\n8,Billings County,92344\r\n9,Foster County,91750\r\n10,Steele County,90179",
+      "data_csv": "rank,place,Median Family Household Income\r\n1,Dunn County,107625\r\n2,Williams County,100650\r\n3,Mercer County,97866\r\n4,Stark County,96087\r\n5,Burleigh County,95104\r\n49,Sheridan County,64000\r\n50,Kidder County,63716\r\n51,Benson County,54962\r\n52,Rolette County,53285\r\n53,Sioux County,42619",
       "srcs": [
         {
           "name": "data.census.gov",
@@ -90,7 +90,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Median Married Couple Family Household Income\r\n1,Williams County,114939\r\n2,Dunn County,110000\r\n3,McKenzie County,109798\r\n4,Burleigh County,108658\r\n5,Stark County,105861\r\n6,Mercer County,105538\r\n7,Billings County,102750\r\n8,Divide County,102540\r\n9,Cass County,101382\r\n10,Morton County,100945",
+      "data_csv": "rank,place,Median Married Couple Family Household Income\r\n1,Williams County,114939\r\n2,Dunn County,110000\r\n3,McKenzie County,109798\r\n4,Burleigh County,108658\r\n5,Stark County,105861\r\n49,Logan County,69342\r\n50,McIntosh County,69010\r\n51,Sheridan County,69000\r\n52,Kidder County,65625\r\n53,Sioux County,63375",
       "srcs": [
         {
           "name": "data.census.gov",
@@ -124,7 +124,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Average Income for Married Couple Family Households\r\n1,Burleigh County,129824\r\n2,Cass County,129532\r\n3,Grand Forks County,111270\r\n4,Ward County,110209",
+      "data_csv": "rank,place,Average Income for Married Couple Family Households\r\n1,Burleigh County,129824\r\n2,Cass County,129532\r\n3,Grand Forks County,111270\r\n4,Ward County,110209\r\n3,Grand Forks County,111270\r\n4,Ward County,110209",
       "srcs": [
         {
           "name": "data.census.gov",
@@ -158,7 +158,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Average Income for Nonfamily Households\r\n1,McKenzie County,83059\r\n2,Williams County,80472\r\n3,Cavalier County,77149\r\n4,Dunn County,73967\r\n5,Mercer County,68320\r\n6,Mountrail County,65007\r\n7,Grant County,62168\r\n8,Steele County,59371\r\n9,Billings County,59074\r\n10,Golden Valley County,57585",
+      "data_csv": "rank,place,Average Income for Nonfamily Households\r\n1,McKenzie County,83059\r\n2,Williams County,80472\r\n3,Cavalier County,77149\r\n4,Dunn County,73967\r\n5,Mercer County,68320\r\n49,Divide County,39224\r\n50,Sioux County,38695\r\n51,Griggs County,37770\r\n52,Nelson County,36831\r\n53,Rolette County,31345",
       "srcs": [
         {
           "name": "data.census.gov",
@@ -192,7 +192,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Household Median Income\r\n1,Burke County,97802\r\n2,Dunn County,84459\r\n3,Divide County,83438\r\n4,Golden Valley County,83295\r\n5,Steele County,81354\r\n6,Williams County,80142\r\n7,Mercer County,78547\r\n8,McKenzie County,78442\r\n9,Mountrail County,76520\r\n10,Bowman County,76447",
+      "data_csv": "rank,place,Household Median Income\r\n1,Burke County,97802\r\n2,Dunn County,84459\r\n3,Divide County,83438\r\n4,Golden Valley County,83295\r\n5,Steele County,81354\r\n49,Kidder County,52419\r\n50,Towner County,51912\r\n51,Rolette County,49434\r\n52,Eddy County,44958\r\n53,Sioux County,39755",
       "srcs": [
         {
           "name": "census.gov",
@@ -226,7 +226,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Individual Median Income\r\n1,Burke County,47431\r\n2,McKenzie County,44009\r\n3,Sargent County,43662\r\n4,Williams County,43408\r\n5,Stark County,42509\r\n6,Steele County,42279\r\n7,Mountrail County,42256\r\n8,Burleigh County,42156\r\n9,Traill County,39759\r\n10,Dunn County,39413",
+      "data_csv": "rank,place,Individual Median Income\r\n1,Burke County,47431\r\n2,McKenzie County,44009\r\n3,Sargent County,43662\r\n4,Williams County,43408\r\n5,Stark County,42509\r\n49,Rolette County,31050\r\n50,Eddy County,29454\r\n51,Logan County,28929\r\n52,Benson County,27188\r\n53,Sioux County,20901",
       "srcs": [
         {
           "name": "census.gov",
@@ -262,7 +262,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,\"People Earning Up to $9,999\"\r\n1,Cass County,19656\r\n2,Grand Forks County,9822\r\n3,Burleigh County,8954\r\n4,Ward County,7335\r\n5,Morton County,3186\r\n6,Stark County,3150\r\n7,Stutsman County,3146\r\n8,Williams County,3050\r\n9,Richland County,2474\r\n10,Rolette County,1579",
+      "data_csv": "rank,place,\"People Earning Up to $9,999\"\r\n1,Cass County,19656\r\n2,Grand Forks County,9822\r\n3,Burleigh County,8954\r\n4,Ward County,7335\r\n5,Morton County,3186\r\n49,Oliver County,170\r\n50,Burke County,156\r\n51,Slope County,110\r\n52,Billings County,103\r\n53,Sheridan County,81",
       "srcs": [
         {
           "name": "census.gov",
@@ -275,7 +275,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,\"People Earning $10,000 and $14,999\"\r\n1,Cass County,9710\r\n2,Burleigh County,5087\r\n3,Grand Forks County,4421\r\n4,Ward County,3836\r\n5,Morton County,1759\r\n6,Stutsman County,1682\r\n7,Stark County,1590\r\n8,Williams County,1203\r\n9,Richland County,1087\r\n10,Ramsey County,922",
+      "data_csv": "rank,place,\"People Earning $10,000 and $14,999\"\r\n1,Cass County,9710\r\n2,Burleigh County,5087\r\n3,Grand Forks County,4421\r\n4,Ward County,3836\r\n5,Morton County,1759\r\n49,Golden Valley County,94\r\n50,Billings County,69\r\n51,Oliver County,68\r\n52,Steele County,62\r\n53,Slope County,54",
       "srcs": [
         {
           "name": "census.gov",
@@ -319,7 +319,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Median Incomes in Real Estate And Rental And Leasing\r\n1,Emmons County,118125\r\n2,McKenzie County,113281\r\n3,Dunn County,93158\r\n4,Walsh County,75938\r\n5,Ransom County,63958\r\n6,McHenry County,61389\r\n7,Ramsey County,61364\r\n8,Williams County,60089\r\n9,Billings County,53281\r\n10,McIntosh County,51875",
+      "data_csv": "rank,place,Median Incomes in Real Estate And Rental And Leasing\r\n1,Emmons County,118125\r\n2,McKenzie County,113281\r\n3,Dunn County,93158\r\n4,Walsh County,75938\r\n5,Ransom County,63958\r\n37,McLean County,10833\r\n38,Bottineau County,8750\r\n39,Barnes County,6563\r\n40,Steele County,4167\r\n41,Dickey County,3125",
       "srcs": [
         {
           "name": "census.gov",
@@ -332,7 +332,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Median Incomes in Health Care And Social Assistance\r\n1,Burke County,59583\r\n2,Steele County,55625\r\n3,Slope County,55417\r\n4,Adams County,46012\r\n5,Pierce County,45417\r\n6,Morton County,43568\r\n7,Burleigh County,43468\r\n8,McHenry County,41667\r\n9,Grand Forks County,40749\r\n10,Rolette County,40625",
+      "data_csv": "rank,place,Median Incomes in Health Care And Social Assistance\r\n1,Burke County,59583\r\n2,Steele County,55625\r\n3,Slope County,55417\r\n4,Adams County,46012\r\n5,Pierce County,45417\r\n49,LaMoure County,27077\r\n50,McIntosh County,26875\r\n51,Divide County,26369\r\n52,Hettinger County,25250\r\n53,Kidder County,23906",
       "srcs": [
         {
           "name": "census.gov",
@@ -385,7 +385,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Mean Income Deficit of Household: Family Household\r\n1,Steele County,25719\r\n2,Ransom County,25146\r\n3,Sioux County,19446\r\n4,Benson County,18693\r\n5,Rolette County,16013\r\n6,Williams County,15870\r\n7,Sargent County,12675\r\n8,Adams County,12516\r\n9,Mountrail County,12251\r\n10,Dunn County,11450",
+      "data_csv": "rank,place,Mean Income Deficit of Household: Family Household\r\n1,Steele County,25719\r\n2,Ransom County,25146\r\n3,Sioux County,19446\r\n4,Benson County,18693\r\n5,Rolette County,16013\r\n46,Burke County,5400\r\n47,Logan County,5108\r\n48,Renville County,4256\r\n49,Slope County,4069\r\n50,Griggs County,1966",
       "srcs": [
         {
           "name": "data.census.gov",
@@ -419,7 +419,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,\"Count of Household: Family Household, Owner Occupied\"\r\n1,Cass County,31049\r\n2,Burleigh County,20308\r\n3,Ward County,12168\r\n4,Grand Forks County,10604\r\n5,Morton County,7392\r\n6,Stark County,6109\r\n7,Williams County,5784\r\n8,Stutsman County,3744\r\n9,Richland County,3261\r\n10,McLean County,2436",
+      "data_csv": "rank,place,\"Count of Household: Family Household, Owner Occupied\"\r\n1,Cass County,31049\r\n2,Burleigh County,20308\r\n3,Ward County,12168\r\n4,Grand Forks County,10604\r\n5,Morton County,7392\r\n49,Logan County,438\r\n50,Sioux County,346\r\n51,Sheridan County,334\r\n52,Slope County,213\r\n53,Billings County,185",
       "srcs": [
         {
           "name": "data.census.gov",
@@ -453,7 +453,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Count of Household: Family Household\r\n1,Cass County,43600\r\n2,Burleigh County,24548\r\n3,Ward County,16828\r\n4,Grand Forks County,15571\r\n5,Williams County,9237\r\n6,Morton County,9019\r\n7,Stark County,7939\r\n8,Stutsman County,4915\r\n9,Richland County,3922\r\n10,McKenzie County,3183",
+      "data_csv": "rank,place,Count of Household: Family Household\r\n1,Cass County,43600\r\n2,Burleigh County,24548\r\n3,Ward County,16828\r\n4,Grand Forks County,15571\r\n5,Williams County,9237\r\n49,Golden Valley County,506\r\n50,Logan County,496\r\n51,Sheridan County,369\r\n52,Slope County,230\r\n53,Billings County,212",
       "srcs": [
         {
           "name": "census.gov",
@@ -487,7 +487,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Average Income for Households\r\n1,Williams County,112921\r\n2,Dunn County,106893\r\n3,McKenzie County,105700\r\n4,Mountrail County,100606\r\n5,Billings County,98764\r\n6,Cavalier County,96680\r\n7,Burke County,93941\r\n8,Stark County,93757\r\n9,Morton County,92356\r\n10,Mercer County,91827",
+      "data_csv": "rank,place,Average Income for Households\r\n1,Williams County,112921\r\n2,Dunn County,106893\r\n3,McKenzie County,105700\r\n4,Mountrail County,100606\r\n5,Billings County,98764\r\n49,Pierce County,65582\r\n50,Benson County,65093\r\n51,Sheridan County,64388\r\n52,Rolette County,61600\r\n53,Sioux County,53928",
       "srcs": [
         {
           "name": "data.census.gov",
@@ -521,7 +521,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Count of Household: Other Family Household\r\n1,Cass County,8771\r\n2,Burleigh County,4877\r\n3,Grand Forks County,3836\r\n4,Ward County,3325\r\n5,Williams County,2133\r\n6,Stark County,1718\r\n7,Morton County,1583\r\n8,Rolette County,1235\r\n9,Richland County,829\r\n10,Stutsman County,805",
+      "data_csv": "rank,place,Count of Household: Other Family Household\r\n1,Cass County,8771\r\n2,Burleigh County,4877\r\n3,Grand Forks County,3836\r\n4,Ward County,3325\r\n5,Williams County,2133\r\n49,Burke County,53\r\n50,Golden Valley County,40\r\n51,Logan County,39\r\n52,Billings County,17\r\n53,Slope County,16",
       "srcs": [
         {
           "name": "census.gov",
@@ -555,7 +555,7 @@
       "dcUrl": "https://datacommons.org/explore#q=family%20earnings%20in%20north%20dakota"
     },
     {
-      "data_csv": "rank,place,Mean Income Deficit of Household: Married Couple Family Household\r\n1,Steele County,25719\r\n2,Ransom County,22740\r\n3,Sioux County,21443\r\n4,Williams County,17531\r\n5,Benson County,17245\r\n6,Divide County,14352\r\n7,Mercer County,13235\r\n8,Rolette County,12933\r\n9,Sargent County,12832\r\n10,Adams County,12516",
+      "data_csv": "rank,place,Mean Income Deficit of Household: Married Couple Family Household\r\n1,Steele County,25719\r\n2,Ransom County,22740\r\n3,Sioux County,21443\r\n4,Williams County,17531\r\n5,Benson County,17245\r\n46,Slope County,4069\r\n47,Bottineau County,3847\r\n48,Burke County,3700\r\n49,Griggs County,2550\r\n50,Renville County,2026",
       "srcs": [
         {
           "name": "data.census.gov",

--- a/server/webdriver/tests/event_page_test.py
+++ b/server/webdriver/tests/event_page_test.py
@@ -23,8 +23,8 @@ from server.webdriver.base import WebdriverBaseTest
 
 BASE_PAGE_URL = '/event/'
 CYCLONE_NICOLE_DCID = 'cyclone/ibtracs_2022309N16290'
-FIRE_EVENT_DCID = 'fireEvent/2022-07-19_0x2e025b0000000000'
-DROUGHT_EVENT_DCID = 'droughtEvent/2020-04-01_grid_1/52_-81'
+FIRE_EVENT_DCID = 'fire/imsr0003Fire20152836427'
+DROUGHT_EVENT_DCID = 'stormEvent/nws5512667'
 
 
 # Class to test Event Pages.
@@ -108,21 +108,26 @@ class TestEventPage(WebdriverBaseTest):
 
     # Assert page title is correct
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
-        EC.title_contains('FireEvent at Ketapang on 2022-07-19'))
+        EC.title_contains('0003 Fire 2015 (2836427)'))
 
     # Check header section
     element_present = EC.presence_of_element_located((By.TAG_NAME, 'h1'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
     title = self.driver.find_element(By.XPATH,
                                      '//*[@id="main-pane"]/div[1]/div[1]/h1')
-    self.assertEqual(title.text, 'FireEvent at Ketapang on 2022-07-19')
+    self.assertEqual(title.text, '0003 Fire 2015 (2836427)')
     dcid_subtitle = self.driver.find_element(
         By.XPATH, '//*[@id="main-pane"]/div[1]/div[1]/h3')
-    self.assertEqual(dcid_subtitle.text, 'Fire Event in Indonesia, Asia, Earth')
+    self.assertEqual(
+        dcid_subtitle.text,
+        'Wildland Fire Event in Deschutes County, Oregon, United States, North America, Earth'
+    )
 
     # Check google map section
     element_present = EC.presence_of_element_located(
         (By.CLASS_NAME, 'map-container'))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
+    element_present = EC.presence_of_element_located((By.TAG_NAME, 'iframe'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
     iframe_list = self.driver.find_elements(By.TAG_NAME, 'iframe')
     # assert there is 1 iframe
@@ -143,15 +148,15 @@ class TestEventPage(WebdriverBaseTest):
         '//*[@id="main-pane"]/div[1]/section/div/table/tbody/tr[2]/td')
     # assert the date is correct
     self.assertEqual(date_row[0].text, 'Date')
-    self.assertEqual(date_row[1].text, '2022-07-19 — 2022-07-23')
+    self.assertEqual(date_row[1].text, '2015-01-05')
 
     # Check additional charts section
     element_present = EC.presence_of_element_located((By.TAG_NAME, 'svg'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
     chart_section = self.driver.find_element(By.ID, 'subject-page-main-pane')
     charts = chart_section.find_elements(By.CLASS_NAME, 'chart-container')
-    # assert there are 5+ charts
-    self.assertGreater(len(charts), 5)
+    # assert there are 4+ charts
+    self.assertGreater(len(charts), 4)
     # assert that the first chart has data
     chart_lines = charts[0].find_elements(By.CLASS_NAME, 'line')
     self.assertEqual(len(chart_lines), 1)
@@ -169,21 +174,20 @@ class TestEventPage(WebdriverBaseTest):
 
     # Assert page title is correct
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
-        EC.title_contains(
-            'DroughtEvent at LatLong(52.00000:-81.00000) on 2020-04-01 - Event Page - Data Commons'
-        ))
+        EC.title_contains('stormEvent/nws5512667 - Event Page - Data Commons'))
 
     # Check header section
     element_present = EC.presence_of_element_located((By.TAG_NAME, 'h1'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
     title = self.driver.find_element(By.XPATH,
                                      '//*[@id="main-pane"]/div[1]/div[1]/h1')
-    self.assertEqual(
-        title.text, 'DroughtEvent at LatLong(52.00000:-81.00000) on 2020-04-01')
+    self.assertEqual(title.text, 'stormEvent/nws5512667')
     dcid_subtitle = self.driver.find_element(
         By.XPATH, '//*[@id="main-pane"]/div[1]/div[1]/h3')
-    self.assertEqual(dcid_subtitle.text,
-                     'Drought Event in Canada, North America, Earth')
+    self.assertEqual(
+        dcid_subtitle.text,
+        'Drought Event in Hood County, Texas, United States, North America, Earth'
+    )
 
     # Check google map section
     element_present = EC.presence_of_element_located(
@@ -208,15 +212,16 @@ class TestEventPage(WebdriverBaseTest):
         '//*[@id="main-pane"]/div[1]/section/div/table/tbody/tr[2]/td')
     # assert the date is correct
     self.assertEqual(date_row[0].text, 'Date')
-    self.assertEqual(date_row[1].text, '2020-04-01 — 2020-05-01')
+    self.assertEqual(date_row[1].text,
+                     '2006-05-01T00:00:00-05:00 — 2006-05-08T23:59:00-05:00')
 
     # Check additional charts section
     element_present = EC.presence_of_element_located((By.TAG_NAME, 'svg'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
     chart_section = self.driver.find_element(By.ID, 'subject-page-main-pane')
     charts = chart_section.find_elements(By.CLASS_NAME, 'chart-container')
-    # assert there are 10+ charts
-    self.assertGreater(len(charts), 10)
+    # assert there are 5+ charts
+    self.assertGreater(len(charts), 5)
     # assert that the first chart has data
     chart_lines = charts[0].find_elements(By.CLASS_NAME, 'line')
     self.assertEqual(len(chart_lines), 1)


### PR DESCRIPTION
update goldens for latest nodejs response update (from last week) where:
- scatter plots re-enabled
- ranking table can show top ... bottoms ranks

Also:
- fix webdriver tests by updating the events tested for on the events page are not autogenerated events (because autogenerated events may sometimes be modified). 
- update event page to handle when no location found