### PR TITLE
Don't lint nested python virtual envs

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -62,7 +62,7 @@ function run_lint_fix {
   then
     pip3 install isort -q
   fi
-  yapf -r -i -p --style='{based_on_style: google, indent_width: 2}' server/ nl_server/ shared/ tools/ -e=*pb2.py -e=.env/*
+  yapf -r -i -p --style='{based_on_style: google, indent_width: 2}' server/ nl_server/ shared/ tools/ -e=*pb2.py -e=**/.env/*
   isort server/ nl_server/ shared/ tools/  --skip-glob *pb2.py  --profile google
   deactivate
 }


### PR DESCRIPTION
Updates the lint fix test `run_test.sh -f` to avoid linting files in python envs nested in subdirectories.

The scripts under `tools/summaries` and `tools/sitemap` use their own python `.env` virtual environment which sometimes contain packages that yapf can't parse.

