### PR TITLE
Do not check nl server registry with prediction call on app creation

### DIFF
--- a/nl_server/flask.py
+++ b/nl_server/flask.py
@@ -57,16 +57,6 @@ def create_app():
     # Build the registry before creating the Flask app to make sure all resources
     # are loaded.
     reg = registry.build()
-
-    # Below is a safe check to ensure that the model and embedding is loaded.
-    server_config = reg.server_config()
-    idx_type = server_config.default_indexes[0]
-    embeddings = reg.get_index(idx_type)
-    query = server_config.indexes[idx_type].healthcheck_query
-    result = search.search_vars([embeddings], [query]).get(query)
-    if not result or not result.svs:
-      raise Exception(f'Registry does not have default index {idx_type}')
-
     app = Flask(__name__)
     app.register_blueprint(routes.bp)
     app.config[registry.REGISTRY_KEY] = reg


### PR DESCRIPTION
The prediction call right after the registry constructor consistently throws out error during integration test. This can be found from locally as well.

It's not clear why this happens and this brings up a lot of flakiness during test.

```
ERROR    nl_server.flask:app.py:1414 Exception on /api/search_vars/ [POST]
Traceback (most recent call last):
  File "/workspace/.env/lib/python3.11/site-packages/google/api_core/grpc_helpers.py", line 76, in error_remapped_callable
    return callable_(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.env/lib/python3.11/site-packages/grpc/_channel.py", line 1181, in __call__
    return _end_unary_response_blocking(state, call, False, None)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.env/lib/python3.11/site-packages/grpc/_channel.py", line 1006, in _end_unary_response_blocking
    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "Socket operation on non-socket"
	debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"Socket operation on non-socket", grpc_status:14, created_time:"2024-06-04T22:44:25.944550602+00:00"}"
>
```