### PR TITLE
Try to fix webdriver tests flakiness

### DIFF
--- a/build/ci/cloudbuild.screenshot.yaml
+++ b/build/ci/cloudbuild.screenshot.yaml
@@ -27,7 +27,7 @@ steps:
 
   # Run the screenshot tests
   - id: screenshot_test
-    name: gcr.io/datcom-ci/webdriver-chrome:2023-12-11
+    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
     entrypoint: /bin/bash
     waitFor:
       - package_js

--- a/build/ci/cloudbuild.sdg_sanity.yaml
+++ b/build/ci/cloudbuild.sdg_sanity.yaml
@@ -14,7 +14,7 @@
 
 steps:
   - id: sdg_sanity
-    name: gcr.io/datcom-ci/webdriver-chrome:2023-12-11
+    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
     entrypoint: /bin/bash
     args:
       - -c

--- a/build/ci/cloudbuild.webdriver.yaml
+++ b/build/ci/cloudbuild.webdriver.yaml
@@ -33,7 +33,7 @@ steps:
 
   # Run the webdriver tests
   - id: flask_webdriver_test
-    name: gcr.io/datcom-ci/webdriver-chrome:2023-12-11
+    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
     entrypoint: /bin/sh
     waitFor:
       - package_js

--- a/build/ci/cloudbuild.website_testing.yaml
+++ b/build/ci/cloudbuild.website_testing.yaml
@@ -24,7 +24,7 @@ steps:
 
   # Run Website screenshot
   - id: screenshot
-    name: gcr.io/datcom-ci/webdriver-chrome:2023-12-11
+    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
     entrypoint: /bin/bash
     args:
       - -c
@@ -36,7 +36,7 @@ steps:
 
   # Run Website sanity
   - id: website_sanity
-    name: gcr.io/datcom-ci/webdriver-chrome:2023-12-11
+    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
     entrypoint: /bin/bash
     args:
       - -c
@@ -48,7 +48,7 @@ steps:
 
   # Run Website adversarial
   - id: website_adversarial
-    name: gcr.io/datcom-ci/webdriver-chrome:2023-12-11
+    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
     entrypoint: /bin/bash
     args:
       - -c

--- a/build/webdriver-chrome/Dockerfile
+++ b/build/webdriver-chrome/Dockerfile
@@ -36,7 +36,7 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyri
 RUN apt-get update -y && apt-get install -y google-cloud-sdk
 
 # Install ChromeDriver.
-RUN wget -O /tmp/chromedriver.zip https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/`curl -sS https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE`/linux64/chromedriver-linux64.zip
+RUN wget -O /tmp/chromedriver.zip https://storage.googleapis.com/chrome-for-testing-public/`curl -sS https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE`/linux64/chromedriver-linux64.zip
 RUN unzip /tmp/chromedriver.zip -d /tmp/
 RUN cp /tmp/chromedriver-linux64/chromedriver /usr/bin/
 RUN chown root:root /usr/bin/chromedriver

--- a/build/webdriver-chrome/cloudbuild.yaml
+++ b/build/webdriver-chrome/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 # Version can be found at: https://chromedriver.storage.googleapis.com/LATEST_RELEASE
 substitutions:
-  _VERS: "2023-12-11"
+  _VERS: "2024-06-05"
 
 steps:
   - name: "gcr.io/cloud-builders/docker"

--- a/build/website_cron_testing/Dockerfile
+++ b/build/website_cron_testing/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/datcom-ci/webdriver-chrome:2023-12-11
+FROM gcr.io/datcom-ci/webdriver-chrome:2024-06-05
 
 WORKDIR /resources
 

--- a/nl_server/flask.py
+++ b/nl_server/flask.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import os
 import sys
 
 from flask import Flask
@@ -23,17 +22,13 @@ import torch
 from nl_server import registry
 from nl_server import routes
 from nl_server import search
-import shared.lib.gcp as lib_gcp
-from shared.lib.utils import is_debug_mode
-
-
-def _not_test() -> bool:
-  return os.environ.get('FLASK_ENV') != 'integration_test'
+from shared.lib import gcp as lib_gcp
+from shared.lib import utils as lib_utils
 
 
 def create_app():
 
-  if lib_gcp.in_google_network() and _not_test():
+  if lib_gcp.in_google_network() and not lib_utils.is_test_env():
     client = google.cloud.logging.Client()
     client.setup_logging()
   else:
@@ -45,7 +40,7 @@ def create_app():
     )
 
   log_level = logging.WARNING
-  if is_debug_mode():
+  if lib_utils.is_debug_mode():
     log_level = logging.INFO
   logging.getLogger('werkzeug').setLevel(log_level)
 
@@ -58,7 +53,7 @@ def create_app():
     # are loaded.
     reg = registry.build()
 
-    if _not_test():
+    if not lib_utils.is_test_env():
       # Below is a safe check to ensure that the model and embedding is loaded.
       server_config = reg.server_config()
       idx_type = server_config.default_indexes[0]

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -37,8 +37,8 @@ import server.lib.util as libutil
 import server.services.bigtable as bt
 from server.services.discovery import configure_endpoints_from_ingress
 from server.services.discovery import get_health_check_urls
-import shared.lib.gcp as lib_gcp
-from shared.lib.utils import is_debug_mode
+from shared.lib import gcp as lib_gcp
+from shared.lib import utils as lib_utils
 
 BLOCKLIST_SVG_FILE = "/datacommons/svg/blocklist_svg.json"
 
@@ -238,7 +238,7 @@ def create_app(nl_root=DEFAULT_NL_ROOT):
 
   cfg = lib_config.get_config()
 
-  if lib_gcp.in_google_network():
+  if lib_gcp.in_google_network() and not lib_utils.is_test_env():
     client = google.cloud.logging.Client()
     client.setup_logging()
   else:
@@ -250,7 +250,7 @@ def create_app(nl_root=DEFAULT_NL_ROOT):
     )
 
   log_level = logging.WARNING
-  if is_debug_mode():
+  if lib_utils.is_debug_mode():
     log_level = logging.INFO
   logging.getLogger('werkzeug').setLevel(log_level)
 

--- a/server/webdriver/tests/map_test.py
+++ b/server/webdriver/tests/map_test.py
@@ -31,7 +31,6 @@ PLACE_SEARCH_CA = 'California'
 # Class to test map tool.
 class TestMap(WebdriverBaseTest):
 
-  @pytest.mark.skip(reason="fix this flakey test later")
   def test_server_and_page(self):
     """Test the server can run successfully."""
     TITLE_TEXT = "Map Explorer - Data Commons"
@@ -119,7 +118,6 @@ class TestMap(WebdriverBaseTest):
                   self.TIMEOUT_SEC).until(EC.title_contains(NEW_PAGE_TITLE))
     self.assertEqual(NEW_PAGE_TITLE, self.driver.title)
 
-  @pytest.mark.skip(reason="fix this flakey test later")
   def test_manually_enter_options(self):
     """Test entering place and stat var options manually will cause chart to
     show up.

--- a/shared/lib/utils.py
+++ b/shared/lib/utils.py
@@ -146,3 +146,8 @@ def escape_strings(data):
     # Otherwise, assume data is of a type that doesn't need escaping and just
     # return it as is.
     return data
+
+
+def is_test_env() -> bool:
+  env = os.environ.get('FLASK_ENV', '')
+  return env in ['integration_test', 'test', 'webdriver']

--- a/web_app.py
+++ b/web_app.py
@@ -11,47 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Main entry module specified in app.yaml.
-
-This module contains the request handler codes and the main app.
+"""Main entry for website Flask app.
 """
 
 import logging
 import sys
-import threading
-import time
-
-import requests
 
 from server.__init__ import create_app
 
 app = create_app()
-
-WARM_UP_ENDPOINTS = [
-    "/api/choropleth/geojson?placeDcid=country/USA&placeType=County",
-    "/api/choropleth/geojson?placeDcid=Earth&placeType=Country",
-    "/api/place/parent?dcid=country/USA",
-    "/api/place/descendent/name?dcid=country/USA&descendentType=County",
-]
-
-
-def send_warmup_requests():
-  for endpoint in WARM_UP_ENDPOINTS:
-    # Rery 10 times before giving up, with 5 second intervals
-    for _ in range(10):
-      try:
-        logging.info("Sending warm up requests: %s", endpoint)
-        resp = requests.get("http://127.0.0.1:8080" + endpoint)
-        if resp.status_code == 200:
-          break
-      except Exception as e:
-        logging.error(e)
-      time.sleep(5)
-
-
-if not (app.config["TEST"] or app.config["WEBDRIVER"] or app.config["LOCAL"]):
-  thread = threading.Thread(target=send_warmup_requests)
-  thread.start()
 
 if __name__ == '__main__':
   # This is used when running locally only. When deploying to GKE,


### PR DESCRIPTION
A few things changed here:

* Build a new webdriver docker image with newer chrome webdriver also new linux patches.
* Do not use cloud logging for webdriver tests.
* Remove the warmup requests since they are very limited, never updated and do no contribute much. They incur extra threading in flask.
* Add back skipped webdriver tests.