### PR TITLE
[NL EVAL] Improve dc vs llm stats highlight

### DIFF
--- a/static/css/eval_rig.scss
+++ b/static/css/eval_rig.scss
@@ -126,12 +126,17 @@ label {
   }
 }
 
-.annotation {
-  background-color: lightyellow;
+.dc-stat {
+  background-color: lightblue;
+}
+
+.llm-stat {
+  background-color: lightsalmon;
 }
 
 .annotation.highlight {
-  background-color: yellow;
+  font-size: 22px;
+  font-weight: 500;
 }
 
 #page-screen {

--- a/static/js/apps/eval_rig/query_section.tsx
+++ b/static/js/apps/eval_rig/query_section.tsx
@@ -23,6 +23,7 @@ import rehypeRaw from "rehype-raw";
 import { ANSWER_COL, QA_SHEET } from "./constants";
 import { AppContext, SessionContext } from "./context";
 import { EvalSection } from "./eval_section";
+import { processText } from "./util";
 
 export function QuerySection(): JSX.Element {
   const { allQuery, doc } = useContext(AppContext);
@@ -55,7 +56,7 @@ export function QuerySection(): JSX.Element {
       newHighlighted.classList.add("highlight");
       prevHighlightedRef.current = newHighlighted;
     }
-  }, [sessionCallId]);
+  }, [answer, sessionCallId]);
 
   useEffect(() => {
     loadAnswer(doc, allQuery[sessionQueryId].row);
@@ -80,15 +81,3 @@ export function QuerySection(): JSX.Element {
     </div>
   );
 }
-
-/**
- * Replace [__DC__#(id)(text)] to just text with css class for highlighting.
- * @param text
- * @returns
- */
-const processText = (text: string): string => {
-  return text.replace(
-    /\[\s*__DC__#(\d+)\(([^)]+)\)\s*\]/g,
-    '<span class="annotation annotation-$1">$2</span>'
-  );
-};

--- a/static/js/apps/eval_rig/util.test.ts
+++ b/static/js/apps/eval_rig/util.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { processText } from "./util";
+
+test("processText", () => {
+  const testCases = {
+    "Median household income:** [__DC__#1(116068 USD [1]* || $98,588)]":
+      'Median household income:** <span class="annotation annotation-1"><span class="dc-stat">116068 USD [1]* </span>||<span class="llm-stat"> $98,588</span></span>',
+    "Average household income:** [__DC__#2(128184 Infl. adj. USD (CY) [2]* || $108,748)]":
+      'Average household income:** <span class="annotation annotation-2"><span class="dc-stat">128184 Infl. adj. USD (CY) [2]* </span>||<span class="llm-stat"> $108,748</span></span>',
+  };
+  for (const text in testCases) {
+    expect(processText(text)).toEqual(testCases[text]);
+  }
+});

--- a/static/js/apps/eval_rig/util.ts
+++ b/static/js/apps/eval_rig/util.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Replace [__DC__#(id)(text)] to just text with css class for highlighting.
+ * @param text
+ * @returns
+ */
+export const processText = (text: string): string => {
+  return text.replace(
+    /\[\s*__DC__#(\d+)\(((?:[^)(]+|\([^)]*\))*)\)\s*\]/g,
+    (match, p1, p2) => {
+      // Split the second capturing group by "||"
+      const parts = p2.split("||");
+      let dcStat: string;
+      let llmStat: string;
+      if (parts.length === 2) {
+        dcStat = parts[0];
+        llmStat = parts[1];
+      } else {
+        llmStat = parts[0];
+      }
+      let innerHtml = "";
+      innerHtml += `<span class="dc-stat">${dcStat || " "}</span>||`;
+      innerHtml += `<span class="llm-stat">${llmStat || " "}</span>`;
+      return `<span class="annotation annotation-${p1}">${innerHtml}</span>`;
+    }
+  );
+};


### PR DESCRIPTION
Also fixed 2 bugs for regex parsing and highlight.

![image](https://github.com/datacommonsorg/website/assets/5951856/b79e5679-3d11-498b-a930-327b1a283079)
