### PR TITLE
cd into sanity script folder before running it.

### DIFF
--- a/run_sdg_sanity.sh
+++ b/run_sdg_sanity.sh
@@ -37,6 +37,7 @@ if [[ $NO_PIP != "true" ]]; then
 fi
 
 date_str=$(TZ="America/Los_Angeles" date +"%Y_%m_%d_%H_%M_%S")
-python3 server/webdriver/tests/standalone/sdg_sanity.py --base_url="$sdg_home"
+cd server/webdriver/tests/standalone
+python3 sdg_sanity.py --base_url="$sdg_home"
 gsutil cp ./output/*.csv gs://un-sdg-sanity/$date_str/
 rm ./output/*.csv


### PR DESCRIPTION
* The script now loads a file relative to itself from the file system so `cd`-ing into it from the shell script so it can load it.