### PR TITLE
Create custom dc embeddings file name with model version in it.

### DIFF
--- a/tools/nl/embeddings/build_custom_dc_embeddings.py
+++ b/tools/nl/embeddings/build_custom_dc_embeddings.py
@@ -54,7 +54,7 @@ flags.DEFINE_string(
 )
 
 MODELS_BUCKET = 'datcom-nl-models'
-EMBEDDINGS_CSV_FILENAME = "custom_embeddings.csv"
+EMBEDDINGS_CSV_FILENAME_PREFIX = "custom_embeddings"
 EMBEDDINGS_YAML_FILE_NAME = "custom_embeddings.yaml"
 
 
@@ -92,7 +92,8 @@ def build(model_version: str, sv_sentences_csv_path: str, output_dir: str):
 
   output_dir_handler = create_file_handler(output_dir)
   embeddings_csv_handler = create_file_handler(
-      output_dir_handler.join(EMBEDDINGS_CSV_FILENAME))
+      output_dir_handler.join(
+          f"{EMBEDDINGS_CSV_FILENAME_PREFIX}.{model_version}.csv"))
   embeddings_yaml_handler = create_file_handler(
       output_dir_handler.join(EMBEDDINGS_YAML_FILE_NAME))
 

--- a/tools/nl/embeddings/build_custom_dc_embeddings_test.py
+++ b/tools/nl/embeddings/build_custom_dc_embeddings_test.py
@@ -16,7 +16,7 @@ import os
 import tempfile
 import unittest
 
-from build_custom_dc_embeddings import EMBEDDINGS_CSV_FILENAME
+from build_custom_dc_embeddings import EMBEDDINGS_CSV_FILENAME_PREFIX
 from build_custom_dc_embeddings import EMBEDDINGS_YAML_FILE_NAME
 import build_custom_dc_embeddings as builder
 from file_util import create_file_handler
@@ -83,7 +83,7 @@ class TestEndToEnd(unittest.TestCase):
   def test_generate_yaml(self):
     expected_embeddings_yaml_path = os.path.join(EXPECTED_DIR,
                                                  EMBEDDINGS_YAML_FILE_NAME)
-    fake_embeddings_csv_path = f"/fake/path/to/{EMBEDDINGS_CSV_FILENAME}"
+    fake_embeddings_csv_path = f"/fake/path/to/{EMBEDDINGS_CSV_FILENAME_PREFIX}.csv"
 
     with tempfile.TemporaryDirectory() as temp_dir:
       actual_embeddings_yaml_path = os.path.join(temp_dir,


### PR DESCRIPTION
* This fixes a bug where the NL server uses the base model instead of the FT model.
* It also improves startup and load performance since while the FT model is included in the docker image, the base model is not. Which results in the latter being downloaded on every server startup (or at first load) which makes for longer startup times esp on slow networks.

Before:

![image](https://github.com/datacommonsorg/website/assets/1221814/507bf9db-aebb-4588-8eff-1487fa5cfa43)

After:

![image](https://github.com/datacommonsorg/website/assets/1221814/f30dc9f8-c9f3-4a3c-9a0f-89833e84fb6d)

In the above case, the load time went down from 13s to 5s = an 8s or 60% improvement overall. While the absolute improvement here (tiny embeddings file, fast Google network) is not significant, the difference can be substantial on slower networks (where we have seen timeouts before).