### PR TITLE
Fix Google Sans font breaking in Custom DC

### DIFF
--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -58,10 +58,10 @@ $theme-colors: (
   "primary": $dc-primary-color,
 );
 
-$font-family-sans-serif: "Google Sans", -apple-system, BlinkMacSystemFont,
-  "Segoe UI", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
-  "Segoe UI Emoji", "Segoe UI Symbol";
-$headings-font-family: "Google Sans", $font-family-sans-serif;
+$font-family-sans-serif: "Google Sans", "Google Sans Text", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif,
+  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$headings-font-family: $font-family-sans-serif;
 
 @import "node_modules/bootstrap/scss/bootstrap";
 

--- a/static/css/tools/base_tools.scss
+++ b/static/css/tools/base_tools.scss
@@ -17,7 +17,7 @@
 @import "../base";
 
 body {
-  font-family: "Google Sans";
+  font-family: $font-family-sans-serif;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;


### PR DESCRIPTION
Adds alternate body fonts to the tools, because Google Sans is not an open source font. This will allow other fonts to render in custom DC instead of the default serif font of the browser.