### PR TITLE
Update deployment YAMLs: dev instance IP and certificate name

### DIFF
--- a/deploy/gke/dev.yaml
+++ b/deploy/gke/dev.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 project: datcom-website-dev
-ip: 130.211.4.131
+ip: 34.149.114.214
 domain: dev.datacommons.org
 region:
   primary: us-central1

--- a/gke/mci.yaml.tpl
+++ b/gke/mci.yaml.tpl
@@ -19,7 +19,7 @@ metadata:
   namespace: website
   annotations:
     # multi-domain is the certificate name, it is set in setup_ssl.sh
-    networking.gke.io/pre-shared-certs: website-certificate
+    networking.gke.io/pre-shared-certs: dc-website-cert
     networking.gke.io/static-ip: <IP>
 spec:
   template:


### PR DESCRIPTION
This PR checks in the changes made during the redeployment of dev.datacommons.org on Feb 21, 2024:

Changes:

* The dev instance now lives on a new IP address. `dev.yaml` is updated with the new IP address.
* The ssl cert generated by `setup_ssl.sh` uses a different name for the created cert than is expected by `mci.yaml`. Updated `mci.yaml.tpl` to use the correct cert name.