### PR TITLE
remove redirect for missing trailing slashes on explore links

### DIFF
--- a/server/routes/explore/html.py
+++ b/server/routes/explore/html.py
@@ -22,7 +22,7 @@ from flask import render_template
 bp = Blueprint('explore', __name__, url_prefix='/explore')
 
 
-@bp.route('/')
+@bp.route('', strict_slashes=False)
 def page():
   return render_template('/explore.html',
                          manual_ga_pageview=True,

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -145,12 +145,12 @@
                 <a class="nav-link dropdown-toggle" href="#" id="nav-doc-dropdown" role="button" data-toggle="dropdown"
                   aria-haspopup="true" aria-expanded="false" aria-label="{% trans %}Show documentation links{% endtrans %}">{% trans %}Documentation{% endtrans %}</a>
                 <div class="dropdown-menu" aria-labelledby="nav-doc-dropdown">
-                  <a class="dropdown-item" href="http://docs.datacommons.org">{% trans %}Documentation{% endtrans %}</a>
-                  <a class="dropdown-item" href="http://docs.datacommons.org/api">{% trans %}APIs{% endtrans %}</a>
+                  <a class="dropdown-item" href="https://docs.datacommons.org">{% trans %}Documentation{% endtrans %}</a>
+                  <a class="dropdown-item" href="https://docs.datacommons.org/api">{% trans %}APIs{% endtrans %}</a>
                   {# TODO: UNCOMMENT TO RE-ENABLE BIGQUERY #}
-                  {#<a class="dropdown-item" href="http://docs.datacommons.org/bigquery">{% trans %}BigQuery{% endtrans
+                  {#<a class="dropdown-item" href="https://docs.datacommons.org/bigquery">{% trans %}BigQuery{% endtrans
                     %}</a>#}
-                  <a class="dropdown-item" href="http://docs.datacommons.org/tutorials">{% trans %}Tutorials{% endtrans
+                  <a class="dropdown-item" href="https://docs.datacommons.org/tutorials">{% trans %}Tutorials{% endtrans
                     %}</a>
                   <a class="dropdown-item" href="https://docs.datacommons.org/contributing/">{% trans %}Contribute{%
                     endtrans %}</a>
@@ -221,14 +221,14 @@
             {# TRANSLATORS: The label for a list of documentation links. #}
             <h6>{% trans %}Documentation{% endtrans %}</h6>
             {# TRANSLATORS: The label for a link to our documentation site. #}
-            <a href="http://docs.datacommons.org"><span class="material-icons-outlined">arrow_forward</span><span>{% trans %}Documentation{% endtrans %}</span></a>
+            <a href="https://docs.datacommons.org"><span class="material-icons-outlined">arrow_forward</span><span>{% trans %}Documentation{% endtrans %}</span></a>
             {# TRANSLATORS: The label for a link to our API documentation. #}
-            <a href="http://docs.datacommons.org/api"><span class="material-icons-outlined">arrow_forward</span><span>{% trans %}APIs{% endtrans %}</span></a>
+            <a href="https://docs.datacommons.org/api"><span class="material-icons-outlined">arrow_forward</span><span>{% trans %}APIs{% endtrans %}</span></a>
             {# TODO: UNCOMMENT TO RE-ENABLE BIGQUERY #}
             {# TRANSLATORS: The label for a link to BigQuery integration starter docs. #}
-            {#<a href="http://docs.datacommons.org/bigquery"><span class="material-icons-outlined">arrow_forward</span><span>{% trans %}BigQuery{% endtrans %}</span></a>#}
+            {#<a href="https://docs.datacommons.org/bigquery"><span class="material-icons-outlined">arrow_forward</span><span>{% trans %}BigQuery{% endtrans %}</span></a>#}
             {# TRANSLATORS: The label for a link to our API tutorials. #}
-            <a href="http://docs.datacommons.org/tutorials"><span class="material-icons-outlined">arrow_forward</span><span>{% trans %}Tutorials{% endtrans %}</span></a>
+            <a href="https://docs.datacommons.org/tutorials"><span class="material-icons-outlined">arrow_forward</span><span>{% trans %}Tutorials{% endtrans %}</span></a>
             {# TRANSLATORS: The label for a link to instructions about contributing to the project. #}
             <a href="https://docs.datacommons.org/contributing/"><span class="material-icons-outlined">arrow_forward</span><span>{% trans %}Contribute{% endtrans %}</span></a>
             {# TRANSLATORS: The label for a link to the project's github repository (for open sourced code). #}

--- a/server/templates/custom_dc/iitm/base.html
+++ b/server/templates/custom_dc/iitm/base.html
@@ -104,9 +104,9 @@
               </li>
               <li class="nav-item dropdown"><a data-toggle="dropdown" aria-expanded="false" class="dropdown-toggle nav-link" href="#">Documentation</a>
                 <div role="menu" class="dropdown-menu">
-                  <a class="dropdown-item" href="http://docs.datacommons.org" target="_blank">Documentation</a>
-                  <a class="dropdown-item" href="http://docs.datacommons.org/api" target="_blank">APIs</a>
-                  <a class="dropdown-item" href="http://docs.datacommons.org/tutorials" target="_blank">Tutorials</a>
+                  <a class="dropdown-item" href="https://docs.datacommons.org" target="_blank">Documentation</a>
+                  <a class="dropdown-item" href="https://docs.datacommons.org/api" target="_blank">APIs</a>
+                  <a class="dropdown-item" href="https://docs.datacommons.org/tutorials" target="_blank">Tutorials</a>
                   <a class="dropdown-item" href="/about#contribute">Contribute</a>
                 </div>
               </li>
@@ -159,9 +159,9 @@
           <div class="col-sm-6 col-md-4">
             <h3 class="text-info pb-2 ">Documentation</h3>
             <ul class="list-unstyled d-inline-block d-sm-block">
-              <li class="mb-2"><a class="footer-links" href="http://docs.datacommons.org" target="_blank">Documentation</a></li>
-              <li class="mb-2"><a class="footer-links" href="http://docs.datacommons.org/api" target="_blank">APIs</a></li>
-              <li class="mb-2"><a class="footer-links" href="http://docs.datacommons.org/tutorials" target="_blank">Tutorials</a></li>
+              <li class="mb-2"><a class="footer-links" href="https://docs.datacommons.org" target="_blank">Documentation</a></li>
+              <li class="mb-2"><a class="footer-links" href="https://docs.datacommons.org/api" target="_blank">APIs</a></li>
+              <li class="mb-2"><a class="footer-links" href="https://docs.datacommons.org/tutorials" target="_blank">Tutorials</a></li>
               <li class="mb-2"><a class="footer-links" href="/about#contribute">Contribute</a></li>
               <li class="mb-2"><a class="footer-links" href="http://github.com/datacommonsorg" target="_blank">Github Repository</a></li>
             </ul>

--- a/server/templates/custom_dc/stanford/base.html
+++ b/server/templates/custom_dc/stanford/base.html
@@ -116,12 +116,12 @@
                 <a class="nav-link dropdown-toggle" href="#" id="nav-doc-dropdown" role="button" data-toggle="dropdown"
                   aria-haspopup="true" aria-expanded="false">{% trans %}Documentation{% endtrans %}</a>
                 <div class="dropdown-menu" aria-labelledby="nav-doc-dropdown">
-                  <a class="dropdown-item" href="http://docs.datacommons.org">{% trans %}Documentation{% endtrans %}</a>
-                  <a class="dropdown-item" href="http://docs.datacommons.org/api">{% trans %}APIs{% endtrans %}</a>
+                  <a class="dropdown-item" href="https://docs.datacommons.org">{% trans %}Documentation{% endtrans %}</a>
+                  <a class="dropdown-item" href="https://docs.datacommons.org/api">{% trans %}APIs{% endtrans %}</a>
                   {# TODO: UNCOMMENT TO RE-ENABLE BIGQUERY #}
-                  {#<a class="dropdown-item" href="http://docs.datacommons.org/bigquery">{% trans %}BigQuery{% endtrans
+                  {#<a class="dropdown-item" href="https://docs.datacommons.org/bigquery">{% trans %}BigQuery{% endtrans
                     %}</a>#}
-                  <a class="dropdown-item" href="http://docs.datacommons.org/tutorials">{% trans %}Tutorials{% endtrans
+                  <a class="dropdown-item" href="https://docs.datacommons.org/tutorials">{% trans %}Tutorials{% endtrans
                     %}</a>
                   <a class="dropdown-item" href="https://docs.datacommons.org/contributing/">{% trans %}Contribute{%
                     endtrans %}</a>
@@ -187,14 +187,14 @@
             {# TRANSLATORS: The label for a list of documentation links. #}
             <h6>{% trans %}Documentation{% endtrans %}</h6>
             {# TRANSLATORS: The label for a link to our documentation site. #}
-            <a href="http://docs.datacommons.org">{% trans %}Documentation{% endtrans %}</a>
+            <a href="https://docs.datacommons.org">{% trans %}Documentation{% endtrans %}</a>
             {# TRANSLATORS: The label for a link to our API documentation. #}
-            <a href="http://docs.datacommons.org/api">{% trans %}APIs{% endtrans %}</a>
+            <a href="https://docs.datacommons.org/api">{% trans %}APIs{% endtrans %}</a>
             {# TODO: UNCOMMENT TO RE-ENABLE BIGQUERY #}
             {# TRANSLATORS: The label for a link to BigQuery integration starter docs. #}
-            {#<a href="http://docs.datacommons.org/bigquery">{% trans %}BigQuery{% endtrans %}</a>#}
+            {#<a href="https://docs.datacommons.org/bigquery">{% trans %}BigQuery{% endtrans %}</a>#}
             {# TRANSLATORS: The label for a link to our API tutorials. #}
-            <a href="http://docs.datacommons.org/tutorials">{% trans %}Tutorials{% endtrans %}</a>
+            <a href="https://docs.datacommons.org/tutorials">{% trans %}Tutorials{% endtrans %}</a>
             {# TRANSLATORS: The label for a link to instructions about contributing to the project. #}
             <a href="https://docs.datacommons.org/contributing/">{% trans %}Contribute{% endtrans %}</a>
             {# TRANSLATORS: The label for a link to the project's github repository (for open sourced code). #}


### PR DESCRIPTION
the redirect from /explore landing pages caused a downgrade from https to http.
also fix a few http:// links to docsite.

follow up to #4392