### PR TITLE
[nodejs] Add chart titles as part of returned image

### DIFF
--- a/static/js/chart/draw_bar.ts
+++ b/static/js/chart/draw_bar.ts
@@ -285,7 +285,7 @@ export function drawStackBarChart(
 
   let marginTop = MARGIN.top;
   if (options?.title) {
-    marginTop += addChartTitle(svg, options?.title, chartWidth);
+    marginTop += addChartTitle(svg, options.title, chartWidth);
   }
 
   const y = d3
@@ -954,7 +954,7 @@ export function drawGroupBarChart(
 
   let marginTop = MARGIN.top;
   if (options?.title) {
-    marginTop += addChartTitle(svg, options?.title, chartWidth);
+    marginTop += addChartTitle(svg, options.title, chartWidth);
   }
 
   const y = d3
@@ -1114,7 +1114,7 @@ export function drawHorizontalBarChart(
   containerElement.append(svg.node());
 
   if (options?.title) {
-    marginTop += addChartTitle(svg, options?.title, chartWidth);
+    marginTop += addChartTitle(svg, options.title, chartWidth);
   }
 
   if (label) {

--- a/static/js/chart/draw_bar.ts
+++ b/static/js/chart/draw_bar.ts
@@ -36,6 +36,7 @@ import {
   XLINKNS,
 } from "./draw_constants";
 import {
+  addChartTitle,
   addTooltip,
   addXAxis,
   addYAxis,
@@ -282,6 +283,11 @@ export function drawStackBarChart(
   const xAxis = svg.append("g").attr("class", "x axis");
   const tempYAxis = svg.append("g");
 
+  let marginTop = MARGIN.top;
+  if (options?.title) {
+    marginTop += addChartTitle(svg, options?.title, chartWidth);
+  }
+
   const y = d3
     .scaleLinear()
     .domain([
@@ -289,7 +295,7 @@ export function drawStackBarChart(
       d3.max(series, (d) => d3.max(d, (d1) => d1[1])),
     ])
     .nice()
-    .rangeRound([chartHeight - MARGIN.bottom, MARGIN.top]);
+    .rangeRound([chartHeight - MARGIN.bottom, marginTop]);
 
   const leftWidth = addYAxis(
     tempYAxis,
@@ -317,7 +323,7 @@ export function drawStackBarChart(
   );
 
   // Update and redraw the y-axis based on the new x-axis height.
-  y.rangeRound([chartHeight - bottomHeight, MARGIN.top]);
+  y.rangeRound([chartHeight - bottomHeight, marginTop]);
   tempYAxis.remove();
   addYAxis(yAxis, chartWidth, y, TEXT_FONT_FAMILY, options?.unit);
   updateXAxis(xAxis, bottomHeight, chartHeight, y);
@@ -946,11 +952,16 @@ export function drawGroupBarChart(
   const xAxis = svg.append("g").attr("class", "x axis");
   const tempYAxis = svg.append("g");
 
+  let marginTop = MARGIN.top;
+  if (options?.title) {
+    marginTop += addChartTitle(svg, options?.title, chartWidth);
+  }
+
   const y = d3
     .scaleLinear()
     .domain([minV, maxV])
     .nice()
-    .rangeRound([chartHeight - MARGIN.bottom, MARGIN.top]);
+    .rangeRound([chartHeight - MARGIN.bottom, marginTop]);
   const leftWidth = addYAxis(
     tempYAxis,
     chartWidth,
@@ -982,7 +993,7 @@ export function drawGroupBarChart(
     .padding(0.05);
 
   // Update and redraw the y-axis based on the new x-axis height.
-  y.rangeRound([chartHeight - bottomHeight, MARGIN.top]);
+  y.rangeRound([chartHeight - bottomHeight, marginTop]);
   tempYAxis.remove();
   addYAxis(yAxis, chartWidth, y, TEXT_FONT_FAMILY, options?.unit);
   updateXAxis(xAxis, bottomHeight, chartHeight, y);
@@ -1102,6 +1113,10 @@ export function drawHorizontalBarChart(
   // The node must be attached before any getBBox() calls.
   containerElement.append(svg.node());
 
+  if (options?.title) {
+    marginTop += addChartTitle(svg, options?.title, chartWidth);
+  }
+
   if (label) {
     // Add x-axis label in the top-middle of the axis
     svg
@@ -1109,7 +1124,7 @@ export function drawHorizontalBarChart(
       .attr("id", "x-axis-label")
       .attr("part", "x-axis-label")
       .attr("x", chartWidth / 2)
-      .attr("y", 0)
+      .attr("y", marginTop)
       .attr("fill", AXIS_TEXT_FILL)
       .attr("text-anchor", "middle")
       .attr("dominant-baseline", "hanging")

--- a/static/js/chart/draw_line.ts
+++ b/static/js/chart/draw_line.ts
@@ -37,6 +37,7 @@ import {
   XLINKNS,
 } from "./draw_constants";
 import {
+  addChartTitle,
   addTooltip,
   addXAxis,
   addYAxis,
@@ -365,10 +366,15 @@ export function drawLineChart(
   const highlight = svg.append("g").attr("class", "highlight");
   const chart = svg.append("g").attr("class", "chart-area");
 
+  let marginTop = MARGIN.top;
+  if (options?.title) {
+    marginTop += addChartTitle(svg, options?.title, width);
+  }
+
   const yScale = d3
     .scaleLinear()
     .domain([minV, maxV])
-    .range([height - MARGIN.bottom, MARGIN.top])
+    .range([height - MARGIN.bottom, marginTop])
     .nice(NUM_Y_TICKS);
   const leftWidth = addYAxis(
     yAxis,

--- a/static/js/chart/draw_scatter.ts
+++ b/static/js/chart/draw_scatter.ts
@@ -45,7 +45,7 @@ export interface Point {
   yPopDate?: string;
 }
 
-const MARGINS = {
+const MARGIN = {
   bottom: 30,
   left: 60,
   right: 30,
@@ -109,7 +109,7 @@ function addYLabel(
     .attr(
       "transform",
       `rotate(-90) translate(${-height / 2 - marginTop}, ${
-        MARGINS.left - Y_AXIS_WIDTH
+        MARGIN.left - Y_AXIS_WIDTH
       })`
     );
   return yAxisLabel.node().getBBox().height;
@@ -849,12 +849,12 @@ export function drawScatter(
   const xMinMax = d3.extent(Object.values(points), (point) => point.xVal);
   const yMinMax = d3.extent(Object.values(points), (point) => point.yVal);
 
-  let marginTop = MARGINS.top;
+  let marginTop = MARGIN.top;
   if (chartTitle) {
     marginTop += addChartTitle(svg, chartTitle, properties.width);
   }
 
-  let height = properties.height - marginTop - MARGINS.bottom;
+  let height = properties.height - marginTop - MARGIN.bottom;
   const minXAxisHeight = 30;
   const yAxisLabel = svg.append("g").attr("class", "y-axis-label");
   const yAxisWidth = addYLabel(
@@ -864,7 +864,7 @@ export function drawScatter(
     properties.yLabel,
     properties.yUnit
   );
-  let width = properties.width - MARGINS.left - MARGINS.right - yAxisWidth;
+  let width = properties.width - MARGIN.left - MARGIN.right - yAxisWidth;
   if (options.showDensity) {
     width = width - DENSITY_LEGEND_WIDTH;
   }
@@ -873,7 +873,7 @@ export function drawScatter(
   const xAxisHeight = addXLabel(
     xAxisLabel,
     width,
-    MARGINS.left + yAxisWidth,
+    MARGIN.left + yAxisWidth,
     properties.height,
     properties.xLabel,
     properties.xUnit
@@ -882,7 +882,7 @@ export function drawScatter(
 
   const g = svg
     .append("g")
-    .attr("transform", `translate(${MARGINS.left + yAxisWidth},${marginTop})`);
+    .attr("transform", `translate(${MARGIN.left + yAxisWidth},${marginTop})`);
 
   const xScale = addXAxis(
     g,

--- a/static/js/chart/draw_scatter.ts
+++ b/static/js/chart/draw_scatter.ts
@@ -28,6 +28,7 @@ import { formatNumber } from "../i18n/i18n";
 import { NamedPlace } from "../shared/types";
 import { SHOW_POPULATION_LOG } from "../tools/scatter/context";
 import { wrap } from "./base";
+import { addChartTitle } from "./draw_utils";
 
 /**
  * Represents a point in the scatter plot.
@@ -55,7 +56,6 @@ const STROKE_WIDTH = 1.5;
 const DEFAULT_FILL = "#FFFFFF";
 const DENSITY_LEGEND_FONT_SIZE = "0.7rem";
 const DENSITY_LEGEND_TEXT_HEIGHT = 15;
-const DENSITY_LEGEND_TEXT_PADDING = 5;
 const DENSITY_LEGEND_IMAGE_WIDTH = 10;
 const DENSITY_LEGEND_WIDTH = 75;
 const DEFAULT_MAX_POINT_SIZE = 20;
@@ -316,7 +316,7 @@ function addDensityLegend(
     .attr("width", DENSITY_LEGEND_WIDTH);
   const legendHeight = chartHeight / 2;
 
-  // add legend title
+  // add legend titles
   legend
     .append("g")
     .append("text")
@@ -327,15 +327,10 @@ function addDensityLegend(
   legend
     .append("g")
     .append("text")
-    .attr("dominant-baseline", "hanging")
+    .attr("dominant-baseline", "text-bottom")
     .attr("font-size", DENSITY_LEGEND_FONT_SIZE)
     .text("sparse")
-    .attr(
-      "transform",
-      `translate(0, ${
-        legendHeight - DENSITY_LEGEND_TEXT_HEIGHT + DENSITY_LEGEND_TEXT_PADDING
-      })`
-    );
+    .attr("transform", `translate(0, ${legendHeight})`);
 
   // generate a scale image and append to legend
   const canvas = document.createElement("canvas");
@@ -833,7 +828,8 @@ export function drawScatter(
     yLabel: string,
     xPerCapita: boolean,
     yPerCapita: boolean
-  ) => JSX.Element
+  ) => JSX.Element,
+  chartTitle?: string
 ): void {
   const container = d3.select(svgContainer);
   container.selectAll("*").remove();
@@ -853,13 +849,18 @@ export function drawScatter(
   const xMinMax = d3.extent(Object.values(points), (point) => point.xVal);
   const yMinMax = d3.extent(Object.values(points), (point) => point.yVal);
 
-  let height = properties.height - MARGINS.top - MARGINS.bottom;
+  let marginTop = MARGINS.top;
+  if (chartTitle) {
+    marginTop += addChartTitle(svg, chartTitle, properties.width);
+  }
+
+  let height = properties.height - marginTop - MARGINS.bottom;
   const minXAxisHeight = 30;
   const yAxisLabel = svg.append("g").attr("class", "y-axis-label");
   const yAxisWidth = addYLabel(
     yAxisLabel,
     height - minXAxisHeight,
-    MARGINS.top,
+    marginTop,
     properties.yLabel,
     properties.yUnit
   );
@@ -881,10 +882,7 @@ export function drawScatter(
 
   const g = svg
     .append("g")
-    .attr(
-      "transform",
-      `translate(${MARGINS.left + yAxisWidth},${MARGINS.top})`
-    );
+    .attr("transform", `translate(${MARGINS.left + yAxisWidth},${marginTop})`);
 
   const xScale = addXAxis(
     g,
@@ -927,7 +925,7 @@ export function drawScatter(
       Object.values(points),
       width,
       height,
-      MARGINS.top,
+      marginTop,
       properties.width,
       pointSizeScale
     );

--- a/static/js/chart/draw_utils.ts
+++ b/static/js/chart/draw_utils.ts
@@ -647,6 +647,7 @@ export function updateXAxis(
  * @param svg svg to add title to
  * @param titleText text of the title to add
  * @param width width of the svg
+ * @returns height of the chart title that was added
  */
 export function addChartTitle(
   svg: d3.Selection<SVGGElement, any, any, any>,

--- a/static/js/chart/draw_utils.ts
+++ b/static/js/chart/draw_utils.ts
@@ -640,3 +640,26 @@ export function updateXAxis(
       `translate(0, ${yScale(0) + xAxisHeight - chartHeight})`
     );
 }
+
+/**
+ * Adds a chart title to the top of the svg and returns the height of the chart
+ * title that was added.
+ * @param svg svg to add title to
+ * @param titleText text of the title to add
+ * @param width width of the svg
+ */
+export function addChartTitle(
+  svg: d3.Selection<SVGGElement, any, any, any>,
+  titleText: string,
+  width: number
+): number {
+  const titleElement = svg
+    .append("g")
+    .attr("class", "chart-title")
+    .append("text")
+    .attr("y", 0)
+    .attr("dominant-baseline", "hanging")
+    .text(titleText)
+    .call(wrap, width);
+  return titleElement.node().getBBox().height;
+}

--- a/static/js/chart/types.ts
+++ b/static/js/chart/types.ts
@@ -152,6 +152,8 @@ export interface ChartOptions {
   // Use an svg version of the legend that is added as part of the svg chart and
   // has no interactions.
   useSvgLegend?: boolean;
+  // If set, adds title to the top of the chart
+  title?: string;
 }
 
 export interface GroupLineChartOptions extends ChartOptions {

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -438,9 +438,9 @@ export function draw(
           barHeight: props.barHeight,
           yAxisMargin: props.yAxisMargin,
         },
+        title: chartTitle,
         unit: chartData.unit,
         useSvgLegend,
-        title: chartTitle,
       }
     );
   } else {
@@ -456,9 +456,9 @@ export function draw(
           lollipop: props.useLollipop,
           showTooltipOnHover: props.showTooltipOnHover,
           statVarColorOrder: chartData.statVarOrder,
+          title: chartTitle,
           unit: chartData.unit,
           useSvgLegend,
-          title: chartTitle,
         }
       );
     } else {
@@ -473,9 +473,9 @@ export function draw(
           lollipop: props.useLollipop,
           showTooltipOnHover: props.showTooltipOnHover,
           statVarColorOrder: chartData.statVarOrder,
+          title: chartTitle,
           unit: chartData.unit,
           useSvgLegend,
-          title: chartTitle,
         }
       );
     }

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -416,7 +416,8 @@ export function draw(
   chartData: BarChartData,
   svgContainer: HTMLDivElement,
   svgWidth?: number,
-  useSvgLegend?: boolean
+  useSvgLegend?: boolean,
+  chartTitle?: string
 ): void {
   if (chartData.errorMsg) {
     showError(chartData.errorMsg, svgContainer);
@@ -439,6 +440,7 @@ export function draw(
         },
         unit: chartData.unit,
         useSvgLegend,
+        title: chartTitle,
       }
     );
   } else {
@@ -456,6 +458,7 @@ export function draw(
           statVarColorOrder: chartData.statVarOrder,
           unit: chartData.unit,
           useSvgLegend,
+          title: chartTitle,
         }
       );
     } else {
@@ -472,6 +475,7 @@ export function draw(
           statVarColorOrder: chartData.statVarOrder,
           unit: chartData.unit,
           useSvgLegend,
+          title: chartTitle,
         }
       );
     }

--- a/static/js/components/tiles/line_tile.tsx
+++ b/static/js/components/tiles/line_tile.tsx
@@ -281,9 +281,9 @@ export function draw(
     {
       colors: props.colors,
       timeScale: props.timeScale,
+      title: chartTitle,
       unit: chartData.unit,
       useSvgLegend,
-      title: chartTitle,
     }
   );
   if (!isCompleteLine) {

--- a/static/js/components/tiles/line_tile.tsx
+++ b/static/js/components/tiles/line_tile.tsx
@@ -262,7 +262,8 @@ export function draw(
   props: LineTilePropType,
   chartData: LineChartData,
   svgContainer: HTMLDivElement,
-  useSvgLegend?: boolean
+  useSvgLegend?: boolean,
+  chartTitle?: string
 ): void {
   // TODO: Remove all cases of setting innerHTML directly.
   svgContainer.innerHTML = "";
@@ -282,6 +283,7 @@ export function draw(
       timeScale: props.timeScale,
       unit: chartData.unit,
       useSvgLegend,
+      title: chartTitle,
     }
   );
   if (!isCompleteLine) {

--- a/static/js/components/tiles/scatter_tile.tsx
+++ b/static/js/components/tiles/scatter_tile.tsx
@@ -435,7 +435,8 @@ export function draw(
   svgChartHeight: number,
   tooltip: HTMLDivElement,
   scatterTileSpec: ScatterTileSpec,
-  svgWidth?: number
+  svgWidth?: number,
+  chartTitle?: string
 ): void {
   if (chartData.errorMsg) {
     showError(chartData.errorMsg, svgContainer);
@@ -486,7 +487,8 @@ export function draw(
     plotOptions,
     chartData.points,
     _.noop,
-    getTooltipElement
+    getTooltipElement,
+    chartTitle
   );
 }
 

--- a/static/nodejs_server/bar_tile.ts
+++ b/static/nodejs_server/bar_tile.ts
@@ -60,12 +60,13 @@ function getTileProp(
 
 function getBarChartSvg(
   tileProp: BarTilePropType,
-  chartData: BarChartData
+  chartData: BarChartData,
+  chartTitle: string
 ): SVGSVGElement {
   const tileContainer = document.createElement("div");
   tileContainer.setAttribute("id", tileProp.id);
   document.getElementById(DOM_ID).appendChild(tileContainer);
-  draw(tileProp, chartData, tileContainer, SVG_WIDTH, true);
+  draw(tileProp, chartData, tileContainer, SVG_WIDTH, true, chartTitle);
   const chartSvg = tileContainer.querySelector("svg");
   // viewBox attribute throws off sizing in node server
   chartSvg.removeAttribute("viewBox");
@@ -102,6 +103,10 @@ export async function getBarTileResult(
   );
   try {
     const chartData = await fetchData(tileProp);
+    const chartTitle = getChartTitle(
+      tileConfig.title,
+      getReplacementStrings(chartData)
+    );
     let legend = [];
     if (
       !_.isEmpty(chartData.dataGroup) &&
@@ -113,7 +118,7 @@ export async function getBarTileResult(
       data_csv: dataGroupsToCsv(chartData.dataGroup),
       srcs: getSources(chartData.sources),
       legend,
-      title: getChartTitle(tileConfig.title, getReplacementStrings(chartData)),
+      title: chartTitle,
       type: "BAR",
       unit: chartData.unit,
     };
@@ -129,7 +134,7 @@ export async function getBarTileResult(
       );
       return result;
     }
-    const svg = getBarChartSvg(tileProp, chartData);
+    const svg = getBarChartSvg(tileProp, chartData, chartTitle);
     result.svg = getSvgXml(svg);
     return result;
   } catch (e) {
@@ -163,7 +168,11 @@ export async function getBarChart(
   );
   try {
     const chartData = await fetchData(tileProp);
-    return getBarChartSvg(tileProp, chartData);
+    const chartTitle = getChartTitle(
+      tileConfig.title,
+      getReplacementStrings(chartData)
+    );
+    return getBarChartSvg(tileProp, chartData, chartTitle);
   } catch (e) {
     console.log("Failed to get bar chart");
     return null;

--- a/static/nodejs_server/line_tile.ts
+++ b/static/nodejs_server/line_tile.ts
@@ -59,12 +59,13 @@ function getTileProp(
 
 function getLineChartSvg(
   tileProp: LineTilePropType,
-  chartData: LineChartData
+  chartData: LineChartData,
+  chartTitle: string
 ): SVGSVGElement {
   const tileContainer = document.createElement("div");
   tileContainer.setAttribute("id", CHART_ID);
   document.getElementById(DOM_ID).appendChild(tileContainer);
-  draw(tileProp, chartData, tileContainer, true);
+  draw(tileProp, chartData, tileContainer, true, chartTitle);
   return getProcessedSvg(tileContainer.querySelector("svg"));
 }
 
@@ -89,11 +90,15 @@ export async function getLineTileResult(
   const tileProp = getTileProp(id, tileConfig, place, statVarSpec, apiRoot);
   try {
     const chartData = await fetchData(tileProp);
+    const chartTitle = getChartTitle(
+      tileConfig.title,
+      getReplacementStrings(tileProp)
+    );
     const result: TileResult = {
       data_csv: dataGroupsToCsv(chartData.dataGroup),
       srcs: getSources(chartData.sources),
       legend: chartData.dataGroup.map((dg) => dg.label || "A"),
-      title: getChartTitle(tileConfig.title, getReplacementStrings(tileProp)),
+      title: chartTitle,
       type: "LINE",
       unit: chartData.unit,
     };
@@ -143,7 +148,7 @@ export async function getLineTileResult(
       );
       return result;
     }
-    const svg = getLineChartSvg(tileProp, chartData);
+    const svg = getLineChartSvg(tileProp, chartData, chartTitle);
     result.svg = getSvgXml(svg);
     return result;
   } catch (e) {
@@ -174,7 +179,11 @@ export async function getLineChart(
   );
   try {
     const chartData = await fetchData(tileProp);
-    return getLineChartSvg(tileProp, chartData);
+    const chartTitle = getChartTitle(
+      tileConfig.title,
+      getReplacementStrings(tileProp)
+    );
+    return getLineChartSvg(tileProp, chartData, chartTitle);
   } catch (e) {
     console.log("Failed to get line chart");
     return null;

--- a/static/nodejs_server/scatter_tile.ts
+++ b/static/nodejs_server/scatter_tile.ts
@@ -86,6 +86,10 @@ export async function getScatterTileResult(
 
   try {
     const chartData = await fetchData(tileProp);
+    const chartTitle = getChartTitle(
+      tileConfig.title,
+      getReplacementStrings(tileProp, chartData)
+    );
     const result: TileResult = {
       data_csv: scatterDataToCsv(
         chartData.xStatVar.statVar,
@@ -95,10 +99,7 @@ export async function getScatterTileResult(
         chartData.points
       ),
       srcs: getSources(chartData.sources),
-      title: getChartTitle(
-        tileConfig.title,
-        getReplacementStrings(tileProp, chartData)
-      ),
+      title: chartTitle,
       type: "SCATTER",
     };
     if (useChartUrl) {
@@ -120,7 +121,8 @@ export async function getScatterTileResult(
       SVG_HEIGHT,
       null /* tooltipHtml */,
       tileConfig.scatterTileSpec,
-      SVG_WIDTH
+      SVG_WIDTH,
+      chartTitle
     );
     const svg = getProcessedSvg(svgContainer.querySelector("svg"));
     result.svg = getSvgXml(svg);
@@ -156,6 +158,10 @@ export async function getScatterChart(
   );
   try {
     const chartData = await fetchData(tileProp);
+    const chartTitle = getChartTitle(
+      tileConfig.title,
+      getReplacementStrings(tileProp, chartData)
+    );
     const svgContainer = document.createElement("div");
     draw(
       chartData,
@@ -163,7 +169,8 @@ export async function getScatterChart(
       SVG_HEIGHT,
       null /* tooltipHtml */,
       tileConfig.scatterTileSpec,
-      SVG_WIDTH
+      SVG_WIDTH,
+      chartTitle
     );
     return getProcessedSvg(svgContainer.querySelector("svg"));
   } catch (e) {


### PR DESCRIPTION
<img width="546" alt="Screenshot 2024-01-11 at 3 15 33 PM" src="https://github.com/datacommonsorg/website/assets/69875368/2be2e126-2e8d-45e3-97f1-530773b5c4c5">
<img width="546" alt="Screenshot 2024-01-11 at 3 16 01 PM" src="https://github.com/datacommonsorg/website/assets/69875368/1fdbcdf4-8329-41c5-9172-c30dc4797a3a">
<img width="548" alt="Screenshot 2024-01-11 at 3 14 42 PM" src="https://github.com/datacommonsorg/website/assets/69875368/e5ffc409-0a49-4b3c-95cb-bca086f069e1">

Note: Ideally would like to use larger font for the chart title, but the hack for getting bbox to work on node server depends on the text within a chart to be all the same size .. 