### PR TITLE
Update permission of custom dc autopush deployment script.

### DIFF
--- a/scripts/deploy_custom_dc_autopush.sh
+++ b/scripts/deploy_custom_dc_autopush.sh
@@ -24,4 +24,8 @@ set -e
 
 set -x
 
-gcloud run deploy dc-autopush --project datcom-website-dev --image gcr.io/datcom-ci/datacommons-website-compose:latest --region us-central1
+gcloud run deploy dc-autopush \
+--project datcom-website-dev \
+--image gcr.io/datcom-ci/datacommons-website-compose:latest \
+--region us-central1 \
+--update-env-vars RESTART_TIMESTAMP="$(date)"

--- a/scripts/deploy_custom_dc_autopush.sh
+++ b/scripts/deploy_custom_dc_autopush.sh
@@ -16,6 +16,9 @@
 
 
 # Deploys the latest custom dc image to autopush.
+# The script also updates a RESTART_TIMESTAMP env var 
+# to easily identify the restart time of a given revision.
+
 # latest image = gcr.io/datcom-ci/datacommons-website-compose:latest
 # autopush service: https://pantheon.corp.google.com/run/detail/us-central1/dc-dev/revisions?project=datcom-website-dev
 # autopush URL: https://dc-dev-kqb7thiuka-uc.a.run.app
@@ -25,7 +28,7 @@ set -e
 set -x
 
 gcloud run deploy dc-autopush \
---project datcom-website-dev \
---image gcr.io/datcom-ci/datacommons-website-compose:latest \
---region us-central1 \
---update-env-vars RESTART_TIMESTAMP="$(date)"
+    --project datcom-website-dev \
+    --image gcr.io/datcom-ci/datacommons-website-compose:latest \
+    --region us-central1 \
+    --update-env-vars RESTART_TIMESTAMP="$(date)"


### PR DESCRIPTION
* The cloudbuild indicates a permission error with the script.
![image](https://github.com/datacommonsorg/website/assets/1221814/1f42f93e-8981-4e7c-b04b-557084e9820a)

* Trying to address it by running `git update-index --chmod=+x scripts/deploy_custom_dc_autopush.sh`.
* Also added a restart timestamp env var to easily identify the restart time of a given revision.