### PR TITLE
[biomed nl] update answer table to be scrollable

### DIFF
--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -643,33 +643,60 @@ $box-shadow-8dp: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
   
   .answer-table-title {
     font-size: 32px;
+    margin-bottom: 48px;
   }
 
-  .answer-table {
+  .table-container {
+    overflow: scroll;
+    max-height: 50vH;
+  }
+
+  .table {
     border: 1px solid #DEE2E6;
     border-radius: 3px;
     font-size: 24px;
     font-weight: 400;
-    margin-top: 48px;
 
     thead {
       background-color: #F0F0F0;
+      position: sticky;
+      top: 0;
+      z-index: 2;
 
       th {
         font-weight: 400;
         padding: 8px 0;
+        padding-right: 16px;
+        white-space: nowrap;
+      }
+
+      th:first-child {
+        background-color: #F0F0F0;
+        left: 0;
+        position: sticky;
+        top: 0;
+        z-index: 3;
       }
     }
 
     tbody {
-      tr:nth-child(even) {
+      tr:nth-child(even),
+      tr:nth-child(even) td:first-child {
         background-color: #F0F0F0;
       }
 
-      tr td:nth-child(1) {
+      tr:nth-child(odd),
+      tr:nth-child(odd) td:first-child {
+        background-color: var(--gm-3-white);
+      }
+
+      tr td:first-child {
+        left: 0;
         padding-left: 80px;
+        position: sticky;
         white-space: nowrap;
         width: auto;
+        z-index: 1;
       }
 
       td {

--- a/static/js/components/tiles/answer_table_tile.tsx
+++ b/static/js/components/tiles/answer_table_tile.tsx
@@ -65,40 +65,44 @@ export function AnswerTableTile(props: AnswerTableTilePropType): JSX.Element {
       className={`chart-container answer-table-tile ${ASYNC_ELEMENT_HOLDER_CLASS}`}
     >
       <div className={`answer-table-content ${ASYNC_ELEMENT_CLASS}`}>
-        <div className="answer-table-title">{props.title}</div>
-        <table className="answer-table">
-          <thead>
-            <tr>
-              <th></th>
-              {props.columns.map((col, idx) => {
-                return <th key={`col-header-${idx}`}>{col.header}</th>;
+        {props.title && <div className="answer-table-title">{props.title}</div>}
+        <div className="table-container">
+          <table className="table">
+            <thead>
+              <tr>
+                <th></th>
+                {props.columns.map((col, idx) => {
+                  return <th key={`col-header-${idx}`}>{col.header}</th>;
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {props.entities.map((entity, rowIdx) => {
+                return (
+                  <tr key={`row-${rowIdx}`}>
+                    <td>
+                      <a href={URI_PREFIX + entity}>
+                        {answerData.entityNames[entity] || entity}
+                        <span className="material-icons-outlined">
+                          arrow_forward
+                        </span>
+                      </a>
+                    </td>
+                    {props.columns.map((col, colIdx) => {
+                      return (
+                        <td key={`row-${rowIdx}-col-${colIdx}`}>
+                          {answerData.values[entity][col.propertyExpr].join(
+                            ", "
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
               })}
-            </tr>
-          </thead>
-          <tbody>
-            {props.entities.map((entity, rowIdx) => {
-              return (
-                <tr key={`row-${rowIdx}`}>
-                  <td>
-                    <a href={URI_PREFIX + entity}>
-                      {answerData.entityNames[entity] || entity}
-                      <span className="material-icons-outlined">
-                        arrow_forward
-                      </span>
-                    </a>
-                  </td>
-                  {props.columns.map((col, colIdx) => {
-                    return (
-                      <td key={`row-${rowIdx}-col-${colIdx}`}>
-                        {answerData.values[entity][col.propertyExpr].join(", ")}
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+            </tbody>
+          </table>
+        </div>
       </div>
       <div className="source">source: {answerData.sources.join(", ")}</div>
     </div>


### PR DESCRIPTION
Make ANSWER_TABLE tile table scrollable so that it's easier to see the values when there are mulitple columns and rows. Not styled beyond this.


https://github.com/datacommonsorg/website/assets/69875368/4c8d5d62-abc0-42bb-92ba-19c0c85f57bc

