### PR TITLE
Fixed web server build issue with @datacommonsorg/client

### DIFF
--- a/build/web_server/Dockerfile
+++ b/build/web_server/Dockerfile
@@ -33,6 +33,10 @@ COPY packages/web-components/package.json /workspace/packages/web-components/pac
 COPY packages/web-components/package-lock.json /workspace/packages/web-components/package-lock.json
 RUN npm --prefix /workspace/packages/web-components install --omit=dev
 
+COPY packages/client/package.json /workspace/packages/client/package.json
+COPY packages/client/package-lock.json /workspace/packages/client/package-lock.json
+RUN npm --prefix /workspace/packages/client install --omit=dev
+
 COPY static/package.json /workspace/static/package.json
 COPY static/package-lock.json /workspace/static/package-lock.json
 RUN npm --prefix /workspace/static install --omit=dev


### PR DESCRIPTION
Introduced when adding `@datacommonsorg/client` as a dependency to the frontend code in #4000 
This fix properly installs the npm dependencies (like with the `@datacommonsorg/web-components` dependencies) in the web server docker image