### PR TITLE
[nl] fix userMessage vs userMessages

### DIFF
--- a/server/integration_tests/test_data/demo_feb2023/query_10/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_10/chart_config.json
@@ -9,7 +9,7 @@
     "name": "",
     "place_type": ""
   },
-  "userMessage": {
-    "msg": "Sorry, could not complete your request. No place found in the query."
-  }
+  "userMessages": [
+    "Sorry, could not complete your request. No place found in the query."
+  ]
 }

--- a/server/integration_tests/test_data/e2e_default_place_bogus/chart_config.json
+++ b/server/integration_tests/test_data/e2e_default_place_bogus/chart_config.json
@@ -9,7 +9,7 @@
     "name": "",
     "place_type": ""
   },
-  "userMessage": {
-    "msg": "Sorry, could not complete your request. No place found in the query."
-  }
+  "userMessages": [
+    "Sorry, could not complete your request. No place found in the query."
+  ]
 }

--- a/server/integration_tests/test_data/e2e_triple/whatanimalisthatfoundin/chart_config.json
+++ b/server/integration_tests/test_data/e2e_triple/whatanimalisthatfoundin/chart_config.json
@@ -9,7 +9,7 @@
     "name": "",
     "place_type": ""
   },
-  "userMessage": {
-    "msg": "Sorry, could not complete your request. No entity found in the query."
-  }
+  "userMessages": [
+    "Sorry, could not complete your request. No entity found in the query."
+  ]
 }

--- a/server/integration_tests/test_data/explore_strict_default_place/howtoearnmoneyonlinewithoutinvestment/chart_config.json
+++ b/server/integration_tests/test_data/explore_strict_default_place/howtoearnmoneyonlinewithoutinvestment/chart_config.json
@@ -9,7 +9,7 @@
     "name": "",
     "place_type": ""
   },
-  "userMessage": {
-    "msg": "Sorry, could not complete your request. No place found in the query."
-  }
+  "userMessages": [
+    "Sorry, could not complete your request. No place found in the query."
+  ]
 }

--- a/server/integration_tests/test_data/explore_strict_default_place/whatdoesadietfordiabeteslooklike/chart_config.json
+++ b/server/integration_tests/test_data/explore_strict_default_place/whatdoesadietfordiabeteslooklike/chart_config.json
@@ -9,7 +9,7 @@
     "name": "",
     "place_type": ""
   },
-  "userMessage": {
-    "msg": "Sorry, could not complete your request. No place found in the query."
-  }
+  "userMessages": [
+    "Sorry, could not complete your request. No place found in the query."
+  ]
 }

--- a/server/integration_tests/test_data/inappropriate_query/query_1/chart_config.json
+++ b/server/integration_tests/test_data/inappropriate_query/query_1/chart_config.json
@@ -10,7 +10,7 @@
     "name": "",
     "place_type": ""
   },
-  "userMessage": {
-    "msg": "Sorry, could not complete your request."
-  }
+  "userMessages": [
+    "Sorry, could not complete your request."
+  ]
 }

--- a/server/integration_tests/test_data/strict_default_place/query_1/chart_config.json
+++ b/server/integration_tests/test_data/strict_default_place/query_1/chart_config.json
@@ -9,7 +9,7 @@
     "name": "",
     "place_type": ""
   },
-  "userMessage": {
-    "msg": "Sorry, could not complete your request. No place found in the query."
-  }
+  "userMessages": [
+    "Sorry, could not complete your request. No place found in the query."
+  ]
 }

--- a/server/integration_tests/test_data/strict_default_place/query_2/chart_config.json
+++ b/server/integration_tests/test_data/strict_default_place/query_2/chart_config.json
@@ -9,7 +9,7 @@
     "name": "",
     "place_type": ""
   },
-  "userMessage": {
-    "msg": "Sorry, could not complete your request. No place found in the query."
-  }
+  "userMessages": [
+    "Sorry, could not complete your request. No place found in the query."
+  ]
 }

--- a/server/routes/nl/helpers.py
+++ b/server/routes/nl/helpers.py
@@ -418,9 +418,7 @@ def abort(error_message: str,
       'config': {},
       'context': escaped_context_history,
       'failure': error_message,
-      'userMessage': {
-          'msg': error_message
-      },
+      'userMessages': [error_message]
   }
 
   if not counters:

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -183,8 +183,12 @@ export function App(props: { isDemo: boolean }): JSX.Element {
 
   function processFulfillData(fulfillData: any, shouldSetQuery: boolean): void {
     setDebugData(fulfillData["debug"]);
+    const userMessage = {
+      msgList: fulfillData["userMessages"] || [],
+      showForm: !!fulfillData["showForm"],
+    };
     if (!isFulfillDataValid) {
-      setUserMessage(fulfillData["userMessage"]);
+      setUserMessage(userMessage);
       setLoadingStatus(LoadingStatus.FAILED);
       return;
     }
@@ -193,18 +197,19 @@ export function App(props: { isDemo: boolean }): JSX.Element {
       name: fulfillData["place"]["name"],
       types: [fulfillData["place"]["place_type"]],
     };
+    const relatedThings = fulfillData["relatedThings"] || {};
     const pageMetadata: SubjectPageMetadata = {
       place: mainPlace,
       places: fulfillData["places"],
       pageConfig: fulfillData["config"],
-      childPlaces: fulfillData["relatedThings"]["childPlaces"],
-      peerPlaces: fulfillData["relatedThings"]["peerPlaces"],
-      parentPlaces: fulfillData["relatedThings"]["parentPlaces"],
-      parentTopics: fulfillData["relatedThings"]["parentTopics"],
-      childTopics: fulfillData["relatedThings"]["childTopics"],
-      peerTopics: fulfillData["relatedThings"]["peerTopics"],
-      exploreMore: fulfillData["relatedThings"]["exploreMore"],
-      mainTopics: fulfillData["relatedThings"]["mainTopics"],
+      childPlaces: relatedThings["childPlaces"],
+      peerPlaces: relatedThings["peerPlaces"],
+      parentPlaces: relatedThings["parentPlaces"],
+      parentTopics: relatedThings["parentTopics"],
+      childTopics: relatedThings["childTopics"],
+      peerTopics: relatedThings["peerTopics"],
+      exploreMore: relatedThings["exploreMore"],
+      mainTopics: relatedThings["mainTopics"],
       sessionId: "session" in fulfillData ? fulfillData["session"]["id"] : "",
     };
     if (
@@ -241,10 +246,6 @@ export function App(props: { isDemo: boolean }): JSX.Element {
         }
       }
     }
-    const userMessage = {
-      msgList: fulfillData["userMessages"] || [],
-      showForm: !!fulfillData["showForm"],
-    };
     savedContext.current = fulfillData["context"] || [];
     setPageMetadata(pageMetadata);
     setUserMessage(userMessage);


### PR DESCRIPTION
the abort path and the regular path in NL was returning user messages differently. This was causing some cases to actually not show the user message returned by NL. This PR makes the two paths return user messages in the same way - key `userMessages` and value as a list of strings. 

Example:
autopush: https://screenshot.googleplex.com/6T4AjXJDqNr2U8J
local: https://screenshot.googleplex.com/3pKVLCXxUvs9Vbe