### PR TITLE
[rig eval] make feedback buttons always visible

### DIFF
--- a/static/css/eval_rig.scss
+++ b/static/css/eval_rig.scss
@@ -27,6 +27,13 @@ footer {
 
 #dc-eval-rig {
   padding: 20px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.sign-in {
+  width: fit-content;
 }
 
 #query-section {
@@ -42,11 +49,12 @@ label {
 
 .app-content {
   display: flex;
+  flex-grow: 1;
+  overflow: auto;
 }
 
 #query-section {
   width: 50%;
-  height: 800px;
   padding: 16px;
   overflow: auto; /* This allows the div to scroll */
 
@@ -131,6 +139,7 @@ label {
     gap: 16px;
     padding: 16px 24px;
     flex-grow: 1;
+    overflow: auto;
 
     .question-section .title {
       font-size: 11px;

--- a/static/js/apps/eval_rig/app.tsx
+++ b/static/js/apps/eval_rig/app.tsx
@@ -159,16 +159,19 @@ export function App(props: AppPropType): JSX.Element {
   }
 
   return (
-    <div>
+    <>
       {!user && (
+        <div className="sign-in">
         <GoogleSignIn
           onSignIn={handleUserSignIn}
           scopes={["https://www.googleapis.com/auth/spreadsheets"]}
         />
+
+        </div>
       )}
 
       {user && (
-        <div>
+        <>
           <a
             href={`https://docs.google.com/spreadsheets/d/${props.sheetId}`}
             target="_blank"
@@ -199,8 +202,8 @@ export function App(props: AppPropType): JSX.Element {
               </div>
             </AppContext.Provider>
           )}
-        </div>
+        </>
       )}
-    </div>
+    </>
   );
 }

--- a/static/js/apps/eval_rig/app.tsx
+++ b/static/js/apps/eval_rig/app.tsx
@@ -162,11 +162,10 @@ export function App(props: AppPropType): JSX.Element {
     <>
       {!user && (
         <div className="sign-in">
-        <GoogleSignIn
-          onSignIn={handleUserSignIn}
-          scopes={["https://www.googleapis.com/auth/spreadsheets"]}
-        />
-
+          <GoogleSignIn
+            onSignIn={handleUserSignIn}
+            scopes={["https://www.googleapis.com/auth/spreadsheets"]}
+          />
         </div>
       )}
 


### PR DESCRIPTION
Currently, for certain window sizes, the navigation buttons will be hidden, updated so that the navigation buttons are always visible

https://github.com/datacommonsorg/website/assets/69875368/ed89719d-50dd-40e6-9ca9-5e278752740a

