### PR TITLE
Update .dockerignore to fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,5 +13,6 @@ pytest_log.txt
 **/eval/**/result
 
 import/simple/sample/
-**/tests/
 **/.data
+**/testdata
+**/test_data


### PR DESCRIPTION
Updates .dockerignore to exclude the sanity.py file (in **/tests) to fix a cron-testing docker build failure.