### PR TITLE
Update country count on homepage

### DIFF
--- a/server/templates/static/homepage.html
+++ b/server/templates/static/homepage.html
@@ -67,7 +67,7 @@
       <article>
         <h4>Data from</h4>
         <ul>
-          <li>193 countries
+          <li>195 countries
           <li> 110,000 cities
           <li>5,000 states and provinces
         </ul>

--- a/server/templates/static/homepage.html
+++ b/server/templates/static/homepage.html
@@ -67,7 +67,7 @@
       <article>
         <h4>Data from</h4>
         <ul>
-          <li>256 countries
+          <li>193 countries
           <li> 110,000 cities
           <li>5,000 states and provinces
         </ul>

--- a/server/templates/static/homepage.html
+++ b/server/templates/static/homepage.html
@@ -67,7 +67,7 @@
       <article>
         <h4>Data from</h4>
         <ul>
-          <li>195 countries
+          <li>193 countries
           <li> 110,000 cities
           <li>5,000 states and provinces
         </ul>


### PR DESCRIPTION
Updates the country count on our homepage from 256 to 193.

The original 256 comes from the fact that our KG includes data on disputed regions like the [Republic of Artsakh](https://en.wikipedia.org/wiki/Republic_of_Artsakh) ([dcid: wikidataId/Q244165](https://datacommons.org/place/wikidataId/Q244165)) or [Hong Kong](https://en.wikipedia.org/wiki/Hong_Kong) ([dcid: country/HKG](https://datacommons.org/place/country/HKG)).

This same issue is mentioned in https://github.com/datacommonsorg/docsite/issues/380 and https://github.com/datacommonsorg/website/pull/3921