### PR TITLE
Add frozendict to nl_server

### DIFF
--- a/nl_requirements.txt
+++ b/nl_requirements.txt
@@ -1,3 +1,4 @@
+frozendict==2.3.4
 fsspec==2024.2.0
 datasets==2.18.0
 google-cloud-aiplatform==1.42.1


### PR DESCRIPTION
https://github.com/datacommonsorg/website/pull/4487 introduced frozendict import in shared lib.  The NL server requirements was missing it ([Web server requirements has it](https://github.com/datacommonsorg/website/blob/e868bcc8a374fb72106d52cf7fd55a9d8a58f7bb/server/requirements.txt#L9)).