### PR TITLE
Added 'part' selectors to 'show metadata' link

### DIFF
--- a/static/js/utils/tile_utils.tsx
+++ b/static/js/utils/tile_utils.tsx
@@ -379,16 +379,17 @@ export function TileSources(props: {
   });
   return (
     <div className="sources" {...{ part: "source" }}>
-      Source: {sourcesJsx}
+      Source: <span {...{ part: "source-links" }}>{sourcesJsx}</span>
       {statVarSpecs && statVarSpecs.length > 0 && (
         <>
-          {" "}
-          •{" "}
-          <TileMetadataModal
-            apiRoot={props.apiRoot}
-            containerRef={props.containerRef}
-            statVarSpecs={statVarSpecs}
-          ></TileMetadataModal>
+          <span {...{ part: "source-separator" }}> • </span>
+          <span {...{ part: "source-show-metadata-link" }}>
+            <TileMetadataModal
+              apiRoot={props.apiRoot}
+              containerRef={props.containerRef}
+              statVarSpecs={statVarSpecs}
+            ></TileMetadataModal>
+          </span>
         </>
       )}
     </div>


### PR DESCRIPTION
Gives web component users ability to hide and style the 'show metadata' link