### PR TITLE
NL Server: When at fault, admit it

### DIFF
--- a/nl_server/routes.py
+++ b/nl_server/routes.py
@@ -29,7 +29,14 @@ bp = Blueprint('main', __name__, url_prefix='/')
 
 @bp.route('/healthz')
 def healthz():
-  return ""
+  nl_embeddings = current_app.config[config.NL_EMBEDDINGS_KEY].get(
+      config.DEFAULT_INDEX_TYPE)
+  result = nl_embeddings.detect_svs('life expectancy',
+                                    SV_SCORE_DEFAULT_THRESHOLD,
+                                    skip_multi_sv=True)
+  if result.get('SV'):
+    return 'OK', 200
+  return 'Service Unavailable', 500
 
 
 @bp.route('/api/search_sv/', methods=['GET'])
@@ -61,17 +68,8 @@ def search_sv():
   if request.args.get('skip_multi_sv'):
     skip_multi_sv = True
 
-  try:
-    nl_embeddings = current_app.config[config.NL_EMBEDDINGS_KEY].get(idx)
-    return json.dumps(nl_embeddings.detect_svs(query, threshold, skip_multi_sv))
-  except Exception as e:
-    logging.error(f'Embeddings-based SV detection failed with error: {e}')
-    return json.dumps({
-        'SV': [],
-        'CosineScore': [],
-        'SV_to_Sentences': {},
-        'MultiSV': {}
-    })
+  nl_embeddings = current_app.config[config.NL_EMBEDDINGS_KEY].get(idx)
+  return json.dumps(nl_embeddings.detect_svs(query, threshold, skip_multi_sv))
 
 
 @bp.route('/api/search_places/', methods=['GET'])


### PR DESCRIPTION
This fixes the NL server to not suppress faults.  Also, add a real health-check.

Context:
* This is in response to an outage (b/323064085) where a BAD machine caused embeddings to return empty on a small subset of servers, and redis then caches the empty results and always returns it
* With this fix, the website flask cache won't cache the faulty value (if any). To confirm, this [code here](https://github.com/pallets-eco/flask-caching/blob/a367b9f13109d35c1e3df069f5da4c29110a689c/src/flask_caching/__init__.py#L878-L882) in Flash-Caching only caches the return value, not exceptions.