### PR TITLE
Update bad words python test

### DIFF
--- a/server/integration_tests/nl_test.py
+++ b/server/integration_tests/nl_test.py
@@ -350,4 +350,4 @@ class NLTestMisc(NLTest):
             'number of headless drivers in california',
         ],
         mode='strict',
-        expected_detectors=['Heuristic Based'])
+        expected_detectors=['Hybrid - Heuristic Based'])

--- a/server/lib/nl/common/bad_words.py
+++ b/server/lib/nl/common/bad_words.py
@@ -19,7 +19,6 @@ from typing import Dict, List
 
 from server.lib import config as libconfig
 from shared.lib import gcs
-import logging
 
 cfg = libconfig.get_config()
 BAD_WORDS_PATH = gcs.make_path(libconfig.GLOBAL_CONFIG_BUCKET,

--- a/server/lib/nl/common/bad_words.py
+++ b/server/lib/nl/common/bad_words.py
@@ -19,6 +19,7 @@ from typing import Dict, List
 
 from server.lib import config as libconfig
 from shared.lib import gcs
+import logging
 
 cfg = libconfig.get_config()
 BAD_WORDS_PATH = gcs.make_path(libconfig.GLOBAL_CONFIG_BUCKET,
@@ -142,7 +143,6 @@ def _validate(mode: str, line: str, bad_words: BannedWords, validate: bool):
   if not validate:
     return
   if mode == 'multi':
-    assert ' ' not in line, f'Line {line} has a ":" and a phrase!'
     words = sorted([w.strip() for w in line.split(_DELIM) if w.strip()])
     for w in words:
       if w in bad_words.entries:


### PR DESCRIPTION
This PR removes the assertion that in the bad words test, in `multi` mode, lines should not contain spaces. This assertion breaks when creating cross products that include place names like "united states of america" or "united kingdom". 

This PR also updates the "headless drivers" NL test case to look for the correct detection type.

This should unblock the python and nl test failures seen in unrelated, already approved PRs.