### PR TITLE
Create new biomedical DC instance.

### DIFF
--- a/deploy/gke/biomedical.yaml
+++ b/deploy/gke/biomedical.yaml
@@ -1,0 +1,28 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This is a yaml template to create gcp/gke configuration.
+# Copy this file to `config.yaml` and use that.
+
+project: datcom-biomedical
+domain: biomedical.datacommons.org
+ip: 34.49.89.118
+region:
+  primary: us-central1
+  others:
+    -
+nodes: 1
+storage_project: datcom-store
+control_project: datcom-204919

--- a/deploy/gke/biomedical.yaml
+++ b/deploy/gke/biomedical.yaml
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# This is a yaml template to create gcp/gke configuration.
-# Copy this file to `config.yaml` and use that.
-
 project: datcom-biomedical
 domain: biomedical.datacommons.org
 ip: 34.49.89.118

--- a/deploy/helm_charts/envs/biomedical.yaml
+++ b/deploy/helm_charts/envs/biomedical.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deploy/helm_charts/envs/biomedical.yaml
+++ b/deploy/helm_charts/envs/biomedical.yaml
@@ -1,0 +1,46 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helm config
+project: "datcom-biomedical"
+cluster_prefix: "website"
+
+namespace:
+  name: "website"
+
+website:
+  flaskEnv: biomedical
+  replicas: 5
+  redis:
+    enabled: false
+
+serviceAccount:
+  name: website-ksa
+
+ingress:
+  enabled: true
+
+serviceGroups:
+  recon: null
+  svg:
+    replicas: 2
+  observation:
+    replicas: 5
+  node:
+    replicas: 10
+  default:
+    replicas: 5
+
+nl:
+  enabled: true

--- a/deploy/helm_charts/envs/biomedical.yaml
+++ b/deploy/helm_charts/envs/biomedical.yaml
@@ -22,8 +22,6 @@ namespace:
 website:
   flaskEnv: biomedical
   replicas: 5
-  redis:
-    enabled: false
 
 serviceAccount:
   name: website-ksa
@@ -36,11 +34,11 @@ serviceGroups:
   svg:
     replicas: 2
   observation:
-    replicas: 5
+    replicas: 2
   node:
-    replicas: 10
+    replicas: 2
   default:
-    replicas: 5
+    replicas: 2
 
 nl:
   enabled: true

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -270,12 +270,12 @@ def create_app(nl_root=DEFAULT_NL_ROOT):
   if ingress_config_path:
     configure_endpoints_from_ingress(ingress_config_path)
 
-  register_routes_common(app)
-  if not cfg.CUSTOM:
-    # Only register biomedical DC routes if in main DC
+  if os.environ.get('FLASK_ENV') == 'biomedical':
     register_routes_biomedical_dc(app)
 
+  register_routes_common(app)
   register_routes_base_dc(app)
+
   if cfg.SHOW_DISASTER:
     register_routes_disasters(app)
 
@@ -339,7 +339,8 @@ def create_app(nl_root=DEFAULT_NL_ROOT):
       secret_name = secret_client.secret_version_path(cfg.SECRET_PROJECT,
                                                       'mixer-api-key', 'latest')
       secret_response = secret_client.access_secret_version(name=secret_name)
-      app.config['DC_API_KEY'] = secret_response.payload.data.decode('UTF-8')
+      app.config['DC_API_KEY'] = secret_response.payload.data.decode(
+          'UTF-8').replace('\n', '')
 
   # Initialize translations
   babel = Babel(app, default_domain='all')

--- a/server/app_env/biomedical.py
+++ b/server/app_env/biomedical.py
@@ -13,12 +13,19 @@
 # limitations under the License.
 
 from server.app_env import _base
+from server.app_env import local
 
 
 class Config(_base.Config):
+  API_ROOT = 'https://autopush.api.datacommons.org'
   GCS_BUCKET = 'datcom-website-autopush-resources'
+  HIDE_DEBUG = False
   LOG_QUERY = True
   SHOW_TOPIC = True
   USE_LLM = True
-  HIDE_DEBUG = False
   USE_MEMCACHE = False
+
+
+class LocalConfig(local.Config):
+  API_ROOT = 'https://autopush.api.datacommons.org'
+  SECRET_PROJECT = 'datcom-biomedical'

--- a/server/app_env/biomedical.py
+++ b/server/app_env/biomedical.py
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from server.app_env import _base
+
+
+class Config(_base.Config):
+  GCS_BUCKET = 'datcom-website-autopush-resources'
+  LOG_QUERY = True
+  SHOW_TOPIC = True
+  USE_LLM = True
+  HIDE_DEBUG = False
+  USE_MEMCACHE = False

--- a/server/routes/biomedical/html.py
+++ b/server/routes/biomedical/html.py
@@ -21,7 +21,7 @@ from flask import Blueprint
 from flask import current_app
 from flask import render_template
 
-bp = Blueprint('biomedical', __name__, url_prefix='/bio')
+bp = Blueprint('biomedical', __name__)
 
 _PAGE_CONFIG_FILE = "config/biomedical_landing_page/display_items.json"
 
@@ -35,8 +35,5 @@ def get_page_config() -> dict:
 
 @bp.route('/')
 def main():
-  if os.environ.get('FLASK_ENV') not in ['autopush', 'dev', 'local']:
-    flask.abort(404)
-
   config_data = get_page_config()
   return render_template('/biomedical/landing.html', config_data=config_data)

--- a/server/routes/disease/html.py
+++ b/server/routes/disease/html.py
@@ -22,7 +22,7 @@ from flask import render_template
 
 import server.lib.shared as shared_api
 
-bp = Blueprint('disease', __name__, url_prefix='/bio/disease')
+bp = Blueprint('disease', __name__, url_prefix='/disease')
 
 
 @bp.route('/')

--- a/server/routes/protein/html.py
+++ b/server/routes/protein/html.py
@@ -22,7 +22,7 @@ from flask import render_template
 
 import server.lib.shared as shared_api
 
-bp = Blueprint('protein', __name__, url_prefix='/bio/protein')
+bp = Blueprint('protein', __name__, url_prefix='/protein')
 
 
 @bp.route('/')

--- a/server/templates/disease/landing.html
+++ b/server/templates/disease/landing.html
@@ -35,7 +35,7 @@
        <ul>
          <li class="type-list">
            <strong>Disease</strong>:
-           <a href="/bio/disease/bio/DOID_0080600">A Coronavirus infection that is characterized by fever
+           <a href={{url_for('disease.node', dcid='bio/DOID_0080600')}}>A Coronavirus infection that is characterized by fever
             cough and shortness of breath and that has material basis in SARS-CoV-2.</a>
          </li>
        </ul>

--- a/server/templates/protein/landing.html
+++ b/server/templates/protein/landing.html
@@ -35,7 +35,7 @@
     <ul>
       <li class="type-list">
         <strong>Protein</strong>:
-        <a href="/bio/protein/bio/P53_HUMAN">Cellular tumor antigen p53</a>
+        <a href={{url_for('protein.node', dcid='bio/P53_HUMAN')}}>Cellular tumor antigen p53</a>
       </li>
     </ul>
   </div>

--- a/static/js/biomedical/landing/app.tsx
+++ b/static/js/biomedical/landing/app.tsx
@@ -68,7 +68,7 @@ function getCardSpecsFromConfig(
       // Build card specs for each entry in the config
       const card: CardProps = { ...cardSpec };
       if (!cardSpec.url && addSearchUrl) {
-        card.url = `${BIOMEDICAL_SEARCH_URL}${BIOMEDICAL_SEARCH_QUERY_PARAM}=${cardSpec.text}`;
+        card.url = `${BIOMEDICAL_SEARCH_URL}${BIOMEDICAL_SEARCH_QUERY_PARAM}=${cardSpec.text}&dc=bio`;
       }
       card.tag = categoryConfig.category;
       card.theme =

--- a/static/js/biomedical/landing/header_and_search_section.tsx
+++ b/static/js/biomedical/landing/header_and_search_section.tsx
@@ -102,6 +102,7 @@ function onSearch(query: string): void {
   // Sanitize query to prevent cross-site scripting attacks
   const urlSearchParams = new URLSearchParams();
   urlSearchParams.set(BIOMEDICAL_SEARCH_QUERY_PARAM, query);
+  urlSearchParams.set("dc", "bio");
   window.location.href = `${BIOMEDICAL_SEARCH_URL}${urlSearchParams.toString()}`;
 }
 


### PR DESCRIPTION
Biomedical DC will now be hosted in its own instance, at https://biomedical.datacommons.org.

This PR:
* Adds deployment yamls used to deploy the biomedical pages to the `datcom-biomedical` GCP project
* Sets the biomedical landing page as the homepage when in biomedical DC
* Removes "/bio" from protein and disease browser paths for a simpler URL structure
* Updates the search bar in biomedical DC to include "&dc=bio" to enable biomedical searches

With this change, local development of biomedical DC can be done with
```
./run_server.sh -e biomedical -m
```

And changes can be deployed to biomedical.datacommons.org with
```
./scripts/deploy_gke_helm.sh -e biomedical
```

Changes are now live!
* homepage: https://biomedical.datacommons.org
* search result: https://biomedical.datacommons.org/explore/#q=What%20genes%20are%20associated%20with%20rs13317?&dc=bio
* protein browser: https://biomedical.datacommons.org/protein/
* P53 protein browser page: https://biomedical.datacommons.org/protein/bio/P53_HUMAN
* disease browser: https://biomedical.datacommons.org/disease/
* COVID19 disease browser page: https://biomedical.datacommons.org/disease/bio/DOID_0080600
