### PR TITLE
Fix downloaded model and embeddings paths for custom DC.

### DIFF
--- a/nl_server/config.py
+++ b/nl_server/config.py
@@ -101,7 +101,7 @@ def parse(embeddings_map: Dict[str, Dict[str, str]]) -> List[EmbeddingsIndex]:
     elif is_gcs_path(path):
       logging.info('Downloading embeddings from GCS path: %s', path)
       if store_type == StoreType.MEMORY:
-        local_path = download_gcs_file(path)
+        local_path = download_gcs_file(path, use_anonymous_client=True)
       elif store_type == StoreType.LANCEDB:
         local_path = gcs.download_folder(path)
       if not local_path:

--- a/shared/lib/gcs.py
+++ b/shared/lib/gcs.py
@@ -55,17 +55,17 @@ def download_gcs_file(gcs_path: str, use_anonymous_client: bool = False) -> str:
 # Downloads the `filename` from GCS to TEMP_DIR
 # and returns its path.
 #
-def download_file(bucketname: str,
+def download_file(bucket: str,
                   filename: str,
                   use_anonymous_client: bool = False) -> str:
   if use_anonymous_client:
     storage_client = storage.Client.create_anonymous_client()
   else:
     storage_client = storage.Client()
-  bucket = storage_client.bucket(bucket_name=bucketname)
-  blob = bucket.get_blob(filename)
+  bucket_object = storage_client.bucket(bucket_name=bucket)
+  blob = bucket_object.get_blob(filename)
   # Download
-  local_file_path = _get_local_path(bucketname, filename)
+  local_file_path = _get_local_path(bucket, filename)
   # Create directory to file if it does not exist.
   parent_dir = Path(local_file_path).parent
   if not parent_dir.exists():
@@ -74,17 +74,17 @@ def download_file(bucketname: str,
   return local_file_path
 
 
-def get_or_download_file(bucketname: str,
+def get_or_download_file(bucket: str,
                          filename: str,
                          use_anonymous_client: bool = False) -> str:
   """Returns the local file path if the file already exists. 
   Otherwise it downloads the file from GCS and returns the path it was downloaded to.
   """
-  local_file_path = _get_local_path(bucketname, filename)
+  local_file_path = _get_local_path(bucket, filename)
   if os.path.exists(local_file_path):
     logging.info("Using already downloaded GCS file: %s", local_file_path)
     return local_file_path
-  return download_file(bucketname, filename, use_anonymous_client)
+  return download_file(bucket, filename, use_anonymous_client)
 
 
 def _get_local_path(bucketname: str, filename: str) -> str:

--- a/shared/lib/gcs.py
+++ b/shared/lib/gcs.py
@@ -55,17 +55,17 @@ def download_gcs_file(gcs_path: str, use_anonymous_client: bool = False) -> str:
 # Downloads the `filename` from GCS to TEMP_DIR
 # and returns its path.
 #
-def download_file(bucket: str,
+def download_file(bucketname: str,
                   filename: str,
                   use_anonymous_client: bool = False) -> str:
   if use_anonymous_client:
     storage_client = storage.Client.create_anonymous_client()
   else:
     storage_client = storage.Client()
-  bucket = storage_client.bucket(bucket_name=bucket)
+  bucket = storage_client.bucket(bucket_name=bucketname)
   blob = bucket.get_blob(filename)
   # Download
-  local_file_path = _get_local_path(filename)
+  local_file_path = _get_local_path(bucketname, filename)
   # Create directory to file if it does not exist.
   parent_dir = Path(local_file_path).parent
   if not parent_dir.exists():
@@ -74,17 +74,18 @@ def download_file(bucket: str,
   return local_file_path
 
 
-def get_or_download_file(bucket: str,
+def get_or_download_file(bucketname: str,
                          filename: str,
                          use_anonymous_client: bool = False) -> str:
   """Returns the local file path if the file already exists. 
   Otherwise it downloads the file from GCS and returns the path it was downloaded to.
   """
-  local_file_path = _get_local_path(filename)
+  local_file_path = _get_local_path(bucketname, filename)
   if os.path.exists(local_file_path):
+    logging.info("Using already downloaded GCS file: %s", local_file_path)
     return local_file_path
-  return download_file(bucket, filename, use_anonymous_client)
+  return download_file(bucketname, filename, use_anonymous_client)
 
 
-def _get_local_path(filename: str) -> str:
-  return os.path.join(TEMP_DIR, filename)
+def _get_local_path(bucketname: str, filename: str) -> str:
+  return os.path.join(TEMP_DIR, bucketname, filename)

--- a/shared/lib/gcs.py
+++ b/shared/lib/gcs.py
@@ -41,6 +41,10 @@ def download_gcs_file(gcs_path: str, use_anonymous_client: bool = False) -> str:
   """Downloads the file from the full GCS path (i.e. gs://bucket/path/to/file) 
   to a local path and returns the latter.
   """
+  # If not a GCS path, return the path itself.
+  if not is_gcs_path(gcs_path):
+    return gcs_path
+
   bucket_name, blob_name = get_gcs_parts(gcs_path)
   if not blob_name:
     return ''

--- a/tools/nl/embeddings/build_custom_dc_embeddings.py
+++ b/tools/nl/embeddings/build_custom_dc_embeddings.py
@@ -53,7 +53,6 @@ flags.DEFINE_string(
     "Path where the default FT embeddings.yaml will be saved for Custom DC in download mode."
 )
 
-MODELS_BUCKET = 'datcom-nl-models'
 EMBEDDINGS_CSV_FILENAME_PREFIX = "custom_embeddings"
 EMBEDDINGS_YAML_FILE_NAME = "custom_embeddings.yaml"
 
@@ -143,7 +142,8 @@ def _download_model(model_version: str) -> utils.Context:
 
 
 def _ctx_no_model() -> utils.Context:
-  bucket = storage.Client.create_anonymous_client().bucket(MODELS_BUCKET)
+  bucket = storage.Client.create_anonymous_client().bucket(
+      utils.DEFAULT_MODELS_BUCKET)
   return utils.Context(model=None, model_endpoint=None, bucket=bucket)
 
 

--- a/tools/nl/embeddings/build_custom_dc_embeddings.py
+++ b/tools/nl/embeddings/build_custom_dc_embeddings.py
@@ -14,6 +14,7 @@
 """Build embeddings for custom DCs."""
 
 import os
+import sys
 
 from absl import app
 from absl import flags
@@ -23,6 +24,15 @@ from google.cloud import storage
 import pandas as pd
 import utils
 import yaml
+
+# Import gcs module from shared lib.
+# Since this tool is run standalone from this directory,
+# the shared lib directory needs to be appended to the sys path.
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SHARED_LIB_DIR = os.path.join(_THIS_DIR, "..", "..", "..", "shared", "lib")
+print("SHARED LIB DIR", _SHARED_LIB_DIR)
+sys.path.append(_SHARED_LIB_DIR)
+import gcs  # type: ignore
 
 FLAGS = flags.FLAGS
 
@@ -70,7 +80,8 @@ def download(embeddings_yaml_path: str):
 
   # Download embeddings.
   embeddings_file_name = default_ft_embeddings_info["embeddings"]
-  utils.get_or_download_file_from_gcs(ctx, embeddings_file_name)
+  gcs.download_gcs_file(embeddings_file_name)
+  # utils.get_or_download_file_from_gcs(ctx, embeddings_file_name)
 
   # The prod embeddings.yaml includes multiple embeddings (default, biomed, UN)
   # For custom DC, we only want the default.

--- a/tools/nl/embeddings/build_custom_dc_embeddings.py
+++ b/tools/nl/embeddings/build_custom_dc_embeddings.py
@@ -81,7 +81,6 @@ def download(embeddings_yaml_path: str):
   # Download embeddings.
   embeddings_file_name = default_ft_embeddings_info["embeddings"]
   gcs.download_gcs_file(embeddings_file_name)
-  # utils.get_or_download_file_from_gcs(ctx, embeddings_file_name)
 
   # The prod embeddings.yaml includes multiple embeddings (default, biomed, UN)
   # For custom DC, we only want the default.

--- a/tools/nl/embeddings/utils.py
+++ b/tools/nl/embeddings/utils.py
@@ -167,7 +167,8 @@ def dedup_texts(df: pd.DataFrame) -> Tuple[Dict[str, str], List[List[str]]]:
 
 
 def _download_model_from_gcs(ctx: Context, model_folder_name: str) -> str:
-  # TODO: deprecate this in favor of the function  in nl_server.gcs
+  # TODO: Move download_folder from nl_server.gcs to shared.lib.gcs
+  # and then use that function instead of this one.
   """Downloads a Sentence Tranformer model (or finetuned version) from GCS.
 
   Args:

--- a/tools/nl/embeddings/utils.py
+++ b/tools/nl/embeddings/utils.py
@@ -23,7 +23,6 @@ from typing import Any, Dict, List, Tuple
 
 from file_util import create_file_handler
 from google.cloud import aiplatform
-from google.cloud import storage
 import pandas as pd
 from sentence_transformers import SentenceTransformer
 import yaml


### PR DESCRIPTION
* This fixes the bug mentioned in #4124 with the downloaded model and embeddings paths.
* It also makes local paths of downloaded GCS files consistent with downloaded GCS folders - in that the former is also prefixed with the bucket name now like the latter.
* Finally, the embeddings are downloaded using an anonymous client like they were [previously](https://github.com/datacommonsorg/website/blob/master/nl_server/gcs.py#L31).