### PR TITLE
Reintroduce css styling for search autocomplete

### DIFF
--- a/server/routes/shared_api/autocomplete/helpers.py
+++ b/server/routes/shared_api/autocomplete/helpers.py
@@ -191,6 +191,9 @@ def prepend_custom_places_hack(responses: List[ScoredPrediction],
   Returns:
     List of scored predictions."""
 
+  if len(queries) == 0:
+    return responses
+
   custom_places_responses = []
   single_word_query = queries[-1]
   for place in CUSTOM_PLACES:

--- a/server/webdriver/tests/event_page_test.py
+++ b/server/webdriver/tests/event_page_test.py
@@ -92,7 +92,11 @@ class TestEventPage(BaseDcWebdriverTest):
     charts = chart_section.find_elements(By.CLASS_NAME, 'chart-container')
     # assert there are 4+ charts
     self.assertGreater(len(charts), 4)
+
+
     # assert that the first chart has data
+    line_present = EC.presence_of_element_located((By.CLASS_NAME, 'line'))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(line_present)
     chart_lines = charts[0].find_elements(By.CLASS_NAME, 'line')
     self.assertEqual(len(chart_lines), 1)
 
@@ -159,6 +163,8 @@ class TestEventPage(BaseDcWebdriverTest):
     # assert there are 4+ charts
     self.assertGreater(len(charts), 4)
     # assert that the first chart has data
+    line_present = EC.presence_of_element_located((By.CLASS_NAME, 'line'))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(line_present)
     chart_lines = charts[0].find_elements(By.CLASS_NAME, 'line')
     self.assertEqual(len(chart_lines), 1)
 

--- a/server/webdriver/tests/event_page_test.py
+++ b/server/webdriver/tests/event_page_test.py
@@ -93,7 +93,6 @@ class TestEventPage(BaseDcWebdriverTest):
     # assert there are 4+ charts
     self.assertGreater(len(charts), 4)
 
-
     # assert that the first chart has data
     line_present = EC.presence_of_element_located((By.CLASS_NAME, 'line'))
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(line_present)

--- a/static/css/core.scss
+++ b/static/css/core.scss
@@ -566,6 +566,8 @@ section {
 .header-search-section {
   display: flex;
   align-items: center;
+  flex-direction: column;
+  margin: 24px 0;
   flex-shrink: 0;
   flex-grow: 2;
   @include media-breakpoint-up(xl) {

--- a/static/css/core.scss
+++ b/static/css/core.scss
@@ -565,7 +565,6 @@ section {
 
 .header-search-section {
   display: flex;
-  align-items: center;
   flex-direction: column;
   margin: 24px 0;
   flex-shrink: 0;

--- a/static/css/core.scss
+++ b/static/css/core.scss
@@ -316,7 +316,6 @@ section {
     display: flex;
     flex-grow: 1;
     justify-content: space-between;
-    align-items: center;
     padding: 0 calc(#{var.$spacing} * 3);
     height: $header-desktop-height;
     gap: calc(#{var.$spacing} * 2);


### PR DESCRIPTION
https://github.com/datacommonsorg/website/pull/4684

Changes in the PR above ended up breaking styling for autocomplete. See autopush: https://screenshot.googleplex.com/77CCATTzB2domBv

I believe these 2 lines are the only ones needed to recover the autopush styling. Verified locally.