### PR TITLE
Fix bug in NL feedback

### DIFF
--- a/static/css/shared/_tiles.scss
+++ b/static/css/shared/_tiles.scss
@@ -122,7 +122,6 @@ $box-shadow-8dp: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
 .chart-container.disaster-event-map-tile {
   border: var(--border-primary);
   border-radius: var(--border-radius-primary);
-  overflow: hidden;
   padding: 0;
 }
 


### PR DESCRIPTION
This PR fixes the issue where clicking the NL feedback icons in the charts no longer appears to do anything. This happens because the feedback box got hidden by the chart container for being "out of bounds". 

Before:
![Screenshot 2024-05-29 at 4 45 27 PM](https://github.com/datacommonsorg/website/assets/4034366/3aeb3830-f2cc-4653-8817-5a111625a72c)

After:

![Screenshot 2024-05-29 at 4 44 47 PM](https://github.com/datacommonsorg/website/assets/4034366/c9587af2-f319-4db1-b8b5-ce1b7f6d531e)
