### PR TITLE
[Place Page SEO] Add meta tag to prevent indexing on non-prod place pages

### DIFF
--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -194,8 +194,6 @@ def place(place_dcid=None):
   # Block pages from being indexed if not on the main DC domain. This prevents
   # crawlers from indexing dev or custom DC versions of the place pages.
   block_indexing = not is_canonical_domain(flask.request.base_url)
-  logging.info(f"base_url is {flask.request.base_url}")
-  logging.info(f"Block indexing? {block_indexing}")
 
   response = flask.make_response(
       flask.render_template(

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -16,8 +16,8 @@
 import json
 import logging
 import os
-import time
 import re
+import time
 
 import flask
 from flask import current_app
@@ -47,7 +47,8 @@ CATEGORY_REDIRECTS = {
 PLACE_SUMMARY_PATH = "/datacommons/place-summary/place_summaries.json"
 
 # Main DC domain to use for canonical URLs
-CANONICAL_DOMAIN = 'dev.datacommons.org'
+CANONICAL_DOMAIN = 'datacommons.org'
+
 
 def get_place_summaries() -> dict:
   """Load place summary content from disk"""
@@ -86,8 +87,8 @@ def generate_link_headers(place_dcid: str, category: str,
         'category': category if category in CATEGORIES else None,
         'hl': locale_code if locale_code != 'en' else None
     }
-    localized_url = "https://" + CANONICAL_DOMAIN + flask.url_for('place.place', **
-                                                   canonical_args)
+    localized_url = "https://" + CANONICAL_DOMAIN + flask.url_for(
+        'place.place', **canonical_args)
 
     # Add localized url as a language alternate link to headers
     link_headers.append(
@@ -107,7 +108,7 @@ def generate_link_headers(place_dcid: str, category: str,
 def is_canonical_domain(url: str) -> bool:
   """Check if a url is on the canonical domain
   
-  Used to determine if a request is being called to the main DC instance.
+  Used to determine if the request's URL is on the main DC instance.
   Allows matching of both HTTP and HTTPS urls.
 
   Args:
@@ -197,15 +198,15 @@ def place(place_dcid=None):
   logging.info(f"Block indexing? {block_indexing}")
 
   response = flask.make_response(
-    flask.render_template(
-        'place.html',
-        place_type=place_type,
-        place_name=place_name,
-        place_dcid=place_dcid,
-        category=category if category else '',
-        place_summary=place_summary.get('summary') if place_summary else '',
-        maps_api_key=current_app.config['MAPS_API_KEY'],
-        block_indexing=block_indexing))
+      flask.render_template(
+          'place.html',
+          place_type=place_type,
+          place_name=place_name,
+          place_dcid=place_dcid,
+          category=category if category else '',
+          place_summary=place_summary.get('summary') if place_summary else '',
+          maps_api_key=current_app.config['MAPS_API_KEY'],
+          block_indexing=block_indexing))
   response.headers.set('Link',
                        generate_link_headers(place_dcid, category, locale))
 

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -32,8 +32,8 @@ CATEGORY_REDIRECTS = {
 
 PLACE_SUMMARY_PATH = "/datacommons/place-summary/place_summaries.json"
 
-# Main DC domain to allow search crawlers to index.
-INDEXED_DOMAIN = "https://datacommons.org/"
+# Main DC domain to set as canonical for indexing.
+CANONICAL_ROOT = "https://datacommons.org/"
 
 
 def get_place_summaries() -> dict:
@@ -115,8 +115,9 @@ def place(place_dcid=None):
 
   # Block pages not on the main DC domain from being indexed.
   # This prevents crawlers from indexing duplicate versions of the place pages.
-  block_indexing = flask.request.host_url != INDEXED_DOMAIN
-
+  block_indexing = flask.request.host_url != CANONICAL_ROOT
+  logging.info(f"HOST URL: {flask.request.host_url}")
+  
   return flask.render_template(
       'place.html',
       place_type=place_type,

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -33,7 +33,7 @@ CATEGORY_REDIRECTS = {
 PLACE_SUMMARY_PATH = "/datacommons/place-summary/place_summaries.json"
 
 # Main DC domain to set as canonical for indexing.
-CANONICAL_ROOT = "https://datacommons.org/"
+CANONICAL_ROOT = "https://datacommons.org"
 
 
 def get_place_summaries() -> dict:
@@ -113,11 +113,10 @@ def place(place_dcid=None):
     elapsed_time = (time.time() - start_time) * 1000
     logging.info(f"Place page summary took {elapsed_time:.2f} milliseconds.")
 
-  # Block pages not on the main DC domain from being indexed.
-  # This prevents crawlers from indexing duplicate versions of the place pages.
-  block_indexing = flask.request.host_url != CANONICAL_ROOT
-  logging.info(f"HOST URL: {flask.request.host_url}")
-  
+  # Block pages from being indexed if not on the main DC domain. This prevents
+  # crawlers from indexing dev or custom DC versions of the place pages.
+  block_indexing = CANONICAL_ROOT not in flask.request.base_url
+
   return flask.render_template(
       'place.html',
       place_type=place_type,

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -109,7 +109,9 @@ def is_canonical_domain(url: str) -> bool:
   """Check if a url is on the canonical domain
   
   Used to determine if the request's URL is on the main DC instance.
-  Allows matching of both HTTP and HTTPS urls.
+  Both HTTP and HTTPS urls are matched, and both canonical and staging URLs
+  are matched.
+
 
   Args:
     url: url to check
@@ -117,7 +119,7 @@ def is_canonical_domain(url: str) -> bool:
   Returns:
     True if request is to the canonical domain, False otherwise
   """
-  regex = r"https?://{}".format(CANONICAL_DOMAIN)
+  regex = r"https?://(?:staging.)?{}".format(CANONICAL_DOMAIN)
   return re.match(regex, url) is not None
 
 
@@ -194,6 +196,8 @@ def place(place_dcid=None):
   # Block pages from being indexed if not on the main DC domain. This prevents
   # crawlers from indexing dev or custom DC versions of the place pages.
   block_indexing = not is_canonical_domain(flask.request.base_url)
+  logging.info(f"flask.requests.base_url is {flask.request.base_url}")
+  logging.info(f"Block indexing on place pages? {block_indexing}")
 
   response = flask.make_response(
       flask.render_template(

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -33,7 +33,7 @@ CATEGORY_REDIRECTS = {
 PLACE_SUMMARY_PATH = "/datacommons/place-summary/place_summaries.json"
 
 # Main DC domain to set as canonical for indexing.
-CANONICAL_ROOT = "https://datacommons.org"
+CANONICAL_ROOT = "https://dev.datacommons.org"
 
 
 def get_place_summaries() -> dict:
@@ -117,6 +117,7 @@ def place(place_dcid=None):
   # crawlers from indexing dev or custom DC versions of the place pages.
   block_indexing = CANONICAL_ROOT not in flask.request.base_url
   logging.info(f"base_url is {flask.request.base_url}")
+  logging.info(f"Block indexing? {block_indexing}")
 
   return flask.render_template(
       'place.html',

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -116,6 +116,7 @@ def place(place_dcid=None):
   # Block pages from being indexed if not on the main DC domain. This prevents
   # crawlers from indexing dev or custom DC versions of the place pages.
   block_indexing = CANONICAL_ROOT not in flask.request.base_url
+  logging.info(f"base_url is {flask.request.base_url}")
 
   return flask.render_template(
       'place.html',

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -32,6 +32,9 @@ CATEGORY_REDIRECTS = {
 
 PLACE_SUMMARY_PATH = "/datacommons/place-summary/place_summaries.json"
 
+# Main DC domain to allow search crawlers to index.
+INDEXED_DOMAIN = "https://datacommons.org/"
+
 
 def get_place_summaries() -> dict:
   """Load place summary content from disk"""
@@ -110,6 +113,10 @@ def place(place_dcid=None):
     elapsed_time = (time.time() - start_time) * 1000
     logging.info(f"Place page summary took {elapsed_time:.2f} milliseconds.")
 
+  # Block pages not on the main DC domain from being indexed.
+  # This prevents crawlers from indexing duplicate versions of the place pages.
+  block_indexing = flask.request.host_url != INDEXED_DOMAIN
+
   return flask.render_template(
       'place.html',
       place_type=place_type,
@@ -117,7 +124,8 @@ def place(place_dcid=None):
       place_dcid=place_dcid,
       category=category if category else '',
       place_summary=place_summary.get("summary") if place_summary else '',
-      maps_api_key=current_app.config['MAPS_API_KEY'])
+      maps_api_key=current_app.config['MAPS_API_KEY'],
+      block_indexing=block_indexing)
 
 
 def place_landing():

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import time
+import re
 
 import flask
 from flask import current_app
@@ -45,9 +46,8 @@ CATEGORY_REDIRECTS = {
 
 PLACE_SUMMARY_PATH = "/datacommons/place-summary/place_summaries.json"
 
-# Hostname to use for canonical URLs
-CANONICAL_ROOT = 'https://datacommons.org'
-
+# Main DC domain to use for canonical URLs
+CANONICAL_DOMAIN = 'dev.datacommons.org'
 
 def get_place_summaries() -> dict:
   """Load place summary content from disk"""
@@ -86,7 +86,7 @@ def generate_link_headers(place_dcid: str, category: str,
         'category': category if category in CATEGORIES else None,
         'hl': locale_code if locale_code != 'en' else None
     }
-    localized_url = CANONICAL_ROOT + flask.url_for('place.place', **
+    localized_url = "https://" + CANONICAL_DOMAIN + flask.url_for('place.place', **
                                                    canonical_args)
 
     # Add localized url as a language alternate link to headers
@@ -102,6 +102,22 @@ def generate_link_headers(place_dcid: str, category: str,
       # Set the url of the current locale as the canonical
       link_headers.append(f'<{localized_url}>; rel="canonical"')
   return ', '.join(link_headers)
+
+
+def is_canonical_domain(url: str) -> bool:
+  """Check if a url is on the canonical domain
+  
+  Used to determine if a request is being called to the main DC instance.
+  Allows matching of both HTTP and HTTPS urls.
+
+  Args:
+    url: url to check
+  
+  Returns:
+    True if request is to the canonical domain, False otherwise
+  """
+  regex = r"https?://{}".format(CANONICAL_DOMAIN)
+  return re.match(regex, url) is not None
 
 
 @bp.route('', strict_slashes=False)
@@ -174,168 +190,26 @@ def place(place_dcid=None):
     elapsed_time = (time.time() - start_time) * 1000
     logging.info(f"Place page summary took {elapsed_time:.2f} milliseconds.")
 
+  # Block pages from being indexed if not on the main DC domain. This prevents
+  # crawlers from indexing dev or custom DC versions of the place pages.
+  block_indexing = not is_canonical_domain(flask.request.base_url)
+  logging.info(f"base_url is {flask.request.base_url}")
+  logging.info(f"Block indexing? {block_indexing}")
+
   response = flask.make_response(
-      flask.render_template(
-          'place.html',
-          place_type=place_type,
-          place_name=place_name,
-          place_dcid=place_dcid,
-          category=category if category else '',
-          place_summary=place_summary.get('summary') if place_summary else '',
-          maps_api_key=current_app.config['MAPS_API_KEY']))
+    flask.render_template(
+        'place.html',
+        place_type=place_type,
+        place_name=place_name,
+        place_dcid=place_dcid,
+        category=category if category else '',
+        place_summary=place_summary.get('summary') if place_summary else '',
+        maps_api_key=current_app.config['MAPS_API_KEY'],
+        block_indexing=block_indexing))
   response.headers.set('Link',
                        generate_link_headers(place_dcid, category, locale))
 
   return response
-
-
-def place_landing():
-  """Returns filled template for the place landing page."""
-  template_file = os.path.join('custom_dc', g.env, 'place_landing.html')
-  dcid_json = os.path.join('custom_dc', g.env, 'place_landing_dcids.json')
-  if not os.path.exists(
-      os.path.join(current_app.root_path, 'templates', template_file)):
-    template_file = 'place_landing.html'
-    dcid_json = 'place_landing_dcids.json'
-
-  with open(os.path.join(current_app.root_path, 'templates', dcid_json)) as f:
-    landing_dcids = json.load(f)
-    # Use display names (including state, if applicable) for the static page
-    place_names = place_api.get_display_name(landing_dcids)
-    return flask.render_template(
-        template_file,
-        place_names=place_names,
-        maps_api_key=current_app.config['MAPS_API_KEY'])
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-"""Place Explorer related handlers."""
-
-import json
-import logging
-import os
-import time
-
-import flask
-from flask import current_app
-from flask import g
-
-import server.routes.shared_api.place as place_api
-
-bp = flask.Blueprint('place', __name__, url_prefix='/place')
-
-CATEGORY_REDIRECTS = {
-    "Climate": "Environment",
-}
-
-PLACE_SUMMARY_PATH = "/datacommons/place-summary/place_summaries.json"
-
-# Main DC domain to set as canonical for indexing.
-CANONICAL_ROOT = "https://dev.datacommons.org"
-
-
-def get_place_summaries() -> dict:
-  """Load place summary content from disk"""
-  # When deployed in GKE, the config is a config mounted as volume. Check this
-  # first.
-  if os.path.isfile(PLACE_SUMMARY_PATH):
-    with open(PLACE_SUMMARY_PATH) as f:
-      return json.load(f)
-  # If no mounted config file, use the config that is in the code base.
-  local_path = os.path.join(current_app.root_path,
-                            'config/summaries/place_summaries.json')
-  with open(local_path) as f:
-    return json.load(f)
-
-
-@bp.route('', strict_slashes=False)
-@bp.route('/<path:place_dcid>')
-def place(place_dcid=None):
-  redirect_args = dict(flask.request.args)
-
-  # Strip trailing slashes from place dcids
-  should_redirect = False
-  if place_dcid and place_dcid.endswith('/'):
-    place_dcid = place_dcid.rstrip('/')
-    should_redirect = True
-
-  # Rename legacy "topic" request argument to "category"
-  if 'topic' in flask.request.args:
-    redirect_args['category'] = flask.request.args.get('topic', '')
-    del redirect_args['topic']
-    should_redirect = True
-
-  # Rename legacy category request arguments
-  category = redirect_args.get('category', None)
-  if category in CATEGORY_REDIRECTS:
-    redirect_args['category'] = CATEGORY_REDIRECTS[category]
-    should_redirect = True
-
-  if should_redirect:
-    redirect_args['place_dcid'] = place_dcid
-    return flask.redirect(flask.url_for('place.place', **redirect_args),
-                          code=301)
-
-  dcid = flask.request.args.get('dcid', None)
-  if dcid:
-    # Traffic from "explore more" in Search. Forward along all parameters,
-    # except for dcid, to the new URL format.
-    redirect_args = dict(flask.request.args)
-    redirect_args['place_dcid'] = dcid
-    del redirect_args['dcid']
-    redirect_args['category'] = category
-    url = flask.url_for('place.place',
-                        **redirect_args,
-                        _external=True,
-                        _scheme=current_app.config.get('SCHEME', 'https'))
-    return flask.redirect(url)
-
-  if not place_dcid:
-    return place_landing()
-
-  place_type = place_api.get_place_type(place_dcid)
-  place_names = place_api.get_i18n_name([place_dcid])
-  if place_names and place_names.get(place_dcid):
-    place_name = place_names[place_dcid]
-  else:
-    place_name = place_dcid
-
-  place_summary = {}
-  # Only show summary for Overview page in base DC.
-  if not category and os.environ.get('FLASK_ENV') in [
-      'local', 'autopush', 'dev', 'staging', 'production'
-  ] and g.locale == "en":
-    # Fetch summary text from mounted volume
-    start_time = time.time()
-    place_summary = get_place_summaries().get(place_dcid, {})
-    elapsed_time = (time.time() - start_time) * 1000
-    logging.info(f"Place page summary took {elapsed_time:.2f} milliseconds.")
-
-  # Block pages from being indexed if not on the main DC domain. This prevents
-  # crawlers from indexing dev or custom DC versions of the place pages.
-  block_indexing = CANONICAL_ROOT not in flask.request.base_url
-  logging.info(f"base_url is {flask.request.base_url}")
-  logging.info(f"Block indexing? {block_indexing}")
-
-  return flask.render_template(
-      'place.html',
-      place_type=place_type,
-      place_name=place_name,
-      place_dcid=place_dcid,
-      category=category if category else '',
-      place_summary=place_summary.get("summary") if place_summary else '',
-      maps_api_key=current_app.config['MAPS_API_KEY'],
-      block_indexing=block_indexing)
 
 
 def place_landing():

--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -36,6 +36,10 @@ limitations under the License.
 <meta name="description" content="{{ place_summary or description }}" />
 {% endif %}
 
+{% if block_indexing %}
+<meta name="robots" content="noindex" />
+{% endif %}
+
 {% endblock %}
 
 {% block content %}

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -115,7 +115,7 @@
         "sass-loader": "^13.3.2",
         "tslib": "^2.6.2",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5"
+        "vite": "^4.4.12"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.199",
@@ -24716,7 +24716,7 @@
         "sass-loader": "^13.3.2",
         "tslib": "^2.6.2",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5"
+        "vite": "^4.4.12"
       }
     },
     "@discoveryjs/json-ext": {

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -115,7 +115,7 @@
         "sass-loader": "^13.3.2",
         "tslib": "^2.6.2",
         "typescript": "^5.0.2",
-        "vite": "^4.4.12"
+        "vite": "^4.4.5"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.199",
@@ -24716,7 +24716,7 @@
         "sass-loader": "^13.3.2",
         "tslib": "^2.6.2",
         "typescript": "^5.0.2",
-        "vite": "^4.4.12"
+        "vite": "^4.4.5"
       }
     },
     "@discoveryjs/json-ext": {


### PR DESCRIPTION
This PR adds `<meta name="robots" content="noindex">` as to place pages when not on the main `https://datacommons.org` domain to [prevent search crawlers from indexing](https://developers.google.com/search/docs/crawling-indexing/block-indexing).

This means only the `https://datacommons.org/place/` pages will get indexed, and the crawler will ignore Custom DCs and alternate domains like `browser.datacommons.org` and `dev.datacommons.org`. This will reduce the spurious indexing error alerts for pages that shouldn't be indexed.