### PR TITLE
[evals] use value instead of stringValue when getting cell content

### DIFF
--- a/static/js/apps/eval_retrieval_generation/util.ts
+++ b/static/js/apps/eval_retrieval_generation/util.ts
@@ -189,10 +189,10 @@ function getCalls(
       }
       calls[queryId][callId] = {
         rowIndex: i,
-        question: sheet.getCell(i, header[DC_QUESTION_COL]).value as string,
-        llmStat: sheet.getCell(i, header[LLM_STAT_COL]).value as string,
-        dcResponse: sheet.getCell(i, header[DC_RESPONSE_COL]).value as string,
-        dcStat: sheet.getCell(i, header[DC_STAT_COL]).value as string,
+        question: sheet.getCell(i, header[DC_QUESTION_COL]).value?.toString(),
+        llmStat: sheet.getCell(i, header[LLM_STAT_COL]).value?.toString(),
+        dcResponse: sheet.getCell(i, header[DC_RESPONSE_COL]).value?.toString(),
+        dcStat: sheet.getCell(i, header[DC_STAT_COL]).value?.toString(),
       };
     }
     return calls;

--- a/static/js/apps/eval_retrieval_generation/util.ts
+++ b/static/js/apps/eval_retrieval_generation/util.ts
@@ -189,10 +189,10 @@ function getCalls(
       }
       calls[queryId][callId] = {
         rowIndex: i,
-        question: sheet.getCell(i, header[DC_QUESTION_COL]).stringValue,
-        llmStat: sheet.getCell(i, header[LLM_STAT_COL]).stringValue,
-        dcResponse: sheet.getCell(i, header[DC_RESPONSE_COL]).stringValue,
-        dcStat: sheet.getCell(i, header[DC_STAT_COL]).stringValue,
+        question: sheet.getCell(i, header[DC_QUESTION_COL]).value as string,
+        llmStat: sheet.getCell(i, header[LLM_STAT_COL]).value as string,
+        dcResponse: sheet.getCell(i, header[DC_RESPONSE_COL]).value as string,
+        dcStat: sheet.getCell(i, header[DC_STAT_COL]).value as string,
       };
     }
     return calls;


### PR DESCRIPTION
cell values of type number wasn't fetched when using getCell().stringValue