### PR TITLE
Load custom dc catalog at startup.

### DIFF
--- a/.run_cdc_dev.env
+++ b/.run_cdc_dev.env
@@ -53,3 +53,7 @@ USE_LOCAL_MIXER=true
 ENV_PREFIX=Compose
 ENABLE_ADMIN=true
 DEBUG=true
+# https://stackoverflow.com/a/62703850
+TOKENIZERS_PARALLELISM=false
+# https://github.com/UKPLab/sentence-transformers/issues/1318#issuecomment-1084731111
+OMP_NUM_THREADS=1

--- a/nl_server/config_reader.py
+++ b/nl_server/config_reader.py
@@ -254,17 +254,17 @@ def maybe_load_custom_catalog() -> Dict:
   if gcs.is_gcs_path(custom_catalog_path):
     local_path = gcs.maybe_download(custom_catalog_path)
     if not local_path:
-      logging.info("Custom catalog not found and will not be loaded: %s",
+      logging.info('Custom catalog not found and will not be loaded: %s',
                    custom_catalog_path)
       return None
   else:
     local_path = custom_catalog_path
     if not os.path.exists(custom_catalog_path):
-      logging.info("Custom catalog not found and will not be loaded: %s",
+      logging.info('Custom catalog not found and will not be loaded: %s',
                    custom_catalog_path)
       return None
 
-  logging.info("Loading custom catalog: %s", custom_catalog_path)
+  logging.info('Loading custom catalog: %s', custom_catalog_path)
   with open(local_path, 'r') as f:
     custom_catalog = yaml.safe_load(f)
     logging.info('custom_catalog:\n%s', json.dumps(custom_catalog, indent=2))

--- a/nl_server/flask.py
+++ b/nl_server/flask.py
@@ -22,6 +22,7 @@ import torch
 from nl_server import registry
 from nl_server import routes
 from nl_server import search
+from nl_server.config_reader import maybe_load_custom_catalog
 from shared.lib import gcp as lib_gcp
 from shared.lib import utils as lib_utils
 
@@ -49,9 +50,11 @@ def create_app():
     torch.set_num_threads(1)
 
   try:
+    # Maybe load custom dc catalog.
+    custom_catalog = maybe_load_custom_catalog()
     # Build the registry before creating the Flask app to make sure all resources
     # are loaded.
-    reg = registry.build()
+    reg = registry.build(additional_catalog=custom_catalog)
 
     if not lib_utils.is_test_env():
       # Below is a safe check to ensure that the model and embedding is loaded.

--- a/shared/lib/custom_dc_util.py
+++ b/shared/lib/custom_dc_util.py
@@ -19,6 +19,7 @@ import os
 from shared.lib.gcs import is_gcs_path
 
 _TOPIC_CACHE_PATH = "datacommons/nl/custom_dc_topic_cache.json"
+_CUSTOM_CATALOG_PATH = "datacommons/nl/embeddings/custom_catalog.yaml"
 
 
 def is_custom_dc() -> bool:
@@ -36,6 +37,13 @@ def get_custom_dc_topic_cache_path() -> str:
   if not base_path:
     return base_path
   return os.path.join(base_path, _TOPIC_CACHE_PATH)
+
+
+def get_custom_catalog_path() -> str:
+  base_path = get_custom_dc_user_data_path()
+  if not base_path:
+    return base_path
+  return os.path.join(base_path, _CUSTOM_CATALOG_PATH)
 
 
 def is_gcs_custom_dc_user_data_path() -> bool:

--- a/tools/nl/embeddings/build_embeddings.py
+++ b/tools/nl/embeddings/build_embeddings.py
@@ -14,6 +14,7 @@
 """Build the embeddings index from variable and topic descriptions."""
 
 import logging
+import sys
 from typing import Dict
 
 from absl import app
@@ -35,7 +36,19 @@ flags.DEFINE_string('catalog', '',
                     'A dict of user provided embeddings/model catalog')
 
 
+def _init_logger():
+  # Log to stdout for easy redirect of the output text.
+  # This enables the logs to be captured by the admin tool.
+  logger = logging.getLogger()
+  logger.setLevel(logging.INFO)
+  handler = logging.StreamHandler(sys.stdout)
+  handler.setLevel(logging.INFO)
+  logger.addHandler(handler)
+
+
 def main(_):
+  _init_logger()
+
   # Get embeddings_name
   embeddings_name = FLAGS.embeddings_name
   output_dir = FLAGS.output_dir

--- a/tools/nl/embeddings/build_embeddings.py
+++ b/tools/nl/embeddings/build_embeddings.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Build the embeddings index from variable and topic descriptions."""
 
+import logging
+from typing import Dict
+
 from absl import app
 from absl import flags
 import yaml
@@ -39,12 +42,14 @@ def main(_):
   assert embeddings_name, output_dir
 
   # Prepare the model
+  custom_catalog: Dict = None
   if FLAGS.catalog:
-    catalog = yaml.safe_load(FLAGS.catalog)
-  else:
-    catalog = None
-  catalog = config_reader.read_catalog(catalog_dict=catalog)
+    custom_catalog = yaml.safe_load(FLAGS.catalog)
+    logging.info('Custom catalog: %s', custom_catalog)
+
+  catalog = config_reader.read_catalog(catalog_dict=custom_catalog)
   index_config = catalog.indexes[embeddings_name]
+  logging.info('Index config: %s', index_config)
   # Use default env config: autopush for base DCs and custom env for custom DCs.
   env = config_reader.read_env()
   model = utils.get_model(catalog, env, index_config.model)
@@ -71,12 +76,21 @@ def main(_):
     utils.save_embeddings_lancedb(fm.local_output_dir(), final_embeddings)
   else:
     raise ValueError(f'Unknown store type: {index_config.store_type}')
+  logging.info("Saved embeddings.")
 
   # Save index config
   utils.save_index_config(fm, index_config)
+  logging.info("Saved index config.")
+
+  # Save custom catalog
+  if custom_catalog:
+    utils.save_custom_catalog(fm, custom_catalog)
+    logging.info("Saved custom catalog.")
 
   # Upload to GCS if needed
   fm.maybe_upload_to_gcs()
+
+  logging.info("Build embeddings done.")
 
 
 if __name__ == "__main__":

--- a/tools/nl/embeddings/file_manager.py
+++ b/tools/nl/embeddings/file_manager.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import shutil
 import tempfile
@@ -20,6 +21,7 @@ from shared.lib import gcs
 
 _PREINDEX_CSV = '_preindex.csv'
 _INDEX_CONFIG_YAML = 'index_config.yaml'
+_CUSTOM_CATALOG_YAML = 'custom_catalog.yaml'
 
 
 class FileManager(object):
@@ -65,12 +67,17 @@ class FileManager(object):
   def index_config_path(self):
     return os.path.join(self._local_output_dir, _INDEX_CONFIG_YAML)
 
+  def custom_catalog_path(self):
+    return os.path.join(self._local_output_dir, _CUSTOM_CATALOG_YAML)
+
   def maybe_upload_to_gcs(self):
     """
     Upload the generated files to GCS if the input or output paths are GCS.
     """
     if gcs.is_gcs_path(self._input_dir):
       # This is to upload any generated files in the input directory to GCS
+      logging.info("Uploading input dir to GCS path: %s", self._input_dir)
       gcs.upload_by_path(self._local_input_dir, self._input_dir)
     if gcs.is_gcs_path(self._output_dir):
+      logging.info("Uploading output dir to GCS path: %s", self._output_dir)
       gcs.upload_by_path(self._local_output_dir, self._output_dir)

--- a/tools/nl/embeddings/utils.py
+++ b/tools/nl/embeddings/utils.py
@@ -223,3 +223,8 @@ def save_embeddings_lancedb(local_dir: str, embeddings: List[Embedding]):
 def save_index_config(fm: FileManager, index_config: IndexConfig):
   with open(fm.index_config_path(), 'w') as f:
     yaml.dump(asdict(index_config), f)
+
+
+def save_custom_catalog(fm: FileManager, custom_catalog: Dict):
+  with open(fm.custom_catalog_path(), 'w') as f:
+    yaml.dump(custom_catalog, f)


### PR DESCRIPTION
* Saves custom catalog when building embeddings in `build_embeddings.py`. ([example](https://screenshot.googleplex.com/AJBmDYSE5GXtNPx))
* Loads the saved catalog (if any) at server startup.
* Initializes build embeddings logs so they are captured by the web admin. (similar to [this](https://github.com/datacommonsorg/import/blob/69b0e58ecef656e4706e67b4a47104eec4cf3138/simple/stats/main.py#L54-L60))