### PR TITLE
Fix nginx redirects.

### DIFF
--- a/build/web_compose/nginx.conf
+++ b/build/web_compose/nginx.conf
@@ -6,7 +6,7 @@ http {
 
     location / {
         proxy_pass http://0.0.0.0:7070;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_read_timeout 3600;
     }
 
@@ -16,7 +16,7 @@ http {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_read_timeout 3600;
     }
     error_log /dev/stderr;


### PR DESCRIPTION
* The fix is to use `$http_host` instead of `$host` in `nginx.conf` so that both host and port are used for redirects.

#### Before fix

```
$ curl -H "Host: foo.com" -is http://localhost:8080/admin | grep "Location" 
Location: http://foo.com/admin/
$ curl -H "Host: foo.com:9090" -is http://localhost:8080/admin | grep "Location"
Location: http://foo.com/admin/
```

#### After fix

```
$ curl -H "Host: foo.com" -is http://localhost:8080/admin | grep "Location"     
Location: http://foo.com/admin/
$ curl -H "Host: foo.com:9090" -is http://localhost:8080/admin | grep "Location"
Location: http://foo.com:9090/admin/
```