### PR TITLE
Fix submodule treatment in custom DC build script

### DIFF
--- a/scripts/build_and_deploy_custom_dc_autopush.sh
+++ b/scripts/build_and_deploy_custom_dc_autopush.sh
@@ -28,8 +28,11 @@
 set -e
 set -x
 
-# Get the latest versions of all submodules (maybe newer than pinned versions)
+# Initialize all submodules, then merge them with their masters and update
+# their pinned versions (locally only).
+./scripts/update_git_submodules.sh
 ./scripts/merge_git_submodules.sh
+git commit -am "DO NOT PUSH: Temp commit to update pinned submod versions"
 
 website_rev="$(git rev-parse --short HEAD)"
 mixer_rev="$(git rev-parse --short HEAD:mixer)"


### PR DESCRIPTION
- Actually initialize submodules so that checkout + pull has an effect.
- Make a temporary commit so that HEAD:import and HEAD:mixer are updated.