### PR TITLE
Add Codacy config file to exclude submod paths

### DIFF
--- a/static/.codacy.yaml
+++ b/static/.codacy.yaml
@@ -1,0 +1,5 @@
+exclude_paths:
+  - ".github/**"
+  - "build/**"
+  - "import/**"
+  - "mixer/**"


### PR DESCRIPTION
Also exclude paths that are already excluded based on settings in Codacy UI