### PR TITLE
Copy only static dist artifacts to further reduce docker image size.

### DIFF
--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -148,7 +148,7 @@ COPY build/cdc_services/nginx.conf .
 COPY --from=py-servers /workspace/ .
 COPY --from=py-servers /datacommons/ /datacommons
 # Static website assets.
-COPY --from=static /workspace/ .
+COPY --from=static /workspace/server ./server
 # Downloaded model and embeddings.
 COPY --from=download /tmp/datcom-nl-models /tmp/datcom-nl-models
 


### PR DESCRIPTION
* Instead of copying everything from the static build stage, we only copy artifacts under `/server`.
  + Could've copied only `/server/dist` but being flexible in case it produces other server artifacts in the future.
* This reduces the download size from [1GB to 856 MB](https://screenshot.googleplex.com/6QqSBHdSpwEapBx).
* And the on-disk decompressed size from [3.77GB to 2.79 GB](https://screenshot.googleplex.com/33q5PNapfNEpV7J).
* Cloud build time also improved from [6 mins](https://screenshot.googleplex.com/747AAifhDVKGUi3) to [4 mins](https://screenshot.googleplex.com/9nkrqBLq266CrMd).
* Verified by deploying in the cloud [here](https://screenshot.googleplex.com/3Uojhdv7D2z3g6d).