### PR TITLE
[eval] Fix empty feedback recorded, table parsing

### DIFF
--- a/static/js/apps/eval_retrieval_generation/call_feedback.tsx
+++ b/static/js/apps/eval_retrieval_generation/call_feedback.tsx
@@ -85,8 +85,9 @@ export function CallFeedback(): JSX.Element {
         setResponse(data as Response);
         setStatus(FormStatus.Submitted);
       } else {
+        // If applyToNext has been set, we should just use the state of the
+        // previous question for the next question
         if (applyToNext) {
-          setStatus(FormStatus.Completed);
           return;
         }
         setResponse(EMPTY_RESPONSE[evalType]);

--- a/static/js/apps/eval_retrieval_generation/util.ts
+++ b/static/js/apps/eval_retrieval_generation/util.ts
@@ -23,7 +23,7 @@ const LONG_SPACES = "&nbsp;&nbsp;&nbsp;&nbsp;";
 const TABLE_DIVIDER_PATTERN = /[--][-]+/g;
 // table headers are sometimes country names so there can be symbols used like
 // in "Côte d'Ivoire".
-const TABLE_HEADER_TEXT_PATTERN = /[\w'ô[\]ãéí\s°()%:]+/g;
+const TABLE_HEADER_TEXT_PATTERN = /[\w'ô[\]ãéí\s°()%:-]+/g;
 
 export const processText = (text: string): string => {
   // If "Answer" is in the text, remove it


### PR DESCRIPTION
- fix bug with empty call response being saved to firestore when "apply to next" is selected
- fix table parsing issue when header contains "-"