### PR TITLE
Save embeddings.yaml with only default embeddings for custom DCs.

### DIFF
--- a/tools/nl/embeddings/build_custom_dc_embeddings.py
+++ b/tools/nl/embeddings/build_custom_dc_embeddings.py
@@ -48,13 +48,17 @@ flags.DEFINE_string("sv_sentences_csv_path", None,
 flags.DEFINE_string(
     "output_dir", None,
     "Output directory where the generated embeddings will be saved.")
+flags.DEFINE_string(
+    "embeddings_yaml_path", "/datacommons/nl/embeddings.yaml",
+    "Path where the default FT embeddings.yaml will be saved for Custom DC in download mode."
+)
 
 MODELS_BUCKET = 'datcom-nl-models'
 EMBEDDINGS_CSV_FILENAME = "custom_embeddings.csv"
 EMBEDDINGS_YAML_FILE_NAME = "custom_embeddings.yaml"
 
 
-def download():
+def download(embeddings_yaml_path: str):
   """Downloads the default FT model and embeddings.
   """
   ctx = _ctx_no_model()
@@ -66,6 +70,11 @@ def download():
   # Download embeddings.
   embeddings_file_name = utils.get_default_ft_embeddings_file_name()
   utils.get_or_download_file_from_gcs(ctx, embeddings_file_name)
+
+  # The prod embeddings.yaml includes multiple embeddings (default, biomed, UN)
+  # For custom DC, we only want the default.
+  utils.save_embeddings_yaml_with_only_default_ft_embeddings(
+      embeddings_yaml_path, embeddings_file_name)
 
 
 def build(model_version: str, sv_sentences_csv_path: str, output_dir: str):
@@ -129,7 +138,7 @@ def _ctx_no_model() -> utils.Context:
 
 def main(_):
   if FLAGS.mode == Mode.DOWNLOAD:
-    download()
+    download(FLAGS.embeddings_yaml_path)
     return
 
   assert FLAGS.sv_sentences_csv_path

--- a/tools/nl/embeddings/utils.py
+++ b/tools/nl/embeddings/utils.py
@@ -324,6 +324,13 @@ def _get_default_ft_model_version(embeddings_yaml_file_path: str) -> str:
   return matcher.group(1)
 
 
+def save_embeddings_yaml_with_only_default_ft_embeddings(
+    embeddings_yaml_file_path: str, default_ft_embeddings_file_name: str):
+  data = {_DEFAULT_EMBEDDINGS_INDEX_TYPE: default_ft_embeddings_file_name}
+  with open(embeddings_yaml_file_path, "w") as f:
+    yaml.dump(data, f)
+
+
 def validate_embeddings(embeddings_df: pd.DataFrame,
                         output_dcid_sentences_filepath: str) -> None:
   # Verify that embeddings were created for all DCIDs and Sentences.


### PR DESCRIPTION
Currently, all embeddings specified in embeddings.yaml (default, biomed, UN) are loaded in Custom DCs. We only need the default in them.

When building a custom DC docker image, we [run a script](https://github.com/datacommonsorg/website/blob/3112669701480bc5fe9c1e42051445d631cecace/build/web_compose/Dockerfile#L120) to download and save the default model in the docker image. With this change, we additionally save embeddings.yaml with just the default embeddings in it.

Before:

![image](https://github.com/datacommonsorg/website/assets/1221814/92f730c9-e762-4e07-8024-af658bacd1ae)

After:

![image](https://github.com/datacommonsorg/website/assets/1221814/a49680eb-20c7-4221-9bd5-8ba5249a146b)
