### PR TITLE
Fixed local cdc docker compose setup to use custom embeddings and configured a local data path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ft_final_v20230717230459.all-MiniLM-L6-v2/
 custom_dc/sample/datacommons/**
 
 .cache/
+
+# Ignore Custom Data Commons local .env file
+build/cdc/dev/.env

--- a/build/cdc/dev/.env.sample
+++ b/build/cdc/dev/.env.sample
@@ -23,17 +23,20 @@
 # Required
 MAPS_API_KEY=YOUR-MAPS-API-KEY-HERE
 DC_API_KEY=YOUR-DC-API-KEY-HERE
-
+# Absolute path of the data ouput directory containing a datacommons/datacommons.db file, nl files, and topic cache
+OUTPUT_DIR=/path/to/datacommons/website/custom_dc/sample
 
 # Optional
-# Set to https://api.datacommons.org to use production backend
-DC_API_ROOT=https://autopush.api.datacommons.org
+# Set to https://autopush.api.datacommons.org to use autopush backend
+DC_API_ROOT=https://api.datacommons.org
 
 # Mixer settings
-SQLITE_PATH=custom_dc/data/datacommons.db
 USE_SQLITE=true
 USE_CLOUDSQL=false
 CLOUDSQL_INSTANCE=
+
+# Use custom data commons environment.
+FLASK_ENV=custom
 
 # Default credential location.
 HOST_GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_credentials.json

--- a/build/cdc/dev/docker-compose.yaml
+++ b/build/cdc/dev/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
       - .env
     environment:
       - MAPS_API_KEY
+      - SQLITE_PATH=/app/data/datacommons/datacommons.db
       - MIXER_API_KEY=$DC_API_KEY
       - GOOGLE_APPLICATION_CREDENTIALS=/app/creds.json
     ports:
@@ -39,6 +40,8 @@ services:
       - ./run_mixer.sh:/app/run_mixer.sh
       # GCP credentials
       - "${HOST_GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}:/app/creds.json"
+      # Custom DC user data path containing datacommons/datacommons.db file
+      - "$OUTPUT_DIR:/app/data/"
 
   # Website frontend static assets
   dc-website-static:
@@ -67,10 +70,11 @@ services:
       - DC_API_KEY
       - MAPS_API_KEY
       - ENABLE_MODEL=true
-      - FLASK_ENV=local
       - GOOGLE_CLOUD_PROJECT=datcom-website-dev
       - GOOGLE_APPLICATION_CREDENTIALS=/app/creds.json
+      - IS_CUSTOM_DC=true
       - NL_SERVICE_ROOT_URL=http://dc-nl-python:6060
+      - USER_DATA_PATH=/app/data # Topic cache stored here
       - WEBSITE_MIXER_API_ROOT=http://dc-mixer:8081
     ports:
       - "7070:7070"
@@ -82,6 +86,8 @@ services:
       - ../../../shared:/app/shared
       # GCP credentials
       - "${HOST_GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}:/app/creds.json"
+      # Custom DC user data path containing topic cache json
+      - $OUTPUT_DIR:/app/data
 
   dc-nl-python:
     build:
@@ -92,7 +98,9 @@ services:
     env_file:
       - .env
     environment:
+      - ADDITIONAL_CATALOG_PATH=$OUTPUT_DIR/datacommons/nl/embeddings/custom_catalog.yaml # Custom NL embeddings definition
       - GOOGLE_APPLICATION_CREDENTIALS=/app/creds.json
+      - IS_CUSTOM_DC=true
     ports:
       - "6060:6060"
     networks:
@@ -110,6 +118,8 @@ services:
       - ../../../nl_requirements.txt:/app/nl_requirements.txt
       # GCP credentials
       - "${HOST_GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}:/app/creds.json"
+      # Custom DC output dir containing NL embeddings
+      - $OUTPUT_DIR:$OUTPUT_DIR
 
   nginx:
     image: nginx:latest


### PR DESCRIPTION
Fixes when running `./run_cdc_dev_docker.sh` :

- Updated FLASK_ENV from local to custom to show the custom_dc homepage
- Added IS_CUSTOM_DC true to load only custom dc embeddings
- Added `OUTPUT_DIR` to env configuration, which:
  - Loads the custom topic cache in dc-website
  - Configures the `ADDITIONAL_CATALOG_PATH` (`custom_catalog.yaml`) which contains custom dc embeddings and index definitions
  - Mounts local sqlite database for the `dc-mixer`