### PR TITLE
Set unit to % for all variations where scaling factor equals 100

### DIFF
--- a/static/js/utils/stat_metadata_utils.ts
+++ b/static/js/utils/stat_metadata_utils.ts
@@ -30,7 +30,7 @@ export function getUnit(statMetadata: StatMetadata): string {
   if (statMetadata.unit) {
     return statMetadata.unit;
   }
-  if (statMetadata.scalingFactor === "100") {
+  if (Number(statMetadata.scalingFactor) === 100) {
     return "%";
   }
   return "";


### PR DESCRIPTION
scaling factor can be 100, 100.0, 100.00, etc. We should set the unit to % for all variations.