### PR TITLE
fixed bar chart csv export error

### DIFF
--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -177,7 +177,9 @@ function getDataCsvCallback(props: BarTilePropType): () => Promise<string> {
     const entityProps = props.placeNameProp
       ? [props.placeNameProp, ISO_CODE_ATTRIBUTE]
       : undefined;
-    if ("parentPlace" in props) {
+    // Check for !("places" in props) because parentPlace can be set even if
+    // "places" is also set
+    if (!("places" in props)) {
       return datacommonsClient.getCsv({
         childType: props.enclosedPlaceType,
         date,
@@ -194,7 +196,7 @@ function getDataCsvCallback(props: BarTilePropType): () => Promise<string> {
         entityProps,
         entities: props.places,
         fieldDelimiter: CSV_FIELD_DELIMITER,
-        perCapitaVariables: _.uniq(perCapitaVariables),
+        perCapitaVariables,
         transformHeader: transformCsvHeader,
         variables: props.variables.map((v) => v.statVar),
       });


### PR DESCRIPTION
Fixed bar chart CSV export error for multi-place charts

Example:
http://localhost:8080/explore/#client=ui_query&q=How+does+the+GDP+of+USA+compare+with+that+of+China

## Before
![before1](https://github.com/datacommonsorg/website/assets/13766/23669dc5-7734-4b00-9a47-7e508f14d31b)
![before2](https://github.com/datacommonsorg/website/assets/13766/4113f6ee-5772-415f-9a13-11332cc0ead0)



## After
![after](https://github.com/datacommonsorg/website/assets/13766/86143a9a-f817-4f7a-ac04-4b15745afd9d)

