### PR TITLE
[fixit] increase chart realestate in vis tools and update stat var modal

### DIFF
--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -253,7 +253,7 @@ $headings-font-family: "Google Sans", $font-family-sans-serif;
   border-top: 1px solid $gray-300;
   display: flex;
   flex-direction: row;
-  padding: 26px 0;
+  padding: 4px 0;
   line-height: 2.5rem;
   .container {
     display: flex;

--- a/static/css/tools/base_tools.scss
+++ b/static/css/tools/base_tools.scss
@@ -44,7 +44,6 @@ body {
 #main-footer #sub-footer {
   border-top: none !important;
   margin-bottom: 0 !important;
-  padding-bottom: 1.5rem !important;
 }
 
 @include media-breakpoint-up(lg) {

--- a/static/css/tools/scatter.scss
+++ b/static/css/tools/scatter.scss
@@ -108,13 +108,13 @@
   background: none;
 }
 
-.radio-selection-label,
-.radio-selection-section {
-  padding-top: 0.5rem;
+.radio-selection-label {
+  padding: 0.5rem 0;
 }
 
 .radio-selection-section {
   margin-left: 2rem;
+  padding-top: 0.5rem;
 }
 
 #scatterplot .quadrant-line {

--- a/static/css/tools/visualization.scss
+++ b/static/css/tools/visualization.scss
@@ -89,17 +89,13 @@ $selector-footer-height: 40px;
   flex-direction: column;
   align-items: center;
   gap: 2px;
-  margin: 10px 16px 0 16px;
+  margin: 18px 16px 0 16px;
   cursor: pointer;
-  padding-bottom: 10px;
+  padding-bottom: 13px;
   font-weight: 500;
 
   .label {
     font-size: 14px;
-  }
-
-  .material-icons-outlined {
-    font-size: 24px;
   }
 }
 
@@ -447,7 +443,7 @@ $selector-footer-height: 40px;
 
 #statvar-modal {
   .radio-selection-label {
-    padding-top: 1rem;
+    padding: 0.5rem 0;
   }
 
   .radio-selection-section {

--- a/static/js/apps/visualization/stat_var_selector.tsx
+++ b/static/js/apps/visualization/stat_var_selector.tsx
@@ -141,12 +141,8 @@ export function StatVarSelector(props: StatVarSelectorPropType): JSX.Element {
           </ModalHeader>
           <ModalBody>
             <Container>
-              <div>
-                You selected:{" "}
-                <b>{extraSv ? extraSv.info.title || extraSv.dcid : ""}</b>
-              </div>
               <div className="radio-selection-label">
-                Please choose 1 statistical variable to replace:
+                Select the statistical variable to replace:
               </div>
               <div className="radio-selection-section">
                 {selectedStatVars

--- a/static/js/apps/visualization/vis_type_configs.ts
+++ b/static/js/apps/visualization/vis_type_configs.ts
@@ -39,8 +39,6 @@ export const ORDERED_VIS_TYPE = [
 export interface VisTypeConfig {
   // display name to use for the vis type
   displayName: string;
-  // icon to use to represent the vis type
-  icon: string;
   // stat var hierarchy type to use for this vis type
   svHierarchyType: string;
   // function to get the component to render in the chart area

--- a/static/js/apps/visualization/vis_type_configs/map_config.tsx
+++ b/static/js/apps/visualization/vis_type_configs/map_config.tsx
@@ -217,7 +217,6 @@ function getFooter(): string {
 
 export const MAP_CONFIG = {
   displayName: "Map Explorer",
-  icon: "public",
   svHierarchyType: StatVarHierarchyType.MAP,
   svHierarchyNumExistence: 10,
   singlePlace: true,

--- a/static/js/apps/visualization/vis_type_configs/scatter_config.tsx
+++ b/static/js/apps/visualization/vis_type_configs/scatter_config.tsx
@@ -224,7 +224,6 @@ function getInfoContent(): JSX.Element {
 
 export const SCATTER_CONFIG = {
   displayName: "Scatter Plot",
-  icon: "scatter_plot",
   svHierarchyType: StatVarHierarchyType.SCATTER,
   svHierarchyNumExistence: 10,
   singlePlace: true,

--- a/static/js/apps/visualization/vis_type_configs/timeline_config.tsx
+++ b/static/js/apps/visualization/vis_type_configs/timeline_config.tsx
@@ -272,7 +272,6 @@ function getSqlQueryFn(appContext: AppContextType): () => string {
 
 export const TIMELINE_CONFIG = {
   displayName: "Timeline",
-  icon: "timeline",
   svHierarchyType: StatVarHierarchyType.TIMELINE,
   skipEnclosedPlaceType: true,
   getChartArea,

--- a/static/js/apps/visualization/vis_type_selector.tsx
+++ b/static/js/apps/visualization/vis_type_selector.tsx
@@ -35,9 +35,6 @@ export function VisTypeSelector(): JSX.Element {
             onClick={() => setVisType(type)}
             key={type}
           >
-            <span className="material-icons-outlined">
-              {visTypeConfig.icon}
-            </span>
             <span className="label">{visTypeConfig.displayName}</span>
           </div>
         );

--- a/static/js/tools/scatter/app.test.tsx
+++ b/static/js/tools/scatter/app.test.tsx
@@ -792,7 +792,7 @@ test("all functionalities", async () => {
   });
   await app.update();
   expectTitle(
-    "Establishments Per Capita (2016)vsHousing Units Per Capita (2016)"
+    "Employed Per Capita (2016)vsNumber Of Establishments Per Capita (2016)"
   );
   expectCircles(3, app);
 

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -176,12 +176,8 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
         </ModalHeader>
         <ModalBody>
           <Container>
-            <div>
-              You selected:{" "}
-              <b>{thirdStatVar.info.title || thirdStatVar.dcid}</b>
-            </div>
             <div className="radio-selection-label">
-              Please choose 1 more statistical variable to keep:
+              Select the statistical variable to replace:
             </div>
             <div className="radio-selection-section">
               <FormGroup radio="true" row>
@@ -339,14 +335,14 @@ function confirmStatVars(
   setModalOpened: (open: boolean) => void
 ): void {
   if (modalSelected.y) {
-    x.set({
-      ...x.value,
+    y.set({
+      ...y.value,
       statVarInfo: thirdStatVar.info,
       statVarDcid: thirdStatVar.dcid,
     });
   } else if (modalSelected.x) {
-    y.set({
-      ...y.value,
+    x.set({
+      ...x.value,
       statVarInfo: thirdStatVar.info,
       statVarDcid: thirdStatVar.dcid,
     });

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -159,7 +159,7 @@
         "sass-loader": "^13.3.2",
         "tslib": "^2.6.2",
         "typescript": "^5.0.2",
-        "vite": "^4.4.12"
+        "vite": "^4.5.3"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.199",
@@ -24894,7 +24894,7 @@
         "sass-loader": "^13.3.2",
         "tslib": "^2.6.2",
         "typescript": "^5.0.2",
-        "vite": "^4.4.12"
+        "vite": "^4.5.3"
       }
     },
     "@discoveryjs/json-ext": {


### PR DESCRIPTION
- remove icon from vis tool tabs & decrease height of the footer
     - local: https://screenshot.googleplex.com/6EWutpp37WhMEtH
     - autopush: https://screenshot.googleplex.com/AiHbRJW6wkLkRqh
- update the text in the scatter modal that pops up when extra sv is selected to be more action oriented
    - local new tool: https://screenshot.googleplex.com/9obiAC6X4Z3gUVs
    - autopush new tool: https://screenshot.googleplex.com/5FKEwYxcpJ6Vjq2
    - local old tool: https://screenshot.googleplex.com/xQh7amGkDkkRz6a
    - autopush old tool: https://screenshot.googleplex.com/867pNcRkaqJAvJe