### PR TITLE
fix autopush deployment

### DIFF
--- a/deploy/helm_charts/dc_website/values.yaml
+++ b/deploy/helm_charts/dc_website/values.yaml
@@ -167,3 +167,5 @@ cronTesting:
   screenshotDomain:
   # whether or not sanity tests are enabled
   enableSanity: true
+  # node pool to use
+  nodePool:

--- a/deploy/helm_charts/envs/autopush.yaml
+++ b/deploy/helm_charts/envs/autopush.yaml
@@ -22,6 +22,7 @@ namespace:
 website:
   flaskEnv: autopush
   replicas: 15
+  nodePool: "default-pool"
 
 mixer:
   hostProject:
@@ -51,3 +52,4 @@ nodejs:
 cronTesting:
   enabled: true
   screenshotDomain: "autopush.datacommons.org"
+  nodePool: "pool-1"

--- a/deploy/helm_charts/envs/bard.yaml
+++ b/deploy/helm_charts/envs/bard.yaml
@@ -31,7 +31,7 @@ website:
           "port": "6379"
         }
       }
-  nodeSelector: "default-pool"
+  nodePool: "default-pool"
 
 serviceAccount:
   name: website-ksa

--- a/gke/cron_testing_job.yaml.tpl
+++ b/gke/cron_testing_job.yaml.tpl
@@ -29,6 +29,8 @@ spec:
       template:
         spec:
           serviceAccountName:
+          nodeSelector:
+            cloud.google.com/gke-nodepool:
           containers:
           - name: cron-testing-container
             image: "gcr.io/datcom-ci/website-cron-testing:latest"

--- a/gke/setup_cron_testing.sh
+++ b/gke/setup_cron_testing.sh
@@ -59,7 +59,9 @@ gcloud container clusters get-credentials $CLUSTER_NAME \
 cp cron_testing_job.yaml.tpl cron_testing_job.yaml
 yq eval -i '.spec.jobTemplate.spec.template.spec.containers[0].env += [{"name": "TESTING_ENV", "value": "'"$ENV"'"}]' cron_testing_job.yaml
 export SERVICE_ACCOUNT_NAME=$(yq eval '.serviceAccount.name' ../deploy/helm_charts/envs/$ENV.yaml)
+export NODE_POOL=$(yq eval '.cronTesting.nodePool' ../deploy/helm_charts/envs/$ENV.yaml)
 yq eval -i '.spec.jobTemplate.spec.template.spec.serviceAccountName = env(SERVICE_ACCOUNT_NAME)' cron_testing_job.yaml
+yq eval -i '.spec.jobTemplate.spec.template.spec.nodeSelector."cloud.google.com/gke-nodepool" = env(NODE_POOL)' cron_testing_job.yaml
 
 # Apply config
 kubectl apply -f cron_testing_job.yaml


### PR DESCRIPTION
Update autopush website-app to deploy in default-pool. This fixed deploying autopush when trying manually

Background:
- autopush deployments have been failing since website cron tests have been added
- there are 2 different node pools used in the autopush instance, one with 4 CPU and one with 8 CPU
- I noticed that a lot of website-app pods were deployed in the 8 CPU node pool and they seemed to have a lot of restarts. In a past experiment, we've learned that website-app pods have trouble starting in node pools that have more CPU than 4.
- So I tested moving all the cron jobs to the 8 CPU node pool and all the website-app pods to the 4 CPU node pool and it seemed to work. (Will see how well it does once this PR is in though)