### PR TITLE
Set default value for FLASK_ENV.

### DIFF
--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -127,7 +127,7 @@ FROM gcr.io/datcom-ci/datacommons-services-runtime:2024-08-08 as runner
 # Env defaults.
 ENV WEBSITE_MIXER_API_ROOT=http://127.0.0.1:8081 \
     ENV_PREFIX=Compose \
-    FLASK_ENV=compose \
+    FLASK_ENV=custom \
     ENABLE_ADMIN=false \
     DEBUG=false \
     USE_SQLITE=false \

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -127,6 +127,7 @@ FROM gcr.io/datcom-ci/datacommons-services-runtime:2024-08-08 as runner
 # Env defaults.
 ENV WEBSITE_MIXER_API_ROOT=http://127.0.0.1:8081 \
     ENV_PREFIX=Compose \
+    FLASK_ENV=compose \
     ENABLE_ADMIN=false \
     DEBUG=false \
     USE_SQLITE=false \


### PR DESCRIPTION
* The `FLASK_ENV` value seldom changes, so setting it to a default value alleviates partners from having to provide one themselves.
* Ran into an issue with a partner yesterday where this was not set and it resulted in a startup error.
* Setting a default will get rid of this error.