### PR TITLE
Disable NL server healthz and remove small index

### DIFF
--- a/deploy/nl/embeddings.yaml
+++ b/deploy/nl/embeddings.yaml
@@ -1,4 +1,3 @@
-small: embeddings_small_2023_05_24_23_17_03.csv
 medium_ft: embeddings_medium_2024_01_10_17_42_07.ft_final_v20230717230459.all-MiniLM-L6-v2.csv
 sdg_ft: embeddings_sdg_2023_12_26_10_03_03.ft_final_v20230717230459.all-MiniLM-L6-v2.csv
 

--- a/nl_server/routes.py
+++ b/nl_server/routes.py
@@ -29,14 +29,8 @@ bp = Blueprint('main', __name__, url_prefix='/')
 
 @bp.route('/healthz')
 def healthz():
-  nl_embeddings = current_app.config[config.NL_EMBEDDINGS_KEY].get(
-      config.DEFAULT_INDEX_TYPE)
-  result = nl_embeddings.detect_svs('life expectancy',
-                                    SV_SCORE_DEFAULT_THRESHOLD,
-                                    skip_multi_sv=True)
-  if result.get('SV'):
-    return 'OK', 200
-  return 'Service Unavailable', 500
+  # TODO: Add a better healthz check
+  return ''
 
 
 @bp.route('/api/search_sv/', methods=['GET'])


### PR DESCRIPTION
This is suspected to cause rollout failures in prod.

One plausible theory why this was not seen in autopush/staging, in discussion with Bo and Natalie, is that we maybe pounding HF to download base model, which might be getting throttled.

So, remove the `small` model which is unused now and is the only reason to download from HF.