### PR TITLE
Fix logging config setup in local env

### DIFF
--- a/nl_app.py
+++ b/nl_app.py
@@ -27,8 +27,6 @@ if __name__ == '__main__':
   logging.info("Run nl server in local mode")
 
   if len(sys.argv) == 3 and sys.argv[2] == 'opt':
-    log = logging.getLogger('werkzeug')
-    log.setLevel(logging.ERROR)
     app.run(host='127.0.0.1', port=int(sys.argv[1]))
   else:
     app.run(host='127.0.0.1', port=int(sys.argv[1]), debug=True)

--- a/nl_server/__init__.py
+++ b/nl_server/__init__.py
@@ -29,13 +29,14 @@ def create_app():
   if lib_gcp.in_google_network():
     client = google.cloud.logging.Client()
     client.setup_logging()
-
-  logging.basicConfig(
-      level=logging.INFO,
-      format=
-      "\u3010%(asctime)s\u3011\u3010%(levelname)s\u3011\u3010 %(filename)s:%(lineno)s \u3011 %(message)s ",
-      datefmt="%H:%M:%S",
-  )
+  else:
+    logging.basicConfig(
+        level=logging.INFO,
+        format=
+        "[%(asctime)s][%(levelname)-8s][%(filename)s:%(lineno)s] %(message)s ",
+        datefmt="%H:%M:%S",
+    )
+  logging.getLogger('werkzeug').setLevel(logging.WARNING)
 
   app = Flask(__name__)
   app.register_blueprint(routes.bp)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -237,12 +237,13 @@ def create_app(nl_root=DEFAULT_NL_ROOT):
   if lib_gcp.in_google_network():
     client = google.cloud.logging.Client()
     client.setup_logging()
-  logging.basicConfig(
-      level=logging.INFO,
-      format=
-      "\u3010%(asctime)s\u3011\u3010%(levelname)s\u3011\u3010 %(filename)s:%(lineno)s \u3011 %(message)s ",
-      datefmt="%H:%M:%S",
-  )
+  else:
+    logging.basicConfig(
+        level=logging.INFO,
+        format=
+        "[%(asctime)s][%(levelname)-8s][%(filename)s:%(lineno)s] %(message)s ",
+        datefmt="%H:%M:%S",
+    )
   logging.getLogger('werkzeug').setLevel(logging.WARNING)
 
   # Setup flask config

--- a/shared/lib/gcp.py
+++ b/shared/lib/gcp.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import urllib.request
 
 url = "http://metadata.google.internal/computeMetadata/v1/project/project-id"
@@ -28,5 +27,6 @@ def in_google_network():
     resp.read().decode()
     return True
   except Exception as e:
-    logging.info('Not in Google network: ', e)
+    # Do not use logging here otherwise logging.baseConfig won't have effect
+    print('Not in Google network: ', e)
     return False


### PR DESCRIPTION
Should not call `logging.info` before `logging.basicConfig` otherwise the config won't take effect.

Also updated logging format a bit.