### PR TITLE
Exit cdc_services/run.sh when any background process exits

### DIFF
--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -88,7 +88,7 @@ else
 fi
 
 # Wait for any process to exit
-wait
+wait -n
 
 # Exit with status of process that exited first
 exit $?


### PR DESCRIPTION
This makes startup errors in Mixer or NL servers more obvious.

Bug: b/374820494
Reference: https://docs.docker.com/engine/containers/multi-service_container/#use-a-wrapper-script