### PR TITLE
[rag eval] add concept of feedback stage

### DIFF
--- a/static/js/apps/eval_retrieval_generation/call_feedback.tsx
+++ b/static/js/apps/eval_retrieval_generation/call_feedback.tsx
@@ -234,7 +234,9 @@ export function CallFeedback(): JSX.Element {
                   <div className="title">DATA COMMONS EVALUATION</div>
                   <div className="subtitle">
                     <span>{evalInfo.dcResponse}</span>
-                    <span className="dc-stat">{evalInfo.dcStat}</span>
+                    {evalType === EvalType.RIG && (
+                      <span className="dc-stat">{evalInfo.dcStat}</span>
+                    )}
                   </div>
                   <OneQuestion
                     question={dcResponseQuestion}

--- a/static/js/apps/eval_retrieval_generation/constants.tsx
+++ b/static/js/apps/eval_retrieval_generation/constants.tsx
@@ -42,8 +42,8 @@ export const LLM_STAT_FEEDBACK_COL = LLM_STAT_COL + FB_SUFFIX;
 export const DC_STAT_FEEDBACK_COL = DC_STAT_COL + FB_SUFFIX;
 export const QUERY_OVERALL_FEEDBACK_COL = "overall" + FB_SUFFIX;
 
-// Call Id to use for the query feedback
-export const QUERY_FEEDBACK_CALL_ID = 0;
+// Call Id to use for a new query
+export const NEW_QUERY_CALL_ID = 1;
 // The key used in firestore to save the query overall feedback
 export const QUERY_OVERALL_FEEDBACK_KEY = "overall";
 // Options for the query overall feedback

--- a/static/js/apps/eval_retrieval_generation/context.tsx
+++ b/static/js/apps/eval_retrieval_generation/context.tsx
@@ -17,8 +17,8 @@
 import { GoogleSpreadsheet } from "google-spreadsheet";
 import React, { createContext, useState } from "react";
 
-import { QUERY_FEEDBACK_CALL_ID } from "./constants";
-import { DcCall, EvalType, Query } from "./types";
+import { NEW_QUERY_CALL_ID } from "./constants";
+import { DcCall, EvalType, FeedbackStage, Query } from "./types";
 
 interface AppContextType {
   doc: GoogleSpreadsheet;
@@ -51,15 +51,19 @@ export const AppContext = createContext<AppContextType>({
 interface SessionContextType {
   sessionQueryId: number;
   sessionCallId: number;
+  feedbackStage: FeedbackStage;
   setSessionQueryId: (queryId: number) => void;
   setSessionCallId: (callId: number) => void;
+  setFeedbackStage: (FeedbackStage: FeedbackStage) => void;
 }
 
 export const SessionContext = createContext<SessionContextType>({
   sessionCallId: 1,
   sessionQueryId: null,
+  feedbackStage: null,
   setSessionCallId: () => void {},
   setSessionQueryId: () => void {},
+  setFeedbackStage: () => void {},
 });
 
 export function SessionContextProvider({
@@ -68,14 +72,17 @@ export function SessionContextProvider({
   children: JSX.Element;
 }): JSX.Element {
   const [sessionQueryId, setSessionQueryId] = useState(1);
-  const [sessionCallId, setSessionCallId] = useState(QUERY_FEEDBACK_CALL_ID);
+  const [sessionCallId, setSessionCallId] = useState(NEW_QUERY_CALL_ID);
+  const [feedbackStage, setFeedbackStage] = useState(null);
   return (
     <SessionContext.Provider
       value={{
         sessionQueryId,
         sessionCallId,
+        feedbackStage,
         setSessionQueryId,
         setSessionCallId,
+        setFeedbackStage,
       }}
     >
       {children}

--- a/static/js/apps/eval_retrieval_generation/eval_list.tsx
+++ b/static/js/apps/eval_retrieval_generation/eval_list.tsx
@@ -19,14 +19,17 @@
 import React, { useContext, useState } from "react";
 import { Button, Input, Modal } from "reactstrap";
 
-import { QUERY_FEEDBACK_CALL_ID } from "./constants";
+import { NEW_QUERY_CALL_ID } from "./constants";
 import { AppContext, SessionContext } from "./context";
 import { getCallCount, getField, getPath } from "./data_store";
 import { Query } from "./types";
+import { getFirstFeedbackStage } from "./util";
 
 export function EvalList(): JSX.Element {
-  const { allCall, allQuery, userEmail, sheetId } = useContext(AppContext);
-  const { setSessionCallId, setSessionQueryId } = useContext(SessionContext);
+  const { allCall, allQuery, userEmail, sheetId, evalType } =
+    useContext(AppContext);
+  const { setSessionCallId, setSessionQueryId, setFeedbackStage } =
+    useContext(SessionContext);
 
   const [userEvalsOnly, setUserEvalsOnly] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
@@ -102,9 +105,10 @@ export function EvalList(): JSX.Element {
               <div
                 className={`eval-list-query${completed ? " completed" : ""}`}
                 onClick={() => {
-                  setModalOpen(false);
+                  setFeedbackStage(getFirstFeedbackStage(evalType));
                   setSessionQueryId(query.id);
-                  setSessionCallId(QUERY_FEEDBACK_CALL_ID);
+                  setSessionCallId(NEW_QUERY_CALL_ID);
+                  setModalOpen(false);
                 }}
                 key={query.id}
               >

--- a/static/js/apps/eval_retrieval_generation/feedback_navigation.tsx
+++ b/static/js/apps/eval_retrieval_generation/feedback_navigation.tsx
@@ -20,8 +20,10 @@ import _ from "lodash";
 import React, { useContext } from "react";
 import { Button } from "reactstrap";
 
-import { QUERY_FEEDBACK_CALL_ID } from "./constants";
+import { NEW_QUERY_CALL_ID } from "./constants";
 import { AppContext, SessionContext } from "./context";
+import { EvalType, FeedbackStage } from "./types";
+import { getFirstFeedbackStage } from "./util";
 
 interface FeedbackNavigationPropType {
   checkAndSubmit: () => Promise<boolean>;
@@ -32,9 +34,15 @@ interface FeedbackNavigationPropType {
 export function FeedbackNavigation(
   props: FeedbackNavigationPropType
 ): JSX.Element {
-  const { allQuery, allCall, userEmail } = useContext(AppContext);
-  const { sessionQueryId, setSessionQueryId, sessionCallId, setSessionCallId } =
-    useContext(SessionContext);
+  const { allQuery, allCall, userEmail, evalType } = useContext(AppContext);
+  const {
+    sessionQueryId,
+    setSessionQueryId,
+    sessionCallId,
+    setSessionCallId,
+    feedbackStage,
+    setFeedbackStage,
+  } = useContext(SessionContext);
 
   const userQuery = Object.keys(allQuery)
     .filter(
@@ -62,19 +70,30 @@ export function FeedbackNavigation(
         targetId -= 1;
       }
       setSessionQueryId(targetId);
-      setSessionCallId(QUERY_FEEDBACK_CALL_ID);
+      setFeedbackStage(getFirstFeedbackStage(evalType));
+      setSessionCallId(NEW_QUERY_CALL_ID);
     }
   };
 
   const prev = async () => {
     if (await props.checkAndSubmit()) {
-      setSessionCallId(sessionCallId - 1);
+      if (evalType === EvalType.RIG) {
+        if (sessionCallId === 1) {
+          setFeedbackStage(FeedbackStage.OVERALL);
+        }
+      }
     }
   };
 
   const next = async () => {
     if (await props.checkAndSubmit()) {
-      setSessionCallId(sessionCallId + 1);
+      if (evalType === EvalType.RIG) {
+        if (feedbackStage === FeedbackStage.OVERALL) {
+          setFeedbackStage(FeedbackStage.CALLS);
+        } else {
+          setSessionCallId(sessionCallId + 1);
+        }
+      }
     }
   };
   const nextQuery = async () => {
@@ -84,7 +103,8 @@ export function FeedbackNavigation(
         targetId += 1;
       }
       setSessionQueryId(targetId);
-      setSessionCallId(QUERY_FEEDBACK_CALL_ID);
+      setFeedbackStage(getFirstFeedbackStage(evalType));
+      setSessionCallId(NEW_QUERY_CALL_ID);
     }
   };
 
@@ -95,12 +115,12 @@ export function FeedbackNavigation(
     }
     return (
       sessionQueryId > sortedQueryIds[0] &&
-      sessionCallId === QUERY_FEEDBACK_CALL_ID
+      feedbackStage === FeedbackStage.OVERALL
     );
   };
 
   const showPrev = (): boolean => {
-    return sessionCallId > QUERY_FEEDBACK_CALL_ID;
+    return feedbackStage === FeedbackStage.CALLS;
   };
 
   const showNext = (): boolean => {
@@ -119,7 +139,7 @@ export function FeedbackNavigation(
 
   return (
     <div className="feedback-nav-section">
-      {sessionCallId !== QUERY_FEEDBACK_CALL_ID && (
+      {feedbackStage === FeedbackStage.CALLS && (
         <div className="item-num">
           <span className="highlight">{sessionCallId}</span>
           <span className="regular">/ {numCalls()} ITEMS IN THIS QUERY</span>

--- a/static/js/apps/eval_retrieval_generation/overall_feedback.tsx
+++ b/static/js/apps/eval_retrieval_generation/overall_feedback.tsx
@@ -38,7 +38,7 @@ const RESPONSE_OPTIONS = {
   [QUERY_OVERALL_OPTION_OK]: "No obvious factual inaccuracies",
 };
 
-export function QueryFeedback(): JSX.Element {
+export function OverallFeedback(): JSX.Element {
   const { doc, sheetId, userEmail, allCall, evalType } = useContext(AppContext);
   const { sessionQueryId, sessionCallId } = useContext(SessionContext);
   const [response, setResponse] = useState<string>("");

--- a/static/js/apps/eval_retrieval_generation/query_section.tsx
+++ b/static/js/apps/eval_retrieval_generation/query_section.tsx
@@ -20,13 +20,21 @@ import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 
-import { ANSWER_COL, QA_SHEET } from "./constants";
+import {
+  ANSWER_COL,
+  DC_CALL_SHEET,
+  DC_QUESTION_COL,
+  DC_RESPONSE_COL,
+  QA_SHEET,
+} from "./constants";
 import { AppContext, SessionContext } from "./context";
+import { EvalType, FeedbackStage } from "./types";
 import { processText } from "./util";
 
 export function QuerySection(): JSX.Element {
-  const { allQuery, doc } = useContext(AppContext);
-  const { sessionQueryId, sessionCallId } = useContext(SessionContext);
+  const { allCall, allQuery, doc, evalType } = useContext(AppContext);
+  const { sessionQueryId, sessionCallId, feedbackStage } =
+    useContext(SessionContext);
 
   const [answer, setAnswer] = useState<string>("");
   const prevHighlightedRef = useRef<HTMLSpanElement | null>(null);
@@ -41,10 +49,40 @@ export function QuerySection(): JSX.Element {
     });
   };
 
+  const loadRagCalls = () => {
+    if (!allCall[sessionQueryId]) {
+      setAnswer("");
+      return;
+    }
+    const sheet = doc.sheetsByTitle[DC_CALL_SHEET];
+    const tableIds = Object.keys(allCall[sessionQueryId]).sort(
+      (a, b) => Number(a) - Number(b)
+    );
+    const rowPromises = tableIds.map((tableId) => {
+      const rowIdx = allCall[sessionQueryId][tableId];
+      return sheet.getRows({ offset: rowIdx - 1, limit: 1 });
+    });
+    Promise.all(rowPromises).then((rowsList) => {
+      const answers = [];
+      rowsList.forEach((rows, i) => {
+        const row = rows[0];
+        const rowQ = `**${row.get(DC_QUESTION_COL)}**`;
+        const rowA = `${row.get(DC_RESPONSE_COL)} \xb7 Table ${tableIds[i]}`;
+        answers.push(`${rowQ}\n\n${rowA}`);
+      });
+      setAnswer(answers.join("\n\n"));
+    });
+  };
+
   useEffect(() => {
     // Remove highlight from previous annotation
     if (prevHighlightedRef.current) {
       prevHighlightedRef.current.classList.remove("highlight");
+    }
+
+    // Only highlight calls in call stage
+    if (feedbackStage !== FeedbackStage.CALLS) {
+      return;
     }
 
     // Highlight the new annotation. Note the display index is 1 based.
@@ -58,8 +96,18 @@ export function QuerySection(): JSX.Element {
   }, [answer, sessionCallId]);
 
   useEffect(() => {
-    loadAnswer(doc, allQuery[sessionQueryId].row);
-  }, [doc, allQuery, sessionQueryId]);
+    if (evalType === EvalType.RIG) {
+      loadAnswer(doc, allQuery[sessionQueryId].row);
+    } else {
+      // RAG eval type has different things that should be shown in this section
+      // depending on the feedback stage
+      if (feedbackStage === FeedbackStage.CALLS) {
+        loadRagCalls();
+      } else {
+        loadAnswer(doc, allQuery[sessionQueryId].row);
+      }
+    }
+  }, [doc, allQuery, sessionQueryId, evalType, feedbackStage]);
 
   return (
     <div id="query-section">

--- a/static/js/apps/eval_retrieval_generation/types.tsx
+++ b/static/js/apps/eval_retrieval_generation/types.tsx
@@ -41,3 +41,9 @@ export enum EvalType {
   RIG = "RIG",
   RAG = "RAG",
 }
+
+export enum FeedbackStage {
+  OVERALL = "OVERALL",
+  CALLS = "CALLS",
+  RAG_ANS = "RAG_ANS",
+}

--- a/static/js/apps/eval_retrieval_generation/util.ts
+++ b/static/js/apps/eval_retrieval_generation/util.ts
@@ -16,6 +16,8 @@
 
 import _ from "lodash";
 
+import { EvalType, FeedbackStage } from "./types";
+
 const HTTP_PATTERN = /https:\/\/[^\s]+/g;
 const LONG_SPACES = "&nbsp;&nbsp;&nbsp;&nbsp;";
 const TABLE_DIVIDER_PATTERN = /[--][-]+/g;
@@ -65,4 +67,13 @@ export function processTableText(text: string): string {
   // Replace the table divider that's originally in the text with the one just
   // created
   return text.replace(TABLE_DIVIDER_PATTERN, tableDivider);
+}
+
+// Get the first feedback stage to show for an eval type
+export function getFirstFeedbackStage(evalType: EvalType): FeedbackStage {
+  if (evalType === EvalType.RAG) {
+    return FeedbackStage.CALLS;
+  } else {
+    return FeedbackStage.OVERALL;
+  }
 }


### PR DESCRIPTION
- Add a new FeedbackStage enum to be used when deciding what to display in the query section and feedback sections
- Changes to make RIG eval tool work with this new concept
- only change made for RAG was displaying the rag calls in the query section when feedback stage is the CALLS stage. Actual navigation for RAG will come later