### PR TITLE
Increase webdriver test timeout to 45 minutes

### DIFF
--- a/build/ci/cloudbuild.webdriver.yaml
+++ b/build/ci/cloudbuild.webdriver.yaml
@@ -30,7 +30,7 @@ steps:
         # ./run_test.sh -b will build client packages.
         # These js files generated will be necessery for the flask_webdriver_test task.
         ./run_test.sh -b
-  
+
   # Download the files needed for nl server to run. Do the download here because
   # webdriver runs on mulitple processes & we only want to do the download once.
   - id: download_nl_files
@@ -56,7 +56,7 @@ steps:
         ./run_test.sh --setup_python
         ./run_test.sh -w
 
-timeout: 1800s
+timeout: 2700s # 45 minutes
 
 options:
   machineType: "E2_HIGHCPU_32"


### PR DESCRIPTION
Seeing some timeouts recently: https://pantheon.corp.google.com/logs/query;query=textPayload%3D%22ERROR:%20context%20deadline%20exceeded%22%20resource.labels.build_trigger_id%3D%225048c6dd-76b1-4f0e-a6be-f772acf71633%22;cursorTimestamp=2024-11-18T18:10:08.718263864Z;duration=P7D?referrer=search&e=13803378&mods=-monitoring_api_staging&project=datcom-ci&inv=1&invt=Abh1kQ