### PR TITLE
[toolformer] replace "global" with "world" in queries in toolformer mode

### DIFF
--- a/server/lib/nl/detection/heuristic_detector.py
+++ b/server/lib/nl/detection/heuristic_detector.py
@@ -29,13 +29,19 @@ from server.lib.nl.detection.types import SimpleClassificationAttributes
 from server.lib.nl.explore import params
 from server.lib.nl.explore.params import QueryMode
 
-TOOLFORMER_QUERY_REPLACEMENTS = {"residents": "people"}
+TOOLFORMER_QUERY_REPLACEMENTS = {"residents": "people", "global": "world"}
 
 
 def detect(orig_query: str, cleaned_query: str,
            query_detection_debug_logs: Dict, counters: Counters,
            dargs: DetectionArgs) -> Detection:
-  place_detection = place.detect_from_query_dc(orig_query,
+  # If in toolformer mode, process the query by replacing strings in
+  # the query
+  query_with_string_replacements = orig_query
+  if (params.is_toolformer_mode(dargs.mode)):
+    query_with_string_replacements = dutils.replace_strings_in_query(
+        orig_query, TOOLFORMER_QUERY_REPLACEMENTS)
+  place_detection = place.detect_from_query_dc(query_with_string_replacements,
                                                query_detection_debug_logs,
                                                dargs.allow_triples)
 
@@ -77,11 +83,6 @@ def detect(orig_query: str, cleaned_query: str,
 
   # Step 4: Identify the SV matched based on the query.
   sv_detection_query = dutils.remove_date_from_query(query, classifications)
-  # If in toolformer mode, further process the query by replacing strings in
-  # the query
-  if (params.is_toolformer_mode(dargs.mode)):
-    sv_detection_query = dutils.replace_strings_in_query(
-        sv_detection_query, TOOLFORMER_QUERY_REPLACEMENTS)
   sv_detection_result = dutils.empty_var_detection_result()
   try:
     sv_detection_result = variable.detect_vars(


### PR DESCRIPTION
ran goldens without the `if (params.is_toolformer_mode(dargs.mode))` & there were no diffs