### PR TITLE
Restrict flask /api/variable-group/info to only use POST and ensure 'dcid' exists in request

### DIFF
--- a/server/routes/shared_api/variable_group.py
+++ b/server/routes/shared_api/variable_group.py
@@ -21,21 +21,19 @@ import server.services.datacommons as dc
 bp = Blueprint("variable-group", __name__, url_prefix='/api/variable-group')
 
 
-@bp.route('/info', methods=['GET', 'POST'])
-def get_variable_group_info():
+@bp.route('/info', methods=['POST'])
+def variable_group_info():
   """Gets the stat var group node information.
 
   This is to retrieve the adjacent nodes, including child stat vars, child stat
   var groups and parent stat var groups for the given stat var group node.
   """
-  if request.method == 'GET':
-    dcid = request.args.get("dcid")
-    entities = request.args.getlist("entities")
-    numEntitiesExistence = request.args.get("numEntitiesExistence", 1)
-  else:
-    dcid = request.json.get("dcid")
-    entities = request.json.get("entities")
-    numEntitiesExistence = request.json.get("numEntitiesExistence", 1)
+  dcid = request.json.get("dcid")
+  entities = request.json.get("entities")
+  numEntitiesExistence = request.json.get("numEntitiesExistence", 1)
+  if not dcid:
+    return 'error: must provide a `dcid` field', 400
+
   resp = dc.get_variable_group_info([dcid], entities, numEntitiesExistence)
   result = resp.get("data", [{}])[0].get("info", {})
   if current_app.config["BLOCKLIST_SVG"]:

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -285,8 +285,8 @@ def get_variable_group_info(nodes: List[str],
   """Gets the stat var group node information."""
   url = get_service_url('/v1/bulk/info/variable-group')
   req_dict = {
-      "constrained_entities": entities,
       "nodes": nodes,
+      "constrained_entities": entities,
       "num_entities_existence": numEntitiesExistence
   }
   return post(url, req_dict)

--- a/server/tests/routes/api/varable_group_test.py
+++ b/server/tests/routes/api/varable_group_test.py
@@ -46,8 +46,11 @@ class TestGetVariableGroupInfo(unittest.TestCase):
         return {}
 
     mock_result.side_effect = side_effect
-    response = app.test_client().get(
-        '/api/variable-group/info?dcid=dc/g/Root&entities=geoId/06')
+    response = app.test_client().post('/api/variable-group/info',
+                                      json={
+                                          "dcid": "dc/g/Root",
+                                          "entities": ["geoId/06"]
+                                      })
     assert response.status_code == 200
     result = json.loads(response.data)
     assert result == expected_result


### PR DESCRIPTION
Calling this endpoint without dcid will overload the mixer and internal server error. Only POST request is used in the client, hence removing GET to reduce its exposure even more.