### PR TITLE
Load models once on NL server bootup

### DIFF
--- a/nl_server/config.py
+++ b/nl_server/config.py
@@ -57,7 +57,7 @@ class EmbeddingsIndex:
 def load(embeddings_map: Dict[str, str],
          models_map: Dict[str, str]) -> List[EmbeddingsIndex]:
   # Create Index objects.
-  indexes = _parse(embeddings_map)
+  indexes = parse(embeddings_map)
 
   # This is just a sanity, we can soon deprecate models.yaml
   tuned_models_provided = list(set(models_map.values()))
@@ -85,7 +85,7 @@ def load(embeddings_map: Dict[str, str],
   return indexes
 
 
-def _parse(embeddings_map: Dict[str, str]) -> List[EmbeddingsIndex]:
+def parse(embeddings_map: Dict[str, str]) -> List[EmbeddingsIndex]:
   indexes: List[EmbeddingsIndex] = []
 
   for key, value in embeddings_map.items():

--- a/nl_server/embeddings.py
+++ b/nl_server/embeddings.py
@@ -42,17 +42,19 @@ _NUM_SV_INDEX_MATCHES_WITHOUT_TOPICS = 60
 _TOPIC_PREFIX = 'dc/topic/'
 
 
+def load_model(existing_model_path: str = ""):
+  if existing_model_path:
+    logging.info(f'Loading tuned model from: {existing_model_path}')
+    return SentenceTransformer(existing_model_path)
+  logging.info(f'Loading base model {config.EMBEDDINGS_BASE_MODEL_NAME}')
+  return SentenceTransformer(config.EMBEDDINGS_BASE_MODEL_NAME)
+
+
 class Embeddings:
   """Manages the embeddings."""
 
-  def __init__(self,
-               embeddings_path: str,
-               existing_model_path: str = "") -> None:
-    if existing_model_path:
-      assert os.path.exists(existing_model_path)
-      self.model = SentenceTransformer(existing_model_path)
-    else:
-      self.model = SentenceTransformer(config.EMBEDDINGS_BASE_MODEL_NAME)
+  def __init__(self, embeddings_path: str, model: any) -> None:
+    self.model = model
     self.dataset_embeddings: torch.Tensor = None
     self.dcids: List[str] = []
     self.sentences: List[str] = []

--- a/nl_server/embeddings.py
+++ b/nl_server/embeddings.py
@@ -67,17 +67,16 @@ class Embeddings:
       logging.error(error_str)
       raise Exception("No embedding could be loaded.")
 
-    self.df = ds["train"].to_pandas()
-    self.dcids = self.df['dcid'].values.tolist()
-    self.df = self.df.drop('dcid', axis=1)
+    df = ds["train"].to_pandas()
+    self.dcids = df['dcid'].values.tolist()
+    df = df.drop('dcid', axis=1)
     # Also get the sentence mappings.
     self.sentences = []
-    if 'sentence' in self.df:
-      self.sentences = self.df['sentence'].values.tolist()
-      self.df = self.df.drop('sentence', axis=1)
+    if 'sentence' in df:
+      self.sentences = df['sentence'].values.tolist()
+      df = df.drop('sentence', axis=1)
 
-    self.dataset_embeddings = torch.from_numpy(self.df.to_numpy()).to(
-        torch.float)
+    self.dataset_embeddings = torch.from_numpy(df.to_numpy()).to(torch.float)
 
   #
   # Given a list of queries, searches the in-memory embeddings index

--- a/nl_server/loader.py
+++ b/nl_server/loader.py
@@ -78,16 +78,13 @@ def load_custom_embeddings(app: Flask):
   """
   flask_env = os.environ.get('FLASK_ENV')
   embeddings_map, _ = _load_yamls(flask_env)
-  # TODO: call config._parse() to parse embeddings and assert that the path is local.
-  custom_embeddings_local_path = embeddings_map.get(config.CUSTOM_DC_INDEX)
-  if not custom_embeddings_local_path:
+  custom_embeddings_path = embeddings_map.get(config.CUSTOM_DC_INDEX)
+  if not custom_embeddings_path:
     logging.warning("No custom DC embeddings found, so none will be loaded.")
     return
-
-  custom_idx = config.EmbeddingsIndex(
-      name=config.CUSTOM_DC_INDEX,
-      embeddings_file_name=os.path.basename(custom_embeddings_local_path),
-      embeddings_local_path=custom_embeddings_local_path)
+  # Construct the Custom EmbeddingsIndex by calling into parse() to
+  # set fields like tuned_model correctly.
+  custom_idx = config.parse({config.CUSTOM_DC_INDEX: custom_embeddings_path})[0]
 
   # This lookup will raise an error if embeddings weren't already initialized previously.
   # This is intentional.

--- a/nl_server/loader.py
+++ b/nl_server/loader.py
@@ -84,13 +84,17 @@ def load_custom_embeddings(app: Flask):
     return
   # Construct the Custom EmbeddingsIndex by calling into parse() to
   # set fields like tuned_model correctly.
-  custom_idx = config.parse({config.CUSTOM_DC_INDEX: custom_embeddings_path})[0]
+  custom_idx_list = config.parse(
+      {config.CUSTOM_DC_INDEX: custom_embeddings_path})
+  if not custom_idx_list:
+    logging.warning(f"Unable to parse {custom_embeddings_path}")
+    return
 
   # This lookup will raise an error if embeddings weren't already initialized previously.
   # This is intentional.
   nl_embeddings: embeddings_store.Store = app.config[config.NL_EMBEDDINGS_KEY]
   # Merge custom index with default embeddings.
-  nl_embeddings.merge_custom_index(custom_idx)
+  nl_embeddings.merge_custom_index(custom_idx_list[0])
 
   # Update app config.
   _update_app_config(app, app.config[config.NL_MODEL_KEY], nl_embeddings,

--- a/nl_server/tests/custom_embeddings_test.py
+++ b/nl_server/tests/custom_embeddings_test.py
@@ -125,6 +125,7 @@ class TestEmbeddings(unittest.TestCase):
                                  embeddings_file_name=_CUSTOM_FILE,
                                  embeddings_local_path=os.path.join(
                                      TEMP_DIR, _CUSTOM_FILE))
+
     embeddings.merge_custom_index(custom_idx)
 
     _test_query(self, embeddings.get("medium_ft"), "money", "dc/topic/sdg_1")

--- a/nl_server/tests/embeddings_test.py
+++ b/nl_server/tests/embeddings_test.py
@@ -24,6 +24,7 @@ import yaml
 from nl_server import embeddings_store as store
 from nl_server import gcs
 from nl_server.embeddings import Embeddings
+from nl_server.embeddings import load_model
 from nl_server.loader import NL_CACHE_PATH
 from nl_server.loader import NL_EMBEDDINGS_CACHE_KEY
 
@@ -73,7 +74,7 @@ class TestEmbeddings(unittest.TestCase):
         tuned_model_path = _get_tuned_model_path()
 
       cls.nl_embeddings = Embeddings(_get_embeddings_file_path(),
-                                     tuned_model_path)
+                                     load_model(tuned_model_path))
     else:
       cls.nl_embeddings = embeddings_store.get()
 

--- a/tools/nl/svindex_differ/differ.py
+++ b/tools/nl/svindex_differ/differ.py
@@ -31,6 +31,7 @@ import requests
 
 from nl_server import gcs
 from nl_server.embeddings import Embeddings
+from nl_server.embeddings import load_model
 
 _SV_THRESHOLD = 0.5
 _NUM_SVS = 10
@@ -197,12 +198,12 @@ def run_diff(base_file, test_file, base_model_path, test_model_path, query_file,
   print(
       f"Setting up the Base Embeddings from: {base_file}; Base model from: {base_model_path}"
   )
-  base = Embeddings(base_file, base_model_path)
+  base = Embeddings(base_file, load_model(base_model_path))
   print("=================================")
   print(
       f"Setting up the Test Embeddings from: {test_file}; Test model from: {test_model_path}"
   )
-  test = Embeddings(test_file, test_model_path)
+  test = Embeddings(test_file, load_model(test_model_path))
   print("=================================")
 
   # Get the list of diffs


### PR DESCRIPTION
Avoid keeping unnecessary data frames in memory after load in `embeddings.py`.  This change drops the memory usage from [745MB to 200MB](https://gist.github.com/pradh/43148b72b74d1c5022eb36c4602ef020).

Also, fix a bug in Custom Index using base-model instead of tuned-model on live reload.