### PR TITLE
[rag eval] add claims counters

### DIFF
--- a/static/js/apps/eval_retrieval_generation/call_feedback.tsx
+++ b/static/js/apps/eval_retrieval_generation/call_feedback.tsx
@@ -23,9 +23,12 @@ import { loadSpinner, removeSpinner } from "../../shared/util";
 import {
   DC_CALL_SHEET,
   DC_QUESTION_COL,
+  DC_QUESTION_FEEDBACK_COL,
   DC_RESPONSE_COL,
+  DC_RESPONSE_FEEDBACK_COL,
   DC_STAT_COL,
   LLM_STAT_COL,
+  LLM_STAT_FEEDBACK_COL,
 } from "./constants";
 import { AppContext, SessionContext } from "./context";
 import { getCallData, saveToSheet, saveToStore } from "./data_store";
@@ -121,6 +124,11 @@ export function CallFeedback(): JSX.Element {
     }
     if (status === FormStatus.Completed) {
       loadSpinner(LOADING_CONTAINER_ID);
+      const sheetValues = {
+        [DC_QUESTION_FEEDBACK_COL]: response.question,
+        [DC_RESPONSE_FEEDBACK_COL]: response.dcResponse,
+        [LLM_STAT_FEEDBACK_COL]: response.llmStat || "",
+      };
       return Promise.all([
         saveToStore(
           userEmail,
@@ -129,7 +137,7 @@ export function CallFeedback(): JSX.Element {
           sessionCallId,
           response
         ),
-        saveToSheet(userEmail, doc, sessionQueryId, sessionCallId, response),
+        saveToSheet(userEmail, doc, sessionQueryId, sessionCallId, sheetValues),
       ])
         .then(() => {
           return true;

--- a/static/js/apps/eval_retrieval_generation/claim_counter.tsx
+++ b/static/js/apps/eval_retrieval_generation/claim_counter.tsx
@@ -20,70 +20,29 @@ import _ from "lodash";
 import React from "react";
 
 interface ClaimCounterPropType {
-  claimsCount: number;
-  setClaimsCount: (count: number) => void;
-  falseClaimsCount: number;
-  setFalseClaimsCount: (count: number) => void;
-  disabled: boolean;
+  count: number;
+  onCountUpdated: (count: number) => void;
+  label: string;
+  disabled?: boolean;
 }
 
 export function ClaimCounter(props: ClaimCounterPropType): JSX.Element {
   return (
-    <div className="block-evaluation question-section">
-      <div className="title">BLOCK EVALUATION</div>
-      <div className="subtitle">
-        Count the number of claims (statistical or logical) made by the model.
-      </div>
-      <div className={`counter${props.disabled ? " disabled" : ""}`}>
-        <div className="claims-count">
-          <button
-            className="btn-count"
-            onClick={() =>
-              props.disabled
-                ? _.noop()
-                : props.setClaimsCount(props.claimsCount - 1)
-            }
-          >
-            -
-          </button>
-          <span className="count-text">{props.claimsCount}</span>
-          <button
-            className="btn-count"
-            onClick={() =>
-              props.disabled
-                ? _.noop()
-                : props.setClaimsCount(props.claimsCount + 1)
-            }
-          >
-            +
-          </button>
-          <p className="claim-text">Number of claims found</p>
-        </div>
-        <div className="false-claims-count">
-          <button
-            className="btn-count"
-            onClick={() =>
-              props.disabled
-                ? _.noop()
-                : props.setFalseClaimsCount(props.falseClaimsCount - 1)
-            }
-          >
-            -
-          </button>
-          <span className="count-text">{props.falseClaimsCount}</span>
-          <button
-            className="btn-count"
-            onClick={() =>
-              props.disabled
-                ? _.noop()
-                : props.setFalseClaimsCount(props.falseClaimsCount + 1)
-            }
-          >
-            +
-          </button>
-          <p className="claim-text">False claims found</p>
-        </div>
-      </div>
+    <div className="claims-count">
+      <button
+        className="btn-count"
+        onClick={() => props.onCountUpdated(props.count - 1)}
+      >
+        -
+      </button>
+      <span className="count-text">{props.count}</span>
+      <button
+        className="btn-count"
+        onClick={() => props.onCountUpdated(props.count + 1)}
+      >
+        +
+      </button>
+      <p className="claim-text">{props.label}</p>
     </div>
   );
 }

--- a/static/js/apps/eval_retrieval_generation/constants.tsx
+++ b/static/js/apps/eval_retrieval_generation/constants.tsx
@@ -46,6 +46,21 @@ export const QUERY_OVERALL_FEEDBACK_COL = "overall" + FB_SUFFIX;
 export const NEW_QUERY_CALL_ID = 1;
 // The key used in firestore to save the query overall feedback
 export const QUERY_OVERALL_FEEDBACK_KEY = "overall";
+// Firestore keys used to save claims feedback
+export const RAG_CLAIM_KEYS = {
+  // total stat claims
+  QUERY_TOTAL_STAT_CLAIMS_KEY: "totalStatClaims",
+  // false stat claims
+  QUERY_FALSE_STAT_CLAIMS_KEY: "falseStatClaims",
+  // total inferred claims
+  QUERY_TOTAL_INF_CLAIMS_KEY: "totalInferredClaims",
+  // false inferred claims
+  QUERY_FALSE_INF_CLAIMS_KEY: "falseInferredClaims",
+  // unsubstantiated inferred claims
+  QUERY_UNSUB_INF_CLAIMS_KEY: "unsubInferredClaims",
+  // total tables used in claims
+  QUERY_TABLES_USED_KEY: "tablesUsed",
+};
 // The key used in firestore to save the query total stat claims feedback
 export const QUERY_TOTAL_STAT_CLAIMS_KEY = "totalStatClaims";
 // The key used in firestore to save the query false stat claims feedback

--- a/static/js/apps/eval_retrieval_generation/constants.tsx
+++ b/static/js/apps/eval_retrieval_generation/constants.tsx
@@ -61,18 +61,6 @@ export const RAG_CLAIM_KEYS = {
   // total tables used in claims
   QUERY_TABLES_USED_KEY: "tablesUsed",
 };
-// The key used in firestore to save the query total stat claims feedback
-export const QUERY_TOTAL_STAT_CLAIMS_KEY = "totalStatClaims";
-// The key used in firestore to save the query false stat claims feedback
-export const QUERY_FALSE_STAT_CLAIMS_KEY = "falseStatClaims";
-// The key used in firestore to save the query total inferred claims feedback
-export const QUERY_TOTAL_INF_CLAIMS_KEY = "totalInferredClaims";
-// The key used in firestore to save the query false inferred claims feedback
-export const QUERY_FALSE_INF_CLAIMS_KEY = "falseInferredClaims";
-// The key used in firestore to save the query unsubstantiated inferred claims feedback
-export const QUERY_UNSUB_INF_CLAIMS_KEY = "unsubInferredClaims";
-// The key used in firestore to save the query total tables used feedback
-export const QUERY_TABLES_USED_KEY = "tablesUsed";
 // Options for the query overall feedback
 export const QUERY_OVERALL_OPTION_HALLUCINATION = "LLM_ANSWER_HALLUCINATION";
 export const QUERY_OVERALL_OPTION_OK = "LLM_ANSWER_OKAY";

--- a/static/js/apps/eval_retrieval_generation/constants.tsx
+++ b/static/js/apps/eval_retrieval_generation/constants.tsx
@@ -41,17 +41,23 @@ export const DC_RESPONSE_FEEDBACK_COL = DC_RESPONSE_COL + FB_SUFFIX;
 export const LLM_STAT_FEEDBACK_COL = LLM_STAT_COL + FB_SUFFIX;
 export const DC_STAT_FEEDBACK_COL = DC_STAT_COL + FB_SUFFIX;
 export const QUERY_OVERALL_FEEDBACK_COL = "overall" + FB_SUFFIX;
-export const QUERY_TOTAL_CLAIMS_FEEDBACK_COL = "total_claims" + FB_SUFFIX;
-export const QUERY_FALSE_CLAIMS_FEEDBACK_COL = "false_claims" + FB_SUFFIX;
 
 // Call Id to use for a new query
 export const NEW_QUERY_CALL_ID = 1;
 // The key used in firestore to save the query overall feedback
 export const QUERY_OVERALL_FEEDBACK_KEY = "overall";
-// The key used in firestore to save the query total claims feedback
-export const QUERY_TOTAL_CLAIMS_FEEDBACK_KEY = "totalClaims";
-// The key used in firestore to save the query total false claims feedback
-export const QUERY_FALSE_CLAIMS_FEEDBACK_KEY = "falseClaims";
+// The key used in firestore to save the query total stat claims feedback
+export const QUERY_TOTAL_STAT_CLAIMS_KEY = "totalStatClaims";
+// The key used in firestore to save the query false stat claims feedback
+export const QUERY_FALSE_STAT_CLAIMS_KEY = "falseStatClaims";
+// The key used in firestore to save the query total inferred claims feedback
+export const QUERY_TOTAL_INF_CLAIMS_KEY = "totalInferredClaims";
+// The key used in firestore to save the query false inferred claims feedback
+export const QUERY_FALSE_INF_CLAIMS_KEY = "falseInferredClaims";
+// The key used in firestore to save the query unsubstantiated inferred claims feedback
+export const QUERY_UNSUB_INF_CLAIMS_KEY = "unsubInferredClaims";
+// The key used in firestore to save the query total tables used feedback
+export const QUERY_TABLES_USED_KEY = "tablesUsed";
 // Options for the query overall feedback
 export const QUERY_OVERALL_OPTION_HALLUCINATION = "LLM_ANSWER_HALLUCINATION";
 export const QUERY_OVERALL_OPTION_OK = "LLM_ANSWER_OKAY";

--- a/static/js/apps/eval_retrieval_generation/data_store.tsx
+++ b/static/js/apps/eval_retrieval_generation/data_store.tsx
@@ -34,13 +34,7 @@ import { db } from "../../utils/firebase";
 import {
   CALL_ID_COL,
   DC_FEEDBACK_SHEET,
-  DC_QUESTION_FEEDBACK_COL,
-  DC_RESPONSE_FEEDBACK_COL,
-  LLM_STAT_FEEDBACK_COL,
-  QUERY_FALSE_CLAIMS_FEEDBACK_COL,
   QUERY_ID_COL,
-  QUERY_OVERALL_FEEDBACK_COL,
-  QUERY_TOTAL_CLAIMS_FEEDBACK_COL,
   USER_COL,
 } from "./constants";
 import { Response } from "./types";
@@ -62,13 +56,12 @@ export function getPath(
 }
 
 // Sets a field in a doc at the specified path
-export async function setField(
+export async function setFields(
   path: string,
-  fieldKey: string,
-  fieldValue: string
+  fields: Record<string, string>
 ): Promise<void> {
   const docRef = doc(db, path);
-  setDoc(docRef, { [fieldKey]: fieldValue }, { merge: true });
+  setDoc(docRef, fields, { merge: true });
 }
 
 // Gets all the fields for a specified path
@@ -162,22 +155,14 @@ export async function saveToSheet(
   doc: GoogleSpreadsheet,
   queryId: number,
   callId: number,
-  response?: Response,
-  overallFeedback?: string,
-  totalClaims?: number,
-  falseClaims?: number
+  cellValues: Record<string, string | number>
 ): Promise<void> {
   const sheet = doc.sheetsByTitle[DC_FEEDBACK_SHEET];
   sheet.addRow({
+    ...cellValues,
     [QUERY_ID_COL]: queryId,
     [CALL_ID_COL]: callId,
     [USER_COL]: userEmail,
-    [DC_QUESTION_FEEDBACK_COL]: response?.question || "",
-    [DC_RESPONSE_FEEDBACK_COL]: response?.dcResponse || "",
-    [LLM_STAT_FEEDBACK_COL]: response?.llmStat || "",
-    [QUERY_OVERALL_FEEDBACK_COL]: overallFeedback || "",
-    [QUERY_TOTAL_CLAIMS_FEEDBACK_COL]: totalClaims || "",
-    [QUERY_FALSE_CLAIMS_FEEDBACK_COL]: falseClaims || "",
   });
 }
 

--- a/static/js/apps/eval_retrieval_generation/eval_list.tsx
+++ b/static/js/apps/eval_retrieval_generation/eval_list.tsx
@@ -21,9 +21,13 @@ import { Button, Input, Modal } from "reactstrap";
 
 import {
   NEW_QUERY_CALL_ID,
-  QUERY_FALSE_CLAIMS_FEEDBACK_KEY,
+  QUERY_FALSE_INF_CLAIMS_KEY,
+  QUERY_FALSE_STAT_CLAIMS_KEY,
   QUERY_OVERALL_FEEDBACK_KEY,
-  QUERY_TOTAL_CLAIMS_FEEDBACK_KEY,
+  QUERY_TABLES_USED_KEY,
+  QUERY_TOTAL_INF_CLAIMS_KEY,
+  QUERY_TOTAL_STAT_CLAIMS_KEY,
+  QUERY_UNSUB_INF_CLAIMS_KEY,
 } from "./constants";
 import { AppContext, SessionContext } from "./context";
 import { getAllFields, getCallCount, getPath } from "./data_store";
@@ -65,18 +69,18 @@ export function EvalList(): JSX.Element {
           if (!queryFeedbackResults[i][QUERY_OVERALL_FEEDBACK_KEY]) {
             completed = false;
           }
-          // For RAG eval type, also check that total and false claims are
-          // completed
+          // For RAG eval type, also check that claim counts are completed
           if (evalType === EvalType.RAG) {
             [
-              QUERY_TOTAL_CLAIMS_FEEDBACK_KEY,
-              QUERY_FALSE_CLAIMS_FEEDBACK_KEY,
-            ].forEach((key) => {
-              if (
-                queryFeedbackResults[i][key] !== "0" &&
-                !queryFeedbackResults[i][key]
-              ) {
-                completed = false;
+              QUERY_TOTAL_STAT_CLAIMS_KEY,
+              QUERY_FALSE_STAT_CLAIMS_KEY,
+              QUERY_TOTAL_INF_CLAIMS_KEY,
+              QUERY_FALSE_INF_CLAIMS_KEY,
+              QUERY_UNSUB_INF_CLAIMS_KEY,
+              QUERY_TABLES_USED_KEY
+            ].forEach((countKey) => {
+              if (!(countKey in queryFeedbackResults)) {
+                completed = false
               }
             });
           }

--- a/static/js/apps/eval_retrieval_generation/eval_list.tsx
+++ b/static/js/apps/eval_retrieval_generation/eval_list.tsx
@@ -21,28 +21,13 @@ import { Button, Input, Modal } from "reactstrap";
 
 import {
   NEW_QUERY_CALL_ID,
-  QUERY_FALSE_INF_CLAIMS_KEY,
-  QUERY_FALSE_STAT_CLAIMS_KEY,
   QUERY_OVERALL_FEEDBACK_KEY,
-  QUERY_TABLES_USED_KEY,
-  QUERY_TOTAL_INF_CLAIMS_KEY,
-  QUERY_TOTAL_STAT_CLAIMS_KEY,
-  QUERY_UNSUB_INF_CLAIMS_KEY,
+  RAG_CLAIM_KEYS,
 } from "./constants";
 import { AppContext, SessionContext } from "./context";
 import { getAllFields, getCallCount, getPath } from "./data_store";
 import { EvalType, Query } from "./types";
 import { getFirstFeedbackStage } from "./util";
-
-// feedback keys used specifically for RAG evals
-const RAG_FEEDBACK_KEYS = [
-  QUERY_TOTAL_STAT_CLAIMS_KEY,
-  QUERY_FALSE_STAT_CLAIMS_KEY,
-  QUERY_TOTAL_INF_CLAIMS_KEY,
-  QUERY_FALSE_INF_CLAIMS_KEY,
-  QUERY_UNSUB_INF_CLAIMS_KEY,
-  QUERY_TABLES_USED_KEY,
-];
 
 export function EvalList(): JSX.Element {
   const { allCall, allQuery, userEmail, sheetId, evalType } =
@@ -81,8 +66,8 @@ export function EvalList(): JSX.Element {
           }
           // For RAG eval type, also check that claim counts are completed
           if (evalType === EvalType.RAG) {
-            RAG_FEEDBACK_KEYS.forEach((countKey) => {
-              if (!(countKey in queryFeedbackResults)) {
+            Object.values(RAG_CLAIM_KEYS).forEach((countKey) => {
+              if (!(countKey in queryFeedbackResults[i])) {
                 completed = false;
               }
             });

--- a/static/js/apps/eval_retrieval_generation/eval_list.tsx
+++ b/static/js/apps/eval_retrieval_generation/eval_list.tsx
@@ -34,6 +34,16 @@ import { getAllFields, getCallCount, getPath } from "./data_store";
 import { EvalType, Query } from "./types";
 import { getFirstFeedbackStage } from "./util";
 
+// feedback keys used specifically for RAG evals
+const RAG_FEEDBACK_KEYS = [
+  QUERY_TOTAL_STAT_CLAIMS_KEY,
+  QUERY_FALSE_STAT_CLAIMS_KEY,
+  QUERY_TOTAL_INF_CLAIMS_KEY,
+  QUERY_FALSE_INF_CLAIMS_KEY,
+  QUERY_UNSUB_INF_CLAIMS_KEY,
+  QUERY_TABLES_USED_KEY,
+];
+
 export function EvalList(): JSX.Element {
   const { allCall, allQuery, userEmail, sheetId, evalType } =
     useContext(AppContext);
@@ -71,14 +81,7 @@ export function EvalList(): JSX.Element {
           }
           // For RAG eval type, also check that claim counts are completed
           if (evalType === EvalType.RAG) {
-            [
-              QUERY_TOTAL_STAT_CLAIMS_KEY,
-              QUERY_FALSE_STAT_CLAIMS_KEY,
-              QUERY_TOTAL_INF_CLAIMS_KEY,
-              QUERY_FALSE_INF_CLAIMS_KEY,
-              QUERY_UNSUB_INF_CLAIMS_KEY,
-              QUERY_TABLES_USED_KEY,
-            ].forEach((countKey) => {
+            RAG_FEEDBACK_KEYS.forEach((countKey) => {
               if (!(countKey in queryFeedbackResults)) {
                 completed = false;
               }

--- a/static/js/apps/eval_retrieval_generation/eval_list.tsx
+++ b/static/js/apps/eval_retrieval_generation/eval_list.tsx
@@ -77,10 +77,10 @@ export function EvalList(): JSX.Element {
               QUERY_TOTAL_INF_CLAIMS_KEY,
               QUERY_FALSE_INF_CLAIMS_KEY,
               QUERY_UNSUB_INF_CLAIMS_KEY,
-              QUERY_TABLES_USED_KEY
+              QUERY_TABLES_USED_KEY,
             ].forEach((countKey) => {
               if (!(countKey in queryFeedbackResults)) {
-                completed = false
+                completed = false;
               }
             });
           }

--- a/static/js/apps/eval_retrieval_generation/feedback_navigation.tsx
+++ b/static/js/apps/eval_retrieval_generation/feedback_navigation.tsx
@@ -214,6 +214,12 @@ export function FeedbackNavigation(
     }
   };
 
+  const finish = async () => {
+    if (await props.checkAndSubmit()) {
+      alert("All evaluations completed.")
+    }
+  };
+
   // Button Conditions
 
   function getNextButtonType(): ButtonType {
@@ -258,7 +264,7 @@ export function FeedbackNavigation(
       case ButtonType.NEXT_EVAL_STAGE:
         return nextEvalStage;
       case ButtonType.FINISH:
-        return props.checkAndSubmit;
+        return finish;
       default:
         return _.noop;
     }

--- a/static/js/apps/eval_retrieval_generation/feedback_navigation.tsx
+++ b/static/js/apps/eval_retrieval_generation/feedback_navigation.tsx
@@ -216,7 +216,7 @@ export function FeedbackNavigation(
 
   const finish = async () => {
     if (await props.checkAndSubmit()) {
-      alert("All evaluations completed.")
+      alert("All evaluations completed.");
     }
   };
 

--- a/static/js/apps/eval_retrieval_generation/overall_feedback.tsx
+++ b/static/js/apps/eval_retrieval_generation/overall_feedback.tsx
@@ -21,6 +21,7 @@ import { Button } from "reactstrap";
 
 import { loadSpinner, removeSpinner } from "../../shared/util";
 import {
+  QUERY_OVERALL_FEEDBACK_COL,
   QUERY_OVERALL_FEEDBACK_KEY,
   QUERY_OVERALL_OPTION_HALLUCINATION,
   QUERY_OVERALL_OPTION_IRRELEVANT,
@@ -29,7 +30,7 @@ import {
   QUERY_OVERALL_OPTION_SOMEWHAT_RELEVANT,
 } from "./constants";
 import { AppContext, SessionContext } from "./context";
-import { getField, getPath, saveToSheet, setField } from "./data_store";
+import { getField, getPath, saveToSheet, setFields } from "./data_store";
 import { EvalList } from "./eval_list";
 import { FeedbackNavigation } from "./feedback_navigation";
 import { OneQuestion } from "./one_question";
@@ -76,19 +77,12 @@ export function OverallFeedback(): JSX.Element {
     }
     loadSpinner(LOADING_CONTAINER_ID);
     return Promise.all([
-      setField(
-        getPath(sheetId, sessionQueryId),
-        QUERY_OVERALL_FEEDBACK_KEY,
-        response
-      ),
-      saveToSheet(
-        userEmail,
-        doc,
-        sessionQueryId,
-        sessionCallId,
-        null,
-        response
-      ),
+      setFields(getPath(sheetId, sessionQueryId), {
+        [QUERY_OVERALL_FEEDBACK_KEY]: response,
+      }),
+      saveToSheet(userEmail, doc, sessionQueryId, sessionCallId, {
+        [QUERY_OVERALL_FEEDBACK_COL]: response,
+      }),
     ])
       .then(() => {
         return true;

--- a/static/js/apps/eval_retrieval_generation/rag_ans_feedback.tsx
+++ b/static/js/apps/eval_retrieval_generation/rag_ans_feedback.tsx
@@ -28,6 +28,7 @@ import {
   QUERY_TOTAL_INF_CLAIMS_KEY,
   QUERY_TOTAL_STAT_CLAIMS_KEY,
   QUERY_UNSUB_INF_CLAIMS_KEY,
+  RAG_CLAIM_KEYS,
 } from "./constants";
 import { AppContext, SessionContext } from "./context";
 import { getAllFields, getPath, saveToSheet, setFields } from "./data_store";
@@ -38,20 +39,20 @@ import { EvalType } from "./types";
 
 const LOADING_CONTAINER_ID = "form-container";
 const EMPTY_COUNTS = {
-  [QUERY_TOTAL_STAT_CLAIMS_KEY]: 0,
-  [QUERY_FALSE_STAT_CLAIMS_KEY]: 0,
-  [QUERY_TOTAL_INF_CLAIMS_KEY]: 0,
-  [QUERY_FALSE_INF_CLAIMS_KEY]: 0,
-  [QUERY_UNSUB_INF_CLAIMS_KEY]: 0,
-  [QUERY_TABLES_USED_KEY]: 0,
+  [RAG_CLAIM_KEYS.QUERY_TOTAL_STAT_CLAIMS_KEY]: 0,
+  [RAG_CLAIM_KEYS.QUERY_FALSE_STAT_CLAIMS_KEY]: 0,
+  [RAG_CLAIM_KEYS.QUERY_TOTAL_INF_CLAIMS_KEY]: 0,
+  [RAG_CLAIM_KEYS.QUERY_FALSE_INF_CLAIMS_KEY]: 0,
+  [RAG_CLAIM_KEYS.QUERY_UNSUB_INF_CLAIMS_KEY]: 0,
+  [RAG_CLAIM_KEYS.QUERY_TABLES_USED_KEY]: 0,
 };
 const COUNTER_LABELS = {
-  [QUERY_TOTAL_STAT_CLAIMS_KEY]: "Total claims",
-  [QUERY_FALSE_STAT_CLAIMS_KEY]: "False claims",
-  [QUERY_TOTAL_INF_CLAIMS_KEY]: "Total claims",
-  [QUERY_FALSE_INF_CLAIMS_KEY]: "False claims",
-  [QUERY_UNSUB_INF_CLAIMS_KEY]: "Unsubstantiated claims",
-  [QUERY_TABLES_USED_KEY]: "Unique tables used",
+  [RAG_CLAIM_KEYS.QUERY_TOTAL_STAT_CLAIMS_KEY]: "Total claims",
+  [RAG_CLAIM_KEYS.QUERY_FALSE_STAT_CLAIMS_KEY]: "False claims",
+  [RAG_CLAIM_KEYS.QUERY_TOTAL_INF_CLAIMS_KEY]: "Total claims",
+  [RAG_CLAIM_KEYS.QUERY_FALSE_INF_CLAIMS_KEY]: "False claims",
+  [RAG_CLAIM_KEYS.QUERY_UNSUB_INF_CLAIMS_KEY]: "Unsubstantiated claims",
+  [RAG_CLAIM_KEYS.QUERY_TABLES_USED_KEY]: "Unique tables used",
 };
 
 interface RagAnsResponse {

--- a/static/js/apps/eval_retrieval_generation/rag_ans_feedback.tsx
+++ b/static/js/apps/eval_retrieval_generation/rag_ans_feedback.tsx
@@ -21,15 +21,7 @@ import { Button } from "reactstrap";
 
 import { loadSpinner, removeSpinner } from "../../shared/util";
 import { ClaimCounter } from "./claim_counter";
-import {
-  QUERY_FALSE_INF_CLAIMS_KEY,
-  QUERY_FALSE_STAT_CLAIMS_KEY,
-  QUERY_TABLES_USED_KEY,
-  QUERY_TOTAL_INF_CLAIMS_KEY,
-  QUERY_TOTAL_STAT_CLAIMS_KEY,
-  QUERY_UNSUB_INF_CLAIMS_KEY,
-  RAG_CLAIM_KEYS,
-} from "./constants";
+import { RAG_CLAIM_KEYS } from "./constants";
 import { AppContext, SessionContext } from "./context";
 import { getAllFields, getPath, saveToSheet, setFields } from "./data_store";
 import { EvalList } from "./eval_list";
@@ -161,9 +153,9 @@ export function RagAnsFeedback(): JSX.Element {
             Count the number of STATISTICAL claims made by the model.
           </div>
           {[
-            QUERY_TOTAL_STAT_CLAIMS_KEY,
-            QUERY_FALSE_STAT_CLAIMS_KEY,
-            QUERY_TABLES_USED_KEY,
+            RAG_CLAIM_KEYS.QUERY_TOTAL_STAT_CLAIMS_KEY,
+            RAG_CLAIM_KEYS.QUERY_FALSE_STAT_CLAIMS_KEY,
+            RAG_CLAIM_KEYS.QUERY_TABLES_USED_KEY,
           ].map((cntKey) => {
             return (
               <div
@@ -185,9 +177,9 @@ export function RagAnsFeedback(): JSX.Element {
             Count the number of INFERRED claims made by the model.
           </div>
           {[
-            QUERY_TOTAL_INF_CLAIMS_KEY,
-            QUERY_FALSE_INF_CLAIMS_KEY,
-            QUERY_UNSUB_INF_CLAIMS_KEY,
+            RAG_CLAIM_KEYS.QUERY_TOTAL_INF_CLAIMS_KEY,
+            RAG_CLAIM_KEYS.QUERY_FALSE_INF_CLAIMS_KEY,
+            RAG_CLAIM_KEYS.QUERY_UNSUB_INF_CLAIMS_KEY,
           ].map((cntKey) => {
             return (
               <div

--- a/static/js/apps/eval_retrieval_generation/rag_ans_feedback.tsx
+++ b/static/js/apps/eval_retrieval_generation/rag_ans_feedback.tsx
@@ -165,13 +165,15 @@ export function RagAnsFeedback(): JSX.Element {
             QUERY_TABLES_USED_KEY,
           ].map((cntKey) => {
             return (
-              <div className={`counter${response.isSubmitted ? " disabled" : ""}`}>
-              <ClaimCounter
+              <div
+                className={`counter${response.isSubmitted ? " disabled" : ""}`}
                 key={cntKey}
-                count={response.counts[cntKey]}
-                onCountUpdated={(count) => onCountUpdated(count, cntKey)}
-                label={COUNTER_LABELS[cntKey]}
-              />
+              >
+                <ClaimCounter
+                  count={response.counts[cntKey]}
+                  onCountUpdated={(count) => onCountUpdated(count, cntKey)}
+                  label={COUNTER_LABELS[cntKey]}
+                />
               </div>
             );
           })}
@@ -187,13 +189,15 @@ export function RagAnsFeedback(): JSX.Element {
             QUERY_UNSUB_INF_CLAIMS_KEY,
           ].map((cntKey) => {
             return (
-              <div className={`counter${response.isSubmitted ? " disabled" : ""}`}>
-              <ClaimCounter
+              <div
+                className={`counter${response.isSubmitted ? " disabled" : ""}`}
                 key={cntKey}
-                count={response.counts[cntKey]}
-                onCountUpdated={(count) => onCountUpdated(count, cntKey)}
-                label={COUNTER_LABELS[cntKey]}
-              />
+              >
+                <ClaimCounter
+                  count={response.counts[cntKey]}
+                  onCountUpdated={(count) => onCountUpdated(count, cntKey)}
+                  label={COUNTER_LABELS[cntKey]}
+                />
               </div>
             );
           })}


### PR DESCRIPTION
update claim counter page to have 2 sections w/ 3 counters each:
1. statistical claims
    - total claims
    - false claims
    - unique tables
3. inferred claims
    - total claims
    - false claims
    - unsubstantiated claims

![Screenshot 2024-06-24 at 3 07 33 PM](https://github.com/datacommonsorg/website/assets/69875368/de4bbced-8890-4f26-8e38-51e2b4942c32)
