### PR TITLE
fix webdriver tests

### DIFF
--- a/server/integration_tests/test_data/e2e_answer_places/howabouttheuninsuredpopulation/chart_config.json
+++ b/server/integration_tests/test_data/e2e_answer_places/howabouttheuninsuredpopulation/chart_config.json
@@ -721,7 +721,6 @@
       "Count_Person_Female_NoHealthInsurance": {
         "age": [
           "Count_Person_18To64Years_Female_NoHealthInsurance",
-          "Count_Person_21To64Years_Female_NoHealthInsurance",
           "dc/001qmh9sdqzeb",
           "dc/0flj62fpwwxd",
           "dc/bhlcb3wz4b3v2",
@@ -738,8 +737,6 @@
       },
       "Count_Person_Male_NoHealthInsurance": {
         "age": [
-          "Count_Person_18To64Years_Male_NoHealthInsurance",
-          "Count_Person_21To64Years_Male_NoHealthInsurance",
           "dc/1qdvp8x0t3l11",
           "dc/260gxgmeglpb",
           "dc/33z5t6xqjepp1",
@@ -758,12 +755,6 @@
         "age": [
           "Count_Person_18OrMoreYears_NoHealthInsurance",
           "Count_Person_18To24Years_NoHealthInsurance",
-          "Count_Person_18To64Years_NoHealthInsurance",
-          "Count_Person_19To25Years_NoHealthInsurance",
-          "Count_Person_19To64Years_NoHealthInsurance",
-          "Count_Person_21To64Years_NoHealthInsurance",
-          "Count_Person_25OrMoreYears_NoHealthInsurance",
-          "Count_Person_25To34Years_NoHealthInsurance",
           "dc/6cd3lft0vm4f5",
           "dc/e8e2b0m921k68",
           "dc/kk8cqe86becs4"
@@ -771,21 +762,6 @@
         "gender": [
           "Count_Person_Female_NoHealthInsurance",
           "Count_Person_Male_NoHealthInsurance"
-        ],
-        "householdIncome": [
-          "Count_Person_NoHealthInsurance_100000OrMoreInflationAdjustedUSDCurrentYear_ResidesInHousehold",
-          "Count_Person_NoHealthInsurance_25000OrLessInflationAdjustedUSDCurrentYear_ResidesInHousehold",
-          "Count_Person_NoHealthInsurance_25000To49999InflationAdjustedUSDCurrentYear_ResidesInHousehold",
-          "Count_Person_NoHealthInsurance_50000To74999InflationAdjustedUSDCurrentYear_ResidesInHousehold",
-          "Count_Person_NoHealthInsurance_75000To99999InflationAdjustedUSDCurrentYear_ResidesInHousehold"
-        ],
-        "householdType": [
-          "Count_Person_NoHealthInsurance_FamilyHousehold",
-          "Count_Person_NoHealthInsurance_MarriedCoupleFamilyHousehold",
-          "Count_Person_NoHealthInsurance_NonfamilyHouseholdAndOtherLivingArrangements",
-          "Count_Person_NoHealthInsurance_OtherFamilyHousehold",
-          "Count_Person_NoHealthInsurance_SingleFatherFamilyHousehold",
-          "Count_Person_NoHealthInsurance_SingleMotherFamilyHousehold"
         ],
         "race": [
           "Count_Person_NoHealthInsurance_AmericanIndianOrAlaskaNativeAlone",
@@ -822,38 +798,7 @@
       "Count_Person_WithHealthInsurance": {
         "age": [
           "Count_Person_18OrMoreYears_WithHealthInsurance",
-          "Count_Person_18To24Years_WithHealthInsurance",
-          "Count_Person_18To64Years_WithHealthInsurance",
-          "Count_Person_19To25Years_WithHealthInsurance",
-          "Count_Person_19To64Years_WithHealthInsurance",
-          "Count_Person_21To64Years_WithHealthInsurance",
-          "Count_Person_25OrMoreYears_WithHealthInsurance"
-        ],
-        "race": [
-          "Count_Person_WithHealthInsurance_AmericanIndianOrAlaskaNativeAlone",
-          "Count_Person_WithHealthInsurance_AsianAlone",
-          "Count_Person_WithHealthInsurance_NativeHawaiianOrOtherPacificIslanderAlone"
-        ]
-      },
-      "Count_Person_WithMedicareCoverage": {
-        "age": [
-          "Count_Person_18OrLessYears_WithMedicareCoverage",
-          "Count_Person_18To64Years_WithMedicareCoverage",
-          "Count_Person_19OrLessYears_WithMedicareCoverage",
-          "Count_Person_19To64Years_WithMedicareCoverage",
-          "Count_Person_65OrMoreYears_WithMedicareCoverage"
-        ]
-      },
-      "Count_Person_WithPrivateHealthInsurance": {
-        "age": [
-          "Count_Person_18To24Years_WithPrivateHealthInsurance",
-          "Count_Person_19To25Years_WithPrivateHealthInsurance"
-        ]
-      },
-      "Count_Person_WithPublicHealthInsurance": {
-        "age": [
-          "Count_Person_18To24Years_WithPublicHealthInsurance",
-          "Count_Person_19To25Years_WithPublicHealthInsurance"
+          "Count_Person_18To24Years_WithHealthInsurance"
         ]
       },
       "Percent_Person_18To64Years_Female_NoHealthInsurance": {

--- a/server/integration_tests/test_data/fulfillment_api_comparison/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_comparison/chart_config.json
@@ -394,12 +394,9 @@
     "exploreMore": {
       "dc/0gettc3bc60cb": {
         "hasOccupation": [
-          "dc/b9plt3q5k6gyb",
           "dc/jszfr5wd4f7pb",
           "dc/k33ngtzpqxql6",
-          "dc/kt900ezddrf79",
-          "dc/r0delcsw86kc6",
-          "dc/wqbf0ppbmly7"
+          "dc/kt900ezddrf79"
         ]
       },
       "dc/6rltk4kf75612": {
@@ -415,11 +412,8 @@
       "dc/e9gftzl2hm8h9": {
         "commuteTime": [
           "dc/0mk1gv9me1cn",
-          "dc/2r6wbwvbkrz23",
           "dc/ddyrfe05v5347",
           "dc/e0zlyvx7twnr2",
-          "dc/hntm9bl6g1gn5",
-          "dc/jk6hj15v39b0d",
           "dc/qkm5qdj8rqf5h",
           "dc/xejg6s76dxle2",
           "dc/z00r6r95rb066"
@@ -427,10 +421,7 @@
       },
       "dc/hbkh95kc7pkb6": {
         "hasOccupation": [
-          "dc/2hhr4qp4b4r0b",
           "dc/4xklqxfc27w1f",
-          "dc/9vlv8l9dbgsk7",
-          "dc/j7lkt2ww5qsn5",
           "dc/n2vhkpw0slkv5",
           "dc/nvrxn11yxlen2"
         ]

--- a/server/integration_tests/test_data/fulfillment_api_correlation/chart_config.json
+++ b/server/integration_tests/test_data/fulfillment_api_correlation/chart_config.json
@@ -814,48 +814,7 @@
         ]
       }
     ],
-    "exploreMore": {
-      "dc/0gettc3bc60cb": {
-        "hasOccupation": [
-          "dc/b9plt3q5k6gyb",
-          "dc/jszfr5wd4f7pb",
-          "dc/k33ngtzpqxql6",
-          "dc/kt900ezddrf79",
-          "dc/r0delcsw86kc6",
-          "dc/wqbf0ppbmly7"
-        ]
-      },
-      "dc/6rltk4kf75612": {
-        "hasOccupation": [
-          "dc/7wt44yv38rew",
-          "dc/cs8fvwkmpmlpg",
-          "dc/dn2h9yfcgbkg2",
-          "dc/nfdf9rt7kbggb",
-          "dc/vh36nvvkwxz5g",
-          "dc/zf0wjwwyddbj4"
-        ]
-      },
-      "dc/hbkh95kc7pkb6": {
-        "hasOccupation": [
-          "dc/2hhr4qp4b4r0b",
-          "dc/4xklqxfc27w1f",
-          "dc/9vlv8l9dbgsk7",
-          "dc/j7lkt2ww5qsn5",
-          "dc/n2vhkpw0slkv5",
-          "dc/nvrxn11yxlen2"
-        ]
-      },
-      "dc/vp8cbt6k79t94": {
-        "hasOccupation": [
-          "dc/2r1c78wzvbq58",
-          "dc/bre4whrdn7pt7",
-          "dc/fgt7thnws9vx9",
-          "dc/n99t0lnl3fch6",
-          "dc/v33p7mwnpe9vb",
-          "dc/zcth2y8fqte1f"
-        ]
-      }
-    },
+    "exploreMore": {},
     "mainTopics": [
       {
         "dcid": "dc/topic/WorkCommute",

--- a/server/webdriver/shared.py
+++ b/server/webdriver/shared.py
@@ -61,6 +61,19 @@ def click_sv_group(driver, svg_name):
       break
 
 
+def select_source(driver, source_name, sv_dcid):
+  """With the source selector modal open, choose the source with name
+    source_name for variable with dcid sv_dcid"""
+  wait_for_loading(driver)
+  source_options = driver.find_elements(By.NAME, sv_dcid)
+  for option in source_options:
+    parent = option.find_element(By.XPATH, '..')
+    if source_name in parent.text:
+      option.click()
+      wait_for_loading(driver)
+      break
+
+
 def charts_rendered(driver):
   """
   Wait asynchronously for charts or web components to show up

--- a/server/webdriver/tests/vis_map_test.py
+++ b/server/webdriver/tests/vis_map_test.py
@@ -128,25 +128,26 @@ class TestVisMap(WebdriverBaseTest):
     element_present = EC.presence_of_element_located(
         (By.CLASS_NAME, 'modal-body'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
-    source_options = self.driver.find_elements(By.CSS_SELECTOR,
-                                               '.source-selector-option input')
-    self.assertTrue(len(source_options) > 5)
-    source_options[3].click()
+    shared.select_source(self.driver, "CDC_Mortality_UnderlyingCause",
+                         "Count_Person_Female")
     update_button = self.driver.find_element(By.CSS_SELECTOR,
                                              '.modal-footer .btn')
     update_button.click()
     shared.wait_for_loading(self.driver)
     chart_title = self.driver.find_element(By.CSS_SELECTOR,
                                            '.map-chart .chart-headers h4')
-    self.assertEqual(chart_title.text, "Female Population (2019)")
+    self.assertEqual(chart_title.text, "Female Population (2004 to 2020)")
+    chart_source = self.driver.find_element(
+        By.CSS_SELECTOR, '.map-chart .chart-headers .sources')
+    self.assertTrue("wonder.cdc.gov" in chart_source.text)
     chart_map = self.driver.find_element(By.ID, 'map-items')
     map_regions = chart_map.find_elements(By.TAG_NAME, 'path')
     self.assertEqual(len(map_regions), 58)
     ranking_items = self.driver.find_elements(By.CSS_SELECTOR,
                                               '.ranking-list .place-name')
     self.assertEqual(len(ranking_items), 10)
-    self.assertEqual(ranking_items[0].text, 'Nevada County, CA')
-    self.assertEqual(ranking_items[9].text, 'San Francisco County, CA')
+    self.assertEqual(ranking_items[0].text, 'Madera County, CA')
+    self.assertEqual(ranking_items[9].text, 'Tuolumne County, CA')
 
   def test_manually_enter_options(self):
     """Test entering place and stat var options manually will cause chart to

--- a/server/webdriver/tests/vis_scatter_test.py
+++ b/server/webdriver/tests/vis_scatter_test.py
@@ -138,12 +138,8 @@ class TestVisScatter(WebdriverBaseTest):
     self.driver.find_elements(By.CLASS_NAME,
                               'source-selector-trigger')[1].click()
     # Update the source for the Count_Person_Female sv
-    element_present = EC.element_to_be_clickable(
-        (By.NAME, 'Count_Person_Female'))
-    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
-    source_options = self.driver.find_elements(By.NAME, 'Count_Person_Female')
-    self.assertGreater(len(source_options), 3)
-    source_options[3].click()
+    shared.select_source(self.driver, "CDC_Mortality_UnderlyingCause",
+                         "Count_Person_Female")
     update_button = self.driver.find_element(By.CSS_SELECTOR,
                                              '.modal-footer .btn')
     update_button.click()
@@ -153,8 +149,11 @@ class TestVisScatter(WebdriverBaseTest):
                                            '.scatter-chart .chart-headers h4')
     self.assertEqual(
         chart_title.text,
-        "Population Without Health Insurance (2021) vs Female Population (2019)"
+        "Population Without Health Insurance (2021) vs Female Population (2004 to 2020)"
     )
+    chart_source = self.driver.find_element(
+        By.CSS_SELECTOR, '.scatter-chart .chart-headers .sources')
+    self.assertTrue("wonder.cdc.gov" in chart_source.text)
     chart = self.driver.find_element(By.ID, 'scatterplot')
     circles = chart.find_elements(By.TAG_NAME, 'circle')
     self.assertGreater(len(circles), 20)

--- a/server/webdriver/tests/vis_timeline_test.py
+++ b/server/webdriver/tests/vis_timeline_test.py
@@ -126,11 +126,8 @@ class TestVisTimeline(WebdriverBaseTest):
     element_present = EC.element_to_be_clickable(
         (By.NAME, 'Count_Person_Female'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
-    source_options = self.driver.find_elements(By.NAME, 'Count_Person_Female')
-    for option in source_options:
-      parent = option.find_element(By.XPATH, '..')
-      if 'OECDRegionalStatistics' in parent.text:
-        option.click()
+    shared.select_source(self.driver, "OECDRegionalStatistics",
+                         'Count_Person_Female')
     update_button = self.driver.find_element(By.CSS_SELECTOR,
                                              '.modal-footer .btn')
     update_button.click()


### PR DESCRIPTION
Fix webdriver tests and improve source selector checking by:
- picking the source by source name
- checking that the source has in fact changed in the chart

Also update NL goldens. The diffs all have to do with new commute data that was recently imported which caused svgs to get dropped from consideration when fetching related topics.