### PR TITLE
[nl] Allow fulfillment when there are only multi svs detected

### DIFF
--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -466,6 +466,16 @@ class ExploreTest(NLWebServerTestCase):
             'how many day beijing snow in december?',
         ],
         mode='strict')
+    
+  def test_e2e_strict_multi_sv(self):
+    self.run_detect_and_fulfill(
+        'explore_strict_multi_var',
+        [
+            # This should fulfill even though there are only multi sv candidates
+            # detected and no single svs passed the detection threshold
+            'Does obesity correlate with lack of sleep in US counties'
+        ],
+        mode='strict')
 
   def test_e2e_single_date(self):
     self.run_detect_and_fulfill('e2e_single_date', [

--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -466,7 +466,7 @@ class ExploreTest(NLWebServerTestCase):
             'how many day beijing snow in december?',
         ],
         mode='strict')
-    
+
   def test_e2e_strict_multi_sv(self):
     self.run_detect_and_fulfill(
         'explore_strict_multi_var',

--- a/server/integration_tests/test_data/explore_strict_multi_var/chart_config.json
+++ b/server/integration_tests/test_data/explore_strict_multi_var/chart_config.json
@@ -1,0 +1,145 @@
+{
+  "client": "test_detect-and-fulfill",
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_Obesity_scatter",
+                      "Percent_Person_SleepLessThan7Hours_scatter"
+                    ],
+                    "title": "Prevalence of Obesity (${yDate}) Vs. Percentage That Sleeps Less Than 7 Hours Per Night (${xDate}) in Counties of United States",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "title": "Prevalence of Obesity vs. Percentage That Sleeps Less Than 7 Hours Per Night"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_Obesity"
+                    ],
+                    "title": "Prevalence of Obesity in Counties of United States (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_Obesity"
+                    ],
+                    "title": "Prevalence of Obesity in Counties of United States (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Prevalence of Obesity in Counties of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Percent_Person_SleepLessThan7Hours"
+                    ],
+                    "title": "Percentage That Sleeps Less Than 7 Hours Per Night in Counties of United States (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_SleepLessThan7Hours"
+                    ],
+                    "title": "Percentage That Sleeps Less Than 7 Hours Per Night in Counties of United States (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Percentage That Sleeps Less Than 7 Hours Per Night in Counties of United States"
+          }
+        ],
+        "statVarSpec": {
+          "Percent_Person_Obesity": {
+            "name": "Prevalence of Obesity",
+            "statVar": "Percent_Person_Obesity",
+            "unit": "%"
+          },
+          "Percent_Person_Obesity_scatter": {
+            "name": "Prevalence of Obesity",
+            "noPerCapita": true,
+            "statVar": "Percent_Person_Obesity",
+            "unit": "%"
+          },
+          "Percent_Person_SleepLessThan7Hours": {
+            "name": "Percentage That Sleeps Less Than 7 Hours Per Night",
+            "statVar": "Percent_Person_SleepLessThan7Hours",
+            "unit": "%"
+          },
+          "Percent_Person_SleepLessThan7Hours_scatter": {
+            "name": "Percentage That Sleeps Less Than 7 Hours Per Night",
+            "noPerCapita": true,
+            "statVar": "Percent_Person_SleepLessThan7Hours",
+            "unit": "%"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "containedPlaceTypes": {
+        "Country": "County"
+      },
+      "placeDcid": [
+        "country/USA"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "pastSourceContext": "",
+  "place": {
+    "dcid": "country/USA",
+    "name": "United States",
+    "place_type": "Country"
+  },
+  "placeFallback": {},
+  "placeSource": "CURRENT_QUERY",
+  "places": [
+    {
+      "dcid": "country/USA",
+      "name": "United States",
+      "place_type": "Country"
+    }
+  ],
+  "relatedThings": {},
+  "svSource": "CURRENT_QUERY",
+  "userMessage": ""
+}

--- a/server/integration_tests/test_data/fulfillment_api_sdg_specialvars/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_sdg_specialvars/chart_config.json
@@ -160,6 +160,6 @@
     "varToTopics": {}
   },
   "showForm": true,
-  "svSource": "UNFULFILLED",
-  "userMessage": "Sorry, there were no relevant statistics about the topic for United States of America."
+  "svSource": "UNRECOGNIZED",
+  "userMessage": "Could not recognize any topic from the query."
 }

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -188,9 +188,6 @@ def _maybe_switch_parent_type(
 # Add charts given a place and a list of stat-vars.
 def _add_charts_with_existence_check(state: PopulateState,
                                      places: List[Place]) -> bool:
-  svs = state.uttr.svs
-  logging.info("Add chart %s" % (', '.join(_get_place_names(places))))
-
   # This may set state.uttr.place_fallback
   _maybe_set_fallback(state, places)
 
@@ -251,7 +248,7 @@ def _add_charts_with_existence_check(state: PopulateState,
         not state.ranking_types and num_charts < _MAX_NUM_CHARTS):
       # Note that we want to expand on existing_svs only, and in the
       # order of `svs`
-      ordered_existing_svs = [v for v in svs if v in existing_svs]
+      ordered_existing_svs = [v for v in state.uttr.svs if v in existing_svs]
       found |= _add_charts_for_extended_svs(state=state,
                                             places=places,
                                             svs=ordered_existing_svs,

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -55,7 +55,7 @@ def populate_charts(state: PopulateState) -> bool:
   places = state.uttr.places
   handle_contained_in_type(state, places)
 
-  if not state.uttr.svs:
+  if not state.uttr.svs and not state.uttr.multi_svs:
     state.uttr.counters.err('num_populate_fallbacks', 1)
     state.uttr.sv_source = FulfillmentResult.UNRECOGNIZED
     return False

--- a/server/lib/nl/fulfillment/base.py
+++ b/server/lib/nl/fulfillment/base.py
@@ -55,7 +55,7 @@ def populate_charts(state: PopulateState) -> bool:
   places = state.uttr.places
   handle_contained_in_type(state, places)
 
-  if not state.uttr.svs and not state.uttr.multi_svs:
+  if not state.chart_vars_map:
     state.uttr.counters.err('num_populate_fallbacks', 1)
     state.uttr.sv_source = FulfillmentResult.UNRECOGNIZED
     return False
@@ -64,8 +64,9 @@ def populate_charts(state: PopulateState) -> bool:
 
   if not success:
     state.uttr.counters.err('num_populate_fallbacks', 1)
-    state.uttr.counters.err('failed_populate_main_svs', state.uttr.svs)
-    if state.uttr.svs:
+    state.uttr.counters.err('failed_populate_main_svs',
+                            state.chart_vars_map.keys())
+    if state.chart_vars_map:
       if state.uttr.sv_source == FulfillmentResult.PAST_QUERY:
         # We did not recognize anything in this query, the SV
         # we tried is from the context.
@@ -188,7 +189,7 @@ def _maybe_switch_parent_type(
 def _add_charts_with_existence_check(state: PopulateState,
                                      places: List[Place]) -> bool:
   svs = state.uttr.svs
-  logging.info("Add chart %s %s" % (', '.join(_get_place_names(places)), svs))
+  logging.info("Add chart %s" % (', '.join(_get_place_names(places))))
 
   # This may set state.uttr.place_fallback
   _maybe_set_fallback(state, places)


### PR DESCRIPTION
When there are no svs detected because the scores were too low, we should still try to populate charts for multi sv candidates (if there are any detected)

This fixes the empty result in strict mode for the query 'Does obesity correlate with lack of sleep in US counties' (it returns results in regular mode).

Example: nodejs/query?q=Does%20obesity%20correlate%20with%20lack%20of%20sleep%20in%20US%20counties
currently: empty result
with this change: https://paste.googleplex.com/5581611641339904
