### PR TITLE
[Place Page SEO] Add canonical link to header

### DIFF
--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -30,7 +30,7 @@ CATEGORY_REDIRECTS = {
 
 
 @bp.route('', strict_slashes=False)
-@bp.route('/<path:place_dcid>', strict_slashes=False)
+@bp.route('/<path:place_dcid>/', strict_slashes=False)
 def place(place_dcid=None):
   redirect_args = dict(flask.request.args)
   should_redirect = False

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -30,7 +30,7 @@ CATEGORY_REDIRECTS = {
 
 
 @bp.route('', strict_slashes=False)
-@bp.route('/<path:place_dcid>/', strict_slashes=False)
+@bp.route('/<path:place_dcid>', strict_slashes=False)
 def place(place_dcid=None):
   redirect_args = dict(flask.request.args)
   should_redirect = False

--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -21,14 +21,16 @@ limitations under the License.
 {% set subpage_title = _('Place Explorer') %}
 {% set subpage_url = url_for('place.place') %}
 {% set place_category = category %}
+{% set canonical_base_url = url_for('place.place', place_dcid=place_dcid) %}
+{% set canonical_category_url = url_for('place.place', place_dcid=place_dcid, category=category) %}
 
 {% block head %}
 <link rel="stylesheet" href={{url_for('static', filename='css/place_page.min.css' , t=config['VERSION'])}}>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
 {% if category == '' %}
-<link rel="canonical" href="https://{{ request.host }}/place/{{ place_dcid }}" />
+<link rel="canonical" href="https://{{ request.host }}{{ canonical_base_url }}" />
 {% elif category != '' %}
-<link rel="canonical" href="https://{{ request.host }}/place/{{ place_dcid }}?category={{ category }}" />
+<link rel="canonical" href="https://{{ request.host }}{{ canonical_category_url }}" />
 {% endif %}
 {% endblock %}
 

--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -26,9 +26,9 @@ limitations under the License.
 <link rel="stylesheet" href={{url_for('static', filename='css/place_page.min.css' , t=config['VERSION'])}}>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
 {% if category == '' %}
-<link rel="canonical" href="https://datacommons.org/place/{{ place_dcid }}" />
+<link rel="canonical" href="https://{{ request.host }}/place/{{ place_dcid }}" />
 {% elif category != '' %}
-<link rel="canonical" href="https://datacommons.org/place/{{ place_dcid }}?category={{ category }}" />
+<link rel="canonical" href="https://{{ request.host }}/place/{{ place_dcid }}?category={{ category }}" />
 {% endif %}
 {% endblock %}
 

--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -25,6 +25,11 @@ limitations under the License.
 {% block head %}
 <link rel="stylesheet" href={{url_for('static', filename='css/place_page.min.css' , t=config['VERSION'])}}>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
+{% if category == '' %}
+<link rel="canonical" href="https://datacommons.org/place/{{ place_dcid }}" />
+{% elif category != '' %}
+<link rel="canonical" href="https://datacommons.org/place/{{ place_dcid }}?category={{ category }}" />
+{% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Adds a [canonical link](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method) to the header of our place pages, following the [guidance to consolidate duplicate URLs](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls). This change will help us fix "Duplicate without user-selected canonical" indexing errors. The canonical urls were chosen to match the entries in our sitemaps.