### PR TITLE
Add script to GC old cron testing job outputs

### DIFF
--- a/tools/delete_cron_outputs/README.md
+++ b/tools/delete_cron_outputs/README.md
@@ -1,0 +1,11 @@
+# Delete Cron Outputs
+
+The Cron Testing Jobs that run in GKE save outputs to GCS every 4 hours (in case we need to look at the outputs to debug something) and run everyday. This is a tool to delete old outputs (older than 30 days) from the following folders to keep them at a manageable size:
+
+- gs://datcom-website-periodic-testing
+- gs://datcom-website-screenshot/autopush.datacommons.org/
+
+To run:
+```bash
+./run.sh
+```

--- a/tools/delete_cron_outputs/run.sh
+++ b/tools/delete_cron_outputs/run.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Delete GCS folders that are older than this many days
+MAX_DAYS_OLD=30
+PARENT_FOLDERS=("gs://datcom-website-periodic-testing/bard" "gs://datcom-website-periodic-testing/autopush" "gs://datcom-website-screenshot/autopush.datacommons.org/")
+CURRENT_TS=$(TZ="America/Los_Angeles" date +"%s")
+
+for parent_folder in "${PARENT_FOLDERS[@]}"; do
+  echo "deleting outdated folders in $parent_folder"
+  folders=$(gsutil ls $parent_folder)
+  for folder in $folders; do
+    folder_name=$(basename $folder)
+    # get the folder timestamp from the folder name (which should be a datetime)
+    folder_timestamp=$(date -j -f "%Y_%m_%d_%H_%M_%S" "$folder_name" +"%s")
+    # get the difference in days between current timestamp and folder timestamp
+    timestamp_difference=$((CURRENT_TS - folder_timestamp))
+    days_difference=$(( $timestamp_difference / (60*60*24) ))
+    # delete the folder if its older than MAX_DAYS_OLD
+    if [[ "$days_difference" -gt "$MAX_DAYS_OLD" ]]; then
+      gsutil rm -r $folder
+      echo "deleted $folder"
+      break
+    fi
+  done
+done

--- a/tools/delete_cron_outputs/run.sh
+++ b/tools/delete_cron_outputs/run.sh
@@ -29,12 +29,11 @@ for parent_folder in "${PARENT_FOLDERS[@]}"; do
     folder_timestamp=$(date -j -f "%Y_%m_%d_%H_%M_%S" "$folder_name" +"%s")
     # get the difference in days between current timestamp and folder timestamp
     timestamp_difference=$((CURRENT_TS - folder_timestamp))
-    days_difference=$(( $timestamp_difference / (60*60*24) ))
+    days_difference=$(( timestamp_difference / (60*60*24) ))
     # delete the folder if its older than MAX_DAYS_OLD
     if [[ "$days_difference" -gt "$MAX_DAYS_OLD" ]]; then
       gsutil rm -r $folder
       echo "deleted $folder"
-      break
     fi
   done
 done


### PR DESCRIPTION
A script to delete old outputs from cron testing jobs.

I set this script to delete files older than 30 days, but have not run it to completion yet (tested by just deleting the earliest file and breaking out of the loop), so I can still increase or decrease this number as you guys see fit!