### PR TITLE
Modify the autocomplete processing logic to improve results

### DIFF
--- a/server/routes/shared_api/autocomplete/helpers.py
+++ b/server/routes/shared_api/autocomplete/helpers.py
@@ -23,7 +23,6 @@ import requests
 MAPS_API_URL = "https://maps.googleapis.com/maps/api/place/autocomplete/json?"
 MIN_CHARACTERS_PER_QUERY = 3
 MAX_NUM_OF_QUERIES = 4
-RESPONSE_COUNT_LIMIT = 20
 DISPLAYED_RESPONSE_COUNT_LIMIT = 5
 
 

--- a/server/routes/shared_api/autocomplete/helpers.py
+++ b/server/routes/shared_api/autocomplete/helpers.py
@@ -127,13 +127,15 @@ def predict(queries: List[str], lang: str) -> List[Dict]:
   responses = []
   place_ids = set()
   index = 0
-  while len(responses) < DISPLAYED_RESPONSE_COUNT_LIMIT and index < len(all_responses):
+  while len(responses) < DISPLAYED_RESPONSE_COUNT_LIMIT and index < len(
+      all_responses):
     if all_responses[index]['place_id'] not in place_ids:
       responses.append(all_responses[index])
       place_ids.add(all_responses[index]['place_id'])
-    index +=1
+    index += 1
 
   return responses
+
 
 def get_score(e: Dict) -> float:
   """Returns the score."""

--- a/server/routes/shared_api/autocomplete/helpers.py
+++ b/server/routes/shared_api/autocomplete/helpers.py
@@ -14,7 +14,7 @@
 
 import json
 import re
-from typing import Dict, List, Tuple
+from typing import Dict, List
 from urllib.parse import urlencode
 
 from flask import current_app
@@ -73,7 +73,8 @@ def execute_maps_request(query: str, language: str) -> Dict:
 
 # def get_match_score(name: str, match_string: str) -> float:
 def get_match_score(e: Dict) -> float:
-  """Computes a 'score' based on the matching words in two strings.
+  """Computes a 'score' based on the matching words in two strings. Lowest
+  score is best match.
   Returns:
     Float score."""
   match_string = e['matched_query']

--- a/server/routes/shared_api/autocomplete/helpers.py
+++ b/server/routes/shared_api/autocomplete/helpers.py
@@ -71,7 +71,6 @@ def execute_maps_request(query: str, language: str) -> Dict:
   return json.loads(response.text)
 
 
-# def get_match_score(name: str, match_string: str) -> float:
 def get_match_score(e: Dict) -> float:
   """Computes a 'score' based on the matching words in two strings. Lowest
   score is best match.


### PR DESCRIPTION
Negates the "score", best match has lowest score. This allows us to sort with the first results being the best matches, but preserves the Google Maps ordering for same score responses.
Cleans up the logic a bit to remove dupes at the end. The new sorting requires computing all scores, so this deduping at the end doesnt lead to useless processing.
When computing score, take into account the ordering of the words.
This significantly improves the results from my testing.