### PR TITLE
[Place Page SEO] Suppress "sorry" message if summary is present

### DIFF
--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -150,7 +150,7 @@ function onSearch(q: string): void {
  * Set the text in the page-loading div to a sorry message.
  * Set the text to empty if summary text is present on the page.
  */
-function setSorryMessage(): void {
+function setErrorMessage(): void {
   const summaryText = document.getElementById("place-summary").innerText;
   const loadingElem = document.getElementById("page-loading");
   if (summaryText) {
@@ -185,7 +185,7 @@ function renderPage(): void {
   ])
     .then(([landingPageData]) => {
       if (_.isEmpty(landingPageData)) {
-        setSorryMessage();
+        setErrorMessage();
         return;
       }
       const loadingElem = document.getElementById("page-loading");
@@ -300,7 +300,7 @@ function renderPage(): void {
       window.location.hash = urlHash;
     })
     .catch(() => {
-      setSorryMessage();
+      setErrorMessage();
     });
 }
 

--- a/static/js/place/place.ts
+++ b/static/js/place/place.ts
@@ -146,6 +146,22 @@ function onSearch(q: string): void {
   window.location.href = `/explore#q=${encodeURIComponent(q)}`;
 }
 
+/**
+ * Set the text in the page-loading div to a sorry message.
+ * Set the text to empty if summary text is present on the page.
+ */
+function setSorryMessage(): void {
+  const summaryText = document.getElementById("place-summary").innerText;
+  const loadingElem = document.getElementById("page-loading");
+  if (summaryText) {
+    // If summary text is present, suppress "Sorry" message
+    loadingElem.innerHTML = "";
+  } else {
+    loadingElem.innerText =
+      "Sorry, there was an error loading charts for this place.";
+  }
+}
+
 function renderPage(): void {
   const urlParams = new URLSearchParams(window.location.search);
   const urlHash = window.location.hash;
@@ -168,12 +184,11 @@ function renderPage(): void {
     ]),
   ])
     .then(([landingPageData]) => {
-      const loadingElem = document.getElementById("page-loading");
       if (_.isEmpty(landingPageData)) {
-        loadingElem.innerText =
-          "Sorry, we don't have any charts to show for this place.";
+        setSorryMessage();
         return;
       }
+      const loadingElem = document.getElementById("page-loading");
       loadingElem.style.display = "none";
       const data: PageData = landingPageData;
       const isUsaPlace = isPlaceInUsa(dcid, data.parentPlaces);
@@ -285,9 +300,7 @@ function renderPage(): void {
       window.location.hash = urlHash;
     })
     .catch(() => {
-      const loadingElem = document.getElementById("page-loading");
-      loadingElem.innerText =
-        "Sorry, there was an error loading charts for this place.";
+      setSorryMessage();
     });
 }
 


### PR DESCRIPTION
Updates the place pages to not show the "Sorry, there was an error loading charts for this place." message if summary text is being shown (i.e., there is content on the page). 

This addresses the hypothesis that our "Soft 404" errors come from the crawler picking up our "sorry" message when the crawler cancels our data fetch for being too slow.

Addressing the data fetch latency is a larger change that will come in future PRs.

Before (what crawler sees):
![Screenshot 2024-02-22 at 5 41 08 PM](https://github.com/datacommonsorg/website/assets/4034366/6a852d14-fb81-46c3-9dc9-6d56595304f6)


After (what crawler sees):
![Screenshot 2024-02-22 at 5 40 32 PM](https://github.com/datacommonsorg/website/assets/4034366/da3e5b62-e659-40c3-a4a1-54f2e11edd19)

Behavior when no summary is present:
![Screenshot 2024-02-22 at 5 52 08 PM](https://github.com/datacommonsorg/website/assets/4034366/b2732bad-cb13-4b92-946d-4e448e3c46b9)
