### PR TITLE
Remove feedback Q since it's now prominent on the website.

### DIFF
--- a/server/templates/static/faq.html
+++ b/server/templates/static/faq.html
@@ -176,12 +176,5 @@
       data to improve the product. We log all queries asked in the Search tool,
       but do not associate IP address or any other identifiers with the queries.
       We do use in-session cookies to be able to manage state.
-
-    <dt>Q: How do I ask a question or offer feedback on Data Commons?
-    <dd>You can post your question on the <a
-      href="https://github.com/datacommonsorg/docsite/issues">GitHub forum</a> or
-      fill out <a
-      href="https://docs.google.com/forms/d/1pqliyxlfb4Mle2a77TLdl_LPxRKdQF5uG86pKC9MDu4/edit">this
-      feedback form</a>.
   </dl>
 {% endblock %}


### PR DESCRIPTION
It also had outdated info.