### PR TITLE
Fixed issue when .removeAttribute called on a web component's convertArrayAttribute property

### DIFF
--- a/static/library/utils.ts
+++ b/static/library/utils.ts
@@ -37,6 +37,9 @@ import {
  * @returns A string array of attribute values
  */
 export function convertArrayAttribute(attributeValue: string): string[] {
+  if (!attributeValue) {
+    return undefined;
+  }
   if (attributeValue.startsWith("[")) {
     // Parse as JSON if attribute value begins with a bracket
     return JSON.parse(attributeValue);


### PR DESCRIPTION
Fixes this error in UN staging site:

<img width="1216" alt="Screenshot 2024-06-25 at 12 54 32 AM" src="https://github.com/datacommonsorg/website/assets/13766/26e7af44-4b2f-4dc9-a384-e6d0cb404f30">

Impacts lit elements with properties with decorator:
```
@property({ type: Array<string>, converter: convertArrayAttribute })
```

When React removes a property from an element, it calls `<domElement>.removeAttribute`. This then calls `convertArrayAttribute(undefined)`, which was causing an exception.

TODO: add webdriver unit test for this case