### PR TITLE
[nodejs] use compression to shorten chartUrl

### DIFF
--- a/static/nodejs_server/constants.ts
+++ b/static/nodejs_server/constants.ts
@@ -44,11 +44,17 @@ export const MAP_LEGEND_CONSTANT_WIDTH =
 // Url params used for getting a single chart
 export const CHART_URL_PARAMS = {
   TILE_CONFIG: "config",
-  PLACE: "place",
-  ENCLOSED_PLACE_TYPE: "enclosedPlaceType",
-  STAT_VAR_SPEC: "svSpec",
-  EVENT_TYPE_SPEC: "eventTypeSpec",
+  PLACE: "pl",
+  ENCLOSED_PLACE_TYPE: "plt",
+  STAT_VAR_SPEC: "sv",
+  EVENT_TYPE_SPEC: "evt",
   API_KEY: "apikey",
   // If set, returns chart as an svg. Otherwise, returns chart as a png image.
   AS_SVG: "svg",
+};
+// Map of compressed value to the html encoding to use for that value.
+export const COMPRESSED_VAL_ENCODING = {
+  "+": "%2B",
+  "/": "%2F",
+  "=": "%3D",
 };

--- a/static/nodejs_server/constants.ts
+++ b/static/nodejs_server/constants.ts
@@ -41,14 +41,19 @@ export const FONT_SIZE = "10px";
 // Width of the constant sized part of the map legend
 export const MAP_LEGEND_CONSTANT_WIDTH =
   LEGEND_IMG_WIDTH + LEGEND_MARGIN_RIGHT + LEGEND_TICK_LABEL_MARGIN;
-// Url params used for getting a single chart
-export const CHART_URL_PARAMS = {
+// Url params used for /nodejs/chart-info endpoint
+export const CHART_INFO_PARAMS = {
   TILE_CONFIG: "config",
-  PLACE: "pl",
-  ENCLOSED_PLACE_TYPE: "plt",
-  STAT_VAR_SPEC: "sv",
-  EVENT_TYPE_SPEC: "evt",
+  PLACE: "place",
+  ENCLOSED_PLACE_TYPE: "enclosedPlaceType",
+  STAT_VAR_SPEC: "svSpec",
+  EVENT_TYPE_SPEC: "eventTypeSpec",
+};
+// Url params used for /nodejs/chart endpoint
+export const CHART_PARAMS = {
   API_KEY: "apikey",
+  // props to use for drawing the chart
+  PROPS: "props",
   // If set, returns chart as an svg. Otherwise, returns chart as a png image.
   AS_SVG: "svg",
 };

--- a/static/nodejs_server/types.ts
+++ b/static/nodejs_server/types.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import { StatVarSpec } from "../js/shared/types";
+import {
+  EventTypeSpec,
+  TileConfig,
+} from "../js/types/subject_page_proto_types";
+
 /**
  * Types used for nodejs server
  */
@@ -43,4 +49,13 @@ export interface TileResult {
   };
   // The link to the data commons explore page for this result.
   dcUrl?: string;
+}
+
+// Properties to use for drawing a single chart
+export interface ChartProps {
+  place: string;
+  enclosedPlaceType: string;
+  statVarSpec: StatVarSpec[];
+  tileConfig: TileConfig;
+  eventTypeSpec: Record<string, EventTypeSpec>;
 }

--- a/static/nodejs_server/utils.test.ts
+++ b/static/nodejs_server/utils.test.ts
@@ -20,42 +20,42 @@ const TEST_PLACE = "testPlace";
 const TEST_PLACE_TYPE = "placeType";
 const TEST_SV_SPEC = [
   {
-    name: "sv1",
-    statVar: "svDcid1",
     denom: "denom1",
-    unit: "",
-    scaling: 1,
     log: false,
+    name: "sv1",
+    scaling: 1,
+    statVar: "svDcid1",
+    unit: "",
   },
   {
-    name: "sv2",
-    statVar: "svDcid2",
     denom: "denom2",
-    unit: "",
-    scaling: 1,
     log: false,
+    name: "sv2",
+    scaling: 1,
+    statVar: "svDcid2",
+    unit: "",
   },
 ];
 const TEST_CONFIG = {
-  type: "BAR",
   barTileSpec: { maxPlaces: 15, sort: "DESCENDING" },
   description: "",
   statVarKey: [],
+  type: "BAR",
 };
 const TEST_EVENT_TYPE_SPEC = {
   testSpec: {
-    id: "testSpec",
-    name: "testSpecName",
-    eventTypeDcids: ["stormDcid"],
     color: "blue",
     defaultSeverityFilter: {
+      lowerLimit: 100,
       prop: "area",
       unit: "m2",
       upperLimit: 1000,
-      lowerLimit: 100,
     },
     displayProp: [],
     endDateProp: [],
+    eventTypeDcids: ["stormDcid"],
+    id: "testSpec",
+    name: "testSpecName",
   },
 };
 

--- a/static/nodejs_server/utils.test.ts
+++ b/static/nodejs_server/utils.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChartProps } from "./types";
+import { compressChartProps, decompressChartProps } from "./utils";
+
+const TEST_PLACE = "testPlace";
+const TEST_PLACE_TYPE = "placeType";
+const TEST_SV_SPEC = [
+  {
+    name: "sv1",
+    statVar: "svDcid1",
+    denom: "denom1",
+    unit: "",
+    scaling: 1,
+    log: false,
+  },
+  {
+    name: "sv2",
+    statVar: "svDcid2",
+    denom: "denom2",
+    unit: "",
+    scaling: 1,
+    log: false,
+  },
+];
+const TEST_CONFIG = {
+  type: "BAR",
+  barTileSpec: { maxPlaces: 15, sort: "DESCENDING" },
+  description: "",
+  statVarKey: [],
+};
+const TEST_EVENT_TYPE_SPEC = {
+  testSpec: {
+    id: "testSpec",
+    name: "testSpecName",
+    eventTypeDcids: ["stormDcid"],
+    color: "blue",
+    defaultSeverityFilter: {
+      prop: "area",
+      unit: "m2",
+      upperLimit: 1000,
+      lowerLimit: 100,
+    },
+    displayProp: [],
+    endDateProp: [],
+  },
+};
+
+test("compress and decompress chart props", () => {
+  const cases: ChartProps[] = [
+    {
+      tileConfig: TEST_CONFIG,
+      eventTypeSpec: TEST_EVENT_TYPE_SPEC,
+      place: TEST_PLACE,
+      statVarSpec: TEST_SV_SPEC,
+      enclosedPlaceType: TEST_PLACE_TYPE,
+    },
+  ];
+
+  for (const c of cases) {
+    const compressedChartProp = compressChartProps(c);
+    const decompressedChartProp = decompressChartProps(compressedChartProp);
+    try {
+      expect(decompressedChartProp).toEqual(c);
+    } catch (e) {
+      console.log(`Failed for case with chartProp: ${c}`);
+      throw e;
+    }
+  }
+});

--- a/static/nodejs_server/utils.test.ts
+++ b/static/nodejs_server/utils.test.ts
@@ -62,11 +62,11 @@ const TEST_EVENT_TYPE_SPEC = {
 test("compress and decompress chart props", () => {
   const cases: ChartProps[] = [
     {
-      tileConfig: TEST_CONFIG,
+      enclosedPlaceType: TEST_PLACE_TYPE,
       eventTypeSpec: TEST_EVENT_TYPE_SPEC,
       place: TEST_PLACE,
       statVarSpec: TEST_SV_SPEC,
-      enclosedPlaceType: TEST_PLACE_TYPE,
+      tileConfig: TEST_CONFIG,
     },
   ];
 

--- a/static/nodejs_server/utils.ts
+++ b/static/nodejs_server/utils.ts
@@ -132,11 +132,11 @@ export function getChartUrl(
   // it's used to generate the statVarSpec which itself gets passed in the url.
   delete tileConfigParamVal.statVarKey;
   const chartProps: ChartProps = {
-    place: placeDcid,
     enclosedPlaceType,
+    eventTypeSpec,
+    place: placeDcid,
     statVarSpec,
     tileConfig: tileConfigParamVal,
-    eventTypeSpec,
   };
   const paramMapping = {
     [CHART_PARAMS.API_KEY]: apikey,

--- a/static/src/server.ts
+++ b/static/src/server.ts
@@ -39,7 +39,8 @@ import { getTileEventTypeSpecs } from "../js/utils/tile_utils";
 import { getBarChart, getBarTileResult } from "../nodejs_server/bar_tile";
 import {
   CHART_ID,
-  CHART_URL_PARAMS,
+  CHART_INFO_PARAMS,
+  CHART_PARAMS,
   COMPRESSED_VAL_ENCODING,
 } from "../nodejs_server/constants";
 import {
@@ -54,6 +55,7 @@ import {
   getScatterTileResult,
 } from "../nodejs_server/scatter_tile";
 import { TileResult } from "../nodejs_server/types";
+import { decompressChartProps } from "../nodejs_server/utils";
 const app = express();
 const APP_CONFIGS = {
   local: {
@@ -621,40 +623,20 @@ app.get("/nodejs/query", (req: Request, res: Response) => {
 });
 
 app.get("/nodejs/chart", (req: Request, res: Response) => {
-  // For each value in the request query, process and decompress it.
-  const decompressedReqVals = {};
-  for (const key in req.query) {
-    let val = req.query[key] as string;
-    // Convert all the manually escaped characters back to their original
-    // characters.
-    for (const c in COMPRESSED_VAL_ENCODING) {
-      val = val.replaceAll(COMPRESSED_VAL_ENCODING[c], c);
-    }
-    // decompress the value
-    val = zlib.inflateSync(Buffer.from(val, "base64")).toString();
-    decompressedReqVals[key] = val;
-  }
-  const place = _.escape(decompressedReqVals[CHART_URL_PARAMS.PLACE]);
-  const enclosedPlaceType = _.escape(
-    decompressedReqVals[CHART_URL_PARAMS.ENCLOSED_PLACE_TYPE] as string
+  const chartProps = decompressChartProps(
+    req.query[CHART_PARAMS.PROPS] as string
   );
-  const svSpec =
-    CHART_URL_PARAMS.STAT_VAR_SPEC in decompressedReqVals
-      ? JSON.parse(decompressedReqVals[CHART_URL_PARAMS.STAT_VAR_SPEC])
-      : [];
-  const eventTypeSpec =
-    CHART_URL_PARAMS.EVENT_TYPE_SPEC in decompressedReqVals
-      ? JSON.parse(decompressedReqVals[CHART_URL_PARAMS.EVENT_TYPE_SPEC])
-      : {};
-  const tileConfig =
-    CHART_URL_PARAMS.TILE_CONFIG in decompressedReqVals
-      ? JSON.parse(decompressedReqVals[CHART_URL_PARAMS.TILE_CONFIG])
-      : null;
   const useSvgFormat =
-    req.query[CHART_URL_PARAMS.AS_SVG] === URL_PARAM_VALUE_TRUTHY;
+    req.query[CHART_PARAMS.AS_SVG] === URL_PARAM_VALUE_TRUTHY;
   const contentType = useSvgFormat ? "image/svg+xml" : "image/png";
   res.setHeader("Content-Type", contentType);
-  getTileChart(tileConfig, place, enclosedPlaceType, svSpec, eventTypeSpec)
+  getTileChart(
+    chartProps.tileConfig,
+    chartProps.place,
+    chartProps.enclosedPlaceType,
+    chartProps.statVarSpec,
+    chartProps.eventTypeSpec
+  )
     .then((chart) => {
       if (useSvgFormat) {
         res.status(200).send(chart.outerHTML);
@@ -680,15 +662,15 @@ app.get("/nodejs/chart", (req: Request, res: Response) => {
 
 // TODO: come up with better params
 app.get("/nodejs/chart-info", (req: Request, res: Response) => {
-  const place = _.escape(req.query[CHART_URL_PARAMS.PLACE] as string);
+  const place = _.escape(req.query[CHART_INFO_PARAMS.PLACE] as string);
   const enclosedPlaceType = _.escape(
-    req.query[CHART_URL_PARAMS.ENCLOSED_PLACE_TYPE] as string
+    req.query[CHART_INFO_PARAMS.ENCLOSED_PLACE_TYPE] as string
   );
   const svSpec = JSON.parse(
-    req.query[CHART_URL_PARAMS.STAT_VAR_SPEC] as string
+    req.query[CHART_INFO_PARAMS.STAT_VAR_SPEC] as string
   );
   const tileConfig = JSON.parse(
-    req.query[CHART_URL_PARAMS.TILE_CONFIG] as string
+    req.query[CHART_INFO_PARAMS.TILE_CONFIG] as string
   );
   res.setHeader("Content-Type", "application/json");
   const namedTypedPlace = { dcid: place, name: place, types: [] };

--- a/static/src/server.ts
+++ b/static/src/server.ts
@@ -19,7 +19,6 @@ import express, { Request, Response } from "express";
 import { JSDOM } from "jsdom";
 import _ from "lodash";
 import sharp from "sharp";
-import * as zlib from "zlib";
 
 import {
   fetchDisasterEventData,


### PR DESCRIPTION
Sometimes chartUrl that is returned in the response is too long to send a GET request to. Use compression to shorten the URL

For example, "Which industries have grown the most in California" chartUrls:
current (5810 characters): https://screenshot.googleplex.com/4WUDYVS5N2MQsVj
with compression (1513 characters): https://screenshot.googleplex.com/8HAWVmq7Yef9BQE