### PR TITLE
[cron testing job] fix bug

### DIFF
--- a/build/website_cron_testing/run_website_cron_tests.sh
+++ b/build/website_cron_testing/run_website_cron_tests.sh
@@ -85,7 +85,6 @@ echo "==========================================================================
 mkdir -p input
 gsutil cp gs://datcom-website-adversarial/input/frequent/* input/
 dc_list=("main" "sdg")
-date_str=$(TZ="America/Los_Angeles" date +"%Y_%m_%d_%H_%M_%S")
 for dc in "${dc_list[@]}"
 do
   echo "====================================================================================="


### PR DESCRIPTION
adversarial logs were going into a separate folder because of extra line that gets the date string a second time