### PR TITLE
Fixed css bug that was hiding the stanford custom dc navbar

### DIFF
--- a/static/custom_dc/stanford/overrides.css
+++ b/static/custom_dc/stanford/overrides.css
@@ -15,9 +15,13 @@
  */
 
 :root {
-  --palo-alto: #175E54;
+  --palo-alto: #175e54;
   --palo-alto-dark: #014240;
   --palo-alto-light: #7fa2a2;
+}
+
+#main-nav {
+  background-color: unset;
 }
 
 #main-header {
@@ -29,7 +33,7 @@
 
   .nav-item .nav-link,
   #main-nav .navbar-brand .sep {
-    color: rgba(255,255,255,.5)
+    color: rgba(255, 255, 255, 0.5);
   }
 }
 

--- a/static/custom_dc/stanford/overrides.css
+++ b/static/custom_dc/stanford/overrides.css
@@ -21,12 +21,10 @@
 }
 
 #main-nav {
-  background-color: unset;
+  background-color: var(--palo-alto-dark);
 }
 
 #main-header {
-  background-color: var(--palo-alto-dark);
-
   .navbar-brand a {
     color: #fff;
   }


### PR DESCRIPTION
## Before:
![Screenshot 2024-07-08 at 3 30 32 PM](https://github.com/datacommonsorg/website/assets/13766/c52d87de-ca2a-4230-b55b-20020eb17520)

## After:
![Screenshot 2024-07-08 at 3 31 43 PM](https://github.com/datacommonsorg/website/assets/13766/591f906c-d935-4d6c-b87a-5c55f357e8b5)
