### PR TITLE
Consolidate CDC env file.

### DIFF
--- a/build/web_compose/Dockerfile
+++ b/build/web_compose/Dockerfile
@@ -68,7 +68,7 @@ COPY deploy/nl/. /datacommons/nl/
 COPY nl_server/requirements.txt /workspace/nl_server/requirements.txt
 COPY nl_requirements.txt /workspace/nl_requirements.txt
 # TODO: Undo this once we figure out why lancedb breaks Custom DC Docker
-RUN sed -i'' '/lancedb/d' /workspace/nl_server/requirements.txt
+RUN sed -i'' '/lancedb/d' /workspace/nl_requirements.txt
 RUN pip install --upgrade pip
 RUN pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
 RUN pip3 install --no-cache-dir -r /workspace/nl_server/requirements.txt
@@ -84,15 +84,15 @@ RUN pip3 install -r /workspace/tools/nl/embeddings/requirements.txt
 # Install website NPM dependencies
 COPY packages/web-components/package.json /workspace/packages/web-components/package.json
 COPY packages/web-components/package-lock.json /workspace/packages/web-components/package-lock.json
-RUN npm --prefix /workspace/packages/web-components install --omit=dev
+RUN npm --prefix /workspace/packages/web-components ci --omit=dev
 
 COPY packages/client/package.json /workspace/packages/client/package.json
 COPY packages/client/package-lock.json /workspace/packages/client/package-lock.json
-RUN npm --prefix /workspace/packages/client install
+RUN npm --prefix /workspace/packages/client ci
 
 COPY static/package.json /workspace/static/package.json
 COPY static/package-lock.json /workspace/static/package-lock.json
-RUN npm --prefix /workspace/static install --omit=dev
+RUN npm --prefix /workspace/static ci --omit=dev
 
 # Install packages NPM depenencies
 COPY packages/. /workspace/packages/

--- a/build/web_compose/compose.sh
+++ b/build/web_compose/compose.sh
@@ -19,20 +19,46 @@ export TOKENIZERS_PARALLELISM=false
 # https://github.com/UKPLab/sentence-transformers/issues/1318#issuecomment-1084731111
 export OMP_NUM_THREADS=1
 
+# If OUTPUT_DIR is not specified and the deprecated GCS_DATA_PATH is, use that as OUTPUT_DIR.
+if [[ $OUTPUT_DIR == "" && $GCS_DATA_PATH != "" ]]; then
+    echo "GCS Data Path: $GCS_DATA_PATH"
+    echo "GCS_DATA_PATH is deprecated and will be removed in the future. Use OUTPUT_DIR instead."
+    export OUTPUT_DIR=$GCS_DATA_PATH
+fi
+
+# Set OUTPUT_DIR to same as INPUT_DIR if not specified.
+if [[ $OUTPUT_DIR == "" ]]; then
+    if [[ $INPUT_DIR == "" ]]; then
+        echo "INPUT_DIR not specified."
+        exit 1
+    fi
+    export OUTPUT_DIR=$INPUT_DIR
+fi
+
+# Check for required variables.
+
+if [[ $DC_API_KEY == "" ]]; then
+  echo "DC_API_KEY not specified."
+  exit 1
+fi
+
+if [[ $MAPS_API_KEY == "" ]]; then
+  echo "MAPS_API_KEY not specified."
+  exit 1
+fi
+
+echo "OUTPUT_DIR=$OUTPUT_DIR"
+
+export IS_CUSTOM_DC=true
+export USER_DATA_PATH=$OUTPUT_DIR
+export ADDITIONAL_CATALOG_PATH=$USER_DATA_PATH/datacommons/nl/embeddings/custom_catalog.yaml
+
 if [[ $USE_SQLITE == "true" ]]; then
-    export SQLITE_PATH=/sqlite/datacommons.db
+    export SQLITE_PATH=$OUTPUT_DIR/datacommons/datacommons.db
+    echo "SQLITE_PATH=$SQLITE_PATH"
 fi
 
 nginx -c /workspace/nginx.conf
-
-echo "GCS Data Path: $GCS_DATA_PATH"
-if [[ $GCS_DATA_PATH != "" ]]; then
-    export USER_DATA_PATH=$GCS_DATA_PATH
-else
-    export USER_DATA_PATH=/userdata/
-fi
-export IS_CUSTOM_DC=true
-export ADDITIONAL_CATALOG_PATH=$USER_DATA_PATH/datacommons/nl/embeddings/custom_catalog.yaml
 
 /go/bin/mixer \
     --use_bigquery=false \

--- a/custom_dc/env.list
+++ b/custom_dc/env.list
@@ -1,7 +1,20 @@
+### API Keys ###
+
 # API key for accessing the base Data Commons API.
 DC_API_KEY=
 # API key for accessing Maps and Places APIs for exploration tools.
 MAPS_API_KEY=
+
+### Directories ###
+
+# Input directory in Google Cloud Storage or local drive, containing files to be processed.
+INPUT_DIR=
+# Output directory in Google Cloud Storage or local drive for generated csv files.
+# Leave blank if same as INPUT_DIR.
+OUTPUT_DIR=
+
+### DB parameters ###
+
 # Use local SQLite as the database.
 USE_SQLITE=true
 # Use Google Cloud SQL as the database.
@@ -16,21 +29,23 @@ DB_NAME=datacommons
 DB_USER=
 # The password of the user specified in DB_USER.
 DB_PASS=
+
+### Optional parameters ###
+
 # (Optional) If used, the Redis Memorystore instance IP address.
 REDIS_HOST=
 # (Optional) Secret token to authorize users to perform /admin page operations.
 ADMIN_SECRET=
 # Enable embeddings generation and natural language querying.
+
+### Variables that rarely need to be changed ###
+
 ENABLE_MODEL=true
 # The name of the parent directory for custom CSS, JS, HTML and image files.
 FLASK_ENV=custom
-# (Optional) Secret token to authorize users to perform /admin page operations.
-ADMIN_SECRET=
-# Input directory in Google Cloud Storage or local drive, containing files to be processed.
-INPUT_DIR=
-# The data path of the files stored in Google Cloud Storage, in the form gs://<BUCKET>/<FOLDER>/.
-# GCS_DATA_PATH overrides OUTPUT_DIR.
+
+### Deprecated variables ###
+
+# Deprecated. Use OUTPUT_DIR instead.
+# The data path of the files stored in Google Cloud Storage, in the form gs://<BUCKET>/<FOLDER>.
 GCS_DATA_PATH=
-# Output directory from local drive for generated csv files.
-# Use when GCS_DATA_PATH is not set.
-OUTPUT_DIR=

--- a/custom_dc/env.list
+++ b/custom_dc/env.list
@@ -1,4 +1,4 @@
-### API Keys ###
+### API keys ###
 
 # API key for accessing the base Data Commons API.
 DC_API_KEY=
@@ -7,9 +7,11 @@ MAPS_API_KEY=
 
 ### Directories ###
 
-# Input directory in Google Cloud Storage or local drive, containing files to be processed.
+# Input directory in Google Cloud Storage (GCS) or local drive, containing files to be processed.
+# GCS paths should be in the form gs://<BUCKET>/<FOLDER>.
 INPUT_DIR=
-# Output directory in Google Cloud Storage or local drive for generated csv files.
+# Output directory in Google Cloud Storage (GCS) or local drive for generated csv files.
+# GCS paths should be in the form gs://<BUCKET>/<FOLDER>.
 # Leave blank if same as INPUT_DIR.
 OUTPUT_DIR=
 

--- a/tools/nl/embeddings/utils.py
+++ b/tools/nl/embeddings/utils.py
@@ -25,7 +25,6 @@ import os
 import time
 from typing import Dict, List
 
-import lancedb
 import pandas as pd
 import yaml
 
@@ -210,6 +209,12 @@ def save_embeddings_memory(local_dir: str, embeddings: List[Embedding]):
 
 
 def save_embeddings_lancedb(local_dir: str, embeddings: List[Embedding]):
+  # lancedb has issues in docker containers on certain platforms.
+  # Importing it as a global import causes failures in build_embeddings on those platforms for Custom DC (CDC).
+  # Since this method is never called for building CDC embeddings, we import it locally.
+  # This will need to be addressed before we can support lancedb in CDC.
+  import lancedb
+
   db = lancedb.connect(local_dir)
   records = [{
       _COL_DCID: x.preindex.dcid,


### PR DESCRIPTION
* Consolidates CDC env vars into a single file (`env.list`).
* See [go/cdc-env-file-consolidation](http://go/cdc-env-file-consolidation) for more details.
* As part of the consolidation `sqlite_env.list` and `cloudsql_env.list` need to be removed.
  + We'll remove them from the code once @kmoscoe has removed their mention from the docs.

* `Dockerfile` changes:
  + `lancedb` deps were moved to a different requirements file a few weeks ago. Adapting Dockerfile to that move.
  + Uses `npm ci` vs `npm install` for faster builds. See [this thread](https://stackoverflow.com/a/74068335) for more details.
* The Dockerfile changes are not related to env consolidation so I can do it in a separate PR if needed. LMK.
* Built docker image (`gcr.io/datcom-ci/datacommons-website-compose:keyurs-test`) with these changes and verified in the cloud [here](https://screenshot.googleplex.com/AdiWt7P4umvBuX4).