### PR TITLE
Add Custom DC NL sanity test.

### DIFF
--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -24,7 +24,7 @@ from shared.lib.test_server import NLWebServerTestCase
 
 _dir = os.path.dirname(os.path.abspath(__file__))
 
-_TEST_MODE = os.environ['TEST_MODE']
+_TEST_MODE = os.environ.get('TEST_MODE', '')
 
 _TEST_DATA = 'test_data'
 

--- a/server/integration_tests/test_data/cdc_nl/chart_config.json
+++ b/server/integration_tests/test_data/cdc_nl/chart_config.json
@@ -1,0 +1,442 @@
+{
+  "client": "test_detect-and-fulfill",
+  "config": {
+    "categories": [
+      {
+        "blocks": [
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "statVarKey": [
+                      "gender_wage_gap"
+                    ],
+                    "title": "Gender Wage Gap in Countries of Europe (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "gender_wage_gap"
+                    ],
+                    "title": "Gender Wage Gap in Countries of Europe (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "description": "Gender wage gap.",
+            "title": "Gender Wage Gap in Countries of Europe"
+          }
+        ],
+        "statVarSpec": {
+          "gender_wage_gap": {
+            "name": "Gender Wage Gap",
+            "statVar": "gender_wage_gap"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "containedPlaceTypes": {
+        "Continent": "Country"
+      },
+      "placeDcid": [
+        "europe"
+      ]
+    }
+  },
+  "context": {},
+  "debug": {},
+  "entities": [],
+  "pastSourceContext": "",
+  "place": {
+    "dcid": "europe",
+    "name": "Europe",
+    "place_type": "Continent"
+  },
+  "placeFallback": {},
+  "placeSource": "CURRENT_QUERY",
+  "places": [
+    {
+      "dcid": "europe",
+      "name": "Europe",
+      "place_type": "Continent"
+    }
+  ],
+  "relatedThings": {
+    "childPlaces": {
+      "Country": [
+        {
+          "dcid": "country/ALA",
+          "name": "\u00c5land Islands",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/ALB",
+          "name": "Albania",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/AND",
+          "name": "Andorra",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/ANT",
+          "name": "Netherlands Antilles",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/ARM",
+          "name": "Armenia",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/AUT",
+          "name": "Austria",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/AZE",
+          "name": "Azerbaijan",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/BEL",
+          "name": "Belgium",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/BGR",
+          "name": "Bulgaria",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/BIH",
+          "name": "Bosnia and Herzegovina",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/BLM",
+          "name": "Saint Barth\u00e9lemy",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/BLR",
+          "name": "Belarus",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/CHE",
+          "name": "Switzerland",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/CYP",
+          "name": "Cyprus",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/CZE",
+          "name": "Czech Republic",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/DEU",
+          "name": "Germany",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/DNK",
+          "name": "Denmark",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/ESP",
+          "name": "Spain",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/EST",
+          "name": "Estonia",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/FIN",
+          "name": "Finland",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/FRA",
+          "name": "France",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/FRO",
+          "name": "Faroe Islands",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/FXX",
+          "name": "Metropolitan France",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/GBR",
+          "name": "United Kingdom",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/GEO",
+          "name": "Georgia",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/GGY",
+          "name": "Guernsey",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/GIB",
+          "name": "Gibraltar",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/GLP",
+          "name": "Guadeloupe",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/GRC",
+          "name": "Greece",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/GUF",
+          "name": "French Guiana",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/HRV",
+          "name": "Croatia",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/HUN",
+          "name": "Hungary",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/IMN",
+          "name": "Isle of Man",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/IRL",
+          "name": "Ireland",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/ISL",
+          "name": "Iceland",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/ITA",
+          "name": "Italy",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/JEY",
+          "name": "Jersey",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/KAZ",
+          "name": "Kazakhstan",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/LIE",
+          "name": "Liechtenstein",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/LTU",
+          "name": "Lithuania",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/LUX",
+          "name": "Luxembourg",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/LVA",
+          "name": "Latvia",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/MAF",
+          "name": "Saint Martin (French part)",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/MCO",
+          "name": "Monaco",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/MDA",
+          "name": "Moldova",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/MKD",
+          "name": "Macedonia [FYROM]",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/MLT",
+          "name": "Malta",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/MNE",
+          "name": "Montenegro",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/MTQ",
+          "name": "Martinique",
+          "types": [
+            "Country"
+          ]
+        },
+        {
+          "dcid": "country/MYT",
+          "name": "Mayotte",
+          "types": [
+            "Country"
+          ]
+        }
+      ]
+    },
+    "childTopics": [],
+    "exploreMore": {},
+    "mainTopics": [],
+    "parentPlaces": [],
+    "parentTopics": [],
+    "peerPlaces": [],
+    "peerTopics": []
+  },
+  "svSource": "CURRENT_QUERY",
+  "userMessage": "",
+  "userMessages": []
+}

--- a/server/webdriver/cdc_tests/autopush_test.py
+++ b/server/webdriver/cdc_tests/autopush_test.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 import unittest
-import urllib
-import urllib.request
 
-import requests
 from selenium.webdriver.common.by import By
 
+from server.integration_tests.explore_test import ExploreTest
 from server.webdriver import shared
 from server.webdriver.base_utils import create_driver
 from server.webdriver.base_utils import find_elem
@@ -69,15 +67,10 @@ class CdcAutopushWebdriverTest(unittest.TestCase):
                          'Custom SV (Average Annual Wage) element not found')
 
 
-class CdcAutopushNLTest(unittest.TestCase):
+class CdcAutopushNLTest(ExploreTest):
 
-  def test_detect_and_fulfill(self):
-    """Tests that the detect-and-fulfill endpoint returns a Custom DC SV in the response."""
-    query = "Average annual wages in Europe"
-    url = f'{CDC_AUTOPUSH_URL}/api/explore/detect-and-fulfill?q={query}'
-    response = requests.post(url, json={
-        'contextHistory': [],
-        'dc': '',
-    }).json()
-    svs = response.get('context', [{}])[0].get('svs', [])
-    assert 'average_annual_wage' in svs, 'Custom SV (average_annual_wage) not in detect-and-fulfill response'
+  def get_server_url(self):
+    return CDC_AUTOPUSH_URL
+
+  def test_cdc_nl(self):
+    self.run_detect_and_fulfill('cdc_nl', ['gender wage gap in europe'])

--- a/server/webdriver/cdc_tests/autopush_test.py
+++ b/server/webdriver/cdc_tests/autopush_test.py
@@ -16,6 +16,7 @@ import unittest
 import urllib
 import urllib.request
 
+import requests
 from selenium.webdriver.common.by import By
 
 from server.webdriver import shared
@@ -27,7 +28,7 @@ from server.webdriver.base_utils import wait_elem
 CDC_AUTOPUSH_URL = 'https://dc-autopush-kqb7thiuka-uc.a.run.app'
 
 
-class CdcAutopushTest(unittest.TestCase):
+class CdcAutopushWebdriverTest(unittest.TestCase):
 
   def setUp(self, preferences=None):
     """Runs at the beginning of every individual test."""
@@ -66,3 +67,17 @@ class CdcAutopushTest(unittest.TestCase):
                                '//*[contains(text(), "Average Annual Wage")]')
     self.assertIsNotNone(custom_sv_elem,
                          'Custom SV (Average Annual Wage) element not found')
+
+
+class CdcAutopushNLTest(unittest.TestCase):
+
+  def test_detect_and_fulfill(self):
+    """Tests that the detect-and-fulfill endpoint returns a Custom DC SV in the response."""
+    query = "Average annual wages in Europe"
+    url = f'{CDC_AUTOPUSH_URL}/api/explore/detect-and-fulfill?q={query}'
+    response = requests.post(url, json={
+        'contextHistory': [],
+        'dc': '',
+    }).json()
+    svs = response.get('context', [{}])[0].get('svs', [])
+    assert 'average_annual_wage' in svs, 'Custom SV (average_annual_wage) not in detect-and-fulfill response'


### PR DESCRIPTION
* Adds a simple sanity test that asserts that the detect-and-fulfill response includes a Custom DC SV.
* This PR will only be submitted after this one: https://github.com/datacommonsorg/website/pull/4473
  + Without that PR, custom embeddings will not load on startup, which will cause this test to fail.
  + Ironically, in the future, the failure of this test will be an indicator of a Custom DC NL regression.