### PR TITLE
Switch from "fork" to "spawn" for multiprocessing in tests

### DIFF
--- a/server/integration_tests/__init__.py
+++ b/server/integration_tests/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from shared.lib.test_setup import set_up_macos_for_tests
+from shared.lib.test_setup import set_up_multiprocessing_for_tests
 
-set_up_macos_for_tests()
+set_up_multiprocessing_for_tests()

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,7 +5,6 @@ Flask==2.3.2
 Flask-Babel==2.0.0
 Flask-Caching==2.0.1
 flask_cors==3.0.10
-flask_testing==0.8.1
 frozendict==2.3.4
 geojson_rewind==1.0.1
 google-auth==2.28.1

--- a/server/webdriver/base.py
+++ b/server/webdriver/base.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import multiprocessing
-import os
-import sys
-
 from server.webdriver import shared
 from server.webdriver.base_utils import create_driver
 from shared.lib.test_server import NLWebServerTestCase
-from shared.lib.test_setup import set_up_macos_for_tests
+from shared.lib.test_setup import set_up_multiprocessing_for_tests
 
-set_up_macos_for_tests()
+set_up_multiprocessing_for_tests()
 
 
 # Base test class to setup the server.

--- a/server/webdriver/tests/standalone/cdc/__init__.py
+++ b/server/webdriver/tests/standalone/cdc/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from shared.lib.test_setup import set_up_macos_for_tests
+from shared.lib.test_setup import set_up_multiprocessing_for_tests
 
-set_up_macos_for_tests()
+set_up_multiprocessing_for_tests()

--- a/shared/lib/test_server.py
+++ b/shared/lib/test_server.py
@@ -16,23 +16,27 @@ import multiprocessing
 import os
 import platform
 import socket
+import unittest
 import warnings
-
-from flask_testing import LiveServerTestCase
 
 from nl_server.flask import create_app as create_nl_app
 from server.__init__ import create_app as create_web_app
 import server.lib.util as libutil
 
 
-def find_open_port():
+def find_open_port(skip_port: int | None = None):
   for port in range(12000, 13000):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+      if port == skip_port:
+        continue
       res = sock.connect_ex(('localhost', port))
       if res != 0:
         return port
 
 
+web_port = find_open_port()
+
+nl_port = None
 is_nl_mode = os.environ.get('ENABLE_MODEL') == 'true'
 if is_nl_mode:
   # Start NL server on an unused port, so multiple integration tests can
@@ -45,41 +49,51 @@ if is_nl_mode:
     nl_port = 6060
     should_start_nl_server = False
   else:
-    nl_port = find_open_port()
+    nl_port = find_open_port(web_port)
     should_start_nl_server = True
 
 
-class NLWebServerTestCase(LiveServerTestCase):
+def start_nl_server(port):
+  nl_app = create_nl_app()
+  nl_app.run(port=port, debug=False, use_reloader=False, threaded=True)
+
+
+def start_web_server(web_port, nl_port=None):
+  if nl_port:
+    web_app = create_web_app(f'http://127.0.0.1:{nl_port}')
+  else:
+    web_app = create_web_app()
+  web_app.run(port=web_port, use_reloader=False)
+
+
+class NLWebServerTestCase(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
     if is_nl_mode:
       if should_start_nl_server:
 
-        def start_nl_server(app):
-          app.run(port=nl_port, debug=False, use_reloader=False, threaded=True)
-
-        nl_app = create_nl_app()
         # Create a thread that will contain our running server
-        cls.proc = multiprocessing.Process(target=start_nl_server,
-                                           args=(nl_app,),
-                                           daemon=True)
-        cls.proc.start()
+        cls.nl_proc = multiprocessing.Process(target=start_nl_server,
+                                              args=(nl_port,),
+                                              daemon=True)
+        cls.nl_proc.start()
       else:
-        cls.proc = None
+        cls.nl_proc = None
       libutil.check_backend_ready(
           ['http://127.0.0.1:{}/healthz'.format(nl_port)])
 
+    # Start web app.
+    cls.web_proc = multiprocessing.Process(target=start_web_server,
+                                           args=(web_port, nl_port))
+    cls.web_proc.start()
+    libutil.check_backend_ready([f'http://127.0.0.1:{web_port}/healthz'])
+
+  def get_server_url(cls):
+    return f'http://localhost:{web_port}'
+
   @classmethod
   def tearDownClass(cls):
-    if is_nl_mode and cls.proc:
-      cls.proc.terminate()
-
-  def create_app(self):
-    """Returns the Flask Server running Data Commons."""
-    if is_nl_mode:
-      app = create_web_app('http://127.0.0.1:{}'.format(nl_port))
-    else:
-      app = create_web_app()
-    app.config['LIVESERVER_PORT'] = 0
-    return app
+    if is_nl_mode and cls.nl_proc:
+      cls.nl_proc.terminate()
+    cls.web_proc.terminate()

--- a/shared/lib/test_setup.py
+++ b/shared/lib/test_setup.py
@@ -14,18 +14,15 @@
 
 import multiprocessing
 import os
-import sys
 
 
-def set_up_macos_for_tests():
-  """Ensure Python tests work on MacOS.
+def set_up_multiprocessing_for_tests():
+  """Ensure Python tests work with multiprocessing.
 
-  Explicitly sets multiprocessing start method to 'fork' so tests work with
-  python3.8+ on MacOS:
-  https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+  Explicitly sets to "spawn" as the default can be "fork" in certain Linux,
+  and that does not work consistently well.
 
   This code must only be run once per execution.
   """
-  if sys.version_info >= (3, 8) and sys.platform == "darwin":
-    multiprocessing.set_start_method("fork")
-    os.environ['no_proxy'] = '*'
+  multiprocessing.set_start_method("spawn")
+  os.environ['no_proxy'] = '*'


### PR DESCRIPTION
Some kind of mysterious cloud build platform change broke "fork" start method for python `multiprocessing`.  Generally, "spawn" is apparently a safer alternative, since it doesn't inherit parent state into child (sharing state can mess with locks, and mess up behavior, perhaps like we see now) -- [doc](https://docs.python.org/3/library/multiprocessing.html).

However, "spawn" is [finicky about pickling of methods and objects](https://stackoverflow.com/questions/72766345/attributeerror-cant-pickle-local-object-in-multiprocessing) that get passed to the `run()` method.

So, this change does three things to switch over to "spawn" mode:
1.  Fix the `multiprocessing.Process` call we make to start NL server in a way that makes spawn happy
2. The Web server gets started by an external library (`flask_testing`) in a way that makes spawn unhappy.  So, stop using that (generally unmaintained) library, and instead start web server in our code.
3. Given our support for spawn, we no longer set fork, so avoid the mac-os specific setting.
