### PR TITLE
NL: Use fixed higher thresholds

### DIFF
--- a/nl_server/embeddings_map.py
+++ b/nl_server/embeddings_map.py
@@ -112,6 +112,6 @@ class EmbeddingsMap:
       raise e
 
     # if store successfully created, set it in embeddings_map
-    if store:
+    if store and idx_info.model in self.name_to_emb_model:
       self.embeddings_map[idx_name] = Embeddings(
           model=self.name_to_emb_model[idx_info.model], store=store)

--- a/server/lib/nl/common/commentary.py
+++ b/server/lib/nl/common/commentary.py
@@ -21,7 +21,7 @@ from server.lib.nl.common.utterance import Utterance
 from server.lib.nl.detection.utils import compute_final_threshold
 from server.lib.nl.detection.utils import get_top_sv_score
 from server.lib.nl.explore import params
-from shared.lib.constants import SV_SCORE_HIGH_CONFIDENCE_THRESHOLD_BUMP
+from shared.lib.constants import SV_SCORE_HIGH_CONFIDENCE_THRESHOLD
 
 #
 # List of user messages!
@@ -160,11 +160,11 @@ def user_message(uttr: Utterance) -> UserMessage:
   # prefer showing that, since we say our confidence is low...
 
   # If the score is below this, then we report low confidence
-  # (we reuse the threshold bump we use for determining something
+  # (we reuse the threshold we use for determining something
   #  is "high confidence")
   low_confidence_score_report_threshold = compute_final_threshold(
       uttr.detection.svs_detected.model_threshold,
-      SV_SCORE_HIGH_CONFIDENCE_THRESHOLD_BUMP)
+      SV_SCORE_HIGH_CONFIDENCE_THRESHOLD)
 
   if (uttr.rankedCharts and
       (uttr.sv_source == FulfillmentResult.CURRENT_QUERY or

--- a/server/lib/nl/detection/heuristic_detector.py
+++ b/server/lib/nl/detection/heuristic_detector.py
@@ -79,14 +79,14 @@ def detect(orig_query: str,
                      attributes=SimpleClassificationAttributes()))
 
   # Step 4: Identify the SV matched based on the query.
-  sv_threshold_bump = params.sv_threshold_bump(mode)
+  sv_threshold_override = params.sv_threshold_override(mode)
   sv_detection_query = dutils.remove_date_from_query(query, classifications)
   skip_topics = mode == params.QueryMode.TOOLFORMER
   sv_detection_result = dutils.empty_var_detection_result()
   try:
     sv_detection_result = variable.detect_vars(
         sv_detection_query, index_type, counters,
-        query_detection_debug_logs["query_transformations"], sv_threshold_bump,
+        query_detection_debug_logs["query_transformations"], sv_threshold_override,
         reranker, skip_topics)
   except ValueError as e:
     counters.err('detect_vars_value_error', {
@@ -96,7 +96,7 @@ def detect(orig_query: str,
   # Set the SVDetection.
   sv_detection = dutils.create_sv_detection(sv_detection_query,
                                             sv_detection_result,
-                                            sv_threshold_bump, allow_triples)
+                                            sv_threshold_override, allow_triples)
 
   return Detection(original_query=orig_query,
                    cleaned_query=cleaned_query,

--- a/server/lib/nl/detection/heuristic_detector.py
+++ b/server/lib/nl/detection/heuristic_detector.py
@@ -86,8 +86,8 @@ def detect(orig_query: str,
   try:
     sv_detection_result = variable.detect_vars(
         sv_detection_query, index_type, counters,
-        query_detection_debug_logs["query_transformations"], sv_threshold_override,
-        reranker, skip_topics)
+        query_detection_debug_logs["query_transformations"],
+        sv_threshold_override, reranker, skip_topics)
   except ValueError as e:
     counters.err('detect_vars_value_error', {
         'q': sv_detection_query,
@@ -96,7 +96,8 @@ def detect(orig_query: str,
   # Set the SVDetection.
   sv_detection = dutils.create_sv_detection(sv_detection_query,
                                             sv_detection_result,
-                                            sv_threshold_override, allow_triples)
+                                            sv_threshold_override,
+                                            allow_triples)
 
   return Detection(original_query=orig_query,
                    cleaned_query=cleaned_query,

--- a/server/lib/nl/detection/utils.py
+++ b/server/lib/nl/detection/utils.py
@@ -182,19 +182,20 @@ def _get_sv_and_prop_candidates(
 
 
 def compute_final_threshold(model_threshold: float,
-                            threshold_bump: float) -> float:
-  return model_threshold + abs((1 - model_threshold) * threshold_bump)
+                            threshold_override: float) -> float:
+  # Pick the higher of the two.
+  return max(model_threshold, threshold_override)
 
 
 def create_sv_detection(query: str,
                         var_detection_result: dvars.VarDetectionResult,
-                        sv_threshold_bump: float = 0,
+                        sv_threshold_override: float = 0,
                         allow_triples: bool = False) -> SVDetection:
   sv_candidates, prop_candidates = _get_sv_and_prop_candidates(
       var_detection_result, allow_triples)
 
   sv_threshold = compute_final_threshold(var_detection_result.model_threshold,
-                                         sv_threshold_bump)
+                                         sv_threshold_override)
   return SVDetection(query=query,
                      single_sv=sv_candidates,
                      multi_sv=var_detection_result.multi_var,

--- a/server/lib/nl/detection/variable.py
+++ b/server/lib/nl/detection/variable.py
@@ -50,7 +50,7 @@ def detect_vars(orig_query: str,
                 index_type: str,
                 counters: ctr.Counters,
                 debug_logs: Dict,
-                threshold_bump: float = 0,
+                threshold_override: float = 0,
                 reranker: str = '',
                 skip_topics: bool = False) -> vars.VarDetectionResult:
   #
@@ -90,7 +90,7 @@ def detect_vars(orig_query: str,
   #
   # If caller had an overriden threshold bump, apply that.
   multi_var_threshold = dutils.compute_final_threshold(model_threshold,
-                                                       threshold_bump)
+                                                       threshold_override)
   result_monovar = query2results[query_monovar]
   result_multivar = _prepare_multivar_candidates(multi_querysets, query2results,
                                                  multi_var_threshold)

--- a/server/lib/nl/explore/params.py
+++ b/server/lib/nl/explore/params.py
@@ -71,12 +71,12 @@ SPECIAL_DC_LIST = SDG_DC_LIST + [DCNames.UNDATA_DC]
 
 
 # Get the SV score threshold for the given mode.
-def sv_threshold_bump(mode: str) -> bool | None:
+def sv_threshold_override(mode: str) -> bool | None:
   if mode == QueryMode.STRICT:
-    return constants.SV_SCORE_HIGH_CONFIDENCE_THRESHOLD_BUMP
+    return constants.SV_SCORE_HIGH_CONFIDENCE_THRESHOLD
   elif mode == QueryMode.TOOLFORMER:
-    return constants.SV_SCORE_TOOLFORMER_THRESHOLD_BUMP
-  # By default no bump.
+    return constants.SV_SCORE_TOOLFORMER_THRESHOLD
+  # The default is 0, so model-score will be used.
   return 0.0
 
 

--- a/shared/lib/constants.py
+++ b/shared/lib/constants.py
@@ -378,22 +378,13 @@ NON_GEO_PLACE_TYPES: FrozenSet[str] = frozenset([
 SV_SCORE_DEFAULT_THRESHOLD = 0.5
 
 #
-# The Cosine score "bump" is the increase over default model-threshold
-# that is applied as follows:
-#
-#    model-threshold + (1 - model-threshold) * bump
-#
-# That is, we increase the threshold by this fraction of the
-# (1 - model-threshold) window that the scores are valid in.
-#
-# Bump value for high-confidence threshold.
-# bump of 0.4 => a threshold of 0.7 if default is 0.5
-#             => a threshold of 0.82 if default is 0.7
-SV_SCORE_HIGH_CONFIDENCE_THRESHOLD_BUMP = 0.4
-# Bump value for when running in mode=toolformer.
-# bump of 0.6 => a threshold of 0.8 if default is 0.5
-#             => a threshold of 0.88 if default is 0.7
-SV_SCORE_TOOLFORMER_THRESHOLD_BUMP = 0.6
+# The Cosine high-confidence score threshold override.
+# NOTE: Used only when the model-threshold is lower than this.
+SV_SCORE_HIGH_CONFIDENCE_THRESHOLD = 0.7
+
+# The Cosine score threshold for mode=toolformer.
+# NOTE: Used only when the model-threshold is lower than this.
+SV_SCORE_TOOLFORMER_THRESHOLD = 0.8
 
 # A cosine score differential we use to indicate if scores
 # that differ by up to this amount are "near" SVs.


### PR DESCRIPTION
Reason:  turns out that the bigger models have a shorter range of scores, and having a % based higher confidence threshold makes "Low confidence" message more common, and could hurt Bard recall.