### PR TITLE
[timeline] fix ratio bug

### DIFF
--- a/static/js/tools/shared_util.ts
+++ b/static/js/tools/shared_util.ts
@@ -185,13 +185,14 @@ export function computeRatio(
   let j = 0; // denominator position
   for (let i = 0; i < num.length; i++) {
     const numDate = Date.parse(num[i].date);
-    const denomDate = Date.parse(denom[j].date);
+    let denomDate = Date.parse(denom[j].date);
     while (j < denom.length - 1 && numDate > denomDate) {
       const denomDateNext = Date.parse(denom[j + 1].date);
       const nextBetter =
         Math.abs(denomDateNext - numDate) < Math.abs(denomDate - numDate);
       if (nextBetter) {
         j++;
+        denomDate = Date.parse(denom[j].date);
       } else {
         break;
       }


### PR DESCRIPTION
there was a bug in picking the denominator observation where when comparing if next denom is better, it was comparing with the earliest denominator & not the previous denominator. This caused weird behavior for per capita timelines

autopush: https://screenshot.googleplex.com/6gh9Nyjr7kg638C
local: https://screenshot.googleplex.com/BHUsQPMih5X27Hy