### PR TITLE
Fix custom DC tests (NL goldens, shared tests)

### DIFF
--- a/run_cdc_tests.sh
+++ b/run_cdc_tests.sh
@@ -20,4 +20,9 @@ set -e
 source .env/bin/activate
 export FLASK_ENV=webdriver
 
+# Like run_test.sh, use flag -g for updating goldens.
+if [[ "$1" == "-g" ]]; then
+  export TEST_MODE=write
+fi
+
 python3 -m pytest -n 5 --reruns 2 server/webdriver/cdc_tests/

--- a/server/integration_tests/test_data/cdc_nl/chart_config.json
+++ b/server/integration_tests/test_data/cdc_nl/chart_config.json
@@ -34,7 +34,6 @@
               }
             ],
             "denom": "Count_Person",
-            "description": "Gender wage gap.",
             "title": "Gender Wage Gap in Countries of Europe"
           }
         ],

--- a/server/templates/custom_dc/custom/browser_landing.html
+++ b/server/templates/custom_dc/custom/browser_landing.html
@@ -26,8 +26,8 @@
 
 {% block content %}
   <div class="container">
-    <h1 class="mb-4">Knowledge Graph</h1>
-    <p>
+    <h1 id="kg-title"class="mb-4">Knowledge Graph</h1>
+    <p id="kg-desc">
       The Data Commons Knowledge Graph is constructed by synthesizing a single
       database from many different data sources.
       This knowledge graph can be used both to explore what data is available and

--- a/server/webdriver/shared_tests/browser_test.py
+++ b/server/webdriver/shared_tests/browser_test.py
@@ -44,21 +44,21 @@ class BrowserTestMixin():
     self.assertIn(title_text, self.driver.title)
 
     # Wait for title to be present
-    h1_locator = (By.CSS_SELECTOR, '#intro-text h1')
+    title_locator = (By.CSS_SELECTOR, '#kg-title')
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
-        EC.text_to_be_present_in_element(h1_locator, 'Knowledge Graph'))
-    h1_element = self.driver.find_element(*h1_locator)
-    self.assertEqual("Knowledge Graph", h1_element.text)
+        EC.text_to_be_present_in_element(title_locator, 'Knowledge Graph'))
+    title_element = self.driver.find_element(*title_locator)
+    self.assertEqual("Knowledge Graph", title_element.text)
 
     # Assert intro is correct
-    intro_locator = (By.CSS_SELECTOR, '#intro-text .container header p')
+    description_locator = (By.CSS_SELECTOR, '#kg-desc')
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
-        EC.presence_of_element_located(intro_locator))
-    intro_element = self.driver.find_element(*intro_locator)
-    expected_intro_start = 'The Data Commons Knowledge Graph is constructed'
+        EC.presence_of_element_located(description_locator))
+    description_element = self.driver.find_element(*description_locator)
+    expected_description_start = 'The Data Commons Knowledge Graph is constructed'
     self.assertTrue(
-        intro_element.text.startswith(expected_intro_start),
-        f"Intro text does not start with expected text. Found: {intro_element.text}"
+        description_element.text.startswith(expected_description_start),
+        f"Intro text does not start with expected text. Found: {description_element.text}"
     )
 
   def test_page_serve_ca_population(self):

--- a/server/webdriver/shared_tests/ranking_test.py
+++ b/server/webdriver/shared_tests/ranking_test.py
@@ -61,8 +61,7 @@ class RankingTestMixin():
     )
 
     title_present = EC.text_to_be_present_in_element(
-        (By.CSS_SELECTOR, '#main-navbar-container .navbar-brand'),
-        self.dc_title_string)
+        (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(title_present)
 
     subtitle_present = EC.text_to_be_present_in_element(
@@ -109,8 +108,7 @@ class RankingTestMixin():
     )
 
     title_present = EC.text_to_be_present_in_element(
-        (By.CSS_SELECTOR, '#main-navbar-container .navbar-brand'),
-        self.dc_title_string)
+        (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(title_present)
 
     subtitle_present = EC.text_to_be_present_in_element(

--- a/server/webdriver/tests/homepage_test.py
+++ b/server/webdriver/tests/homepage_test.py
@@ -29,8 +29,7 @@ class TestHomepage(HomepageTestMixin, BaseDcWebdriverTest):
     self.driver.get(self.url_ + '/')
 
     title_present = EC.text_to_be_present_in_element(
-        (By.CSS_SELECTOR, '#main-navbar-container .navbar-brand'),
-        self.dc_title_string)
+        (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(title_present)
 
     hero_msg = self.driver.find_elements(By.ID, 'hero')[0]
@@ -44,8 +43,7 @@ class TestHomepage(HomepageTestMixin, BaseDcWebdriverTest):
     self.driver.get(self.url_ + '/?hl=it')
 
     title_present = EC.text_to_be_present_in_element(
-        (By.CSS_SELECTOR, '#main-navbar-container .navbar-brand'),
-        self.dc_title_string)
+        (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(title_present)
 
     hero_msg = self.driver.find_elements(By.ID, 'hero')[0]
@@ -101,8 +99,7 @@ class TestHomepage(HomepageTestMixin, BaseDcWebdriverTest):
     self.driver.get(self.url_ + '/?ac_on=true')
 
     title_present = EC.text_to_be_present_in_element(
-        (By.CSS_SELECTOR, '#main-navbar-container .navbar-brand'),
-        self.dc_title_string)
+        (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(title_present)
 
     search_box_input = self.driver.find_element(By.ID, 'query-search-input')

--- a/static/js/apps/browser_landing/app.tsx
+++ b/static/js/apps/browser_landing/app.tsx
@@ -35,8 +35,8 @@ export function App(): ReactElement {
     <>
       <IntroText>
         <header>
-          <h1>Knowledge Graph</h1>
-          <p>
+          <h1 id="kg-title">Knowledge Graph</h1>
+          <p id="kg-desc">
             The Data Commons Knowledge Graph is constructed by synthesizing a
             single database from many different data sources. This knowledge
             graph can be used both to explore what data is available and to


### PR DESCRIPTION
- In one file, don't reference h1 by a selector only present in main DC
- In another file, add some CSS selectors specifically for tests to use
- Add option to run_cdc_tests for regenerating goldens

To prevent failures from recurring, we should make custom DC tests run before merge instead of just after autopush.
