### PR TITLE
fixed scatter plot y axis label wrapping issue and overlapping density legend

### DIFF
--- a/static/js/chart/base.test.ts
+++ b/static/js/chart/base.test.ts
@@ -81,6 +81,10 @@ beforeEach(() => {
   // JSDom does not define SVGTSpanElements, and use SVGElement instead. Defines
   // a shim for getComputedTextLength where each character is 1 px wide.
   (window.SVGElement as any).prototype.getComputedTextLength = function () {
+    // Title elements don't contribute to width
+    if (this.tagName === "title") {
+      return 0;
+    }
     return this.textContent.length;
   };
 
@@ -122,7 +126,10 @@ describe("wrap tests", () => {
     document.body.innerHTML = `<svg width=100><text>${label}</text></svg>`;
     wrap(d3.selectAll("text"), width);
 
-    expect(d3.selectAll("text").text()).toBe(expectedLabels.join(""));
+    d3.selectAll("tspan").each(function (a, i) {
+      const tspanText = d3.select(this).text();
+      expect(tspanText).toBe(expectedLabels[i]);
+    });
     expect(d3.selectAll("tspan").size()).toBe(expectedLabels.length);
     d3.selectAll("tspan").each(function (d, i) {
       expect(d3.select(this).text()).toBe(expectedLabels[i]);

--- a/static/js/chart/base.ts
+++ b/static/js/chart/base.ts
@@ -28,6 +28,7 @@ const DEFAULT_COLOR = "#000";
 
 const MAX_PREDICTION_COLORS = ["#dc3545", "#fac575"];
 const MIN_PREDICTION_COLORS = ["#007bff", "#66c2a5"];
+const DEFAULT_WRAP_MAX_LINES = 10;
 export class DataPoint {
   value: number;
   label: string;
@@ -108,13 +109,14 @@ function joinLineForWrap(line: string[]): string {
  */
 export function wrap(
   textSelection: d3.Selection<SVGTextElement, any, any, any>,
-  width: number
+  width: number,
+  maxLines: number = DEFAULT_WRAP_MAX_LINES
 ): void {
   textSelection.each(function () {
     const text = d3.select(this);
     const dominantBaseline = text.attr("dominant-baseline");
-    const words = text
-      .text()
+    const textString = text.text();
+    const words = textString
       .replace(/-/g, "-#") // Handle e.g. "ABC-AB A" -> "ABC-", "AB" "A"
       .split(/[\s#]/)
       .filter((w) => w.trim() != "")
@@ -126,11 +128,17 @@ export function wrap(
     const dy = parseFloat(text.attr("dy") || "0");
 
     let lineToFit: string[] = [];
+
+    // Set text title in for hover-over in case the text display is truncated
+    text.append("title").text(textString);
     for (
       let lineNumber = 0;
       words.length > 0 || lineToFit.length > 0;
       lineNumber++
     ) {
+      if (lineNumber == maxLines) {
+        break;
+      }
       const tspan = text
         .append("tspan")
         .attr("x", 0)
@@ -159,6 +167,10 @@ export function wrap(
       } while (tspan.node().getComputedTextLength() < width);
       // Can't fit - prepare for the next line.
       const word = lineToFit.pop();
+      // If the last line will be cut off, add an elipsis
+      if (word && lineNumber === maxLines - 1) {
+        lineToFit.push("...");
+      }
       if (lineToFit.length) {
         tspan.text(joinLineForWrap(lineToFit));
         lineToFit = [word];

--- a/static/js/chart/draw_scatter.ts
+++ b/static/js/chart/draw_scatter.ts
@@ -73,6 +73,11 @@ const MIN_HIGHLIGHT_POINTS = 4;
 const MIN_TEXT_LABEL_HEIGHT = 10;
 const MIN_TEXT_LABEL_LENGTH = 95;
 
+// If SVG goes smaller than Y_LABEL_WRAP_SVG_WIDTH_BREAKPOINT, reduce the number
+// of wrapped lines to this value
+const Y_LABEL_WRAP_MAX_LINES_SMALL = 3;
+const Y_LABEL_WRAP_SVG_WIDTH_BREAKPOINT = 400;
+
 enum ScaleType {
   LOG,
   SYMLOG,
@@ -91,13 +96,16 @@ type ScatterScale =
  * @param marginTop top margin for the label
  * @param label label text to add
  * @param unit unit text to add to the label
+ * @param maxLines maximum number of wrapped text lines lines to show before
+ *        truncating
  */
 function addYLabel(
   labelElement: d3.Selection<SVGGElement, any, any, any>,
   height: number,
   marginTop: number,
   label: string,
-  unit?: string
+  unit?: string,
+  maxLines?: number
 ): number {
   const unitLabelString = unit ? ` (${unit})` : "";
   const yAxisLabel = labelElement
@@ -105,7 +113,9 @@ function addYLabel(
     .attr("text-anchor", "middle")
     .attr("y", 0)
     .text(label + unitLabelString)
-    .call(wrap, height)
+    .call((d, height) => {
+      wrap(d, height, maxLines);
+    }, height)
     .attr(
       "transform",
       `rotate(-90) translate(${-height / 2 - marginTop}, ${
@@ -430,14 +440,16 @@ function addDensity(
     .domain([contours.length, 0]);
 
   // Add a legend to show what each color means
-  addDensityLegend(
-    svg,
-    contours,
-    densityColorScale,
-    chartHeight,
-    marginTop,
-    svgWidth
-  );
+  if (chartWidth > 0) {
+    addDensityLegend(
+      svg,
+      contours,
+      densityColorScale,
+      chartHeight,
+      marginTop,
+      svgWidth
+    );
+  }
 
   // color the dots according to which contour it's in
   dots
@@ -854,19 +866,28 @@ export function drawScatter(
     marginTop += addChartTitle(svg, chartTitle, properties.width);
   }
 
-  let height = properties.height - marginTop - MARGIN.bottom;
+  let height = Math.max(0, properties.height - marginTop - MARGIN.bottom);
   const minXAxisHeight = 30;
   const yAxisLabel = svg.append("g").attr("class", "y-axis-label");
+  // Number of lines to show in the y axis label before truncating
+  const yAxisLabelMaxLines =
+    svgContainerWidth < Y_LABEL_WRAP_MAX_LINES_SMALL
+      ? Y_LABEL_WRAP_MAX_LINES_SMALL
+      : undefined;
   const yAxisWidth = addYLabel(
     yAxisLabel,
     height - minXAxisHeight,
     marginTop,
     properties.yLabel,
-    properties.yUnit
+    properties.yUnit,
+    yAxisLabelMaxLines
   );
-  let width = properties.width - MARGIN.left - MARGIN.right - yAxisWidth;
+  let width = Math.max(
+    0,
+    properties.width - MARGIN.left - MARGIN.right - yAxisWidth
+  );
   if (options.showDensity) {
-    width = width - DENSITY_LEGEND_WIDTH;
+    width = Math.max(0, width - DENSITY_LEGEND_WIDTH);
   }
 
   const xAxisLabel = svg.append("g").attr("class", "x-axis-label");
@@ -878,7 +899,7 @@ export function drawScatter(
     properties.xLabel,
     properties.xUnit
   );
-  height = height - xAxisHeight;
+  height = Math.max(0, height - xAxisHeight);
 
   const g = svg
     .append("g")

--- a/static/js/chart/draw_scatter.ts
+++ b/static/js/chart/draw_scatter.ts
@@ -880,12 +880,6 @@ export function drawScatter(
     svgContainerWidth < Y_LABEL_WRAP_SVG_WIDTH_BREAKPOINT
       ? Y_LABEL_WRAP_MAX_LINES_SMALL
       : undefined;
-  console.log(
-    "yAxisLabelMaxLines= ",
-    yAxisLabelMaxLines,
-    "svgContainerWidth=",
-    svgContainerWidth
-  );
   const yAxisWidth = addYLabel(
     yAxisLabel,
     height - minXAxisHeight,

--- a/static/js/chart/draw_scatter.ts
+++ b/static/js/chart/draw_scatter.ts
@@ -73,6 +73,9 @@ const MIN_HIGHLIGHT_POINTS = 4;
 const MIN_TEXT_LABEL_HEIGHT = 10;
 const MIN_TEXT_LABEL_LENGTH = 95;
 
+// Truncate x label text after wrapping this many times
+const X_LABEL_WRAP_MAX_LINES = 3;
+
 // If SVG goes smaller than Y_LABEL_WRAP_SVG_WIDTH_BREAKPOINT, reduce the number
 // of wrapped lines to this value
 const Y_LABEL_WRAP_MAX_LINES_SMALL = 3;
@@ -140,7 +143,8 @@ function addXLabel(
   marginLeft: number,
   containerHeight: number,
   label: string,
-  unit?: string
+  unit?: string,
+  maxLines?: number
 ): number {
   const unitLabelString = unit ? ` (${unit})` : "";
   const padding = 5;
@@ -149,7 +153,9 @@ function addXLabel(
     .attr("text-anchor", "middle")
     .attr("y", 0)
     .text(label + unitLabelString)
-    .call(wrap, width);
+    .call((d, width) => {
+      wrap(d, width, maxLines);
+    }, width);
   const xAxisHeight = xAxisLabel.node().getBBox().height + padding;
   xAxisLabel.attr(
     "transform",
@@ -871,9 +877,15 @@ export function drawScatter(
   const yAxisLabel = svg.append("g").attr("class", "y-axis-label");
   // Number of lines to show in the y axis label before truncating
   const yAxisLabelMaxLines =
-    svgContainerWidth < Y_LABEL_WRAP_MAX_LINES_SMALL
+    svgContainerWidth < Y_LABEL_WRAP_SVG_WIDTH_BREAKPOINT
       ? Y_LABEL_WRAP_MAX_LINES_SMALL
       : undefined;
+  console.log(
+    "yAxisLabelMaxLines= ",
+    yAxisLabelMaxLines,
+    "svgContainerWidth=",
+    svgContainerWidth
+  );
   const yAxisWidth = addYLabel(
     yAxisLabel,
     height - minXAxisHeight,
@@ -897,7 +909,8 @@ export function drawScatter(
     MARGIN.left + yAxisWidth,
     properties.height,
     properties.xLabel,
-    properties.xUnit
+    properties.xUnit,
+    X_LABEL_WRAP_MAX_LINES
   );
   height = Math.max(0, height - xAxisHeight);
 


### PR DESCRIPTION
Fixes issue where large y axis labels cut off the chart in mobile

Before:
![Screenshot 2024-03-26 at 10 18 57 AM](https://github.com/datacommonsorg/website/assets/13766/a5d3fff9-f6af-4346-9146-13806608b53b)

After:
![Screenshot 2024-03-26 at 10 28 15 AM](https://github.com/datacommonsorg/website/assets/13766/50aab220-bf4f-4df8-9dce-b1923408083d)

Just before breakpoint:
![Screenshot 2024-03-26 at 10 10 24 AM](https://github.com/datacommonsorg/website/assets/13766/0a76393f-cac5-4302-a0e4-79a2171c5eea)

