### PR TITLE
[biomed nl] some naming updates

### DIFF
--- a/server/config/nl_page/prop_titles.json
+++ b/server/config/nl_page/prop_titles.json
@@ -14,5 +14,27 @@
   "<-geneID{typeOf:DiseaseGeneAssociation}->diseaseOntologyID": {
     "displayName": "associated disease",
     "titleFormat": "The associated diseases for {entity} are"
+  },
+  "->mRNA": {
+    "displayName": "mRNA"
+  },
+  "<-mRNA": {
+    "displayName": "mRNA"
+  },
+  "->preferredMeSHConcept": {
+    "displayName": "Preferred MeSH Concept"
+
+  },
+  "<-preferredMeSHConcept": {
+    "displayName": "Preferred MeSH Concept"
+
+  },
+  "->hasMeSHQualifier": {
+    "displayName": "Has MeSH Qualifier"
+    
+  },
+  "<-hasMeSHQualifier": {
+    "displayName": "Has MeSH Qualifier"
+    
   }
 }

--- a/server/integration_tests/test_data/e2e_triple/howaboutcoryluscornutamarshall/chart_config.json
+++ b/server/integration_tests/test_data/e2e_triple/howaboutcoryluscornutamarshall/chart_config.json
@@ -12,7 +12,7 @@
                     "answerTableTileSpec": {
                       "columns": [
                         {
-                          "header": "->phylum",
+                          "header": "Phylum",
                           "propertyExpr": "->phylum"
                         }
                       ]
@@ -31,7 +31,7 @@
                       "dc/wq2j4gte42ysg",
                       "dc/yb99f7tx3f4nf"
                     ],
-                    "title": "The phylum for Corylus, Corylus and 10 more other are as follows:",
+                    "title": "The Phylum for Corylus are as follows:",
                     "type": "ANSWER_TABLE"
                   }
                 ]

--- a/server/integration_tests/test_data/e2e_triple/whatgenesareassociatedwiththegeneticvariantrs13317andrs7903146/chart_config.json
+++ b/server/integration_tests/test_data/e2e_triple/whatgenesareassociatedwiththegeneticvariantrs13317andrs7903146/chart_config.json
@@ -12,7 +12,7 @@
                     "answerTableTileSpec": {
                       "columns": [
                         {
-                          "header": "<-referenceSNPClusterID{typeOf:GeneticVariantGeneAssociation}->geneSymbol",
+                          "header": "associated gene",
                           "propertyExpr": "<-referenceSNPClusterID{typeOf:GeneticVariantGeneAssociation}->geneSymbol"
                         }
                       ]

--- a/server/integration_tests/test_data/e2e_triple/whatisbetacoronavirus1thespeciesof/chart_config.json
+++ b/server/integration_tests/test_data/e2e_triple/whatisbetacoronavirus1thespeciesof/chart_config.json
@@ -12,7 +12,7 @@
                     "answerTableTileSpec": {
                       "columns": [
                         {
-                          "header": "->virusHost",
+                          "header": "Virus Host",
                           "propertyExpr": "->virusHost"
                         }
                       ]
@@ -21,7 +21,7 @@
                       "bio/Betacoronavirus1",
                       "bio/D000073641"
                     ],
-                    "title": "The virusHost for Betacoronavirus 1 and Betacoronavirus 1 are as follows:",
+                    "title": "The Virus Host for Betacoronavirus 1 are as follows:",
                     "type": "ANSWER_TABLE"
                   }
                 ]

--- a/server/integration_tests/test_data/e2e_triple/whatisthephylumofvolvox/chart_config.json
+++ b/server/integration_tests/test_data/e2e_triple/whatisthephylumofvolvox/chart_config.json
@@ -12,7 +12,7 @@
                     "answerTableTileSpec": {
                       "columns": [
                         {
-                          "header": "->phylum",
+                          "header": "Phylum",
                           "propertyExpr": "->phylum"
                         }
                       ]
@@ -41,7 +41,7 @@
                       "dc/z9x1mlh4pxzb7",
                       "dc/zsn19vpl9fy76"
                     ],
-                    "title": "The phylum for Volvox, Volvox and 20 more other are as follows:",
+                    "title": "The Phylum for Volvox are as follows:",
                     "type": "ANSWER_TABLE"
                   }
                 ]

--- a/server/integration_tests/test_data/e2e_triple/whatstrandorientationdoesfgfr1have/chart_config.json
+++ b/server/integration_tests/test_data/e2e_triple/whatstrandorientationdoesfgfr1have/chart_config.json
@@ -12,7 +12,7 @@
                     "answerTableTileSpec": {
                       "columns": [
                         {
-                          "header": "->strandOrientation",
+                          "header": "Strand Orientation",
                           "propertyExpr": "->strandOrientation"
                         }
                       ]
@@ -26,7 +26,7 @@
                       "bio/mm10_Fgfr1",
                       "bio/mm9_Fgfr1"
                     ],
-                    "title": "The strandOrientation for FGFR1, FGFR1 and 5 more other are as follows:",
+                    "title": "The Strand Orientation for FGFR1 are as follows:",
                     "type": "ANSWER_TABLE"
                   }
                 ]

--- a/server/integration_tests/test_data/e2e_triple/whattypeofgeneisit/chart_config.json
+++ b/server/integration_tests/test_data/e2e_triple/whattypeofgeneisit/chart_config.json
@@ -12,7 +12,7 @@
                     "answerTableTileSpec": {
                       "columns": [
                         {
-                          "header": "->typeOfGene",
+                          "header": "Type Of Gene",
                           "propertyExpr": "->typeOfGene"
                         }
                       ]
@@ -21,7 +21,7 @@
                       "bio/dm3_Is",
                       "bio/dm6_Is"
                     ],
-                    "title": "The typeOfGene for Is and Is are as follows:",
+                    "title": "The Type Of Gene for Is are as follows:",
                     "type": "ANSWER_TABLE"
                   }
                 ]

--- a/server/integration_tests/test_data/e2e_triple/whatvirusspeciesarers13317andrs7903146/chart_config.json
+++ b/server/integration_tests/test_data/e2e_triple/whatvirusspeciesarers13317andrs7903146/chart_config.json
@@ -12,199 +12,199 @@
                     "answerTableTileSpec": {
                       "columns": [
                         {
-                          "header": "->alignmentQuality",
+                          "header": "Alignment Quality",
                           "propertyExpr": "->alignmentQuality"
                         },
                         {
-                          "header": "->alleleOrigin",
+                          "header": "Allele Origin",
                           "propertyExpr": "->alleleOrigin"
                         },
                         {
-                          "header": "->averageHeterozygosity",
+                          "header": "Average Heterozygosity",
                           "propertyExpr": "->averageHeterozygosity"
                         },
                         {
-                          "header": "->averageHeterozygositySE",
+                          "header": "Average Heterozygosity SE",
                           "propertyExpr": "->averageHeterozygositySE"
                         },
                         {
-                          "header": "->class",
+                          "header": "Class",
                           "propertyExpr": "->class"
                         },
                         {
-                          "header": "->clinVarAlleleID",
+                          "header": "Clin Var Allele ID",
                           "propertyExpr": "->clinVarAlleleID"
                         },
                         {
-                          "header": "->clinVarReviewStatus",
+                          "header": "Clin Var Review Status",
                           "propertyExpr": "->clinVarReviewStatus"
                         },
                         {
-                          "header": "->clinVarVariationID",
+                          "header": "Clin Var Variation ID",
                           "propertyExpr": "->clinVarVariationID"
                         },
                         {
-                          "header": "->clinicalSignificance",
+                          "header": "Clinical Significance",
                           "propertyExpr": "->clinicalSignificance"
                         },
                         {
-                          "header": "->clinicalSource",
+                          "header": "Clinical Source",
                           "propertyExpr": "->clinicalSource"
                         },
                         {
-                          "header": "->diseaseName",
+                          "header": "Disease Name",
                           "propertyExpr": "->diseaseName"
                         },
                         {
-                          "header": "->exceptions",
+                          "header": "Exceptions",
                           "propertyExpr": "->exceptions"
                         },
                         {
-                          "header": "->functionalCategory",
+                          "header": "Functional Category",
                           "propertyExpr": "->functionalCategory"
                         },
                         {
-                          "header": "->geneID",
+                          "header": "Gene ID",
                           "propertyExpr": "->geneID"
                         },
                         {
-                          "header": "->geneSymbol",
+                          "header": "Gene Symbol",
                           "propertyExpr": "->geneSymbol"
                         },
                         {
-                          "header": "->geneticVariantAttribute",
+                          "header": "Genetic Variant Attribute",
                           "propertyExpr": "->geneticVariantAttribute"
                         },
                         {
-                          "header": "->geneticVariantClass",
+                          "header": "Genetic Variant Class",
                           "propertyExpr": "->geneticVariantClass"
                         },
                         {
-                          "header": "->geneticVariantFunctionalCategory",
+                          "header": "Genetic Variant Functional Category",
                           "propertyExpr": "->geneticVariantFunctionalCategory"
                         },
                         {
-                          "header": "->geneticVariantMolecularType",
+                          "header": "Genetic Variant Molecular Type",
                           "propertyExpr": "->geneticVariantMolecularType"
                         },
                         {
-                          "header": "->hg19GenomicLocation",
+                          "header": "Hg19 Genomic Location",
                           "propertyExpr": "->hg19GenomicLocation"
                         },
                         {
-                          "header": "->hg19GenomicPosition",
+                          "header": "Hg19 Genomic Position",
                           "propertyExpr": "->hg19GenomicPosition"
                         },
                         {
-                          "header": "->hg38GenomicLocation",
+                          "header": "Hg38 Genomic Location",
                           "propertyExpr": "->hg38GenomicLocation"
                         },
                         {
-                          "header": "->hg38GenomicPosition",
+                          "header": "Hg38 Genomic Position",
                           "propertyExpr": "->hg38GenomicPosition"
                         },
                         {
-                          "header": "->hgvsNomenclature",
+                          "header": "Hgvs Nomenclature",
                           "propertyExpr": "->hgvsNomenclature"
                         },
                         {
-                          "header": "->humanPhenotypeOntologyID",
+                          "header": "Human Phenotype Ontology ID",
                           "propertyExpr": "->humanPhenotypeOntologyID"
                         },
                         {
-                          "header": "->inChromosome",
+                          "header": "In Chromosome",
                           "propertyExpr": "->inChromosome"
                         },
                         {
-                          "header": "->locType",
+                          "header": "Loc Type",
                           "propertyExpr": "->locType"
                         },
                         {
-                          "header": "->medGenID",
+                          "header": "Med Gen ID",
                           "propertyExpr": "->medGenID"
                         },
                         {
-                          "header": "->mondoID",
+                          "header": "Mondo ID",
                           "propertyExpr": "->mondoID"
                         },
                         {
-                          "header": "->nAllelesWithFreq",
+                          "header": "N Alleles With Freq",
                           "propertyExpr": "->nAllelesWithFreq"
                         },
                         {
-                          "header": "->name",
+                          "header": "Name",
                           "propertyExpr": "->name"
                         },
                         {
-                          "header": "->ncbiGeneID",
+                          "header": "Ncbi Gene ID",
                           "propertyExpr": "->ncbiGeneID"
                         },
                         {
-                          "header": "->observedAllele",
+                          "header": "Observed Allele",
                           "propertyExpr": "->observedAllele"
                         },
                         {
-                          "header": "->ofSpecies",
+                          "header": "Of Species",
                           "propertyExpr": "->ofSpecies"
                         },
                         {
-                          "header": "->omimID",
+                          "header": "Omim ID",
                           "propertyExpr": "->omimID"
                         },
                         {
-                          "header": "->orphaNumber",
+                          "header": "Orpha Number",
                           "propertyExpr": "->orphaNumber"
                         },
                         {
-                          "header": "->pharmGKBID",
+                          "header": "Pharm GKBID",
                           "propertyExpr": "->pharmGKBID"
                         },
                         {
-                          "header": "->provenance",
+                          "header": "Provenance",
                           "propertyExpr": "->provenance"
                         },
                         {
-                          "header": "->referenceAlleleNCBI",
+                          "header": "Reference Allele NCBI",
                           "propertyExpr": "->referenceAlleleNCBI"
                         },
                         {
-                          "header": "->referenceAllleUCSC",
+                          "header": "Reference Allle UCSC",
                           "propertyExpr": "->referenceAllleUCSC"
                         },
                         {
-                          "header": "->referenceSNPClusterID",
+                          "header": "Reference SNP Cluster ID",
                           "propertyExpr": "->referenceSNPClusterID"
                         },
                         {
-                          "header": "->rsID",
+                          "header": "Rs ID",
                           "propertyExpr": "->rsID"
                         },
                         {
-                          "header": "->sequenceOntologyID",
+                          "header": "Sequence Ontology ID",
                           "propertyExpr": "->sequenceOntologyID"
                         },
                         {
-                          "header": "->snomedCT",
+                          "header": "Snomed CT",
                           "propertyExpr": "->snomedCT"
                         },
                         {
-                          "header": "->strandOrientation",
+                          "header": "Strand Orientation",
                           "propertyExpr": "->strandOrientation"
                         },
                         {
-                          "header": "->submitter",
+                          "header": "Submitter",
                           "propertyExpr": "->submitter"
                         },
                         {
-                          "header": "->submitterCount",
+                          "header": "Submitter Count",
                           "propertyExpr": "->submitterCount"
                         },
                         {
-                          "header": "->typeOf",
+                          "header": "Type Of",
                           "propertyExpr": "->typeOf"
                         },
                         {
-                          "header": "->validationStatus",
+                          "header": "Validation Status",
                           "propertyExpr": "->validationStatus"
                         }
                       ]
@@ -213,6 +213,7 @@
                       "bio/rs13317",
                       "bio/rs7903146"
                     ],
+                    "title": "Here are all the properties for rs13317 and rs7903146",
                     "type": "ANSWER_TABLE"
                   }
                 ]

--- a/server/lib/nl/config_builder/answer.py
+++ b/server/lib/nl/config_builder/answer.py
@@ -33,7 +33,7 @@ def answer_table_block(builder: base.Builder, cspec: ChartSpec):
               entities=[e.dcid for e in cspec.entities])
   for prop in cspec.props:
     column = tile.answer_table_tile_spec.columns.add()
-    column.header = prop
+    column.header = base.get_property_display_name(prop)
     column.property_expr = prop
   block = builder.new_chart(cspec, skip_title=True)
   block.columns.add().tiles.append(tile)

--- a/server/lib/nl/fulfillment/triple.py
+++ b/server/lib/nl/fulfillment/triple.py
@@ -53,7 +53,7 @@ def _get_entity_string(entities: List[Entity]) -> str:
     entity_name_lowercase = entity_name.lower()
     if not entity_name_lowercase in seen_entity_names:
       unique_entity_names.append(entity_name)
-    seen_entity_names.add(entity_name_lowercase)
+      seen_entity_names.add(entity_name_lowercase)
 
   # if there is only 1 unique entity name, return it
   if len(unique_entity_names) == 1:

--- a/server/lib/nl/fulfillment/triple.py
+++ b/server/lib/nl/fulfillment/triple.py
@@ -18,7 +18,7 @@ from flask import current_app
 
 from server.lib.fetch import properties
 from server.lib.nl.common.utterance import ChartType
-import server.lib.nl.common.utterance as nl_uttr
+from server.lib.nl.config_builder.base import get_property_display_name
 from server.lib.nl.fulfillment.types import ChartVars
 from server.lib.nl.fulfillment.types import Entity
 from server.lib.nl.fulfillment.types import PopulateState
@@ -34,6 +34,7 @@ _IN_ARROW = '<-'
 _OUT_TITLE = 'The {property} for {entity} is:'
 _IN_TITLE = '{entity} is the {property} for:'
 _MULTI_ENTITY_TITLE = 'The {property} for {entity} are as follows:'
+_OVERVIEW_TITLE = 'Here are all the properties for {entity}'
 _MAX_ENTITIES_IN_TITLE = 3
 
 
@@ -44,20 +45,34 @@ def _entity_name(entity: Entity) -> str:
 
 # Gets a title string for a list of entities
 def _get_entity_string(entities: List[Entity]) -> str:
-  if len(entities) == 1:
-    return _entity_name(entities[0])
+  # Get the list of unique entity names
+  seen_entity_names = set()
+  unique_entity_names = []
+  for e in entities:
+    entity_name = _entity_name(e)
+    entity_name_lowercase = entity_name.lower()
+    if not entity_name_lowercase in seen_entity_names:
+      unique_entity_names.append(entity_name)
+    seen_entity_names.add(entity_name_lowercase)
+
+  # if there is only 1 unique entity name, return it
+  if len(unique_entity_names) == 1:
+    return unique_entity_names[0]
+
+  # otherwise, add commas and spaces to make the list of entities into a proper
+  # string
   entity_str = ''
-  max_entries = min(_MAX_ENTITIES_IN_TITLE, len(entities))
+  max_entries = min(_MAX_ENTITIES_IN_TITLE, len(unique_entity_names))
   # Join together the first max_entries - 1 number of entities with a ', '
-  entity_str = ', '.join([_entity_name(e) for e in entities[:max_entries - 1]])
-  if max_entries < len(entities):
+  entity_str = ', '.join(unique_entity_names[:max_entries - 1])
+  if max_entries < len(unique_entity_names):
     # If not all entities are named in the title, get the number of unnamed
     # entities and add that to the title
-    num_unnamed = len(entities) - max_entries + 1
-    entity_str += f' and {num_unnamed} more other'
+    num_unnamed = len(unique_entity_names) - max_entries + 1
+    entity_str += f' and {num_unnamed} more others'
   else:
     # Otherwise just add the last entity name to the title.
-    entity_str += f' and {_entity_name(entities[max_entries - 1])}'
+    entity_str += f' and {unique_entity_names[-1]}'
   return entity_str
 
 
@@ -67,19 +82,21 @@ def _get_entity_string(entities: List[Entity]) -> str:
 def _get_title(entities: List[Entity], prop_expression: str) -> str:
   entity_str = _get_entity_string(entities)
   override_prop_titles = current_app.config['NL_PROP_TITLES']
+
+  # If there is an override title format, return that as the title
   override_title_format = override_prop_titles.get(prop_expression,
                                                    {}).get('titleFormat', '')
   if override_title_format:
     return override_title_format.format(entity=entity_str)
-  elif len(entities) > 1:
-    prop_display_name = prop_expression[len(_OUT_ARROW):]
+
+  # build the title for each case
+  prop_display_name = get_property_display_name(prop_expression)
+  if len(entities) > 1:
     return _MULTI_ENTITY_TITLE.format(property=prop_display_name,
                                       entity=entity_str)
   elif prop_expression.startswith(_OUT_ARROW):
-    prop_display_name = prop_expression[len(_OUT_ARROW):]
     return _OUT_TITLE.format(property=prop_display_name, entity=entity_str)
   elif prop_expression.startswith(_IN_ARROW):
-    prop_display_name = prop_expression[len(_IN_ARROW):]
     return _IN_TITLE.format(property=prop_display_name, entity=entity_str)
   return ''
 
@@ -109,7 +126,9 @@ def _add_multi_entity_overview(state: PopulateState) -> bool:
   for prop_list in properties(entity_dcids).values():
     prop_set.update(prop_list)
   prop_list = [f'{_OUT_ARROW}{prop}' for prop in sorted(list(prop_set))]
-  cv = ChartVars(props=prop_list)
+  chart_title = _OVERVIEW_TITLE.format(
+      entity=_get_entity_string(state.uttr.entities))
+  cv = ChartVars(props=prop_list, title=chart_title)
   return add_chart_to_utterance(ChartType.ANSWER,
                                 state,
                                 cv, [],
@@ -136,9 +155,11 @@ def populate(state: PopulateState) -> bool:
       break
   # If there is a single entity, always add an entity overview chart
   if len(state.uttr.entities) == 1:
+    chart_title = _OVERVIEW_TITLE.format(
+        entity=_get_entity_string(state.uttr.entities))
     chart_added |= add_chart_to_utterance(ChartType.ENTITY_OVERVIEW,
                                           state,
-                                          ChartVars(), [],
+                                          ChartVars(title=chart_title), [],
                                           entities=state.uttr.entities)
   elif not chart_added:
     # If there is more than 1 entity and no charts added yet, add an overview


### PR DESCRIPTION
- add chart title for entity overview charts

autopush: https://screenshot.googleplex.com/8URapF9YZabLWb5
local: https://screenshot.googleplex.com/8KC75DLA3PbmVUw

- update "and <n> more other" -> "and <n> more others"
- updates property names in table headers to be an actual name
- updates the entity string to only show unique entity names

autopush: https://screenshot.googleplex.com/3s9BQHG3xavYQXm
local: https://screenshot.googleplex.com/3FPMc4KEdb8UagP

naming/messaging that still need to be improved & will come in a separate PR:
- the template for the message (i.e., right now it's `the <property> for <entity> is:`)
- how the table heading should differentiate between in and out arcs