### PR TITLE
Upgrade torch to 2.2.2; Otherwise pip tries to ignore the torch-cpu and downloads cuda torch 2.2.2

### DIFF
--- a/build/nl_server/Dockerfile
+++ b/build/nl_server/Dockerfile
@@ -25,7 +25,7 @@ COPY nl_app.py /workspace/nl_app.py
 COPY nl_server/requirements.txt /workspace/nl_server/requirements.txt
 # --no-cache-dir removes ~/.cache files, which can be a few GB.
 RUN pip install --upgrade pip setuptools
-RUN pip3 install torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
 RUN pip3 install --no-cache-dir -r /workspace/nl_server/requirements.txt
 # Flask
 COPY nl_server/. /workspace/nl_server/

--- a/build/web_compose/Dockerfile
+++ b/build/web_compose/Dockerfile
@@ -67,7 +67,7 @@ COPY nl_app.py /workspace/nl_app.py
 COPY deploy/nl/. /datacommons/nl/
 COPY nl_server/requirements.txt /workspace/nl_server/requirements.txt
 RUN pip install --upgrade pip
-RUN pip3 install 2 --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
 RUN pip3 install -r /workspace/nl_server/requirements.txt
 
 # Import Tool

--- a/build/web_compose/Dockerfile
+++ b/build/web_compose/Dockerfile
@@ -67,7 +67,7 @@ COPY nl_app.py /workspace/nl_app.py
 COPY deploy/nl/. /datacommons/nl/
 COPY nl_server/requirements.txt /workspace/nl_server/requirements.txt
 RUN pip install --upgrade pip
-RUN pip3 install torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install 2 --extra-index-url https://download.pytorch.org/whl/cpu
 RUN pip3 install -r /workspace/nl_server/requirements.txt
 
 # Import Tool

--- a/run_test.sh
+++ b/run_test.sh
@@ -20,7 +20,7 @@ function setup_python {
   python3 -m venv .env
   source .env/bin/activate
   pip3 install -r server/requirements.txt
-  pip3 install torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
+  pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
   pip3 install -r nl_server/requirements.txt
   deactivate
 }

--- a/tools/nl/embeddings/finetuning/run.sh
+++ b/tools/nl/embeddings/finetuning/run.sh
@@ -64,6 +64,6 @@ cd ../
 python3 -m venv .env
 source .env/bin/activate
 python3 -m pip install --upgrade pip
-pip3 install torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
+pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
 pip3 install -r requirements.txt
 python3 -m finetuning.finetune --start_from="$START_FROM" --generate="$GENERATE" --pretuned_model="$INTERMEDIATE_FINETUNED_MODEL"

--- a/tools/nl/embeddings/run.sh
+++ b/tools/nl/embeddings/run.sh
@@ -91,7 +91,7 @@ python3 -m venv .env
 source .env/bin/activate
 cd tools/nl/embeddings
 python3 -m pip install --upgrade pip
-pip3 install torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
+pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
 pip3 install -r requirements.txt
 
 if [[ "$MODEL_ENDPOINT_ID" != "" ]];then

--- a/tools/nl/embeddings/run_custom.sh
+++ b/tools/nl/embeddings/run_custom.sh
@@ -18,7 +18,7 @@ set -e
 python3 -m venv .env
 source .env/bin/activate
 python3 -m pip install --upgrade pip
-pip3 install torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
+pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
 pip3 install -r requirements.txt
 
 python3 build_custom_dc_embeddings.py "$@"

--- a/tools/nl/svindex_differ/run.sh
+++ b/tools/nl/svindex_differ/run.sh
@@ -26,7 +26,7 @@ cd ../../..
 python3 -m venv .env
 source .env/bin/activate
 python3 -m pip install --upgrade pip
-pip3 install torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
+pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
 pip3 install -r nl_server/requirements.txt
 pip3 install -r tools/nl/svindex_differ/requirements.txt
 


### PR DESCRIPTION
Note torch 2.2.2 is released in 3/27: https://pypi.org/project/torch/2.2.2/. This corresponds to our docker image size blow up. 