### PR TITLE
Add a direct link to the required version of protoc

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -59,7 +59,7 @@ website and mixer changes.
 - Protoc 3.21.9
 
   Install [`protoc`](https://grpc.io/docs/protoc-installation/) at version
-  3.21.9.
+  [3.21.9](https://github.com/protocolbuffers/protobuf/releases/tag/v21.9).
 
 - [Optional] gcloud
 


### PR DESCRIPTION
When I was onboarding, I found the versioning for protoc confusing, and it also took me a while to figure out where I could download the required version. Adding a direct link for convenience for future readers/contributors.