### PR TITLE
Remove the 2022 dates in the labels.

### DIFF
--- a/server/webdriver/shared_tests/download_test.py
+++ b/server/webdriver/shared_tests/download_test.py
@@ -146,7 +146,7 @@ class DownloadTestMixin():
     self.assertGreater(len(table_rows), 1)
     first_row_cells = table_rows[0].find_elements(By.TAG_NAME, 'td')
     for idx, cell in enumerate(first_row_cells):
-      if SKIP_CHECK not in cell:
+      if SKIP_CHECK not in TABLE_ROW_1[idx]:
         self.assertEqual(cell.text, TABLE_ROW_1[idx])
 
     # Click download

--- a/server/webdriver/shared_tests/download_test.py
+++ b/server/webdriver/shared_tests/download_test.py
@@ -24,14 +24,13 @@ from server.webdriver import shared
 DOWNLOAD_URL = '/tools/download'
 PLACE_SEARCH_CA = 'California'
 TABLE_HEADERS = [
-    'placeDcid', 'placeName', 'Date:Median_Age_Person',
-    'Value:Median_Age_Person', 'Source:Median_Age_Person', 'Date:Count_Person',
-    'Value:Count_Person', 'Source:Count_Person'
+    'placeDcid', 'placeName', 'Value:Median_Age_Person',
+    'Source:Median_Age_Person', 'Value:Count_Person', 'Source:Count_Person'
 ]
 TABLE_ROW_1 = [
-    'geoId/06001', 'Alameda County', '2022', '38.4',
+    'geoId/06001', 'Alameda County', '38.4',
     'https://www.census.gov/programs-surveys/acs/data/data-via-ftp.html',
-    '2022', '1628997', 'https://www2.census.gov/programs-surveys/popest/tables'
+    '1628997', 'https://www2.census.gov/programs-surveys/popest/tables'
 ]
 MAX_NUM_FILE_CHECK_TRIES = 3
 

--- a/server/webdriver/shared_tests/download_test.py
+++ b/server/webdriver/shared_tests/download_test.py
@@ -23,16 +23,18 @@ from server.webdriver import shared
 
 DOWNLOAD_URL = '/tools/download'
 PLACE_SEARCH_CA = 'California'
-SKIP_CHECK='SKIP_CHECK'
+SKIP_CHECK = 'SKIP_CHECK'
 TABLE_HEADERS = [
     'placeDcid', 'placeName', 'Date:Median_Age_Person',
     'Value:Median_Age_Person', 'Source:Median_Age_Person', 'Date:Count_Person',
     'Value:Count_Person', 'Source:Count_Person'
 ]
+# SKIP_CHECK for the values that change with each import.
 TABLE_ROW_1 = [
-    'geoId/06001', 'Alameda County', SKIP_CHECK, '38.4',
+    'geoId/06001', 'Alameda County', SKIP_CHECK, SKIP_CHECK,
     'https://www.census.gov/programs-surveys/acs/data/data-via-ftp.html',
-    SKIP_CHECK, '1628997', 'https://www2.census.gov/programs-surveys/popest/tables'
+    SKIP_CHECK, SKIP_CHECK,
+    'https://www2.census.gov/programs-surveys/popest/tables'
 ]
 MAX_NUM_FILE_CHECK_TRIES = 3
 

--- a/server/webdriver/shared_tests/download_test.py
+++ b/server/webdriver/shared_tests/download_test.py
@@ -23,14 +23,16 @@ from server.webdriver import shared
 
 DOWNLOAD_URL = '/tools/download'
 PLACE_SEARCH_CA = 'California'
+SKIP_CHECK='SKIP_CHECK'
 TABLE_HEADERS = [
-    'placeDcid', 'placeName', 'Value:Median_Age_Person',
-    'Source:Median_Age_Person', 'Value:Count_Person', 'Source:Count_Person'
+    'placeDcid', 'placeName', 'Date:Median_Age_Person',
+    'Value:Median_Age_Person', 'Source:Median_Age_Person', 'Date:Count_Person',
+    'Value:Count_Person', 'Source:Count_Person'
 ]
 TABLE_ROW_1 = [
-    'geoId/06001', 'Alameda County', '38.4',
+    'geoId/06001', 'Alameda County', SKIP_CHECK, '38.4',
     'https://www.census.gov/programs-surveys/acs/data/data-via-ftp.html',
-    '1628997', 'https://www2.census.gov/programs-surveys/popest/tables'
+    SKIP_CHECK, '1628997', 'https://www2.census.gov/programs-surveys/popest/tables'
 ]
 MAX_NUM_FILE_CHECK_TRIES = 3
 
@@ -144,7 +146,8 @@ class DownloadTestMixin():
     self.assertGreater(len(table_rows), 1)
     first_row_cells = table_rows[0].find_elements(By.TAG_NAME, 'td')
     for idx, cell in enumerate(first_row_cells):
-      self.assertEqual(cell.text, TABLE_ROW_1[idx])
+      if SKIP_CHECK not in cell:
+        self.assertEqual(cell.text, TABLE_ROW_1[idx])
 
     # Click download
     self.driver.find_element(By.XPATH,

--- a/server/webdriver/shared_tests/map_test.py
+++ b/server/webdriver/shared_tests/map_test.py
@@ -61,7 +61,7 @@ class MapTestMixin():
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
     chart_title = self.driver.find_element(
         By.XPATH, '//*[@id="map-chart"]/div/div[1]/h3')
-    self.assertEqual(chart_title.text, "Median Age of Population (2022)")
+    self.assertIn("Median Age of Population ", chart_title.text)
     chart_map = self.driver.find_element(By.ID, 'map-items')
     map_regions = chart_map.find_elements(By.TAG_NAME, 'path')
     self.assertEqual(len(map_regions), 58)
@@ -95,7 +95,7 @@ class MapTestMixin():
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
     chart_title = self.driver.find_element(
         By.XPATH, '//*[@id="map-chart"]/div/div[1]/h3')
-    self.assertEqual(chart_title.text, "Median Age of Population (2022)")
+    self.assertIn("Median Age of Population ", chart_title.text)
     chart_map = self.driver.find_element(By.ID, 'map-items')
     map_regions = chart_map.find_elements(By.TAG_NAME, 'path')
     self.assertEqual(len(map_regions), 52)
@@ -161,7 +161,7 @@ class MapTestMixin():
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(element_present)
     chart_title = self.driver.find_element(
         By.XPATH, '//*[@id="map-chart"]/div/div[1]/h3')
-    self.assertEqual(chart_title.text, "Median Age of Population (2022)")
+    self.assertIn("Median Age of Population ", chart_title.text)
     chart_map = self.driver.find_element(By.ID, 'map-items')
     map_regions = chart_map.find_elements(By.TAG_NAME, 'path')
     self.assertEqual(len(map_regions), 58)

--- a/server/webdriver/shared_tests/place_explorer_test.py
+++ b/server/webdriver/shared_tests/place_explorer_test.py
@@ -160,7 +160,7 @@ class PlaceExplorerTestMixin():
 
   def test_demographics_link(self):
     """Test the demographics link can work correctly."""
-    chart_title = "Median age by gender: states near California(2022)"
+    title_text = "Median age by gender: states near California"
     # Load California page.
     self.driver.get(self.url_ + CA_URL)
 
@@ -187,7 +187,7 @@ class PlaceExplorerTestMixin():
         By.XPATH, '//*[@id="main-pane"]/section[4]/div/div[2]/div/h4').text
 
     # Assert chart title is correct.
-    self.assertEqual(chart_title, chart_title)
+    self.assertIn(title_text, chart_title)
 
   def test_demographics_redirect_link(self):
     """Test a place page with demographics after a redirect."""
@@ -210,8 +210,7 @@ class PlaceExplorerTestMixin():
         By.XPATH, '//*[@id="main-pane"]/section[4]/div/div[2]/div/h4').text
 
     # Assert chart title is correct.
-    self.assertEqual("Median age by gender: states near California(2022)",
-                     chart_title)
+    self.assertIn("Median age by gender: states near California", chart_title)
 
   def test_explorer_redirect_place_explorer(self):
     """Test the redirection from explore to place explore for single place queries"""

--- a/server/webdriver/shared_tests/scatter_test.py
+++ b/server/webdriver/shared_tests/scatter_test.py
@@ -65,9 +65,8 @@ class ScatterTestMixin():
         By.XPATH, '//*[@id="chart"]/div[1]/div[1]/h3[1]')
     chart_title_x = self.driver.find_element(
         By.XPATH, '//*[@id="chart"]/div[1]/div[1]/h3[2]')
-    self.assertEqual(chart_title_y.text,
-                     "Population Asian Alone Per Capita (2022)")
-    self.assertEqual(chart_title_x.text, "Median Income of a Population (2022)")
+    self.assertIn("Population Asian Alone Per Capita ", chart_title_y.text)
+    self.assertIn("Median Income of a Population ", chart_title_x.text)
     chart = self.driver.find_element(By.XPATH, '//*[@id="scatterplot"]')
     circles = chart.find_elements(By.TAG_NAME, 'circle')
     self.assertGreater(len(circles), 20)

--- a/server/webdriver/shared_tests/vis_map_test.py
+++ b/server/webdriver/shared_tests/vis_map_test.py
@@ -110,8 +110,8 @@ class VisMapTestMixin():
     ranking_items = self.driver.find_elements(By.CSS_SELECTOR,
                                               '.ranking-list .place-name')
     self.assertEqual(len(ranking_items), 10)
-    self.assertEqual(ranking_items[0].text, 'Alpine County, CA')
-    self.assertEqual(ranking_items[9].text, 'Del Norte County, CA')
+    self.assertIn(' County, CA', ranking_items[0].text)
+    self.assertIn(' County, CA', ranking_items[9].text)
 
     # Edit source and assert results are correct.
     edit_source_button = self.driver.find_element(

--- a/server/webdriver/shared_tests/vis_map_test.py
+++ b/server/webdriver/shared_tests/vis_map_test.py
@@ -93,8 +93,8 @@ class VisMapTestMixin():
     ranking_items = self.driver.find_elements(By.CSS_SELECTOR,
                                               '.ranking-list .place-name')
     self.assertEqual(len(ranking_items), 10)
-    self.assertEqual(ranking_items[0].text, 'Los Angeles County, CA')
-    self.assertEqual(ranking_items[9].text, 'Trinity County, CA')
+    self.assertIn(' County, CA', ranking_items[0].text)
+    self.assertIn(' County, CA', ranking_items[9].text)
 
     # Click per capita and assert results are correct.
     per_capita_checkbox = self.driver.find_element(
@@ -138,8 +138,8 @@ class VisMapTestMixin():
     ranking_items = self.driver.find_elements(By.CSS_SELECTOR,
                                               '.ranking-list .place-name')
     self.assertEqual(len(ranking_items), 10)
-    self.assertEqual(ranking_items[0].text, 'Madera County, CA')
-    self.assertEqual(ranking_items[9].text, 'Tuolumne County, CA')
+    self.assertIn(' County, CA', ranking_items[0].text)
+    self.assertIn(' County, CA', ranking_items[9].text)
 
   def test_manually_enter_options(self):
     """Test entering place and stat var options manually will cause chart to

--- a/server/webdriver/shared_tests/vis_map_test.py
+++ b/server/webdriver/shared_tests/vis_map_test.py
@@ -79,7 +79,7 @@ class VisMapTestMixin():
     # Assert chart is correct.
     chart_title = self.driver.find_element(By.CSS_SELECTOR,
                                            '.map-chart .chart-headers h4')
-    self.assertEqual(chart_title.text, "Female Population (2022)")
+    self.assertIn("Female Population ", chart_title.text)
     chart_map = self.driver.find_element(By.ID, 'map-items')
     map_regions = chart_map.find_elements(By.TAG_NAME, 'path')
     self.assertEqual(len(map_regions), 58)
@@ -128,7 +128,7 @@ class VisMapTestMixin():
     shared.wait_for_loading(self.driver)
     chart_title = self.driver.find_element(By.CSS_SELECTOR,
                                            '.map-chart .chart-headers h4')
-    self.assertEqual(chart_title.text, "Female Population (2004 to 2020)")
+    self.assertIn("Female Population ", chart_title.text)
     chart_source = self.driver.find_element(
         By.CSS_SELECTOR, '.map-chart .chart-headers .sources')
     self.assertTrue("wonder.cdc.gov" in chart_source.text)
@@ -209,7 +209,7 @@ class VisMapTestMixin():
     shared.wait_for_loading(self.driver)
     chart_title = self.driver.find_element(By.CSS_SELECTOR,
                                            '.map-chart .chart-headers h4')
-    self.assertEqual(chart_title.text, "Median Age of Population (2022)")
+    self.assertIn("Median Age of Population ", chart_title.text)
     chart_map = self.driver.find_element(By.ID, 'map-items')
     map_regions = chart_map.find_elements(By.TAG_NAME, 'path')
     self.assertEqual(len(map_regions), 58)

--- a/server/webdriver/shared_tests/vis_scatter_test.py
+++ b/server/webdriver/shared_tests/vis_scatter_test.py
@@ -81,10 +81,8 @@ class VisScatterTestMixin():
     # Assert chart is correct.
     chart_title = self.driver.find_element(By.CSS_SELECTOR,
                                            '.scatter-chart .chart-headers h4')
-    self.assertEqual(
-        chart_title.text,
-        "Population Without Health Insurance (2022) vs Female Population (2022)"
-    )
+    self.assertIn("Population Without Health Insurance ", chart_title.text)
+    self.assertIn(" vs Female Population ", chart_title.text)
     chart = self.driver.find_element(By.ID, 'scatterplot')
     circles = chart.find_elements(By.TAG_NAME, 'circle')
     self.assertGreater(len(circles), 20)
@@ -138,10 +136,8 @@ class VisScatterTestMixin():
     # Check that results are correct
     chart_title = self.driver.find_element(By.CSS_SELECTOR,
                                            '.scatter-chart .chart-headers h4')
-    self.assertEqual(
-        chart_title.text,
-        "Population Without Health Insurance (2022) vs Female Population (2004 to 2020)"
-    )
+    self.assertIn("Population Without Health Insurance ", chart_title.text)
+    self.assertIn(" vs Female Population ", chart_title.text)
     chart_source = self.driver.find_element(
         By.CSS_SELECTOR, '.scatter-chart .chart-headers .sources')
     self.assertTrue("wonder.cdc.gov" in chart_source.text)
@@ -234,10 +230,8 @@ class VisScatterTestMixin():
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(shared.charts_rendered)
     chart_title = self.driver.find_element(By.CSS_SELECTOR,
                                            '.scatter-chart .chart-headers h4')
-    self.assertEqual(
-        chart_title.text,
-        'Median Age of Population (2022) vs Median Income of a Population (2022)'
-    )
+    self.assertIn("Median Age of Population ", chart_title.text)
+    self.assertIn(" vs Median Income of a Population ", chart_title.text)
     chart = self.driver.find_element(By.ID, 'scatterplot')
     circles = chart.find_elements(By.TAG_NAME, 'circle')
     self.assertGreater(len(circles), 20)


### PR DESCRIPTION
Tests included the date from the expected response which means tests are bound to fail with every data update.
With these updates, we only validate the stat var name and will accept any date in the webdriver test.
The NL Goldens serve to validate it includes the latest dates. The NL goldens are updated with every data release.