### PR TITLE
Fix map tool stat var search with many places

### DIFF
--- a/run_server.sh
+++ b/run_server.sh
@@ -22,7 +22,6 @@ function cleanup {
 }
 trap cleanup SIGINT
 
-
 source .env/bin/activate
 
 PORT=8080
@@ -36,32 +35,36 @@ function help {
   echo "-x       Enable embedding eval playground"
   echo "-d       [Local dev] Enable disaster JSON cache"
   echo "-l       [Local dev] Use local mixer"
+  echo "-g       [Local dev] Use Gunicorn"
   exit 1
 }
 
-while getopts ":e:p:m?d?l?x" OPTION; do
+while getopts ":e:p:m?d?l?xg" OPTION; do
   case $OPTION in
-    e)
-      export FLASK_ENV=$OPTARG
-      ;;
-    p)
-      export PORT=$OPTARG
-      ;;
-    m)
-      export ENABLE_MODEL=true
-      ;;
-    x)
-      export ENABLE_EVAL_TOOL=false
-      ;;
-    d)
-      export ENABLE_DISASTER_JSON=true
-      ;;
-    l)
-      export USE_LOCAL_MIXER=true
-      ;;
-    *)
-      help
-      ;;
+  e)
+    export FLASK_ENV=$OPTARG
+    ;;
+  p)
+    export PORT=$OPTARG
+    ;;
+  m)
+    export ENABLE_MODEL=true
+    ;;
+  x)
+    export ENABLE_EVAL_TOOL=false
+    ;;
+  d)
+    export ENABLE_DISASTER_JSON=true
+    ;;
+  l)
+    export USE_LOCAL_MIXER=true
+    ;;
+  g)
+    USE_GUNICORN=true
+    ;;
+  *)
+    help
+    ;;
   esac
 done
 
@@ -78,5 +81,9 @@ else
 fi
 echo "Starting localhost with FLASK_ENV='$FLASK_ENV' on port='$PORT'"
 
-protoc -I=./server/config/ --python_out=./server/config ./server/config/subject_page.proto
-python3 web_app.py $PORT
+if [[ $USE_GUNICORN ]]; then
+  gunicorn --log-level info --preload --timeout 1000 --bind localhost:${PORT} -w 4 web_app:app
+else
+  protoc -I=./server/config/ --python_out=./server/config ./server/config/subject_page.proto
+  python3 web_app.py $PORT
+fi

--- a/server/routes/shared_api/stats.py
+++ b/server/routes/shared_api/stats.py
@@ -98,12 +98,17 @@ def stat_var_property():
   return result
 
 
-@bp.route('/stat-var-search')
+@bp.route('/stat-var-search', methods=('GET', 'POST'))
 @cache.cached(timeout=TIMEOUT, query_string=True)
 def search_statvar():
   """Gets the statvars and statvar groups that match the tokens in the query."""
-  query = request.args.get("query")
-  places = request.args.getlist("places")
-  sv_only = request.args.get("svOnly", False)
+  if request.method == 'GET':
+    query = request.args.get("query")
+    places = request.args.getlist("places")
+    sv_only = request.args.get("svOnly", False)
+  else:  # Method is POST
+    query = request.json.get("query")
+    places = request.json.get("places")
+    sv_only = request.json.get("svOnly")
   result = dc.search_statvar(query, places, sv_only)
   return Response(json.dumps(result), 200, mimetype='application/json')

--- a/static/js/shared/ga_events.test.tsx
+++ b/static/js/shared/ga_events.test.tsx
@@ -399,9 +399,10 @@ const STAT_VAR_HIERARCHY_PROPS = {
   deselectSV: () => null,
 };
 
-beforeEach(() =>
-  jest.spyOn(axios, "get").mockImplementation(() => Promise.resolve(null))
-);
+beforeEach(() => {
+  jest.spyOn(axios, "get").mockImplementation(() => Promise.resolve(null));
+  jest.spyOn(axios, "post").mockImplementation(() => Promise.resolve(null));
+});
 
 // Unmount react trees that were mounted with render and clear all mocks.
 afterEach(() => {

--- a/static/js/utils/search_utils.tsx
+++ b/static/js/utils/search_utils.tsx
@@ -28,14 +28,13 @@ export function getStatVarSearchResults(
   places: string[],
   svOnly: boolean
 ): Promise<StatVarSearchResult> {
-  let url = `/api/stats/stat-var-search?query=${query}`;
-  for (const place of places) {
-    url += `&places=${place}`;
-  }
-  if (svOnly) {
-    url += `&svOnly=1`;
-  }
-  return axios.get(url).then((resp) => {
+  const url = "/api/stats/stat-var-search";
+  const payload = {
+    query,
+    places,
+    svOnly,
+  };
+  return axios.post(url, payload).then((resp) => {
     const data = resp.data;
     return {
       matches: data.matches || [],


### PR DESCRIPTION
Fixes b/356689537 where variable search in the new map tool when plotting countries on earth resulted in an error "Request line is too large".

Since the error only reproduces when running the website server with Gunicorn, also added a mode to run_server.sh for ease of reproing.

I've moved all request params to the request body, but if we want to only move places (maybe for the sake of analytics), I can modify this.