### PR TITLE
move vertex ai model info to deployment values

### DIFF
--- a/deploy/helm_charts/dc_website/templates/config_maps.yaml
+++ b/deploy/helm_charts/dc_website/templates/config_maps.yaml
@@ -81,8 +81,8 @@ metadata:
 data:
   embeddings.yaml: {{ required "NL embeddings file is required" .Values.nl.embeddings | quote }}
   models.yaml: {{ required "NL models file is required" .Values.nl.models | quote }}
+  vertex_ai_models.json: {{ .Values.nl.vertex_ai_models | toJson | quote }}
 {{- end }}
-
 
 {{- if .Values.website.redis.enabled }}
 ---

--- a/deploy/helm_charts/dc_website/values.yaml
+++ b/deploy/helm_charts/dc_website/values.yaml
@@ -136,6 +136,8 @@ nl:
   models:
   memory: "2G"
   workers: 1
+  vertex_ai_models:
+
 
 ###############################################################################
 # Config for Stat Var Groups which is shared between Website and Mixer

--- a/deploy/helm_charts/envs/autopush.yaml
+++ b/deploy/helm_charts/envs/autopush.yaml
@@ -44,6 +44,27 @@ serviceAccount:
 
 nl:
   enabled: true
+  vertex_ai_models:
+    dc-all-minilm-l6-v2-model:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "8518340991868993536"
+    uae-large-v1-model:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "4910007712298827776"
+    sfr-embedding-mistral-model:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "224012300019826688"
+    cross-encoder-ms-marco-miniilm-l6-v2:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "3977846152316846080"
+    cross-encoder-mxbai-rerank-base-v1:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "284894457873039360"
 
 serviceGroups:
   recon: null

--- a/deploy/helm_charts/envs/dev.yaml
+++ b/deploy/helm_charts/envs/dev.yaml
@@ -41,6 +41,27 @@ serviceGroups:
 
 nl:
   enabled: true
+  vertex_ai_models:
+    dc-all-minilm-l6-v2-model:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "8518340991868993536"
+    uae-large-v1-model:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "4910007712298827776"
+    sfr-embedding-mistral-model:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "224012300019826688"
+    cross-encoder-ms-marco-miniilm-l6-v2:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "3977846152316846080"
+    cross-encoder-mxbai-rerank-base-v1:
+      project_id: datcom-website-dev
+      location: us-central1
+      prediction_endpoint_id: "284894457873039360"
 
 nodejs:
   enabled: true

--- a/deploy/nl/embeddings.yaml
+++ b/deploy/nl/embeddings.yaml
@@ -64,33 +64,18 @@ models:
   dc-all-minilm-l6-v2-model:
     type: VERTEXAI
     usage: EMBEDDINGS
-    project_id: datcom-website-dev
-    location: us-central1
-    prediction_endpoint_id: "8518340991868993536"
   uae-large-v1-model:
     type: VERTEXAI
     usage: EMBEDDINGS
-    project_id: datcom-website-dev
-    location: us-central1
-    prediction_endpoint_id: "4910007712298827776"
   sfr-embedding-mistral-model:
     type: VERTEXAI
     usage: EMBEDDINGS
-    project_id: datcom-website-dev
-    location: us-central1
-    prediction_endpoint_id: "224012300019826688"
   cross-encoder-ms-marco-miniilm-l6-v2:
     type: VERTEXAI
     usage: RERANKING
-    project_id: datcom-website-dev
-    location: us-central1
-    prediction_endpoint_id: "3977846152316846080"
   cross-encoder-mxbai-rerank-base-v1:
     type: VERTEXAI
     usage: RERANKING
-    project_id: datcom-website-dev
-    location: us-central1
-    prediction_endpoint_id: "284894457873039360"
   ft-final-v20230717230459-all-MiniLM-L6-v2:
     type: LOCAL
     usage: EMBEDDINGS

--- a/nl_server/config.py
+++ b/nl_server/config.py
@@ -18,6 +18,7 @@ from enum import Enum
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Dict
 
 import yaml
@@ -107,14 +108,16 @@ class EmbeddingsConfig:
 #
 # Get Dict of vertex ai model to its info
 #
-def _get_vertex_ai_model_map() -> Dict[str, any]:
+def _get_vertex_ai_model_info() -> Dict[str, any]:
+  # This is the path to model info when deployed in gke.
   if os.path.exists(_VERTEX_AI_MODEL_CONFIG_PATH):
     with open(_VERTEX_AI_MODEL_CONFIG_PATH) as f:
       return json.load(f) or {}
+  # If that path doesn't exist, assume we are running locally and use the values
+  # from autopush.
   else:
-    autopush_env_values = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        f'deploy/helm_charts/envs/autopush.yaml')
+    current_file_path = Path(__file__)
+    autopush_env_values = f'{current_file_path.parent.parent}/deploy/helm_charts/envs/autopush.yaml'
     with open(autopush_env_values) as f:
       autopush_env = yaml.full_load(f)
       return autopush_env['nl']['vertex_ai_models']
@@ -125,9 +128,9 @@ def _get_vertex_ai_model_map() -> Dict[str, any]:
 # object.
 #
 def parse(embeddings_map: Dict[str, any]) -> EmbeddingsConfig:
-  get_vertex_ai_model_map = _get_vertex_ai_model_map()
+  get_vertex_ai_model_info = _get_vertex_ai_model_info()
   if embeddings_map['version'] == 1:
-    return parse_v1(embeddings_map, get_vertex_ai_model_map)
+    return parse_v1(embeddings_map, get_vertex_ai_model_info)
   else:
     raise AssertionError('Could not parse embeddings map: unsupported version.')
 
@@ -137,7 +140,7 @@ def parse(embeddings_map: Dict[str, any]) -> EmbeddingsConfig:
 # EmbeddingsInfo object.
 #
 def parse_v1(embeddings_map: Dict[str, any],
-             vertex_ai_model_map: Dict[str, any]) -> EmbeddingsConfig:
+             vertex_ai_model_info: Dict[str, any]) -> EmbeddingsConfig:
   # parse the models
   models = {}
   for model_name, model_info in embeddings_map.get('models', {}).items():
@@ -147,17 +150,16 @@ def parse_v1(embeddings_map: Dict[str, any],
                                             usage=model_info['usage'],
                                             gcs_folder=model_info['gcs_folder'])
     elif model_type == ModelType.VERTEXAI:
-      if model_name not in vertex_ai_model_map:
+      if model_name not in vertex_ai_model_info:
         logging.error(
             f'Could not find vertex ai model information for {model_name}')
         continue
-      vertex_ai_model_info = vertex_ai_model_map[model_name]
       models[model_name] = VertexAIModelConfig(
           type=model_type,
           usage=model_info['usage'],
-          project_id=vertex_ai_model_info['project_id'],
-          location=vertex_ai_model_info['location'],
-          prediction_endpoint_id=vertex_ai_model_info['prediction_endpoint_id'])
+          project_id=vertex_ai_model_info[model_name]['project_id'],
+          prediction_endpoint_id=vertex_ai_model_info[model_name]
+          ['prediction_endpoint_id'])
     else:
       raise AssertionError(
           'Error parsing information for model {model_name}: unsupported type {model_type}'

--- a/nl_server/config.py
+++ b/nl_server/config.py
@@ -159,7 +159,8 @@ def parse_v1(embeddings_map: Dict[str, any],
           usage=model_info['usage'],
           project_id=vertex_ai_model_info[model_name]['project_id'],
           prediction_endpoint_id=vertex_ai_model_info[model_name]
-          ['prediction_endpoint_id'])
+          ['prediction_endpoint_id'],
+          location=vertex_ai_model_info[model_name]['location'])
     else:
       raise AssertionError(
           'Error parsing information for model {model_name}: unsupported type {model_type}'


### PR DESCRIPTION
We want each environment to be able to use different project/location/endpoints for each vertex ai model so move the specification of those values to the deployment yamls. When running locally, read from autopush values