### PR TITLE
Remove place page for West Berlin (nuts/DE301) from sitemap

### DIFF
--- a/static/sitemap/PriorityPlaces.0.txt
+++ b/static/sitemap/PriorityPlaces.0.txt
@@ -324,7 +324,6 @@ https://datacommons.org/place/wikidataId/Q133118
 https://datacommons.org/place/wikidataId/Q243322
 https://datacommons.org/place/wikidataId/Q128849
 https://datacommons.org/place/wikidataId/Q147187
-https://datacommons.org/place/nuts/DE301
 https://datacommons.org/place/wikidataId/Q2280
 https://datacommons.org/place/wikidataId/Q37951
 https://datacommons.org/place/wikidataId/Q205327

--- a/tools/sitemap/main.py
+++ b/tools/sitemap/main.py
@@ -125,8 +125,8 @@ def get_global_cities_with_population_over_500k() -> List[str]:
   with open(BQ_CSV) as f:
     cities = csv.DictReader(f)
     for city in cities:
-      # Filter out West Berlin, does not have charts and as a historical city
-      # will not get any new charts added.
+      # Filter out West Berlin, which does not have charts and because it no
+      # longer exists, it will not get any new charts added.
       # TODO (juliawu): This is a temporary change to cleanup our sitemaps
       #                 while the node in the KG is being fixed. Once the
       #                 KG is updated, replace this fix with an updated
@@ -176,8 +176,8 @@ def updateRobotTxt():
 
 def main():
   dc.set_api_key('noop')
-  # for place_type in PLACES:
-  #   write_place_url(place_type)
+  for place_type in PLACES:
+    write_place_url(place_type)
   write_priority_places_sitemap()
   updateRobotTxt()
 

--- a/tools/sitemap/main.py
+++ b/tools/sitemap/main.py
@@ -125,7 +125,13 @@ def get_global_cities_with_population_over_500k() -> List[str]:
   with open(BQ_CSV) as f:
     cities = csv.DictReader(f)
     for city in cities:
-      if 'dcid' in city:
+      # Filter out West Berlin, does not have charts and as a historical city
+      # will not get any new charts added.
+      # TODO (juliawu): This is a temporary change to cleanup our sitemaps
+      #                 while the node in the KG is being fixed. Once the
+      #                 KG is updated, replace this fix with an updated
+      #                 BQ query which filters out nodes with a dissolutionDate.
+      if 'dcid' in city and city['dcid'] != "nuts/DE301":
         dcids.append(city['dcid'])
   return dcids
 
@@ -170,8 +176,8 @@ def updateRobotTxt():
 
 def main():
   dc.set_api_key('noop')
-  for place_type in PLACES:
-    write_place_url(place_type)
+  # for place_type in PLACES:
+  #   write_place_url(place_type)
   write_priority_places_sitemap()
   updateRobotTxt()
 

--- a/tools/sitemap/requirements.txt
+++ b/tools/sitemap/requirements.txt
@@ -1,3 +1,2 @@
 datacommons
 requests
-yapf


### PR DESCRIPTION
Removes the place page for West Berlin (nuts/DE301) from our sitemap. This place page does not have any charts on it, and because this city no longer exists, we won't be adding new charts to it. This PR removes it from our sitemaps so it doesn't get indexed.

Also removes the unused `yapf` in requirements.txt which was causing some version conflict errors.