### PR TITLE
Added disableEntityLink option to bar chart web component

### DIFF
--- a/packages/web-components/examples/all-charts.html
+++ b/packages/web-components/examples/all-charts.html
@@ -545,6 +545,19 @@
       stacked
       lollipop
     ></datacommons-bar>
+    <datacommons-bar
+      header="Median income by gender of select US states (entity links disabled)"
+      variables="Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
+      places="geoId/01 geoId/02 geoId/04 geoId/05"
+      disableEntityLink
+    ></datacommons-bar>
+    <datacommons-bar
+      header="Median income by gender of select US states (stacked, entity links disabled)"
+      variables="Median_Income_Person_15OrMoreYears_Male_WithIncome Median_Income_Person_15OrMoreYears_Female_WithIncome"
+      places="geoId/01 geoId/02 geoId/04 geoId/05"
+      stacked
+      disableEntityLink
+    ></datacommons-bar>
     <h2>Scatter</h2>
     <datacommons-scatter
       header="Population vs Median Household Income for US States"

--- a/static/js/chart/draw_bar.ts
+++ b/static/js/chart/draw_bar.ts
@@ -317,7 +317,7 @@ export function drawStackBarChart(
     chartHeight,
     x,
     false,
-    labelToLink,
+    options?.disableEntityLink ? null : labelToLink,
     null,
     options?.apiRoot
   );
@@ -981,7 +981,7 @@ export function drawGroupBarChart(
     chartHeight,
     x0,
     false,
-    labelToLink,
+    options?.disableEntityLink ? null : labelToLink,
     null,
     options?.apiRoot
   );

--- a/static/js/chart/types.ts
+++ b/static/js/chart/types.ts
@@ -154,6 +154,8 @@ export interface ChartOptions {
   useSvgLegend?: boolean;
   // If set, adds title to the top of the chart
   title?: string;
+  // Optional: Disable the place href link for this component
+  disableEntityLink?: boolean;
 }
 
 export interface GroupLineChartOptions extends ChartOptions {

--- a/static/js/components/tiles/bar_tile.tsx
+++ b/static/js/components/tiles/bar_tile.tsx
@@ -109,6 +109,8 @@ interface BarTileSpecificSpec {
   lazyLoadMargin?: string;
   // Optional: listen for property value changes with this event name
   subscribe?: string;
+  // Optional: Disable the entity href link for this component
+  disableEntityLink?: boolean;
 }
 
 export type BarTilePropType = MultiOrContainedInPlaceMultiVariableTileType &
@@ -575,6 +577,7 @@ export function draw(
           title: chartTitle,
           unit: chartData.unit,
           useSvgLegend,
+          disableEntityLink: props.disableEntityLink,
         }
       );
     } else {
@@ -592,6 +595,7 @@ export function draw(
           title: chartTitle,
           unit: chartData.unit,
           useSvgLegend,
+          disableEntityLink: props.disableEntityLink,
         }
       );
     }

--- a/static/library/bar_component.ts
+++ b/static/library/bar_component.ts
@@ -229,6 +229,10 @@ export class DatacommonsBarComponent extends LitElement {
   @property({ type: Array<string>, converter: convertArrayAttribute })
   sources?: string[];
 
+  // Optional: Disable the entity href link for this component
+  @property({ type: Boolean, converter: convertBooleanAttribute })
+  disableEntityLink?: boolean;
+
   render(): HTMLDivElement {
     const statVarDcids: string[] = this.variables;
     const statVarSpec = [];
@@ -273,6 +277,7 @@ export class DatacommonsBarComponent extends LitElement {
       useLollipop: this.lollipop,
       yAxisMargin: this.yAxisMargin,
       subscribe: this.subscribe,
+      disableEntityLink: this.disableEntityLink,
     };
 
     return createWebComponentElement(BarTile, barTileProps);


### PR DESCRIPTION
(UN ask)

Adds `disableEntityLink` option to bar chart web components to remove the entity link from x-axis:

![9Yy4WfAEkGGD5PY](https://github.com/user-attachments/assets/208c3066-9d19-4c92-908f-c8ef85d007e3)
