### PR TITLE
Run chmod as a separate step when building docker image.

### DIFF
--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -153,7 +153,10 @@ COPY --from=static /workspace/server ./server
 COPY --from=download /tmp/datcom-nl-models /tmp/datcom-nl-models
 
 # Copy executable script.
-COPY --chmod=0755 build/cdc_services/run.sh .
+COPY build/cdc_services/run.sh .
+
+# Make script executable.
+RUN chmod +x run.sh
 
 # Add virtual env to the path.
 ENV PATH="/workspace/venv/bin:$PATH"

--- a/server/webdriver/cdc_tests/autopush_test.py
+++ b/server/webdriver/cdc_tests/autopush_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
 from selenium.webdriver.common.by import By
@@ -23,7 +24,12 @@ from server.webdriver.base_utils import find_elem
 from server.webdriver.base_utils import wait_elem
 
 # From project datcom-website-dev > Cloud Run: dc-autopush > Revisions
-CDC_AUTOPUSH_URL = 'https://dc-autopush-kqb7thiuka-uc.a.run.app'
+DEFAULT_CDC_TEST_BASE_URL = 'https://dc-autopush-kqb7thiuka-uc.a.run.app'
+
+# Get base test url from the CDC_TEST_BASE_URL env variable, defaulting to DEFAULT_CDC_TEST_BASE_URL
+CDC_TEST_BASE_URL = os.environ.get('CDC_TEST_BASE_URL',
+                                   DEFAULT_CDC_TEST_BASE_URL)
+print(f'Running CDC tests against base URL: {CDC_TEST_BASE_URL}')
 
 
 class CdcAutopushWebdriverTest(unittest.TestCase):
@@ -33,7 +39,7 @@ class CdcAutopushWebdriverTest(unittest.TestCase):
     # Maximum time, in seconds, before throwing a TimeoutException.
     self.TIMEOUT_SEC = shared.TIMEOUT
     self.driver = create_driver(preferences)
-    self._base_url = CDC_AUTOPUSH_URL
+    self._base_url = CDC_TEST_BASE_URL
 
   def tearDown(self):
     """Runs at the end of every individual test."""
@@ -70,7 +76,7 @@ class CdcAutopushWebdriverTest(unittest.TestCase):
 class CdcAutopushNLTest(ExploreTest):
 
   def get_server_url(self):
-    return CDC_AUTOPUSH_URL
+    return CDC_TEST_BASE_URL
 
   def test_cdc_nl(self):
     self.run_detect_and_fulfill('cdc_nl', ['gender wage gap in europe'])

--- a/server/webdriver/cdc_tests/autopush_test.py
+++ b/server/webdriver/cdc_tests/autopush_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 
 from selenium.webdriver.common.by import By
@@ -24,12 +23,7 @@ from server.webdriver.base_utils import find_elem
 from server.webdriver.base_utils import wait_elem
 
 # From project datcom-website-dev > Cloud Run: dc-autopush > Revisions
-DEFAULT_CDC_TEST_BASE_URL = 'https://dc-autopush-kqb7thiuka-uc.a.run.app'
-
-# Get base test url from the CDC_TEST_BASE_URL env variable, defaulting to DEFAULT_CDC_TEST_BASE_URL
-CDC_TEST_BASE_URL = os.environ.get('CDC_TEST_BASE_URL',
-                                   DEFAULT_CDC_TEST_BASE_URL)
-print(f'Running CDC tests against base URL: {CDC_TEST_BASE_URL}')
+CDC_AUTOPUSH_URL = 'https://dc-autopush-kqb7thiuka-uc.a.run.app'
 
 
 class CdcAutopushWebdriverTest(unittest.TestCase):
@@ -39,7 +33,7 @@ class CdcAutopushWebdriverTest(unittest.TestCase):
     # Maximum time, in seconds, before throwing a TimeoutException.
     self.TIMEOUT_SEC = shared.TIMEOUT
     self.driver = create_driver(preferences)
-    self._base_url = CDC_TEST_BASE_URL
+    self._base_url = CDC_AUTOPUSH_URL
 
   def tearDown(self):
     """Runs at the end of every individual test."""
@@ -76,7 +70,7 @@ class CdcAutopushWebdriverTest(unittest.TestCase):
 class CdcAutopushNLTest(ExploreTest):
 
   def get_server_url(self):
-    return CDC_TEST_BASE_URL
+    return CDC_AUTOPUSH_URL
 
   def test_cdc_nl(self):
     self.run_detect_and_fulfill('cdc_nl', ['gender wage gap in europe'])


### PR DESCRIPTION
* When building the new services image locally, @kmoscoe ran into an error that said buildkit was required when building this image.
* The only statement in the Dockerfile that requires buildkit is [this one](https://github.com/datacommonsorg/website/blob/2f0779132258148b217aa3e9b9356e2fd48e2a01/build/cdc_services/Dockerfile#L156) where chmod is run as part of COPY.
* Separating it out into its own command gets rid of this requirement so partners don't need to worry about enabling it.
* However, I've still kept it enabled for both [manual](https://github.com/datacommonsorg/website/blob/2f0779132258148b217aa3e9b9356e2fd48e2a01/build/ci/cloudbuild.push_cdc_services_image.yaml#L28) and [auto](https://github.com/datacommonsorg/website/blob/2f0779132258148b217aa3e9b9356e2fd48e2a01/scripts/build_cdc_services_and_tag_latest.sh#L35) builds since it turns out that building with buildkit enabled is much faster.
  + The services build takes[ 11 min](https://screenshot.googleplex.com/BsGTg99qQoPZbSQ) with buildkit disabled and [5 min](https://screenshot.googleplex.com/NcaB2mWoPvywPyf) with it enabled.