### PR TITLE
[NL param] Use a list of index types everywhere

### DIFF
--- a/server/lib/nl/detection/llm_detector.py
+++ b/server/lib/nl/detection/llm_detector.py
@@ -149,7 +149,7 @@ def detect(query: str, prev_utterance: utterance.Utterance,
 
   query_detection_debug_logs["llm_response"] = llm_resp
   query_detection_debug_logs["query_transformations"] = {
-      "sv_detection_query_index_types": [dargs.embeddings_index_types]
+      "sv_detection_query_index_types": dargs.embeddings_index_types
   }
 
   # SV Detection.

--- a/server/lib/nl/detection/llm_detector.py
+++ b/server/lib/nl/detection/llm_detector.py
@@ -149,7 +149,7 @@ def detect(query: str, prev_utterance: utterance.Utterance,
 
   query_detection_debug_logs["llm_response"] = llm_resp
   query_detection_debug_logs["query_transformations"] = {
-      "sv_detection_query_index_types": [dargs.embeddings_index_type]
+      "sv_detection_query_index_types": [dargs.embeddings_index_types]
   }
 
   # SV Detection.

--- a/server/lib/nl/detection/types.py
+++ b/server/lib/nl/detection/types.py
@@ -433,8 +433,8 @@ class Detection:
 
 @dataclass
 class DetectionArgs:
-  # Name of the embeddings index type to override ENV default
-  embeddings_index_type: str
+  # Name of the embeddings index types to override ENV default
+  embeddings_index_types: List[str]
   # Query mode. e.g., `strict`, `toolformer_rig`, `toolformer_rag`
   mode: str
   # Reranker model name

--- a/server/lib/nl/detection/variable.py
+++ b/server/lib/nl/detection/variable.py
@@ -78,7 +78,7 @@ def detect_vars(orig_query: str, debug_logs: Dict,
   #
   # Make API call to the NL models/embeddings server.
   skip_topics = dargs.mode == params.QueryMode.TOOLFORMER_RIG
-  resp = dc.nl_search_vars(all_queries, dargs.embeddings_index_type,
+  resp = dc.nl_search_vars(all_queries, dargs.embeddings_index_types,
                            skip_topics, dargs.reranker)
   query2results = {
       q: vars.dict_to_var_candidates(r) for q, r in resp['queryResults'].items()

--- a/server/lib/nl/explore/params.py
+++ b/server/lib/nl/explore/params.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Dict
+from typing import Dict, List
 
 from server.lib.nl.detection.types import DetectionArgs
 from shared.lib import constants
@@ -124,18 +124,18 @@ def is_bio(insight_ctx: Dict) -> bool:
   return insight_ctx.get(Params.DC.value) == DCNames.BIO_DC.value
 
 
-def dc_to_embedding_type(dc: str, embeddings_type: str) -> str:
+def dc_to_embedding_types(dc: str, embeddings_types: List[str]) -> str:
   if dc in SDG_DC_LIST:
-    return 'sdg_ft'
+    return ['sdg_ft']
   elif dc == DCNames.UNDATA_DC.value:
-    return 'undata_ft'
+    return ['undata_ft']
   elif dc == DCNames.UNDATA_ILO_DC.value:
-    return 'undata_ilo_ft'
+    return ['undata_ilo_ft']
   elif dc == DCNames.UNDATA_DEV_DC.value:
-    return 'undata_dev_ft'
+    return ['undata_dev_ft']
   elif dc == DCNames.BIO_DC.value:
-    return 'bio_ft'
-  return embeddings_type
+    return ['bio_ft']
+  return embeddings_types
 
 
 def is_toolformer_mode(mode: QueryMode) -> bool:

--- a/server/lib/nl/explore/params.py
+++ b/server/lib/nl/explore/params.py
@@ -124,7 +124,7 @@ def is_bio(insight_ctx: Dict) -> bool:
   return insight_ctx.get(Params.DC.value) == DCNames.BIO_DC.value
 
 
-def dc_to_embedding_types(dc: str, embeddings_types: List[str]) -> str:
+def dc_to_embedding_types(dc: str, embeddings_types: List[str]) -> List[str]:
   if dc in SDG_DC_LIST:
     return ['sdg_ft']
   elif dc == DCNames.UNDATA_DC.value:

--- a/server/routes/explore/helpers.py
+++ b/server/routes/explore/helpers.py
@@ -96,7 +96,8 @@ def parse_query_and_detect(request: Dict, backend: str, client: str,
   i18n = i18n_str and i18n_str.lower() == 'true'
 
   # Index-type default is in nl_server.
-  embeddings_index_type = request.args.get(params.Params.INDEX.value, '')
+  idx_param_str = request.args.get(params.Params.INDEX.value, '')
+  embeddings_index_types = idx_param_str.split(',')
   original_query = request.args.get('q')
   if not original_query:
     err_json = helpers.abort(
@@ -109,7 +110,8 @@ def parse_query_and_detect(request: Dict, backend: str, client: str,
   if request.get_json():
     context_history = request.get_json().get('contextHistory', [])
   dc = request.get_json().get('dc', '')
-  embeddings_index_type = params.dc_to_embedding_type(dc, embeddings_index_type)
+  embeddings_index_types = params.dc_to_embedding_types(dc,
+                                                        embeddings_index_types)
 
   detector_type = request.args.get(params.Params.DETECTOR.value,
                                    default=RequestedDetectorType.Hybrid.value,
@@ -189,7 +191,7 @@ def parse_query_and_detect(request: Dict, backend: str, client: str,
       params.Params.INCLUDE_STOP_WORDS.value, '')
 
   detection_args = DetectionArgs(
-      embeddings_index_type=embeddings_index_type,
+      embeddings_index_types=embeddings_index_types,
       mode=mode,
       reranker=reranker,
       allow_triples=allow_triples,

--- a/server/routes/explore/helpers.py
+++ b/server/routes/explore/helpers.py
@@ -97,7 +97,7 @@ def parse_query_and_detect(request: Dict, backend: str, client: str,
 
   # Index-type default is in nl_server.
   idx_param_str = request.args.get(params.Params.INDEX.value, '')
-  embeddings_index_types = idx_param_str.split(',')
+  embeddings_index_types = [x.strip() for x in idx_param_str.split(',')]
   original_query = request.args.get('q')
   if not original_query:
     err_json = helpers.abort(

--- a/server/routes/nl/api.py
+++ b/server/routes/nl/api.py
@@ -42,9 +42,9 @@ def search_vector():
   """Performs vector search for a given query and embedding index.
   """
   query = request.args.get('query')
-  index = request.args.get('index')
+  idx = request.args.get('idx')
   if not query:
     flask.abort(400, 'Must provde a `query`')
-  if not index:
-    flask.abort(400, 'Must provde an `index`')
-  return dc.nl_search_vars([query], index)
+  if not idx:
+    flask.abort(400, 'Must provde an `idx`')
+  return dc.nl_search_vars([query], idx.split(','))

--- a/server/routes/nl/api.py
+++ b/server/routes/nl/api.py
@@ -44,7 +44,7 @@ def search_vector():
   query = request.args.get('query')
   idx = request.args.get('idx')
   if not query:
-    flask.abort(400, 'Must provde a `query`')
+    flask.abort(400, 'Must provide a `query`')
   if not idx:
-    flask.abort(400, 'Must provde an `idx`')
+    flask.abort(400, 'Must provide an `idx`')
   return dc.nl_search_vars([query], idx.split(','))

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -336,9 +336,13 @@ def resolve(nodes, prop):
   return post(url, {'nodes': nodes, 'property': prop})
 
 
-def nl_search_vars(queries, index_type, skip_topics=False, reranker=''):
+def nl_search_vars(queries,
+                   index_types: List[str],
+                   skip_topics=False,
+                   reranker=''):
   """Search sv from NL server."""
-  url = f'{current_app.config["NL_ROOT"]}/api/search_vars?idx={index_type}'
+  idx_params = ','.join(index_types)
+  url = f'{current_app.config["NL_ROOT"]}/api/search_vars?idx={idx_params}'
   if skip_topics:
     url = f'{url}&skip_topics={skip_topics}'
   if reranker:

--- a/static/js/apps/eval_embeddings/index_score_box.tsx
+++ b/static/js/apps/eval_embeddings/index_score_box.tsx
@@ -190,7 +190,7 @@ export function IndexScoreBox(props: IndexScoreBoxProps): JSX.Element {
 const searchVector = async (sentence: string, indexName: string) => {
   return axios
     .get(`/api/nl/search-vector`, {
-      params: { query: sentence, index: indexName },
+      params: { query: sentence, idx: [indexName] },
       paramsSerializer: stringifyFn,
     })
     .then((resp) => {


### PR DESCRIPTION
NL server now allows a list of indexes. With this change, we don't need to merge index during embedding build time, but rather include them in the runtime.

This allows not replicate the same embeddings in multiple indexes and makes embedding build atomic for each source folder.