### PR TITLE
Apply best practices to base custom dc docker image.

### DIFF
--- a/build/python_node_go_protoc_envoy/Dockerfile
+++ b/build/python_node_go_protoc_envoy/Dockerfile
@@ -29,7 +29,7 @@ ENV GO111MODULE=on
 ENV PATH="${PATH}:/root/go/bin"
 
 RUN apt update \
-    && apt install -y curl zip wget gcc libc6-dev \
+    && apt install -y --no-install-recommends curl zip wget gcc libc6-dev unzip gpg \
     # Install Node
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
     && . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION} \
@@ -48,9 +48,10 @@ RUN apt update \
     && go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0 \
     && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0 \
     # Install Envoy
-    && apt install -y debian-keyring debian-archive-keyring apt-transport-https lsb-release \
+    && apt install -y --no-install-recommends debian-keyring debian-archive-keyring apt-transport-https lsb-release \
     && curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg \
     && echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/debian $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list \
     && apt update \
-    && apt install -y getenvoy-envoy
+    && apt install -y --no-install-recommends getenvoy-envoy \
+    && rm -rf /var/lib/apt/lists/*

--- a/build/python_node_go_protoc_envoy/Dockerfile
+++ b/build/python_node_go_protoc_envoy/Dockerfile
@@ -15,41 +15,42 @@
 
 FROM python:3.11.4-slim as base
 
-RUN apt update
-RUN apt install -y curl zip wget gcc libc6-dev
-
-# Install Node
+# Env setup
+# Node
 ENV NODE_VERSION=18.17.1
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
-RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
-
-# Install Golang
-RUN curl -O https://dl.google.com/go/go1.20.7.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.20.7.linux-amd64.tar.gz
+# Golang
 ENV PATH="${PATH}:/usr/local/go/bin"
-RUN go version
-
-# Install Protoc
-RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip
-RUN unzip protoc-3.19.4-linux-x86_64.zip -d /usr/local/protoc-3.19.4-linux-x86_64
-RUN chmod +x /usr/local/protoc-3.19.4-linux-x86_64/bin/protoc
+# Protoc
 ENV PATH="${PATH}:/usr/local/protoc-3.19.4-linux-x86_64/bin"
-RUN protoc --version
-
-# Install protobuf go plugin
+# Protobuf go plugin
 ENV GO111MODULE=on
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0
-RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
 ENV PATH="${PATH}:/root/go/bin"
 
-# Install Envoy
-RUN apt install -y debian-keyring debian-archive-keyring apt-transport-https lsb-release
-RUN curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
-RUN echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check
-RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/debian $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list
-RUN apt update
-RUN apt install -y getenvoy-envoy
+RUN apt update \
+    && apt install -y curl zip wget gcc libc6-dev \
+    # Install Node
+    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
+    && . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION} \
+    && . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION} \
+    && . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION} \
+    # Install Golang
+    && curl -O https://dl.google.com/go/go1.20.7.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.20.7.linux-amd64.tar.gz \
+    && go version \
+    # Install Protoc
+    && curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip \
+    && unzip protoc-3.19.4-linux-x86_64.zip -d /usr/local/protoc-3.19.4-linux-x86_64 \
+    && chmod +x /usr/local/protoc-3.19.4-linux-x86_64/bin/protoc \
+    && protoc --version \
+    # Install protobuf go plugin
+    && go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0 \
+    && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0 \
+    # Install Envoy
+    && apt install -y debian-keyring debian-archive-keyring apt-transport-https lsb-release \
+    && curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg \
+    && echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/debian $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list \
+    && apt update \
+    && apt install -y getenvoy-envoy

--- a/build/python_node_go_protoc_envoy/cloudbuild.yaml
+++ b/build/python_node_go_protoc_envoy/cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 substitutions:
-  _VERS: "2023-10-05"
+  _VERS: "2024-01-29"
 
 steps:
   - name: "gcr.io/cloud-builders/docker"


### PR DESCRIPTION
* Applied some of the [best practices][practices] for building docker images for the base custom dc docker image.
* Although the overall image size did not change by much, it reduced number of layers with non-zero size in the base image from 18 to 1. Since the base image won't change often, collapsing it into a single layer should help in the future.
* Ran cloud build and pushed the new image to the [cloud directory][directory].
  + Will use this image with the custom DC docker image locally and verify it works before pushing the latter to the cloud.

[practices]: https://www.ecloudcontrol.com/best-practices-to-reduce-docker-images-size
[directory]: gcr.io/datcom-ci/python-node-go-protoc-envoy