### PR TITLE
Fix stat var explorer for custom DC data

### DIFF
--- a/static/js/tools/stat_var/page.tsx
+++ b/static/js/tools/stat_var/page.tsx
@@ -340,40 +340,32 @@ class Page extends Component<unknown, PageStateType> {
             ? displayNameResult[sv][0].value
             : "";
         displayName = displayName || description;
+        const urlMap = {};
         const provIds = [];
         for (const provId in summaryResult[sv]?.provenanceSummary) {
           provIds.push(provId);
         }
-        if (provIds.length === 0) {
-          this.setState({
-            description,
-            displayName,
-            error: false,
-            statVar: sv,
-            summary: summaryResult[sv],
-          });
-        } else {
+        if (provIds.length > 0) {
           axios
             .get<PropertyValues>("/api/node/propvals/out", {
               params: { dcids: provIds, prop: "url" },
               paramsSerializer: stringifyFn,
             })
             .then((resp) => {
-              const urlMap = {};
               for (const dcid in resp.data) {
                 urlMap[dcid] =
                   resp.data[dcid].length > 0 ? resp.data[dcid][0].value : "";
               }
-              this.setState({
-                description,
-                displayName,
-                error: false,
-                statVar: sv,
-                summary: summaryResult[sv],
-                urls: urlMap,
-              });
             });
         }
+        this.setState({
+          description,
+          displayName,
+          error: false,
+          statVar: sv,
+          summary: summaryResult[sv],
+          urls: urlMap,
+        });
       })
       .catch(() => {
         this.setState({

--- a/static/js/tools/stat_var/page.tsx
+++ b/static/js/tools/stat_var/page.tsx
@@ -331,42 +331,49 @@ class Page extends Component<unknown, PageStateType> {
       .then((resp) => resp.data);
     Promise.all([descriptionPromise, displayNamePromise, summaryPromise])
       .then(([descriptionResult, displayNameResult, summaryResult]) => {
+        const description =
+          descriptionResult[sv].length > 0
+            ? descriptionResult[sv][0].value
+            : "";
+        let displayName =
+          displayNameResult[sv].length > 0
+            ? displayNameResult[sv][0].value
+            : "";
+        displayName = displayName || description;
         const provIds = [];
         for (const provId in summaryResult[sv]?.provenanceSummary) {
           provIds.push(provId);
         }
         if (provIds.length === 0) {
-          return;
-        }
-        axios
-          .get<PropertyValues>("/api/node/propvals/out", {
-            params: { dcids: provIds, prop: "url" },
-            paramsSerializer: stringifyFn,
-          })
-          .then((resp) => {
-            const urlMap = {};
-            for (const dcid in resp.data) {
-              urlMap[dcid] =
-                resp.data[dcid].length > 0 ? resp.data[dcid][0].value : "";
-            }
-            const description =
-              descriptionResult[sv].length > 0
-                ? descriptionResult[sv][0].value
-                : "";
-            let displayName =
-              displayNameResult[sv].length > 0
-                ? displayNameResult[sv][0].value
-                : "";
-            displayName = displayName || description;
-            this.setState({
-              description,
-              displayName,
-              error: false,
-              statVar: sv,
-              summary: summaryResult[sv],
-              urls: urlMap,
-            });
+          this.setState({
+            description,
+            displayName,
+            error: false,
+            statVar: sv,
+            summary: summaryResult[sv],
           });
+        } else {
+          axios
+            .get<PropertyValues>("/api/node/propvals/out", {
+              params: { dcids: provIds, prop: "url" },
+              paramsSerializer: stringifyFn,
+            })
+            .then((resp) => {
+              const urlMap = {};
+              for (const dcid in resp.data) {
+                urlMap[dcid] =
+                  resp.data[dcid].length > 0 ? resp.data[dcid][0].value : "";
+              }
+              this.setState({
+                description,
+                displayName,
+                error: false,
+                statVar: sv,
+                summary: summaryResult[sv],
+                urls: urlMap,
+              });
+            });
+        }
       })
       .catch(() => {
         this.setState({

--- a/static/js/tools/stat_var/page.tsx
+++ b/static/js/tools/stat_var/page.tsx
@@ -59,6 +59,9 @@ interface PageStateType {
   showSvHierarchyModal: boolean;
 }
 
+// TODO: Add webdriver tests for the stat var explorer, including when
+//       various stat var properties are missing as could be possible in
+//       custom DC.
 class Page extends Component<unknown, PageStateType> {
   constructor(props: unknown) {
     super(props);


### PR DESCRIPTION
Fixes a bug in the stat var explorer on custom DC, where clicking on a custom stat var seems to do nothing.

The root cause turned out to be because custom loaded stat vars don't provide a provenance, and the stat var explorer doesn't update state if no provenances were found. This PR adds a state update even if no provenances are provided.

Screenshot:
![Screenshot 2024-05-13 at 12 10 31 PM](https://github.com/datacommonsorg/website/assets/4034366/d66468c9-1f81-4c71-9622-9e74fba2f67a)
