### PR TITLE
Removed empty calls to named_typed endpoint from explore page

### DIFF
--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -208,7 +208,8 @@ export function Block(props: BlockPropType): JSX.Element {
       .map((c) => {
         return c.tiles.map((t) => t.placeDcidOverride);
       })
-      .flat();
+      .flat()
+      .filter((name) => !!name);
 
     if (!overridePlaces.length) {
       setOverridePlaceTypes({});


### PR DESCRIPTION
Before: 20 extra calls

<img width="1652" alt="Screenshot 2024-05-01 at 1 25 16 PM" src="https://github.com/datacommonsorg/website/assets/13766/aacffab5-85e7-4695-a462-0091bf51a918">
<img width="1670" alt="Screenshot 2024-05-01 at 1 25 24 PM" src="https://github.com/datacommonsorg/website/assets/13766/4e73fa94-9aa4-47c1-a996-be8f5124a9fa">

After: Extra calls removed
<img width="1673" alt="Screenshot 2024-05-01 at 1 25 50 PM" src="https://github.com/datacommonsorg/website/assets/13766/15e3897a-84bd-4c9f-8dc4-ab5216551f38">
