### PR TITLE
StatVar Hierarchy - Allow wrapping SV names

### DIFF
--- a/static/css/stat_var_hierarchy.scss
+++ b/static/css/stat_var_hierarchy.scss
@@ -61,7 +61,6 @@ $small-font-size: 0.75rem;
   align-items: center;
   display: flex;
   margin-bottom: 4px;
-  white-space: nowrap;
 }
 
 .node-title .bullet + .title {

--- a/static/css/stat_var_hierarchy.scss
+++ b/static/css/stat_var_hierarchy.scss
@@ -58,9 +58,12 @@ $small-font-size: 0.75rem;
 }
 
 .node-title {
-  align-items: center;
   display: flex;
   margin-bottom: 4px;
+}
+
+.node-title input {
+  margin-top: 0.4rem;
 }
 
 .node-title .bullet + .title {

--- a/static/css/tools/stat_var_widget.scss
+++ b/static/css/tools/stat_var_widget.scss
@@ -120,8 +120,7 @@ $resize-handle-width: 5px;
 }
 
 #hierarchy-section {
-  width:auto;
-  overflow-wrap: break-word;
+  width: fit-content;
   padding: 0 8px 15px;
 }
 
@@ -166,15 +165,15 @@ $resize-handle-width: 5px;
   background-color: $transparent-red;
 }
 
-// .node-title {
-//   /**
-//    * Width of line items / nodes in the stat var selector tree
-//    * Calculated by taking the entire component width, subtracting margins, and
-//    * subtracting the resize handle
-//    */
-//   min-width: $widget-min-width - 2 * $container-outer-horizontal-margin -
-//     $resize-handle-width;
-// }
+.node-title {
+  /**
+   * Width of line items / nodes in the stat var selector tree
+   * Calculated by taking the entire component width, subtracting margins, and
+   * subtracting the resize handle
+   */
+  min-width: $widget-min-width - 2 * $container-outer-horizontal-margin -
+    $resize-handle-width;
+}
 
 form.node-title {
   padding-left: 2px;
@@ -191,7 +190,7 @@ form.node-title {
 
 #stat-var-hierarchy-section .node-title .material-icons + .title {
   font-size: $medium-font-size;
-  // line-height: 2em;
+  line-height: 2em;
 }
 
 #tree-widget-tooltip {

--- a/static/css/tools/stat_var_widget.scss
+++ b/static/css/tools/stat_var_widget.scss
@@ -165,18 +165,9 @@ $resize-handle-width: 5px;
   background-color: $transparent-red;
 }
 
-.node-title {
-  /**
-   * Width of line items / nodes in the stat var selector tree
-   * Calculated by taking the entire component width, subtracting margins, and
-   * subtracting the resize handle
-   */
-  min-width: $widget-min-width - 2 * $container-outer-horizontal-margin -
-    $resize-handle-width;
-}
-
 form.node-title {
   padding-left: 2px;
+  align-items: flex-start;
 }
 
 #hierarchy-section .node-title:hover {

--- a/static/css/tools/stat_var_widget.scss
+++ b/static/css/tools/stat_var_widget.scss
@@ -120,7 +120,8 @@ $resize-handle-width: 5px;
 }
 
 #hierarchy-section {
-  width: fit-content;
+  width:auto;
+  overflow-wrap: break-word;
   padding: 0 8px 15px;
 }
 
@@ -165,15 +166,15 @@ $resize-handle-width: 5px;
   background-color: $transparent-red;
 }
 
-.node-title {
-  /**
-   * Width of line items / nodes in the stat var selector tree
-   * Calculated by taking the entire component width, subtracting margins, and
-   * subtracting the resize handle
-   */
-  min-width: $widget-min-width - 2 * $container-outer-horizontal-margin -
-    $resize-handle-width;
-}
+// .node-title {
+//   /**
+//    * Width of line items / nodes in the stat var selector tree
+//    * Calculated by taking the entire component width, subtracting margins, and
+//    * subtracting the resize handle
+//    */
+//   min-width: $widget-min-width - 2 * $container-outer-horizontal-margin -
+//     $resize-handle-width;
+// }
 
 form.node-title {
   padding-left: 2px;
@@ -190,7 +191,7 @@ form.node-title {
 
 #stat-var-hierarchy-section .node-title .material-icons + .title {
   font-size: $medium-font-size;
-  line-height: 2em;
+  // line-height: 2em;
 }
 
 #tree-widget-tooltip {


### PR DESCRIPTION
View screenshots:
https://screenshot.googleplex.com/ACMikc5N3iotPJ6
https://screenshot.googleplex.com/4PmospyvmAUciQ9

And in Scatterplot:
https://screenshot.googleplex.com/AuP4ukWJuoTSXC9

Based on Mocks from Adriana: https://www.figma.com/design/bK4jZkyB0FqfMhA1AUZVuu/2024-%E2%80%A2-Data-Commons?node-id=1776-75&node-type=frame&t=uNasymbV149qi8ze-0