### PR TITLE
Create initial multi stage CDC services docker image.

### DIFF
--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -1,0 +1,75 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# #### Stage 1: Build mixer. ####
+FROM golang:1.20.7 AS mixer
+
+WORKDIR /workspace
+
+# Install the protobuf compiler and Go plugins.
+RUN apt-get update \
+    && apt-get install -y protobuf-compiler \
+    && go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0 \
+    && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
+
+COPY mixer/go.mod mixer/go.sum ./
+RUN go mod download -x
+
+# Copy files
+COPY mixer/proto/ proto
+COPY mixer/internal/ internal
+COPY mixer/cmd/ cmd
+COPY mixer/esp/ esp
+
+# Build protobuf.
+RUN protoc \
+    --include_source_info \
+    --include_imports \
+    --proto_path=proto \
+    --go_out=paths=source_relative:internal/proto \
+    --go-grpc_out=paths=source_relative:internal/proto \
+    --go-grpc_opt=require_unimplemented_servers=false \
+    --experimental_allow_proto3_optional \
+    --descriptor_set_out mixer-grpc.pb \
+    proto/*.proto proto/**/*.proto
+
+# Build mixer.
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/mixer cmd/main.go
+
+
+# #### Final stage: Runtime env. ####
+FROM gcr.io/datcom-ci/datacommons-services-runtime:2024-08-05 as runner
+
+# Env that should not change
+ENV USE_LOCAL_MIXER=true \
+    ENV_PREFIX=Compose \
+    ENABLE_ADMIN=true
+
+RUN rm -rf /workspace
+
+WORKDIR /workspace
+
+# Copy scripts, dependencies and files from the build stages.
+COPY --from=mixer /workspace/bin/ bin
+COPY --from=mixer /workspace/esp/ esp
+COPY --from=mixer /workspace/internal/ internal
+COPY --from=mixer /workspace/mixer-grpc.pb .
+
+# Copy executable script.
+COPY --chmod=0755 build/cdc_services/run.sh .
+
+RUN echo "Running ls " && echo $(pwd) && ls -l . && echo "Running ls bin" && ls -l bin && echo "Running ls esp" && ls -l esp
+
+# Set the default command to run the script.
+CMD ./run.sh

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -49,27 +49,26 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/mixer cmd/main.go
 
 
 # #### Final stage: Runtime env. ####
-FROM gcr.io/datcom-ci/datacommons-services-runtime:2024-08-05 as runner
+FROM gcr.io/datcom-ci/datacommons-services-runtime:2024-08-06 as runner
 
 # Env that should not change
 ENV USE_LOCAL_MIXER=true \
     ENV_PREFIX=Compose \
     ENABLE_ADMIN=true
 
-RUN rm -rf /workspace
-
 WORKDIR /workspace
 
-# Copy scripts, dependencies and files from the build stages.
+# Copy scripts, dependencies and files from build stages and from local file system.
+# Mixer.
 COPY --from=mixer /workspace/bin/ bin
 COPY --from=mixer /workspace/esp/ esp
 COPY --from=mixer /workspace/internal/ internal
 COPY --from=mixer /workspace/mixer-grpc.pb .
+# nginx.
+COPY build/cdc_services/nginx.conf .
 
 # Copy executable script.
 COPY --chmod=0755 build/cdc_services/run.sh .
-
-RUN echo "Running ls " && echo $(pwd) && ls -l . && echo "Running ls bin" && ls -l bin && echo "Running ls esp" && ls -l esp
 
 # Set the default command to run the script.
 CMD ./run.sh

--- a/build/cdc_services/nginx.conf
+++ b/build/cdc_services/nginx.conf
@@ -10,6 +10,7 @@ http {
     #     proxy_read_timeout 3600;
     # }
 
+    # Make mixer api available at /core/api/
     location /core/api/ {
         rewrite /core/api/(.*) /$1 break;
         proxy_pass http://localhost:8081;

--- a/build/cdc_services/nginx.conf
+++ b/build/cdc_services/nginx.conf
@@ -1,0 +1,24 @@
+events {}
+
+http {
+  server {
+    listen 8080;
+
+    # location / {
+    #     proxy_pass http://0.0.0.0:7070;
+    #     proxy_set_header Host $http_host;
+    #     proxy_read_timeout 3600;
+    # }
+
+    location /core/api/ {
+        rewrite /core/api/(.*) /$1 break;
+        proxy_pass http://localhost:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_read_timeout 3600;
+    }
+    error_log /dev/stderr;
+  }
+}

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+export MIXER_API_KEY=$DC_API_KEY
+# https://stackoverflow.com/a/62703850
+export TOKENIZERS_PARALLELISM=false
+# https://github.com/UKPLab/sentence-transformers/issues/1318#issuecomment-1084731111
+export OMP_NUM_THREADS=1
+
+# If OUTPUT_DIR is not specified and the deprecated GCS_DATA_PATH is, use that as OUTPUT_DIR.
+if [[ $OUTPUT_DIR == "" && $GCS_DATA_PATH != "" ]]; then
+    echo "GCS Data Path: $GCS_DATA_PATH"
+    echo "GCS_DATA_PATH is deprecated and will be removed in the future. Use OUTPUT_DIR instead."
+    export OUTPUT_DIR=$GCS_DATA_PATH
+fi
+
+# Check for required variables.
+
+if [[ $DC_API_KEY == "" ]]; then
+  echo "DC_API_KEY not specified."
+  exit 1
+fi
+
+if [[ $MAPS_API_KEY == "" ]]; then
+  echo "MAPS_API_KEY not specified."
+  exit 1
+fi
+
+if [[ $OUTPUT_DIR == "" ]]; then
+    echo "OUTPUT_DIR not specified."
+    exit 1
+fi
+
+echo "OUTPUT_DIR=$OUTPUT_DIR"
+
+export IS_CUSTOM_DC=true
+export USER_DATA_PATH=$OUTPUT_DIR
+export ADDITIONAL_CATALOG_PATH=$USER_DATA_PATH/datacommons/nl/embeddings/custom_catalog.yaml
+
+if [[ $USE_SQLITE == "true" ]]; then
+    export SQLITE_PATH=$OUTPUT_DIR/datacommons/datacommons.db
+    echo "SQLITE_PATH=$SQLITE_PATH"
+fi
+
+# nginx -c /workspace/nginx.conf
+
+ls -l /workspace
+ls -l /workspace/bin
+ls -l /workspace/esp
+
+/workspace/bin/mixer \
+    --use_bigquery=false \
+    --use_base_bigtable=false \
+    --use_custom_bigtable=false \
+    --use_branch_bigtable=false \
+    --sqlite_path=$SQLITE_PATH \
+    --use_sqlite=$USE_SQLITE \
+    --use_cloudsql=$USE_CLOUDSQL \
+    --cloudsql_instance=$CLOUDSQL_INSTANCE \
+    --remote_mixer_domain=$DC_API_ROOT &
+
+envoy -l warning --config-path /workspace/esp/envoy-config.yaml &
+
+# if [[ $DEBUG == "true" ]] then
+#     if [[ $ENABLE_MODEL == "true" ]] then
+#         echo "Starting NL Server in debug mode."
+#         python3 nl_app.py 6060 &
+#     fi
+#     echo "Starting Website Server in debug mode."
+#     python3 web_app.py 7070 &
+# else
+#     if [[ $ENABLE_MODEL == "true" ]] then
+#         echo "Starting NL Server."
+#         gunicorn --log-level info --preload --timeout 1000 --bind 0.0.0.0:6060 -w 1 nl_app:app &
+#     fi
+#     echo "Starting Website Server."
+#     gunicorn --log-level info --preload --timeout 1000 --bind 0.0.0.0:7070 -w 4 web_app:app &
+# fi
+
+# Wait for any process to exit
+wait
+
+# Exit with status of process that exited first
+exit $?

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 set -e
-set -x
 
 export MIXER_API_KEY=$DC_API_KEY
 # https://stackoverflow.com/a/62703850
@@ -57,11 +56,7 @@ if [[ $USE_SQLITE == "true" ]]; then
     echo "SQLITE_PATH=$SQLITE_PATH"
 fi
 
-# nginx -c /workspace/nginx.conf
-
-ls -l /workspace
-ls -l /workspace/bin
-ls -l /workspace/esp
+nginx -c /workspace/nginx.conf
 
 /workspace/bin/mixer \
     --use_bigquery=false \

--- a/build/cdc_services_runtime/Dockerfile
+++ b/build/cdc_services_runtime/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Installs the runtime dependencies for the gcr.io/datcom-ci/datacommons-services docker.
+# The dependencies are as follows (add to this list if and when new dependencies are added):
+# - python 3.11
+# - envoy
+# - sqlite3
+
+FROM python:3.11.4-slim as runner
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y upgrade \
+    && apt update \
+    # Install envoy.
+    && apt install -y --no-install-recommends curl gpg debian-keyring debian-archive-keyring apt-transport-https lsb-release \
+    && curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg \
+    && echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/debian $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list \
+    && apt update \
+    && apt install -y --no-install-recommends getenvoy-envoy \
+    # sqlite3 - used by mixer.
+    && apt install -y --no-install-recommends sqlite3 libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/build/cdc_services_runtime/Dockerfile
+++ b/build/cdc_services_runtime/Dockerfile
@@ -16,7 +16,7 @@
 # The dependencies are as follows (add to this list if and when new dependencies are added):
 # - python 3.11
 # - envoy
-# - sqlite3
+# - nginx
 
 FROM python:3.11.4-slim as runner
 
@@ -29,6 +29,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y upgrade \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/debian $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list \
     && apt update \
     && apt install -y --no-install-recommends getenvoy-envoy \
-    # sqlite3 - used by mixer.
-    && apt install -y --no-install-recommends sqlite3 libsqlite3-dev \
+    # Install nginx.
+    && apt install -y --no-install-recommends nginx \
     && rm -rf /var/lib/apt/lists/*

--- a/build/cdc_services_runtime/cloudbuild.yaml
+++ b/build/cdc_services_runtime/cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 substitutions:
-  _VERS: "2024-08-05"
+  _VERS: "2024-08-06"
 
 steps:
   - name: "gcr.io/cloud-builders/docker"

--- a/build/cdc_services_runtime/cloudbuild.yaml
+++ b/build/cdc_services_runtime/cloudbuild.yaml
@@ -1,0 +1,29 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+substitutions:
+  _VERS: "2024-08-05"
+
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      - build
+      - "--build-arg=VERS=${_VERS}"
+      - --tag=gcr.io/datcom-ci/datacommons-services-runtime:${_VERS}
+      - --tag=gcr.io/datcom-ci/datacommons-services-runtime:latest
+      - "."
+
+images:
+  - "gcr.io/datcom-ci/datacommons-services-runtime:${_VERS}"
+  - "gcr.io/datcom-ci/datacommons-services-runtime:latest"

--- a/build/ci/cloudbuild.push_cdc_services_image.yaml
+++ b/build/ci/cloudbuild.push_cdc_services_image.yaml
@@ -12,24 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cloud build file to manually trigger building and pushing a CDC data docker image.
+# Cloud build file to manually trigger building and pushing a CDC services docker image.
 # This cloud build is typically executed by invoking
-# the wrapper script ./scripts/push_cdc_data_image.sh.
+# the wrapper script ./scripts/push_cdc_services_image.sh.
 
 steps:
 
-  - id: push-cdc-data-image
+  - id: push-cdc-services-image
     name: gcr.io/cloud-builders/docker
     entrypoint: "bash"
     args:
       - -c
       - |
         set -e
-        docker build -f build/cdc_data/Dockerfile \
-          --network=cloudbuild \
-          -t gcr.io/datcom-ci/datacommons-data:${_TAG} \
+        DOCKER_BUILDKIT=1 docker build -f build/cdc_services/Dockerfile \
+          --tag gcr.io/datcom-ci/datacommons-services:${_TAG} \
           .
-        docker push gcr.io/datcom-ci/datacommons-data:${_TAG}
+        docker push gcr.io/datcom-ci/datacommons-services:${_TAG}
 
 timeout: 3600s
 options:

--- a/scripts/push_cdc_services_image.sh
+++ b/scripts/push_cdc_services_image.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build CDC services Docker image with a test image tag and push to Cloud Container Registry.
+# The image tag should be specified as an argument when invoking this script:
+# e.g. ./scripts/push_cdc_services_image.sh my-test-image-tag
+
+set -e
+
+IMAGE_TAG=$1
+
+if [[ $IMAGE_TAG == "" ]]; then
+  echo "No image tag specified." >&2
+  echo "Usage ./scripts/push_cdc_services_image.sh my-test-image-tag" >&2
+  exit 1
+fi
+
+set -x
+
+gcloud builds submit . \
+  --async \
+  --project=datcom-ci \
+  --config=build/ci/cloudbuild.push_cdc_services_image.yaml \
+  --substitutions=_TAG=$IMAGE_TAG


### PR DESCRIPTION
* Currently this new image only includes mixer. NL and website servers will be added in the next PR.
* A key difference from the existing web compose image is that the final image only includes runtime dependencies and no build only dependencies.
  + The runtime deps are limited to python, envoy and nginx.
  + Build only deps that are no longer in the final image include go, protoc, node and gcloud. This makes a significant difference in the size of the final image.
* Another major difference is that mixer is built as a self contained library vs previously where it required go at runtime.
* The runtime dependencies are encapsulated in its own image and pushed to this registry: [gcr.io/datcom-ci/datacommons-services-runtime](https://gcr.io/datcom-ci/datacommons-services-runtime)
* The services images are pushed to this registry: [gcr.io/datcom-ci/datacommons-services](https://gcr.io/datcom-ci/datacommons-services)
   + Currently it includes the 1 image I pushed by running `./script/push_cdc_services_image.sh`.
* `run.sh` and `nginx.conf` are copies of `compose.sh` and `nginx.conf` from web compose, with NL and website portions commented out. I'll uncomment them when I add support for them.
* @hqpho - this does not include the auto and release deployment scripts since you're working on it separately (and also this is not fully ready yet!)