### PR TITLE
Add alternate health check route for website server

### DIFF
--- a/server/routes/static.py
+++ b/server/routes/static.py
@@ -90,6 +90,13 @@ def healthz():
   return "very healthy"
 
 
+# Alternate health check route in case /healthz is intercepted by infrastructure
+# (e.g. when running as a Cloud Run service)
+@bp.route('/health')
+def health():
+  return "super healthy"
+
+
 # TODO(beets): Move this to a separate handler so it won't be installed on all apps.
 @bp.route('/mcf_playground')
 def mcf_playground():

--- a/shared/lib/test_server.py
+++ b/shared/lib/test_server.py
@@ -28,7 +28,7 @@ class NLWebServerTestCase(unittest.TestCase):
   def setUpClass(cls):
     # If this check fail, you need to start up website and NL servers
     # with ./run_servers.sh before running pytest.
-    libutil.check_backend_ready([f'{cls.get_class_server_url()}/healthz'])
+    libutil.check_backend_ready([f'{cls.get_class_server_url()}/health'])
 
   @classmethod
   def get_class_server_url(cls):


### PR DESCRIPTION
Routes ending with "z" are reserved by Cloud Run: https://cloud.google.com/run/docs/known-issues#ah