### PR TITLE
Set up git email before creating temp commit

### DIFF
--- a/scripts/build_and_deploy_custom_dc_autopush.sh
+++ b/scripts/build_and_deploy_custom_dc_autopush.sh
@@ -32,6 +32,10 @@ set -x
 # their pinned versions (locally only).
 ./scripts/update_git_submodules.sh
 ./scripts/merge_git_submodules.sh
+
+# Configure Git to create commits with Cloud Build's service account
+git config user.email $(gcloud auth list --filter=status:ACTIVE --format='value(account)')
+
 git commit -am "DO NOT PUSH: Temp commit to update pinned submod versions"
 
 website_rev="$(git rev-parse --short HEAD)"


### PR DESCRIPTION
Without this extra line, `git commit` fails with an error about requiring identity.