### PR TITLE
Updated scatter plot explorer copy

### DIFF
--- a/static/js/components/content/tools.tsx
+++ b/static/js/components/content/tools.tsx
@@ -60,7 +60,7 @@ const Tools = ({ routes }: ToolsProps): ReactElement => {
               id="scatter-button"
             >
               <span className="tool-icon scaterplot"></span>
-              Scatter Plot Tool
+              Scatter Plot Explorer
             </a>
           </li>
           <li>


### PR DESCRIPTION
Updated the new homepage's "Scatter Plot Tool" button to read "Scatter Plot Explorer" to align with the link name in the header.