### PR TITLE
Specify length of short hashes for custom DC image labels

### DIFF
--- a/scripts/get_commits_label.sh
+++ b/scripts/get_commits_label.sh
@@ -18,12 +18,12 @@
 
 # Optionally use the commit before HEAD for the main repo.
 if [[ "$1" == "--head-is-temporary" ]]; then
-  website_rev="$(git rev-parse --short HEAD~1)"
+  website_rev="$(git rev-parse --short=7 HEAD~1)"
 else
-  website_rev="$(git rev-parse --short HEAD)"
+  website_rev="$(git rev-parse --short=7 HEAD)"
 fi
-mixer_rev="$(git rev-parse --short HEAD:mixer)"
-import_rev="$(git rev-parse --short HEAD:import)"
+mixer_rev="$(git rev-parse --short=7 HEAD:mixer)"
+import_rev="$(git rev-parse --short=7 HEAD:import)"
 image_label="${website_rev}-${mixer_rev}-${import_rev}"
 
 echo "$image_label"


### PR DESCRIPTION
Otherwise the length is determined based on what's required for uniqueness based on the commits fetched, which can be different when only a single branch is fetched.