### PR TITLE
Update variable count on homepage

### DIFF
--- a/server/templates/static/homepage.html
+++ b/server/templates/static/homepage.html
@@ -74,7 +74,7 @@
       </article>
       <article>
         <p>
-          Over 240B data points across 450k variables from the
+          Over 240B data points across 260k variables from the
           <a href="https://www.who.int/" target="_blank">World Health
           Organization</a>, <a href="https://www.cdc.gov/index.htm"
           target="_blank">Centers for Disease Control and Prevention</a>, <a


### PR DESCRIPTION
Updates the stat var count on our homepage from 450k to 260k. The original 450k included some biomedical stat vars that are not yet accessible to the public.

Before:
![image](https://github.com/datacommonsorg/website/assets/4034366/7c7fe11d-91be-49f3-8d32-f0ae8349deff)


After:
![image](https://github.com/datacommonsorg/website/assets/4034366/b044c8b7-b67d-439b-93f7-61ec85c16de3)
