### PR TITLE
Autocomplete Trigger Improvements

### DIFF
--- a/static/js/components/nl_search_bar/auto_complete_input.tsx
+++ b/static/js/components/nl_search_bar/auto_complete_input.tsx
@@ -72,6 +72,8 @@ export function AutoCompleteInput(
   const [hoveredIdx, setHoveredIdx] = useState(-1);
   const [triggerSearch, setTriggerSearch] = useState("");
   const [inputActive, setInputActive] = useState(false);
+  const [lastAutoCompleteSelection, setLastAutoCompleteSelection] =
+    useState("");
 
   const isHeaderBar = props.barType == "header";
   let lang = "";
@@ -123,17 +125,40 @@ export function AutoCompleteInput(
 
     const selectionApplied =
       hoveredIdx >= 0 &&
-      results.placeResults.length >= hoveredIdx &&
+      hoveredIdx < results.placeResults.length &&
       currentText.trim().endsWith(results.placeResults[hoveredIdx].name);
-    setHoveredIdx(-1);
 
-    if (_.isEmpty(currentText) || selectionApplied) {
+    let lastSelection = lastAutoCompleteSelection;
+    if (selectionApplied) {
       // Reset all suggestion results.
       setResults({ placeResults: [], svResults: [] });
+      setHoveredIdx(-1);
+      // Set the autocomplete selection.
+      setLastAutoCompleteSelection(results.placeResults[hoveredIdx].name);
       return;
+    } else if (_.isEmpty(currentText)) {
+      // Reset all suggestion results.
+      setResults({ placeResults: [], svResults: [] });
+      setLastAutoCompleteSelection("");
+      setHoveredIdx(-1);
+      return;
+    } else if (!currentText.includes(lastAutoCompleteSelection)) {
+      // If the user backspaces into the last selection, reset it.
+      lastSelection = "";
+      setLastAutoCompleteSelection(lastSelection);
+      // fall through
     }
 
-    sendDebouncedAutoCompleteRequest(currentText);
+    let queryForAutoComplete = currentText;
+    if (!_.isEmpty(lastSelection)) {
+      // if the last selection is still present, only send what comes after to autocomplete.
+      const splitQuery = queryForAutoComplete.split(lastSelection);
+      if (splitQuery.length == 2) {
+        queryForAutoComplete = splitQuery[1].trim();
+      }
+    }
+
+    sendDebouncedAutoCompleteRequest(queryForAutoComplete);
   }
 
   const triggerAutoCompleteRequest = useCallback(async (query: string) => {


### PR DESCRIPTION
Modifies the autocomplete query trigger to take into account the last selection.
Before: https://screencast.googleplex.com/cast/NTIzMzU4Njg3NjcxMDkxMnw5MTBiMjA5OS1lYg
After: https://screencast.googleplex.com/cast/NTkyNDU3NjgzNDg3OTQ4OHw2MzIzMTFiMi1kMg

With this change, we only send to autocomplete the part of the last query selection.