### PR TITLE
[CDC Autopush] Fix submod pull no-op case

### DIFF
--- a/scripts/build_custom_dc_and_tag_latest.sh
+++ b/scripts/build_custom_dc_and_tag_latest.sh
@@ -32,7 +32,7 @@ set -x
 # Configure Git to create commits with Cloud Build's service account
 git config user.email $(gcloud auth list --filter=status:ACTIVE --format='value(account)')
 
-git commit -am "DO NOT PUSH: Temp commit to update pinned submod versions"
+git commit --allow-empty -am "DO NOT PUSH: Temp commit to update pinned submod versions (empty if submods are already up-to-date)"
 
 website_rev="$(git rev-parse --short HEAD)"
 mixer_rev="$(git rev-parse --short HEAD:mixer)"


### PR DESCRIPTION
Allow an empty commit when pulling in latest submods in case they're already up-to-date. This should fix current autopush build failures.