### PR TITLE
Speed up NL cloudbuild even more

### DIFF
--- a/build/ci/cloudbuild.nl.yaml
+++ b/build/ci/cloudbuild.nl.yaml
@@ -23,7 +23,7 @@ steps:
       - |
         ./run_test.sh --setup_python
 
-  - id: explore_test_detection_fulfillment
+  - id: explore_test_detection
     name: python:3.11.3
     entrypoint: /bin/sh
     waitFor:
@@ -31,7 +31,17 @@ steps:
     args:
       - -c
       - |
-        ./run_test.sh --explore -k 'ExploreTestDetectionFulfillment'
+        ./run_test.sh --explore -k 'ExploreTestDetection'
+
+  - id: explore_test_fulfillment
+    name: python:3.11.3
+    entrypoint: /bin/sh
+    waitFor:
+      - setup_python
+    args:
+      - -c
+      - |
+        ./run_test.sh --explore -k 'ExploreTestFulfillment'
 
   - id: explore_test_e2e_1
     name: python:3.11.3
@@ -53,7 +63,7 @@ steps:
       - |
         ./run_test.sh --explore -k 'ExploreTestEE2'
 
-  - id: nl_test
+  - id: nl_test_demo
     name: python:3.11.3
     entrypoint: /bin/sh
     waitFor:
@@ -61,6 +71,17 @@ steps:
     args:
       - -c
       - |
-        ./run_test.sh --nl
+        ./run_test.sh --nl -k 'NLTestDemo'
+
+  - id: nl_test_misc
+    name: python:3.11.3
+    entrypoint: /bin/sh
+    waitFor:
+      - setup_python
+    args:
+      - -c
+      - |
+        ./run_test.sh --nl -k 'NLTestMisc'
+
 options:
   machineType: "E2_HIGHCPU_32"

--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -259,7 +259,7 @@ class ExploreTest(NLWebServerTestCase):
     self.assertTrue(success, f"wanted: {i18n_lang}, got {detected}")
 
 
-class ExploreTestDetectionFulfillment(ExploreTest):
+class ExploreTestDetection(ExploreTest):
 
   def test_detection_basic(self):
     self.run_detection('detection_api_basic', ['Commute in California'],
@@ -368,6 +368,9 @@ class ExploreTestDetectionFulfillment(ExploreTest):
   #       ],
   #       check_detection=True,
   #       reranker='cross-encoder-mxbai-rerank-base-v1')
+
+
+class ExploreTestFulfillment(ExploreTest):
 
   def test_fulfillment_basic(self):
     req = {


### PR DESCRIPTION
Previous test split reduces the time from ~10m to ~6m. This tries to split the 2 most long running test. The whole run should then be around 4-5min.

![image](https://github.com/datacommonsorg/website/assets/5951856/92704862-0464-41eb-9891-f70bf70f3d8b)

