### PR TITLE
Fix size of Custom DC default logo

### DIFF
--- a/server/templates/custom_dc/custom/base.html
+++ b/server/templates/custom_dc/custom/base.html
@@ -71,7 +71,7 @@
         <div class="container-fluid">
           <div class="navbar-brand">
             {% if LOGO_PATH %}
-            <div id="main-header-logo">
+            <div class="main-header-logo">
                 <a href="{{ url_for('static.homepage') }}">
                   <img src="{{ LOGO_PATH }}" />
                 </a>


### PR DESCRIPTION
The height attribute has not been applied since https://github.com/datacommonsorg/website/pull/4683 changed `#main-header-logo` to `.main-header-logo`.