### PR TITLE
Create smaller, faster building services docker.

### DIFF
--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -112,7 +112,7 @@ WORKDIR /workspace/static
 RUN npm run-script build
 
 
-# #### Stage 3: Download base dc model and embeddings from GCS. ####
+# #### Stage 4: Download base dc model and embeddings from GCS. ####
 FROM --platform=linux/amd64 google/cloud-sdk:slim as download
 
 # Copy model and embeddings.

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -127,7 +127,7 @@ FROM gcr.io/datcom-ci/datacommons-services-runtime:2024-08-08 as runner
 # Env defaults.
 ENV WEBSITE_MIXER_API_ROOT=http://127.0.0.1:8081 \
     ENV_PREFIX=Compose \
-    ENABLE_ADMIN=true \
+    ENABLE_ADMIN=false \
     DEBUG=false \
     USE_SQLITE=false \
     USE_CLOUDSQL=false \

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -48,13 +48,91 @@ RUN protoc \
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/mixer cmd/main.go
 
 
-# #### Final stage: Runtime env. ####
-FROM gcr.io/datcom-ci/datacommons-services-runtime:2024-08-06 as runner
+# #### Stage 2: Build python servers (website and NL). ####
+FROM --platform=linux/amd64 python:3.11.4-slim as py-servers
 
-# Env that should not change
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+
+WORKDIR /workspace
+
+# Copy requirements.
+# Copy nl_requirements.txt since it is referenced by embeddings requirements.txt
+COPY server/requirements.txt ./server/requirements.txt
+COPY nl_server/requirements.txt ./nl_server/requirements.txt
+COPY nl_requirements.txt ./nl_requirements.txt
+
+# Create a virtual env and install requirements.
+# Remove lancedb - it is not used by custom dc.
+RUN python -m venv ./venv
+ENV PATH="/workspace/venv/bin:$PATH"
+RUN pip3 install --upgrade pip setuptools \
+    && sed -i'' '/lancedb/d' /workspace/nl_requirements.txt \
+    && pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu \
+    && pip3 install --no-cache-dir -r /workspace/server/requirements.txt \
+    && pip3 install --no-cache-dir -r /workspace/nl_server/requirements.txt
+
+# Copy website app script.
+COPY web_app.py ./web_app.py
+# Copy server module.
+COPY server/. ./server/
+# Copy NL app script.
+COPY nl_app.py ./nl_app.py
+# Copy nl_server module.
+COPY nl_server/. ./nl_server/
+# Copy the shared module.
+COPY shared/. ./shared/
+# Copy yaml files.
+COPY deploy/nl/. /datacommons/nl/
+
+
+# #### Stage 3: Build static website assets. ####
+FROM --platform=linux/amd64 node:20 as static
+
+WORKDIR /workspace
+
+# Insall npm dependencies.
+COPY packages/web-components/package.json ./packages/web-components/package.json
+COPY packages/web-components/package-lock.json ./packages/web-components/package-lock.json
+
+COPY packages/client/package.json ./packages/client/package.json
+COPY packages/client/package-lock.json ./packages/client/package-lock.json
+
+COPY static/package.json ./static/package.json
+COPY static/package-lock.json ./static/package-lock.json
+
+RUN npm --prefix /workspace/packages/web-components ci --omit=dev \
+    && npm --prefix /workspace/packages/client ci \
+    && npm --prefix /workspace/static ci --omit=dev
+
+# Build static assets.
+COPY packages/. ./packages/
+COPY static/. ./static/
+WORKDIR /workspace/static
+RUN npm run-script build
+
+
+# #### Stage 3: Download base dc model and embeddings from GCS. ####
+FROM --platform=linux/amd64 google/cloud-sdk:slim as download
+
+# Copy model and embeddings.
+RUN mkdir -p /tmp/datcom-nl-models \
+    && gsutil -m cp -R gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/ \
+    && gsutil cp -R gs://datcom-nl-models/embeddings_medium_2024_05_09_18_01_32.ft_final_v20230717230459.all-MiniLM-L6-v2.csv /tmp/datcom-nl-models/
+
+
+# #### Final stage: Runtime env. ####
+FROM gcr.io/datcom-ci/datacommons-services-runtime:2024-08-08 as runner
+
+# Env defaults.
 ENV WEBSITE_MIXER_API_ROOT=http://127.0.0.1:8081 \
     ENV_PREFIX=Compose \
-    ENABLE_ADMIN=true
+    ENABLE_ADMIN=true \
+    DEBUG=false \
+    USE_SQLITE=false \
+    USE_CLOUDSQL=false \
+    DC_API_ROOT=https://api.datacommons.org \
+    ENABLE_MODEL=false
 
 WORKDIR /workspace
 
@@ -66,9 +144,19 @@ COPY --from=mixer /workspace/internal/ internal
 COPY --from=mixer /workspace/mixer-grpc.pb .
 # nginx.
 COPY build/cdc_services/nginx.conf .
+# Website and NL servers.
+COPY --from=py-servers /workspace/ .
+COPY --from=py-servers /datacommons/ /datacommons
+# Static website assets.
+COPY --from=static /workspace/ .
+# Downloaded model and embeddings.
+COPY --from=download /tmp/datcom-nl-models /tmp/datcom-nl-models
 
 # Copy executable script.
 COPY --chmod=0755 build/cdc_services/run.sh .
+
+# Add virtual env to the path.
+ENV PATH="/workspace/venv/bin:$PATH"
 
 # Set the default command to run the script.
 CMD ./run.sh

--- a/build/cdc_services/nginx.conf
+++ b/build/cdc_services/nginx.conf
@@ -4,11 +4,11 @@ http {
   server {
     listen 8080;
 
-    # location / {
-    #     proxy_pass http://0.0.0.0:7070;
-    #     proxy_set_header Host $http_host;
-    #     proxy_read_timeout 3600;
-    # }
+    location / {
+        proxy_pass http://0.0.0.0:7070;
+        proxy_set_header Host $http_host;
+        proxy_read_timeout 3600;
+    }
 
     # Make mixer api available at /core/api/
     location /core/api/ {

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -71,21 +71,21 @@ nginx -c /workspace/nginx.conf
 
 envoy -l warning --config-path /workspace/esp/envoy-config.yaml &
 
-# if [[ $DEBUG == "true" ]] then
-#     if [[ $ENABLE_MODEL == "true" ]] then
-#         echo "Starting NL Server in debug mode."
-#         python3 nl_app.py 6060 &
-#     fi
-#     echo "Starting Website Server in debug mode."
-#     python3 web_app.py 7070 &
-# else
-#     if [[ $ENABLE_MODEL == "true" ]] then
-#         echo "Starting NL Server."
-#         gunicorn --log-level info --preload --timeout 1000 --bind 0.0.0.0:6060 -w 1 nl_app:app &
-#     fi
-#     echo "Starting Website Server."
-#     gunicorn --log-level info --preload --timeout 1000 --bind 0.0.0.0:7070 -w 4 web_app:app &
-# fi
+if [[ $DEBUG == "true" ]] then
+    if [[ $ENABLE_MODEL == "true" ]] then
+        echo "Starting NL Server in debug mode."
+        python3 nl_app.py 6060 &
+    fi
+    echo "Starting Website Server in debug mode."
+    python3 web_app.py 7070 &
+else
+    if [[ $ENABLE_MODEL == "true" ]] then
+        echo "Starting NL Server."
+        gunicorn --log-level info --preload --timeout 1000 --bind 0.0.0.0:6060 -w 1 nl_app:app &
+    fi
+    echo "Starting Website Server."
+    gunicorn --log-level info --preload --timeout 1000 --bind 0.0.0.0:7070 -w 4 web_app:app &
+fi
 
 # Wait for any process to exit
 wait

--- a/build/cdc_services_runtime/Dockerfile
+++ b/build/cdc_services_runtime/Dockerfile
@@ -18,17 +18,14 @@
 # - envoy
 # - nginx
 
-FROM python:3.11.4-slim as runner
+# Stage 1: envoy.
+FROM --platform=linux/amd64 envoyproxy/envoy:v1.31.0 as envoy
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y upgrade \
-    && apt update \
-    # Install envoy.
-    && apt install -y --no-install-recommends curl gpg debian-keyring debian-archive-keyring apt-transport-https lsb-release \
-    && curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg \
-    && echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/debian $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list \
-    && apt update \
-    && apt install -y --no-install-recommends getenvoy-envoy \
-    # Install nginx.
-    && apt install -y --no-install-recommends nginx \
-    && rm -rf /var/lib/apt/lists/*
+# Final stage: final runtime.
+FROM --platform=linux/amd64 python:3.11.4-slim as runtime
+
+# Copy envoy.
+COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
+
+# Install nginx.
+RUN apt-get update && apt-get -y upgrade && apt update && apt install -y nginx

--- a/build/cdc_services_runtime/cloudbuild.yaml
+++ b/build/cdc_services_runtime/cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 substitutions:
-  _VERS: "2024-08-06"
+  _VERS: "2024-08-08"
 
 steps:
   - name: "gcr.io/cloud-builders/docker"


### PR DESCRIPTION
* This PR creates the full multi-stage services image.
* The new image is more than 50% smaller to download - [1 GB](https://screenshot.googleplex.com/5qum85dSxSxUieq) vs [2.3 GB](https://screenshot.googleplex.com/767mwgPEqk3es35)
   + On-disk decompressed size is [3.77 GB vs 7.69 GB](https://screenshot.googleplex.com/Bxw7rvUJcdJXmJd)
* It is also about 3x faster to build in the cloud - [6 min](https://screenshot.googleplex.com/747AAifhDVKGUi3) vs [18 min](https://screenshot.googleplex.com/3ta43Yd9yUEwy2z)
* The new image bundles the embeddings in the image thereby improving the startup time (20 sec vs 30 sec on my machine).
* Verified by running it both locally and in the [cloud](https://screenshot.googleplex.com/6bEjV3Eer4sJCvb).
* Also disabled the web admin in the new services image so data docker is the only option to load data.
  + Will remove the admin code once the doc is updated and we've completely deprecated the older image.
* Updated the runtime image as well to be multi-stage.
* Next steps
   + Auto build and publish the new image - cc @hqpho 
   + Update doc to use new image - cc @kmoscoe 
   + Remove web admin