### PR TITLE
Create scripts to auto build / deploy the new services docker.

### DIFF
--- a/scripts/build_cdc_services_and_tag_latest.sh
+++ b/scripts/build_cdc_services_and_tag_latest.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates a new custom DC services docker image and tags it latest.
+# Also tags it with a custom label from an argument.
+
+# Usage: From root, ./scripts/build_cdc_services_and_tag_latest.sh $IMAGE_LABEL
+
+# The latest image = gcr.io/datcom-ci/datacommons-services:latest
+
+set -e
+set -x
+
+image_label=$1
+if [[ $image_label = "" ]]; then
+  echo "Expected positional argument with image label."
+  echo "Usage: ./scripts/build_cdc_services_and_tag_latest.sh \$IMAGE_LABEL"
+  exit 1
+fi
+
+# Build a new image and push it to Container Registry, tagging it as latest
+docker build -f build/cdc_services/Dockerfile \
+  --tag "gcr.io/datcom-ci/datacommons-services:${image_label}" \
+  --tag gcr.io/datcom-ci/datacommons-services:latest \
+  .
+docker push "gcr.io/datcom-ci/datacommons-services:${image_label}"
+docker push gcr.io/datcom-ci/datacommons-services:latest

--- a/scripts/deploy_cdc_services_latest_to_autopush.sh
+++ b/scripts/deploy_cdc_services_latest_to_autopush.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploys the custom DC services image tagged "latest" to the dc-autopush2 service.
+# TODO: Deploy to dc-autopush instead of dc-autopush2 once we have deprecated the datacommons-website-compose image.
+
+# The script also updates a RESTART_TIMESTAMP env var
+# to easily identify the restart time of a given revision.
+
+# Usage: From root, ./scripts/deploy_cdc_services_latest_to_autopush.sh
+
+# The latest image = gcr.io/datcom-ci/datacommons-services:latest
+# autopush service: https://pantheon.corp.google.com/run/detail/us-central1/dc-autopush2/revisions?project=datcom-website-dev
+# autopush URL: https://dc-autopush2-496370955550.us-central1.run.app
+
+set -e
+set -x
+
+# Deploy latest image to dc-autopush2 Cloud Run service
+gcloud run deploy dc-autopush2 \
+  --project datcom-website-dev \
+  --image gcr.io/datcom-ci/datacommons-services:latest \
+  --region us-central1 \
+  --update-env-vars RESTART_TIMESTAMP="$(date)"


### PR DESCRIPTION
* The deployment script deploys to a new [dc-autopush2](https://pantheon.corp.google.com/run/detail/us-central1/dc-autopush2/revisions?e=13803378&mods=-monitoring_api_staging&project=datcom-website-dev) cloud run service.
  + @hqpho - decided to use a dedicated service vs using the existing `dc-dev` one so we can continue using the latter for ad hoc testing.
* Once this PR is in, the [autopush yaml](https://source.cloud.google.com/datcom-ci/deployment/+/master:cloudbuild-compose-autopush.yaml) will be updated to trigger these scripts.