### PR TITLE
Improve multi-var fulfillment with uneven #matches

### DIFF
--- a/server/config/nl_page/topic_cache.json
+++ b/server/config/nl_page/topic_cache.json
@@ -15781,8 +15781,8 @@
         "Maternal Mortality"
       ],
       "relevantVariableList": [
-        "WHO/MORT_MATERNALNUM",
-        "sdg/SH_STA_MORT.SEX--F"
+        "sdg/SH_STA_MORT.SEX--F",
+        "WHO/MORT_MATERNALNUM"
       ],
       "typeOf": [
         "Topic"

--- a/server/integration_tests/test_data/e2e_correlation_bugs/chart_config.json
+++ b/server/integration_tests/test_data/e2e_correlation_bugs/chart_config.json
@@ -86,9 +86,449 @@
               }
             ],
             "title": "Hispanic or Latino Americans Below Poverty Line in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_WithDiabetes_scatter",
+                      "Count_Person_Female_AbovePovertyLevelInThePast12Months_HispanicOrLatino_scatter"
+                    ],
+                    "title": "Diabetes (${yDate}) Vs. Hispanic Monoracial Women Above Poverty Line (${xDate}) in Counties of California",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Diabetes vs. Hispanic Monoracial Women Above poverty line"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Female_AbovePovertyLevelInThePast12Months_HispanicOrLatino"
+                    ],
+                    "title": "Hispanic Monoracial Women Above Poverty Line in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Female_AbovePovertyLevelInThePast12Months_HispanicOrLatino"
+                    ],
+                    "title": "Hispanic Monoracial Women Above Poverty Line in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Hispanic Monoracial Women Above Poverty Line in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_WithDiabetes_scatter",
+                      "Count_Person_AbovePovertyLevelInThePast12Months_HispanicOrLatino_scatter"
+                    ],
+                    "title": "Diabetes (${yDate}) Vs. Hispanic Population Above Poverty Line (${xDate}) in Counties of California",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Diabetes vs. Hispanic Population Above poverty line"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_AbovePovertyLevelInThePast12Months_HispanicOrLatino"
+                    ],
+                    "title": "Hispanic Population Above Poverty Line in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_AbovePovertyLevelInThePast12Months_HispanicOrLatino"
+                    ],
+                    "title": "Hispanic Population Above Poverty Line in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Hispanic Population Above Poverty Line in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_WithDiabetes_scatter",
+                      "Count_Person_Male_AbovePovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone_scatter"
+                    ],
+                    "title": "Diabetes (${yDate}) Vs. African American Men Above Poverty Line Over the Last Year (${xDate}) in Counties of California",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Diabetes vs. African American Men Above poverty line Over the Last Year"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Male_AbovePovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone"
+                    ],
+                    "title": "African American Men Above Poverty Line Over the Last Year in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Male_AbovePovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone"
+                    ],
+                    "title": "African American Men Above Poverty Line Over the Last Year in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "African American Men Above Poverty Line Over the Last Year in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_WithDiabetes_scatter",
+                      "Count_Person_Male_BelowPovertyLevelInThePast12Months_HispanicOrLatino_scatter"
+                    ],
+                    "title": "Diabetes (${yDate}) Vs. Hispanic Men Below Poverty Line (${xDate}) in Counties of California",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Diabetes vs. Hispanic Men Below Poverty Line"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Male_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
+                    ],
+                    "title": "Hispanic Men Below Poverty Line in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Male_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
+                    ],
+                    "title": "Hispanic Men Below Poverty Line in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Hispanic Men Below Poverty Line in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_WithDiabetes_scatter",
+                      "Count_Person_Female_BelowPovertyLevelInThePast12Months_HispanicOrLatino_scatter"
+                    ],
+                    "title": "Diabetes (${yDate}) Vs. Hispanic Women Below Poverty Line (${xDate}) in Counties of California",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Diabetes vs. Hispanic Women Below Poverty Line"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Female_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
+                    ],
+                    "title": "Hispanic Women Below Poverty Line in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Female_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
+                    ],
+                    "title": "Hispanic Women Below Poverty Line in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Hispanic Women Below Poverty Line in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_WithDiabetes_scatter",
+                      "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone_scatter"
+                    ],
+                    "title": "Diabetes (${yDate}) Vs. Asians Below Poverty Line (${xDate}) in Counties of California",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Diabetes vs. Asians Below Poverty Line"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone"
+                    ],
+                    "title": "Asians Below Poverty Line in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone"
+                    ],
+                    "title": "Asians Below Poverty Line in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Asians Below Poverty Line in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_WithDiabetes_scatter",
+                      "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone_scatter"
+                    ],
+                    "title": "Diabetes (${yDate}) Vs. Black or African Americans Below Poverty (${xDate}) in Counties of California",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Diabetes vs. Black or African Americans Below Poverty"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone"
+                    ],
+                    "title": "Black or African Americans Below Poverty in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone"
+                    ],
+                    "title": "Black or African Americans Below Poverty in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Black or African Americans Below Poverty in Counties of California"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Percent_Person_WithDiabetes_scatter",
+                      "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone_scatter"
+                    ],
+                    "title": "Diabetes (${yDate}) Vs. Native Hawaiian or Other Pacific Islander Americans Below Poverty Line (${xDate}) in Counties of California",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Diabetes vs. Native Hawaiian or Other Pacific Islander Americans Below Poverty Line"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone"
+                    ],
+                    "title": "Native Hawaiian or Other Pacific Islander Americans Below Poverty Line in Counties of California (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone"
+                    ],
+                    "title": "Native Hawaiian or Other Pacific Islander Americans Below Poverty Line in Counties of California (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Native Hawaiian or Other Pacific Islander Americans Below Poverty Line in Counties of California"
           }
         ],
         "statVarSpec": {
+          "Count_Person_AbovePovertyLevelInThePast12Months_HispanicOrLatino": {
+            "name": "Hispanic Population Above poverty line",
+            "statVar": "Count_Person_AbovePovertyLevelInThePast12Months_HispanicOrLatino"
+          },
+          "Count_Person_AbovePovertyLevelInThePast12Months_HispanicOrLatino_scatter": {
+            "name": "Hispanic Population Above poverty line",
+            "statVar": "Count_Person_AbovePovertyLevelInThePast12Months_HispanicOrLatino"
+          },
+          "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone": {
+            "name": "Asians Below Poverty Line",
+            "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone"
+          },
+          "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone_scatter": {
+            "name": "Asians Below Poverty Line",
+            "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone"
+          },
+          "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone": {
+            "name": "Black or African Americans Below Poverty",
+            "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone"
+          },
+          "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone_scatter": {
+            "name": "Black or African Americans Below Poverty",
+            "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone"
+          },
           "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino": {
             "name": "Hispanic or Latino Americans Below Poverty Line",
             "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
@@ -96,6 +536,46 @@
           "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino_scatter": {
             "name": "Hispanic or Latino Americans Below Poverty Line",
             "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
+          },
+          "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone": {
+            "name": "Native Hawaiian or Other Pacific Islander Americans Below Poverty Line",
+            "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone"
+          },
+          "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone_scatter": {
+            "name": "Native Hawaiian or Other Pacific Islander Americans Below Poverty Line",
+            "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone"
+          },
+          "Count_Person_Female_AbovePovertyLevelInThePast12Months_HispanicOrLatino": {
+            "name": "Hispanic Monoracial Women Above poverty line",
+            "statVar": "Count_Person_Female_AbovePovertyLevelInThePast12Months_HispanicOrLatino"
+          },
+          "Count_Person_Female_AbovePovertyLevelInThePast12Months_HispanicOrLatino_scatter": {
+            "name": "Hispanic Monoracial Women Above poverty line",
+            "statVar": "Count_Person_Female_AbovePovertyLevelInThePast12Months_HispanicOrLatino"
+          },
+          "Count_Person_Female_BelowPovertyLevelInThePast12Months_HispanicOrLatino": {
+            "name": "Hispanic Women Below Poverty Line",
+            "statVar": "Count_Person_Female_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
+          },
+          "Count_Person_Female_BelowPovertyLevelInThePast12Months_HispanicOrLatino_scatter": {
+            "name": "Hispanic Women Below Poverty Line",
+            "statVar": "Count_Person_Female_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
+          },
+          "Count_Person_Male_AbovePovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone": {
+            "name": "African American Men Above poverty line Over the Last Year",
+            "statVar": "Count_Person_Male_AbovePovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone"
+          },
+          "Count_Person_Male_AbovePovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone_scatter": {
+            "name": "African American Men Above poverty line Over the Last Year",
+            "statVar": "Count_Person_Male_AbovePovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone"
+          },
+          "Count_Person_Male_BelowPovertyLevelInThePast12Months_HispanicOrLatino": {
+            "name": "Hispanic Men Below Poverty Line",
+            "statVar": "Count_Person_Male_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
+          },
+          "Count_Person_Male_BelowPovertyLevelInThePast12Months_HispanicOrLatino_scatter": {
+            "name": "Hispanic Men Below Poverty Line",
+            "statVar": "Count_Person_Male_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
           },
           "Percent_Person_WithDiabetes": {
             "name": "Diabetes",
@@ -495,15 +975,71 @@
     },
     "childTopics": [],
     "exploreMore": {
+      "Count_Person_AbovePovertyLevelInThePast12Months_HispanicOrLatino": {
+        "age": [
+          "Count_Person_12To17Years_AbovePovertyLevelInThePast12Months_HispanicOrLatino",
+          "Count_Person_18To59Years_AbovePovertyLevelInThePast12Months_HispanicOrLatino",
+          "Count_Person_60To74Years_AbovePovertyLevelInThePast12Months_HispanicOrLatino",
+          "Count_Person_6OrLessYears_AbovePovertyLevelInThePast12Months_HispanicOrLatino",
+          "Count_Person_75To84Years_AbovePovertyLevelInThePast12Months_HispanicOrLatino",
+          "Count_Person_85OrMoreYears_AbovePovertyLevelInThePast12Months_HispanicOrLatino"
+        ]
+      },
+      "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone": {
+        "age": [
+          "Count_Person_12To17Years_BelowPovertyLevelInThePast12Months_AsianAlone",
+          "Count_Person_18To59Years_BelowPovertyLevelInThePast12Months_AsianAlone",
+          "Count_Person_60To74Years_BelowPovertyLevelInThePast12Months_AsianAlone",
+          "Count_Person_6OrLessYears_BelowPovertyLevelInThePast12Months_AsianAlone",
+          "Count_Person_75To84Years_BelowPovertyLevelInThePast12Months_AsianAlone",
+          "Count_Person_85OrMoreYears_BelowPovertyLevelInThePast12Months_AsianAlone"
+        ]
+      },
+      "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone": {
+        "age": [
+          "Count_Person_12To17Years_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone",
+          "Count_Person_18To59Years_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone",
+          "Count_Person_60To74Years_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone",
+          "Count_Person_6OrLessYears_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone",
+          "Count_Person_75To84Years_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone",
+          "Count_Person_85OrMoreYears_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone"
+        ]
+      },
       "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino": {
         "age": [
           "Count_Person_12To17Years_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
           "Count_Person_18To59Years_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
           "Count_Person_60To74Years_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
           "Count_Person_6OrLessYears_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
-          "Count_Person_6To11Years_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
           "Count_Person_75To84Years_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
           "Count_Person_85OrMoreYears_BelowPovertyLevelInThePast12Months_HispanicOrLatino"
+        ]
+      },
+      "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone": {
+        "age": [
+          "Count_Person_12To17Years_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
+          "Count_Person_18To59Years_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
+          "Count_Person_60To74Years_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
+          "Count_Person_6OrLessYears_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
+          "Count_Person_75To84Years_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
+          "Count_Person_85OrMoreYears_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone"
+        ]
+      },
+      "Count_Person_Male_BelowPovertyLevelInThePast12Months_HispanicOrLatino": {
+        "age": [
+          "dc/05sgpg5lkl0j3",
+          "dc/09szykgkfnwzf",
+          "dc/2kxtg8p02r8m2",
+          "dc/2tqnf30z8dlk6",
+          "dc/4x51zbljbhdsb",
+          "dc/7ec5kvhmd9lr7",
+          "dc/7whbh9y32dkq1",
+          "dc/frw1cl3ygsxzh",
+          "dc/rqzdxj4lkdsx1",
+          "dc/s2m3q5svmvf9h",
+          "dc/tl7sdvd65ql5d",
+          "dc/w2n8clm9v8cb3",
+          "dc/yl5sv6vx88jxd"
         ]
       }
     },

--- a/server/integration_tests/test_data/e2e_correlation_simple_place/foreignbornvs.nativeborninsunnyvale/chart_config.json
+++ b/server/integration_tests/test_data/e2e_correlation_simple_place/foreignbornvs.nativeborninsunnyvale/chart_config.json
@@ -28,6 +28,60 @@
                 "tiles": [
                   {
                     "statVarKey": [
+                      "Count_Person_5OrMoreYears_ForeignBorn",
+                      "Count_Person_PlaceOfBirthAsia"
+                    ],
+                    "title": "Population: Foreign Born and Population: Foreign Born, Asia in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Foreign Born and Population: Foreign Born, Asia"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_ForeignBorn",
+                      "Count_Person_ForeignBorn_PlaceOfBirthCaribbean"
+                    ],
+                    "title": "Population: Foreign Born and Foreign-born Caribbean Origin in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Foreign Born and Foreign-born Caribbean Origin"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_5OrMoreYears_ForeignBorn",
+                      "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico"
+                    ],
+                    "title": "Population: Foreign Born and Foreign-born Central American Origin (Except Mexico) in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Foreign Born and Foreign-born Central American Origin (Except Mexico)"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
                       "dc/xdfcsgf05b4mc",
                       "dc/6bkn9vt30f5c1"
                     ],
@@ -46,9 +100,21 @@
             "name": "Population: Foreign Born",
             "statVar": "Count_Person_5OrMoreYears_ForeignBorn"
           },
+          "Count_Person_ForeignBorn_PlaceOfBirthCaribbean": {
+            "name": "Foreign-born Caribbean origin",
+            "statVar": "Count_Person_ForeignBorn_PlaceOfBirthCaribbean"
+          },
+          "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico": {
+            "name": "Foreign-born Central American origin (except Mexico)",
+            "statVar": "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico"
+          },
           "Count_Person_Native": {
             "name": "Population: Native",
             "statVar": "Count_Person_Native"
+          },
+          "Count_Person_PlaceOfBirthAsia": {
+            "name": "Population: Foreign Born, Asia",
+            "statVar": "Count_Person_PlaceOfBirthAsia"
           },
           "dc/6bkn9vt30f5c1": {
             "name": "Population: Foreign Born, American Indian or Alaska Native Alone",
@@ -105,29 +171,71 @@
     ],
     "exploreMore": {
       "Count_Person_5OrMoreYears_ForeignBorn": {
+        "placeOfBirth": [
+          "Count_Person_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_PlaceOfBirthAsia"
+        ],
         "race": [
           "dc/6bkn9vt30f5c1",
           "dc/xdfcsgf05b4mc"
+        ]
+      },
+      "Count_Person_ForeignBorn_PlaceOfBirthCaribbean": {
+        "age": [
+          "Count_Person_15OrMoreYears_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_16OrMoreYears_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_18To24Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_25To44Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_45To54Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_55To64Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_5OrLessYears_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_5To17Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_65To74Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_75To84Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_85OrMoreYears_ForeignBorn_PlaceOfBirthCaribbean"
+        ]
+      },
+      "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico": {
+        "age": [
+          "Count_Person_15OrMoreYears_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_16OrMoreYears_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_18To24Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_25To44Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_45To54Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_55To64Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_5OrLessYears_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_5To17Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_65To74Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_75To84Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_85OrMoreYears_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico"
+        ]
+      },
+      "Count_Person_PlaceOfBirthAsia": {
+        "age": [
+          "Count_Person_15OrMoreYears_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_16OrMoreYears_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_18To24Years_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_25To44Years_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_45To54Years_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_55To64Years_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_5OrLessYears_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_5To17Years_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_65To74Years_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_75To84Years_ForeignBorn_PlaceOfBirthAsia",
+          "Count_Person_85OrMoreYears_ForeignBorn_PlaceOfBirthAsia"
         ]
       },
       "dc/6bkn9vt30f5c1": {
         "abilityToSpeakEnglish": [
           "dc/834l34hp5krkd",
           "dc/slhc0k07wwmq1"
-        ],
-        "languageSpokenAtHome": [
-          "dc/dc2zeq33ew2p2",
-          "dc/wygcf0xy4dgrd"
         ]
       },
       "dc/xdfcsgf05b4mc": {
         "abilityToSpeakEnglish": [
           "dc/ktkbjq2bkp8xc",
           "dc/qx3kfy4r5ce49"
-        ],
-        "languageSpokenAtHome": [
-          "dc/mjmz36lytkxtb",
-          "dc/xvdx8kfyj41kh"
         ]
       }
     },

--- a/server/integration_tests/test_data/e2e_correlation_simple_place/nativebornvs.medianincomeinsunnyvale/chart_config.json
+++ b/server/integration_tests/test_data/e2e_correlation_simple_place/nativebornvs.medianincomeinsunnyvale/chart_config.json
@@ -146,12 +146,152 @@
             ],
             "denom": "Count_Person",
             "title": "Population: Foreign Born, Asia"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "dc/6bkn9vt30f5c1"
+                    ],
+                    "title": "Population: Foreign Born, American Indian or Alaska Native Alone in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Population: Foreign Born, American Indian or Alaska Native Alone in Sunnyvale",
+                    "statVarKey": [
+                      "dc/6bkn9vt30f5c1"
+                    ],
+                    "title": "Population: Foreign Born, American Indian or Alaska Native Alone in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Population: Foreign Born, American Indian or Alaska Native Alone"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_ForeignBorn_PlaceOfBirthCaribbean"
+                    ],
+                    "title": "Foreign-born Caribbean Origin in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Foreign-born Caribbean Origin in Sunnyvale",
+                    "statVarKey": [
+                      "Count_Person_ForeignBorn_PlaceOfBirthCaribbean"
+                    ],
+                    "title": "Foreign-born Caribbean Origin in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Foreign-born Caribbean Origin"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico"
+                    ],
+                    "title": "Foreign-born Central American Origin (Except Mexico) in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Foreign-born Central American Origin (Except Mexico) in Sunnyvale",
+                    "statVarKey": [
+                      "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico"
+                    ],
+                    "title": "Foreign-born Central American Origin (Except Mexico) in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Foreign-born Central American Origin (Except Mexico)"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Median_Age_Person_Native"
+                    ],
+                    "title": "Median Age: Native in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Median Age: Native in Sunnyvale",
+                    "statVarKey": [
+                      "Median_Age_Person_Native"
+                    ],
+                    "title": "Median Age: Native in Sunnyvale",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Median Age: Native"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Median_Age_Person_Native",
+                      "Median_Age_Person_ForeignBorn"
+                    ],
+                    "title": "Median Age: Native and Median Age: Foreign Born in Sunnyvale",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "title": "Related: Median Age: Native and Median Age: Foreign Born"
           }
         ],
         "statVarSpec": {
           "Count_Person_ForeignBorn": {
             "name": "Population: Foreign Born",
             "statVar": "Count_Person_ForeignBorn"
+          },
+          "Count_Person_ForeignBorn_PlaceOfBirthCaribbean": {
+            "name": "Foreign-born Caribbean origin",
+            "statVar": "Count_Person_ForeignBorn_PlaceOfBirthCaribbean"
+          },
+          "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico": {
+            "name": "Foreign-born Central American origin (except Mexico)",
+            "statVar": "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico"
           },
           "Count_Person_Native": {
             "name": "Population: Native",
@@ -161,6 +301,14 @@
             "name": "Population: Foreign Born, Asia",
             "statVar": "Count_Person_PlaceOfBirthAsia"
           },
+          "Median_Age_Person_ForeignBorn": {
+            "name": "Median Age: Foreign Born",
+            "statVar": "Median_Age_Person_ForeignBorn"
+          },
+          "Median_Age_Person_Native": {
+            "name": "Median Age: Native",
+            "statVar": "Median_Age_Person_Native"
+          },
           "Median_Earnings_Person": {
             "name": "Individual Median Earnings",
             "statVar": "Median_Earnings_Person"
@@ -168,6 +316,10 @@
           "Median_Income_Person": {
             "name": "Individual Median Income",
             "statVar": "Median_Income_Person"
+          },
+          "dc/6bkn9vt30f5c1": {
+            "name": "Population: Foreign Born, American Indian or Alaska Native Alone",
+            "statVar": "dc/6bkn9vt30f5c1"
           }
         }
       }
@@ -231,6 +383,32 @@
           "Count_Person_Upto5Years_ForeignBorn"
         ]
       },
+      "Count_Person_ForeignBorn_PlaceOfBirthCaribbean": {
+        "age": [
+          "Count_Person_18To24Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_25To44Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_45To54Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_55To64Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_5OrLessYears_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_5To17Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_65To74Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_75To84Years_ForeignBorn_PlaceOfBirthCaribbean",
+          "Count_Person_85OrMoreYears_ForeignBorn_PlaceOfBirthCaribbean"
+        ]
+      },
+      "Count_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico": {
+        "age": [
+          "Count_Person_18To24Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_25To44Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_45To54Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_55To64Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_5OrLessYears_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_5To17Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_65To74Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_75To84Years_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico",
+          "Count_Person_85OrMoreYears_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico"
+        ]
+      },
       "Count_Person_PlaceOfBirthAsia": {
         "age": [
           "Count_Person_18To24Years_ForeignBorn_PlaceOfBirthAsia",
@@ -242,6 +420,19 @@
           "Count_Person_65To74Years_ForeignBorn_PlaceOfBirthAsia",
           "Count_Person_75To84Years_ForeignBorn_PlaceOfBirthAsia",
           "Count_Person_85OrMoreYears_ForeignBorn_PlaceOfBirthAsia"
+        ]
+      },
+      "Median_Age_Person_ForeignBorn": {
+        "placeOfBirth": [
+          "Median_Age_Person_ForeignBorn_PlaceOfBirthAsia",
+          "Median_Age_Person_ForeignBorn_PlaceOfBirthCaribbean",
+          "Median_Age_Person_ForeignBorn_PlaceOfBirthCentralAmericaExceptMexico"
+        ]
+      },
+      "dc/6bkn9vt30f5c1": {
+        "abilityToSpeakEnglish": [
+          "dc/834l34hp5krkd",
+          "dc/slhc0k07wwmq1"
         ]
       }
     },

--- a/server/integration_tests/test_data/e2e_india_demo/howdoesliteracyratecomparetopovertyinindia/chart_config.json
+++ b/server/integration_tests/test_data/e2e_india_demo/howdoesliteracyratecomparetopovertyinindia/chart_config.json
@@ -9,30 +9,55 @@
               {
                 "tiles": [
                   {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
                     "statVarKey": [
-                      "Count_Person_BelowPovertyLevelInThePast12Months"
+                      "Count_Person_Literate_scatter",
+                      "Count_Person_BelowPovertyLevelInThePast12Months_scatter"
                     ],
-                    "title": "Population Below Poverty Line in India",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Population Below Poverty Line in India",
-                    "statVarKey": [
-                      "Count_Person_BelowPovertyLevelInThePast12Months"
-                    ],
-                    "title": "Population Below Poverty Line in India",
-                    "type": "HIGHLIGHT"
+                    "title": "Population: Literate (${yDate}) Vs. Population Below Poverty Line (${xDate}) in Administrative Area 1 Places of India",
+                    "type": "SCATTER"
                   }
                 ]
               }
             ],
             "denom": "Count_Person",
             "startWithDenom": true,
-            "title": "Population Below Poverty Line"
+            "title": "Population: Literate vs. Population Below poverty line"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Literate"
+                    ],
+                    "title": "Population: Literate in Administrative Area 1 Places of India (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Literate"
+                    ],
+                    "title": "Population: Literate in Administrative Area 1 Places of India (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "startWithDenom": true,
+            "title": "Population: Literate in Administrative Area 1 Places of India"
           },
           {
             "columns": [
@@ -72,28 +97,53 @@
               {
                 "tiles": [
                   {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
                     "statVarKey": [
-                      "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person"
+                      "Count_Person_Illiterate_scatter",
+                      "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person_scatter"
                     ],
-                    "title": "Population Below Poverty Line (Per Capita) in India",
-                    "type": "LINE"
+                    "title": "Population: Illiterate (${yDate}) Vs. Population Below Poverty Line (Per Capita) (${xDate}) in Administrative Area 1 Places of India",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "startWithDenom": true,
+            "title": "Population: Illiterate vs. Population Below poverty line (Per Capita)"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Count_Person_Illiterate"
+                    ],
+                    "title": "Population: Illiterate in Administrative Area 1 Places of India (${date})",
+                    "type": "MAP"
                   }
                 ]
               },
               {
                 "tiles": [
                   {
-                    "description": "Population Below Poverty Line (Per Capita) in India",
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
                     "statVarKey": [
-                      "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person"
+                      "Count_Person_Illiterate"
                     ],
-                    "title": "Population Below Poverty Line (Per Capita) in India",
-                    "type": "HIGHLIGHT"
+                    "title": "Population: Illiterate in Administrative Area 1 Places of India (${date})",
+                    "type": "RANKING"
                   }
                 ]
               }
             ],
-            "title": "Population Below Poverty Line (Per Capita)"
+            "title": "Population: Illiterate in Administrative Area 1 Places of India"
           },
           {
             "columns": [
@@ -125,6 +175,50 @@
               }
             ],
             "title": "Population Below Poverty Line (Per Capita) in Administrative Area 1 Places of India"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Literate_scatter",
+                      "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person_scatter"
+                    ],
+                    "title": "Population: Literate (${yDate}) Vs. Population Below Poverty Line (Per Capita) (${xDate}) in Administrative Area 1 Places of India",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "startWithDenom": true,
+            "title": "Population: Literate vs. Population Below poverty line (Per Capita)"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Count_Person_Illiterate_scatter",
+                      "Count_Person_BelowPovertyLevelInThePast12Months_scatter"
+                    ],
+                    "title": "Population: Illiterate (${yDate}) Vs. Population Below Poverty Line (${xDate}) in Administrative Area 1 Places of India",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "startWithDenom": true,
+            "title": "Population: Illiterate vs. Population Below poverty line"
           }
         ],
         "statVarSpec": {
@@ -135,6 +229,31 @@
           "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person": {
             "name": "Population Below poverty line (Per Capita)",
             "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person"
+          },
+          "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person_scatter": {
+            "name": "Population Below poverty line (Per Capita)",
+            "noPerCapita": true,
+            "statVar": "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person"
+          },
+          "Count_Person_BelowPovertyLevelInThePast12Months_scatter": {
+            "name": "Population Below poverty line",
+            "statVar": "Count_Person_BelowPovertyLevelInThePast12Months"
+          },
+          "Count_Person_Illiterate": {
+            "name": "Population: Illiterate",
+            "statVar": "Count_Person_Illiterate"
+          },
+          "Count_Person_Illiterate_scatter": {
+            "name": "Population: Illiterate",
+            "statVar": "Count_Person_Illiterate"
+          },
+          "Count_Person_Literate": {
+            "name": "Population: Literate",
+            "statVar": "Count_Person_Literate"
+          },
+          "Count_Person_Literate_scatter": {
+            "name": "Population: Literate",
+            "statVar": "Count_Person_Literate"
           }
         }
       }
@@ -440,14 +559,35 @@
       }
     ],
     "exploreMore": {
-      "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person": {
+      "Count_Person_Illiterate": {
+        "gender": [
+          "Count_Person_Illiterate_Female",
+          "Count_Person_Illiterate_Male"
+        ],
         "placeOfResidenceClassification": [
-          "Count_Person_Rural_BelowPovertyLevelInThePast12Months_AsAFractionOf_Count_Person",
-          "Count_Person_Urban_BelowPovertyLevelInThePast12Months_AsAFractionOf_Count_Person"
+          "Count_Person_Illiterate_Rural",
+          "Count_Person_Illiterate_Urban"
+        ],
+        "religion": [
+          "indianCensus/Count_Person_Religion_Buddhist_Illiterate",
+          "indianCensus/Count_Person_Religion_Christian_Illiterate"
+        ]
+      },
+      "Count_Person_Literate": {
+        "gender": [
+          "Count_Person_Literate_Female",
+          "Count_Person_Literate_Male"
         ]
       }
     },
     "mainTopics": [
+      {
+        "dcid": "dc/topic/Literacy",
+        "name": "Literacy",
+        "types": [
+          "Topic"
+        ]
+      },
       {
         "dcid": "dc/topic/Poverty",
         "name": "Poverty",

--- a/server/integration_tests/test_data/e2e_us_demo/howdoeshouseholdincomecomparewithratesofdiabetesinusacounties/chart_config.json
+++ b/server/integration_tests/test_data/e2e_us_demo/howdoeshouseholdincomecomparewithratesofdiabetesinusacounties/chart_config.json
@@ -85,6 +85,261 @@
               }
             ],
             "title": "Diabetes in Counties of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Mean_Income_Household_FamilyHousehold_scatter",
+                      "Percent_Person_WithDiabetes_scatter"
+                    ],
+                    "title": "Average Income for Family Households (${yDate}) Vs. Diabetes (${xDate}) in Counties of United States",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "title": "Average Income for Family Households vs. Diabetes"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Mean_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Average Income for Family Households in Counties of United States (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Mean_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Average Income for Family Households in Counties of United States (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Average Income for Family Households in Counties of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Median_Income_Household_FamilyHousehold_scatter",
+                      "Percent_Person_WithDiabetes_scatter"
+                    ],
+                    "title": "Median Family Household Income (${yDate}) Vs. Diabetes (${xDate}) in Counties of United States",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "title": "Median Family Household Income vs. Diabetes"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Median_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Median Family Household Income in Counties of United States (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Median_Income_Household_FamilyHousehold"
+                    ],
+                    "title": "Median Family Household Income in Counties of United States (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Median Family Household Income in Counties of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Median_Income_Household_scatter",
+                      "Percent_Person_WithDiabetes_scatter"
+                    ],
+                    "title": "Household Median Income (${yDate}) Vs. Diabetes (${xDate}) in Counties of United States",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "title": "Household Median Income vs. Diabetes"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Median_Income_Household"
+                    ],
+                    "title": "Household Median Income in Counties of United States (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Median_Income_Household"
+                    ],
+                    "title": "Household Median Income in Counties of United States (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Household Median Income in Counties of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Median_Income_Household_MarriedCoupleFamilyHousehold_scatter",
+                      "Percent_Person_WithDiabetes_scatter"
+                    ],
+                    "title": "Median Married Couple Family Household Income (${yDate}) Vs. Diabetes (${xDate}) in Counties of United States",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "title": "Median Married Couple Family Household Income vs. Diabetes"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Median_Income_Household_MarriedCoupleFamilyHousehold"
+                    ],
+                    "title": "Median Married Couple Family Household Income in Counties of United States (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Median_Income_Household_MarriedCoupleFamilyHousehold"
+                    ],
+                    "title": "Median Married Couple Family Household Income in Counties of United States (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Median Married Couple Family Household Income in Counties of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "scatterTileSpec": {
+                      "highlightTopRight": true
+                    },
+                    "statVarKey": [
+                      "Median_Income_Household_NonfamilyHousehold_scatter",
+                      "Percent_Person_WithDiabetes_scatter"
+                    ],
+                    "title": "Nonfamily Household Median Income (${yDate}) Vs. Diabetes (${xDate}) in Counties of United States",
+                    "type": "SCATTER"
+                  }
+                ]
+              }
+            ],
+            "title": "Nonfamily Household Median Income vs. Diabetes"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "Median_Income_Household_NonfamilyHousehold"
+                    ],
+                    "title": "Nonfamily Household Median Income in Counties of United States (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Median_Income_Household_NonfamilyHousehold"
+                    ],
+                    "title": "Nonfamily Household Median Income in Counties of United States (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Nonfamily Household Median Income in Counties of United States"
           }
         ],
         "statVarSpec": {
@@ -92,10 +347,55 @@
             "name": "Average Income for Households",
             "statVar": "Mean_Income_Household"
           },
+          "Mean_Income_Household_FamilyHousehold": {
+            "name": "Average Income for Family Households",
+            "statVar": "Mean_Income_Household_FamilyHousehold"
+          },
+          "Mean_Income_Household_FamilyHousehold_scatter": {
+            "name": "Average Income for Family Households",
+            "noPerCapita": true,
+            "statVar": "Mean_Income_Household_FamilyHousehold"
+          },
           "Mean_Income_Household_scatter": {
             "name": "Average Income for Households",
             "noPerCapita": true,
             "statVar": "Mean_Income_Household"
+          },
+          "Median_Income_Household": {
+            "name": "Household Median Income",
+            "statVar": "Median_Income_Household"
+          },
+          "Median_Income_Household_FamilyHousehold": {
+            "name": "Median Family Household Income",
+            "statVar": "Median_Income_Household_FamilyHousehold"
+          },
+          "Median_Income_Household_FamilyHousehold_scatter": {
+            "name": "Median Family Household Income",
+            "noPerCapita": true,
+            "statVar": "Median_Income_Household_FamilyHousehold"
+          },
+          "Median_Income_Household_MarriedCoupleFamilyHousehold": {
+            "name": "Median Married Couple Family Household Income",
+            "statVar": "Median_Income_Household_MarriedCoupleFamilyHousehold"
+          },
+          "Median_Income_Household_MarriedCoupleFamilyHousehold_scatter": {
+            "name": "Median Married Couple Family Household Income",
+            "noPerCapita": true,
+            "statVar": "Median_Income_Household_MarriedCoupleFamilyHousehold"
+          },
+          "Median_Income_Household_NonfamilyHousehold": {
+            "name": "Nonfamily Household Median Income",
+            "statVar": "Median_Income_Household_NonfamilyHousehold"
+          },
+          "Median_Income_Household_NonfamilyHousehold_scatter": {
+            "name": "Nonfamily Household Median Income",
+            "noPerCapita": true,
+            "statVar": "Median_Income_Household_NonfamilyHousehold"
+          },
+          "Median_Income_Household_scatter": {
+            "name": "Household Median Income",
+            "noPerCapita": true,
+            "statVar": "Median_Income_Household"
           },
           "Percent_Person_WithDiabetes": {
             "name": "Diabetes",
@@ -500,6 +800,12 @@
           "Mean_Income_Household_FamilyHousehold",
           "Mean_Income_Household_MarriedCoupleFamilyHousehold",
           "Mean_Income_Household_NonfamilyHousehold"
+        ]
+      },
+      "Median_Income_Household": {
+        "benefitsStatus": [
+          "Median_Income_Household_WithFoodStampsInThePast12Months",
+          "Median_Income_Household_WithoutFoodStampsInThePast12Months"
         ]
       }
     },

--- a/server/integration_tests/test_data/e2e_us_demo/howdoobesityratescomparewithratesofdiabetesinusacounties/chart_config.json
+++ b/server/integration_tests/test_data/e2e_us_demo/howdoobesityratescomparewithratesofdiabetesinusacounties/chart_config.json
@@ -85,6 +85,23 @@
               }
             ],
             "title": "Diabetes in Counties of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NCD_BMI_30A",
+                      "Percent_Person_WithDiabetes"
+                    ],
+                    "title": "% Obesity Among Adults, BMI >= 30 and Diabetes in United States",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "title": "% Obesity Among Adults, BMI >= 30 and Diabetes"
           }
         ],
         "statVarSpec": {
@@ -109,6 +126,10 @@
             "noPerCapita": true,
             "statVar": "Percent_Person_WithDiabetes",
             "unit": "%"
+          },
+          "WHO/NCD_BMI_30A": {
+            "name": "% Obesity Among Adults, BMI >= 30",
+            "statVar": "WHO/NCD_BMI_30A"
           }
         }
       }

--- a/server/integration_tests/test_data/explore_strict_multi_var/chart_config.json
+++ b/server/integration_tests/test_data/explore_strict_multi_var/chart_config.json
@@ -85,6 +85,23 @@
               }
             ],
             "title": "Percentage That Sleeps Less Than 7 Hours Per Night in Counties of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/NCD_BMI_30A",
+                      "Percent_Person_SleepLessThan7Hours"
+                    ],
+                    "title": "% Obesity Among Adults, BMI >= 30 and Percentage That Sleeps Less Than 7 Hours Per Night in United States",
+                    "type": "LINE"
+                  }
+                ]
+              }
+            ],
+            "title": "% Obesity Among Adults, BMI >= 30 and Percentage That Sleeps Less Than 7 Hours Per Night"
           }
         ],
         "statVarSpec": {
@@ -109,6 +126,10 @@
             "noPerCapita": true,
             "statVar": "Percent_Person_SleepLessThan7Hours",
             "unit": "%"
+          },
+          "WHO/NCD_BMI_30A": {
+            "name": "% Obesity Among Adults, BMI >= 30",
+            "statVar": "WHO/NCD_BMI_30A"
           }
         }
       }

--- a/server/integration_tests/test_data/international/query_2/chart_config.json
+++ b/server/integration_tests/test_data/international/query_2/chart_config.json
@@ -361,34 +361,6 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "WHO/MORT_MATERNALNUM"
-                    ],
-                    "title": "Number of Maternal Deaths in China",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Number of Maternal Deaths in China",
-                    "statVarKey": [
-                      "WHO/MORT_MATERNALNUM"
-                    ],
-                    "title": "Number of Maternal Deaths in China",
-                    "type": "HIGHLIGHT"
-                  }
-                ]
-              }
-            ],
-            "title": "Number of Maternal Deaths"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
                       "sdg/SH_STA_MORT.SEX--F"
                     ],
                     "title": "Maternal Mortality Ratio in China",
@@ -411,6 +383,34 @@
             ],
             "footnote": "Includes data from the following sources: estimates by WHO, UNICEF, UNFPA, world bank group and UNDESA/Population division. Geneva: world health organization; 2023.",
             "title": "Maternal Mortality Ratio"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/MORT_MATERNALNUM"
+                    ],
+                    "title": "Number of Maternal Deaths in China",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Number of Maternal Deaths in China",
+                    "statVarKey": [
+                      "WHO/MORT_MATERNALNUM"
+                    ],
+                    "title": "Number of Maternal Deaths in China",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "title": "Number of Maternal Deaths"
           },
           {
             "columns": [

--- a/server/integration_tests/test_data/sdg/query_3/chart_config.json
+++ b/server/integration_tests/test_data/sdg/query_3/chart_config.json
@@ -395,37 +395,6 @@
                 "tiles": [
                   {
                     "statVarKey": [
-                      "WHO/MORT_MATERNALNUM"
-                    ],
-                    "title": "Number of Maternal Deaths in the World (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "WHO/MORT_MATERNALNUM"
-                    ],
-                    "title": "Number of Maternal Deaths in the World (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "title": "Number of Maternal Deaths in the World"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
                       "sdg/SH_STA_MORT.SEX--F"
                     ],
                     "title": "Maternal Mortality Ratio in the World",
@@ -480,6 +449,37 @@
             ],
             "footnote": "Includes data from the following sources: estimates by WHO, UNICEF, UNFPA, world bank group and UNDESA/Population division. Geneva: world health organization; 2023.",
             "title": "Maternal Mortality Ratio in the World"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "WHO/MORT_MATERNALNUM"
+                    ],
+                    "title": "Number of Maternal Deaths in the World (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "WHO/MORT_MATERNALNUM"
+                    ],
+                    "title": "Number of Maternal Deaths in the World (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "title": "Number of Maternal Deaths in the World"
           },
           {
             "columns": [

--- a/server/tests/lib/subject_page_config_content_test.py
+++ b/server/tests/lib/subject_page_config_content_test.py
@@ -32,6 +32,8 @@ BLOCK_TYPE_ALLOWED_TILES = {
         TileType.PLACE_OVERVIEW: "",
         TileType.GAUGE: "",
         TileType.DONUT: "",
+        TileType.ANSWER_MESSAGE: "",
+        TileType.ANSWER_TABLE: "",
     },
     BlockType.DISASTER_EVENT: {
         TileType.DISASTER_EVENT_MAP: "",


### PR DESCRIPTION
In multi-var fulfillment, when we have pairs of SVs like:  `([LHS1], [RHS1, RHS2, RHS3, RHS4])`, previously, RHS2-4 go unused.  In the case of [poverty vs. literacy rate], the topic on the RHS got pushed down with the recent model changes, and this bug gets triggered.

This PR fills the empties with the first topic/SV on the shorter side, so that every var on the longer side is considered.  This may still not be ideal, and the other extreme is to do a full-cross, but that might lead to a lot more candidates.

Testing:  notice that this change restores the scatter diff in server/integration_tests/test_data/e2e_india_demo/howdoesliteracyratecomparetopovertyinindia/chart_config.json

![image](https://github.com/datacommonsorg/website/assets/4375037/5d701e08-6ac3-4bd7-bc88-71f4aab695aa)
