### PR TITLE
Remove stat var hierarchy config from custom dc base.html

### DIFF
--- a/server/templates/custom_dc/custom/base.html
+++ b/server/templates/custom_dc/custom/base.html
@@ -47,7 +47,7 @@
   <link href="{{ OVERRIDE_CSS_PATH }}" rel="stylesheet">
   {% endif %}
   <script>
-    globalThis.STAT_VAR_HIERARCHY_CONFIG = {{ config['STAT_VAR_HIERARCHY_CONFIG'] | tojson }};
+    globalThis.STAT_VAR_HIERARCHY_CONFIG = {};
   </script>
 </head>
 

--- a/server/templates/custom_dc/custom/base.html
+++ b/server/templates/custom_dc/custom/base.html
@@ -46,9 +46,6 @@
   {% if OVERRIDE_CSS_PATH %}
   <link href="{{ OVERRIDE_CSS_PATH }}" rel="stylesheet">
   {% endif %}
-  <script>
-    globalThis.STAT_VAR_HIERARCHY_CONFIG = {};
-  </script>
 </head>
 
 <body>


### PR DESCRIPTION
A quick fix for a bug in Custom DC. The script in custom/base.html leads to a server error broken page when following the custom DC quick start guide. 

This PR removes the script so that users can follow the custom DC quick start guide. A more complete fix to re-enable features from #3911 will come in a follow-up PR once we determine root cause of the issue.