### PR TITLE
[vis tool] fix source selector on timeline

### DIFF
--- a/server/routes/shared_api/facets.py
+++ b/server/routes/shared_api/facets.py
@@ -62,7 +62,7 @@ def get_facets_within():
                                   True)
 
 
-@bp.route('/')
+@bp.route('/', strict_slashes=False)
 def get_facets():
   """Gets the available facets for a list of stat vars for a list of places.
   """


### PR DESCRIPTION
This fixes the source selector for the timelines on vis tool (https://screenshot.googleplex.com/kX3735zMTDF7uFR). The problem was that the endpoint for fetching the facets enforced strict slashes, but the client was not passing in a slash and so the client was being redirected to a location it could not access.