### PR TITLE
[Place Page SEO] Add Canonical and Localization HTTP headers

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -94,17 +94,16 @@ function run_py_test {
   python3 -m venv .env
   source .env/bin/activate
   export FLASK_ENV=test
-  python3 -m pytest server/tests/routes/place_test.py
-  # python3 -m pytest server/tests/ -s
-  # python3 -m pytest shared/tests/ -s
-  # python3 -m pytest nl_server/tests/ -s
+  python3 -m pytest server/tests/ -s
+  python3 -m pytest shared/tests/ -s
+  python3 -m pytest nl_server/tests/ -s
 
-  # # Tests within tools/nl/embeddings
-  # echo "Running tests within tools/nl/embeddings:"
-  # cd tools/nl/embeddings
-  # pip3 install -r requirements.txt
-  # python3 -m pytest ./ -s
-  # cd ../../..
+  # Tests within tools/nl/embeddings
+  echo "Running tests within tools/nl/embeddings:"
+  cd tools/nl/embeddings
+  pip3 install -r requirements.txt
+  python3 -m pytest ./ -s
+  cd ../../..
 
   pip3 install yapf==0.33.0 -q
   if ! command -v isort &> /dev/null

--- a/run_test.sh
+++ b/run_test.sh
@@ -94,16 +94,17 @@ function run_py_test {
   python3 -m venv .env
   source .env/bin/activate
   export FLASK_ENV=test
-  python3 -m pytest server/tests/ -s
-  python3 -m pytest shared/tests/ -s
-  python3 -m pytest nl_server/tests/ -s
+  python3 -m pytest server/tests/routes/place_test.py
+  # python3 -m pytest server/tests/ -s
+  # python3 -m pytest shared/tests/ -s
+  # python3 -m pytest nl_server/tests/ -s
 
-  # Tests within tools/nl/embeddings
-  echo "Running tests within tools/nl/embeddings:"
-  cd tools/nl/embeddings
-  pip3 install -r requirements.txt
-  python3 -m pytest ./ -s
-  cd ../../..
+  # # Tests within tools/nl/embeddings
+  # echo "Running tests within tools/nl/embeddings:"
+  # cd tools/nl/embeddings
+  # pip3 install -r requirements.txt
+  # python3 -m pytest ./ -s
+  # cd ../../..
 
   pip3 install yapf==0.33.0 -q
   if ! command -v isort &> /dev/null

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -107,7 +107,7 @@ def place(place_dcid=None):
   locale = flask.request.args.get('hl')
   if locale not in AVAILABLE_LANGUAGES:
     locale = 'en'
-  
+
   is_overview = (not category) or (category == 'Overview')
 
   place_summary = {}
@@ -131,20 +131,21 @@ def place(place_dcid=None):
           place_summary=place_summary.get('summary') if place_summary else '',
           maps_api_key=current_app.config['MAPS_API_KEY']))
 
-  # Compute localized urls for http header, used by search crawlers
+  # Compute localized canonical urls for http header, used by search crawlers
   link_headers = []
   for locale_code in AVAILABLE_LANGUAGES:
     canonical_args = {
-      'place_dcid': place_dcid,
-      'category': category if category else None,
-      'hl': locale_code if locale_code != 'en' else None
+        'place_dcid': place_dcid,
+        'category': category if category else None,
+        'hl': locale_code if locale_code != 'en' else None
     }
-    localized_url = CANONICAL_ROOT + flask.url_for('place.place', **canonical_args)
+    localized_url = CANONICAL_ROOT + flask.url_for('place.place', **
+                                                   canonical_args)
 
     # Add localized url as a language alternate link to headers
     link_headers.append(
         f'<{localized_url}>; rel="alternate"; hreflang="{locale_code}"')
-    
+
     if locale_code == locale:
       # Set the url of the current locale as the canonical
       link_headers.append(f'<{localized_url}>; rel="canonical"')

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -27,6 +27,18 @@ import server.routes.shared_api.place as place_api
 
 bp = flask.Blueprint('place', __name__, url_prefix='/place')
 
+CATEGORIES = [
+    "Economics",
+    "Health",
+    "Equity",
+    "Crime",
+    "Education",
+    "Demographics",
+    "Housing",
+    "Environment",
+    "Energy",
+]
+
 CATEGORY_REDIRECTS = {
     "Climate": "Environment",
 }
@@ -136,7 +148,7 @@ def place(place_dcid=None):
   for locale_code in AVAILABLE_LANGUAGES:
     canonical_args = {
         'place_dcid': place_dcid,
-        'category': category if category else None,
+        'category': category if category in CATEGORIES else None,
         'hl': locale_code if locale_code != 'en' else None
     }
     localized_url = CANONICAL_ROOT + flask.url_for('place.place', **

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -62,7 +62,9 @@ def get_place_summaries() -> dict:
   with open(local_path) as f:
     return json.load(f)
 
-def generate_link_headers(place_dcid: str, category: str, current_locale: str) -> str:
+
+def generate_link_headers(place_dcid: str, category: str,
+                          current_locale: str) -> str:
   """Generate canonical and alternate link HTTP headers
   
   Search crawlers look for rel="canonical" link headers to determine which
@@ -70,7 +72,11 @@ def generate_link_headers(place_dcid: str, category: str, current_locale: str) -
 
   Args:
     place_dcid: DCID of the place the page is about
-    
+    category: category of the page
+    current_locale: locale of the page
+  
+  Returns:
+    String to pass as value for 'Link' HTTP header
   """
   link_headers = []
   for locale_code in AVAILABLE_LANGUAGES:
@@ -171,7 +177,8 @@ def place(place_dcid=None):
           category=category if category else '',
           place_summary=place_summary.get('summary') if place_summary else '',
           maps_api_key=current_app.config['MAPS_API_KEY']))
-  response.headers.set('Link', generate_link_headers(place_dcid, category, locale))
+  response.headers.set('Link',
+                       generate_link_headers(place_dcid, category, locale))
 
   return response
 

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -68,7 +68,8 @@ def generate_link_headers(place_dcid: str, category: str,
   """Generate canonical and alternate link HTTP headers
   
   Search crawlers look for rel="canonical" link headers to determine which
-  version of a page to crawl and rel="alternative" link headers
+  version of a page to crawl and rel="alternative" link headers to identify
+  different localized versions of the same page.
 
   Args:
     place_dcid: DCID of the place the page is about
@@ -91,6 +92,11 @@ def generate_link_headers(place_dcid: str, category: str,
     # Add localized url as a language alternate link to headers
     link_headers.append(
         f'<{localized_url}>; rel="alternate"; hreflang="{locale_code}"')
+
+    if locale_code == 'en':
+      # Set English as default if user is in unsupported locale
+      link_headers.append(
+          f'<{localized_url}>; rel="alternate"; hreflang="x-default"')
 
     if locale_code == current_locale:
       # Set the url of the current locale as the canonical

--- a/server/tests/routes/place_test.py
+++ b/server/tests/routes/place_test.py
@@ -224,6 +224,8 @@ class TestPlacePageHeaders(unittest.TestCase):
         'Link')
     assert '<https://datacommons.org/place/geoId/06?hl=ru>; rel="alternate"; hreflang="ru"' in response.headers.get(
         'Link')
+    assert '<https://datacommons.org/place/geoId/06>; rel="alternate"; hreflang="x-default"' in response.headers.get(
+        'Link')
 
     # Test available languages listed as alternates for category page
     response = app.test_client().get('/place/geoId/06?category=Health',
@@ -234,6 +236,8 @@ class TestPlacePageHeaders(unittest.TestCase):
         'Link')
     assert '<https://datacommons.org/place/geoId/06?category=Health&hl=ru>; rel="alternate"; hreflang="ru"' in response.headers.get(
         'Link')
+    assert '<https://datacommons.org/place/geoId/06?category=Health>; rel="alternate"; hreflang="x-default"' in response.headers.get(
+        'Link')
 
     # Test available languages listed as alternates for localized page
     response = app.test_client().get('/place/geoId/06?category=Health&hl=ru',
@@ -243,4 +247,6 @@ class TestPlacePageHeaders(unittest.TestCase):
     assert '<https://datacommons.org/place/geoId/06?category=Health>; rel="alternate"; hreflang="en"' in response.headers.get(
         'Link')
     assert '<https://datacommons.org/place/geoId/06?category=Health&hl=ru>; rel="alternate"; hreflang="ru"' in response.headers.get(
+        'Link')
+    assert '<https://datacommons.org/place/geoId/06?category=Health>; rel="alternate"; hreflang="x-default"' in response.headers.get(
         'Link')

--- a/server/tests/routes/place_test.py
+++ b/server/tests/routes/place_test.py
@@ -135,3 +135,112 @@ class TestPlacePage(unittest.TestCase):
           follow_redirects=True)
       assert '/place?dcid=geoId/06&utm_medium=explore&mprop=count&popt=Person&hl=fr' in request.url
       assert response.status_code == 200
+
+
+class TestPlacePageHeaders(unittest.TestCase):
+
+  @patch('server.routes.shared_api.place.get_i18n_name')
+  @patch('server.routes.shared_api.place.get_place_type')
+  def test_place_page_canonical_header(self, mock_get_place_type,
+                                       mock_get_i18n_name):
+    mock_get_i18n_name.return_value = {'geoId/06': 'California'}
+    mock_get_place_type.return_value = 'State'
+
+    # Test main page gives canonical without query parameters
+    response = app.test_client().get('/place/geoId/06', follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06>; rel="canonical"' in response.headers.get(
+        'Link')
+
+    # Test "Overview" page gives canonical without query parameters
+    response = app.test_client().get('/place/geoId/06?category=Overview',
+                                     follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06>; rel="canonical"' in response.headers.get(
+        'Link')
+
+    # Test category page gives a canonical with category included
+    response = app.test_client().get('/place/geoId/06?category=Health',
+                                     follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06?category=Health>; rel="canonical"' in response.headers.get(
+        'Link')
+
+    # Test English locale page gives canonical without locale included (default)
+    response = app.test_client().get('/place/geoId/06?hl=en',
+                                     follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06>; rel="canonical"' in response.headers.get(
+        'Link')
+
+    # Test localized main page gives a canonical with locale included
+    response = app.test_client().get('/place/geoId/06?hl=ru',
+                                     follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06?hl=ru>; rel="canonical"' in response.headers.get(
+        'Link')
+
+    # Test localized category page gives a canonical with locale included.
+    response = app.test_client().get('/place/geoId/06?category=Health&hl=ru',
+                                     follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06?category=Health&hl=ru>; rel="canonical"' in response.headers.get(
+        'Link')
+
+    # Test bad category input gives a canonical without category
+    response = app.test_client().get('/place/geoId/06?category=foobar',
+                                     follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06>; rel="canonical"' in response.headers.get(
+        'Link')
+
+    # Test bad locale input gives a canonical without locale
+    response = app.test_client().get('/place/geoId/06?hl=foobar',
+                                     follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06>; rel="canonical"' in response.headers.get(
+        'Link')
+
+  @patch('server.routes.shared_api.place.get_i18n_name')
+  @patch('server.routes.shared_api.place.get_place_type')
+  def test_place_page_alternate_header(self, mock_get_place_type,
+                                       mock_get_i18n_name):
+    mock_get_i18n_name.return_value = {'geoId/06': 'California'}
+    mock_get_place_type.return_value = 'State'
+
+    # Test available languages listed as alternates for main page
+    response = app.test_client().get('/place/geoId/06', follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06>; rel="alternate"; hreflang="en"' in response.headers.get(
+        'Link')
+    assert '<https://datacommons.org/place/geoId/06?hl=ru>; rel="alternate"; hreflang="ru"' in response.headers.get(
+        'Link')
+
+    # Test available languages listed as alternates for category page
+    response = app.test_client().get('/place/geoId/06?category=Health',
+                                     follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06?category=Health>; rel="alternate"; hreflang="en"' in response.headers.get(
+        'Link')
+    assert '<https://datacommons.org/place/geoId/06?category=Health&hl=ru>; rel="alternate"; hreflang="ru"' in response.headers.get(
+        'Link')
+
+    # Test available languages listed as alternates for localized page
+    response = app.test_client().get('/place/geoId/06?category=Health&hl=ru',
+                                     follow_redirects=False)
+    assert response.status_code == 200
+    assert 'Link' in response.headers
+    assert '<https://datacommons.org/place/geoId/06?category=Health>; rel="alternate"; hreflang="en"' in response.headers.get(
+        'Link')
+    assert '<https://datacommons.org/place/geoId/06?category=Health&hl=ru>; rel="alternate"; hreflang="ru"' in response.headers.get(
+        'Link')


### PR DESCRIPTION
This PR adds:

* A [`rel="canonical"` link](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls?sjid=16312852956349874621-NC#rel-canonical-header-method) as an HTTP response header. This fix the "duplicate without user selected canonical" errors on the place pages.

* A [`rel="alternate"` link](https://developers.google.com/search/docs/specialty/international/localized-versions#http) to the HTTP response header. This will help the crawler understand we have translated versions of the same page, which will also help reduce "duplicate" errors.

* Tests for both

* Fixes a bug where the summary text is not actually limited to the English locale.
