### PR TITLE
Only show the Google Map widget on Place pages for places contained within the US

### DIFF
--- a/packages/client/src/data_commons_web_client_types.ts
+++ b/packages/client/src/data_commons_web_client_types.ts
@@ -186,4 +186,5 @@ export interface RelatedPlacesApiResponse {
   nearbyPlaces: Place[];
   place: Place;
   similarPlaces: Place[];
+  parentPlaces: Place[];
 }

--- a/server/routes/dev_place/api.py
+++ b/server/routes/dev_place/api.py
@@ -164,12 +164,10 @@ def related_places(place_dcid: str):
   similar_places = [all_place_by_dcid[dcid] for dcid in similar_place_dcids]
   child_places = [all_place_by_dcid[dcid] for dcid in child_place_dcids]
 
-  response = RelatedPlacesApiResponse(
-      childPlaceType=child_place_type,
-      childPlaces=child_places,
-      nearbyPlaces=nearby_places,
-      place=place,
-      similarPlaces=similar_places,
-      parentPlaces=parent_places
-  )
+  response = RelatedPlacesApiResponse(childPlaceType=child_place_type,
+                                      childPlaces=child_places,
+                                      nearbyPlaces=nearby_places,
+                                      place=place,
+                                      similarPlaces=similar_places,
+                                      parentPlaces=parent_places)
   return jsonify(response)

--- a/server/routes/dev_place/api.py
+++ b/server/routes/dev_place/api.py
@@ -150,6 +150,7 @@ def related_places(place_dcid: str):
   child_place_dcids = place_utils.fetch_child_place_dcids(place,
                                                           child_place_type,
                                                           locale=g.locale)
+  parent_places = place_utils.get_parent_places(place.dcid)
 
   # Fetch all place objects in one request to reduce latency (includes name and typeOf)
   all_place_dcids = [
@@ -169,5 +170,6 @@ def related_places(place_dcid: str):
       nearbyPlaces=nearby_places,
       place=place,
       similarPlaces=similar_places,
+      parentPlaces=parent_places
   )
   return jsonify(response)

--- a/server/routes/dev_place/types.py
+++ b/server/routes/dev_place/types.py
@@ -68,3 +68,4 @@ class RelatedPlacesApiResponse:
   nearbyPlaces: List[Place]
   place: Place
   similarPlaces: List[Place]
+  parentPlaces: List[Place] = None

--- a/server/routes/dev_place/utils.py
+++ b/server/routes/dev_place/utils.py
@@ -62,11 +62,12 @@ def get_parent_places(dcid: str) -> List[Place]:
   Returns:
     A list of places that are all the parents of the given DCID.
   """
-  parents_resp = place_api.parent_places([dcid],
-                                        include_admin_areas=True).get(dcid, [])
+  parents_resp = place_api.parent_places([dcid], include_admin_areas=True).get(
+      dcid, [])
   all_parents = []
   for parent in parents_resp:
-    all_parents.append(Place(dcid=parent['dcid'], name=parent['name'], types=parent['type']))
+    all_parents.append(
+        Place(dcid=parent['dcid'], name=parent['name'], types=parent['type']))
 
   return all_parents
 

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -37,7 +37,7 @@ import {
   defaultDataCommonsClient,
   defaultDataCommonsWebClient,
 } from "../utils/data_commons_client";
-import { isPlaceDcidInUsa } from "./util";
+import { isPlaceContainedInUsa } from "./util";
 
 /**
  * Returns the stat var key for a chart.
@@ -356,9 +356,10 @@ const PlaceOverviewTable = (props: { placeDcid: string }) => {
 const PlaceOverview = (props: {
   place: NamedTypedPlace;
   placeSummary: string;
+  parentPlaces: NamedTypedPlace[];
 }) => {
-  const { place, placeSummary } = props;
-  const isInUsa = isPlaceDcidInUsa(place.dcid);
+  const { place, placeSummary, parentPlaces } = props;
+  const isInUsa = isPlaceContainedInUsa(place.dcid, parentPlaces.map(place => place.dcid))
   return (
     <div className="place-overview">
       <div className="place-icon">
@@ -459,6 +460,7 @@ export const DevPlaceMain = () => {
   // Derived place data
   const [childPlaceType, setChildPlaceType] = useState<string>();
   const [childPlaces, setChildPlaces] = useState<NamedTypedPlace[]>([]);
+  const [parentPlaces, setParentPlaces] = useState<NamedTypedPlace[]>([]);
   const [pageConfig, setPageConfig] = useState<SubjectPageConfig>();
 
   const urlParams = new URLSearchParams(window.location.search);
@@ -510,6 +512,7 @@ export const DevPlaceMain = () => {
       );
       setChildPlaceType(relatedPlacesApiResponse.childPlaceType);
       setChildPlaces(relatedPlacesApiResponse.childPlaces);
+      setParentPlaces(relatedPlacesApiResponse.parentPlaces);
       setPageConfig(pageConfig);
     })();
   }, [place]);
@@ -525,7 +528,7 @@ export const DevPlaceMain = () => {
         placeSubheader={placeSubheader}
       />
       <PlaceTopicTabs category={category} place={place} />
-      <PlaceOverview place={place} placeSummary={placeSummary} />
+      <PlaceOverview place={place} placeSummary={placeSummary} parentPlaces={parentPlaces}/>
       <RelatedPlaces place={place} childPlaces={childPlaces} />
       {place && pageConfig && (
         <PlaceCharts

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -359,7 +359,9 @@ const PlaceOverview = (props: {
   parentPlaces: NamedTypedPlace[];
 }) => {
   const { place, placeSummary, parentPlaces } = props;
-  const isInUsa = isPlaceContainedInUsa(parentPlaces.map(place => place.dcid))
+  const isInUsa = isPlaceContainedInUsa(
+    parentPlaces.map((place) => place.dcid)
+  );
   return (
     <div className="place-overview">
       <div className="place-icon">
@@ -528,7 +530,11 @@ export const DevPlaceMain = () => {
         placeSubheader={placeSubheader}
       />
       <PlaceTopicTabs category={category} place={place} />
-      <PlaceOverview place={place} placeSummary={placeSummary} parentPlaces={parentPlaces}/>
+      <PlaceOverview
+        place={place}
+        placeSummary={placeSummary}
+        parentPlaces={parentPlaces}
+      />
       <RelatedPlaces place={place} childPlaces={childPlaces} />
       {place && pageConfig && (
         <PlaceCharts

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -359,7 +359,7 @@ const PlaceOverview = (props: {
   parentPlaces: NamedTypedPlace[];
 }) => {
   const { place, placeSummary, parentPlaces } = props;
-  const isInUsa = isPlaceContainedInUsa(place.dcid, parentPlaces.map(place => place.dcid))
+  const isInUsa = isPlaceContainedInUsa(parentPlaces.map(place => place.dcid))
   return (
     <div className="place-overview">
       <div className="place-icon">

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -37,6 +37,7 @@ import {
   defaultDataCommonsClient,
   defaultDataCommonsWebClient,
 } from "../utils/data_commons_client";
+import { isPlaceDcidInUsa } from "./util";
 
 /**
  * Returns the stat var key for a chart.
@@ -357,6 +358,7 @@ const PlaceOverview = (props: {
   placeSummary: string;
 }) => {
   const { place, placeSummary } = props;
+  const isInUsa = isPlaceDcidInUsa(place.dcid);
   return (
     <div className="place-overview">
       <div className="place-icon">
@@ -365,10 +367,13 @@ const PlaceOverview = (props: {
       <div className="place-name">{place.name}</div>
       <div className="place-summary">{placeSummary}</div>
       <div className="row place-map">
-        <div className="col-md-3">
-          <GoogleMap dcid={place.dcid}></GoogleMap>
-        </div>
+        {isInUsa && (
+          <div className="col-md-3">
+            <GoogleMap dcid={place.dcid}></GoogleMap>
+          </div>
+        )}
         <div className="col-md-9">
+          {!isInUsa && <br></br>}
           <PlaceOverviewTable placeDcid={place.dcid} />
         </div>
       </div>

--- a/static/js/place/util.ts
+++ b/static/js/place/util.ts
@@ -18,23 +18,10 @@ import { defineMessages } from "react-intl";
 import { intl } from "../i18n/i18n";
 import { USA_PLACE_DCID } from "../shared/constants";
 
-/*
- * Returns true if the place is in the USA by comparing the place DCID format
- * only.
- */
-export function isPlaceDcidInUsa(dcid: string): boolean {
-  // TODO(gmechali): We should expose an endpoint to fetch only the parent
-  // place DCIDs and use isPlaceInUsa.
-  const regex = /^(geoId\/\d{2}|\d{5}|\d{7})|(zip\/\d{5})$/;
-  return regex.test(dcid);
-}
 /**
- * Given a list of parent places, return true if the place is in USA.
+ * Given a list of parent places, return true if one of them is the USA country DCID.
  */
-export function isPlaceInUsa(dcid: string, parentPlaces: string[]): boolean {
-  if (dcid === USA_PLACE_DCID) {
-    return true;
-  }
+export function isPlaceContainedInUsa(parentPlaces: string[]): boolean {
   for (const parent of parentPlaces) {
     if (parent === USA_PLACE_DCID) {
       return true;
@@ -42,6 +29,13 @@ export function isPlaceInUsa(dcid: string, parentPlaces: string[]): boolean {
   }
   return false;
 }
+/**
+ * Given a DCID and list of parent places, returns whether this dcid is the USA, or contained in the USA.
+ */
+export function isPlaceInUsa(dcid: string, parentPlaces: string[]): boolean {
+  return dcid === USA_PLACE_DCID || isPlaceContainedInUsa(parentPlaces);
+}
+
 /**
  * A set of place types to render a choropleth for.
  */

--- a/static/js/place/util.ts
+++ b/static/js/place/util.ts
@@ -18,6 +18,16 @@ import { defineMessages } from "react-intl";
 import { intl } from "../i18n/i18n";
 import { USA_PLACE_DCID } from "../shared/constants";
 
+/*
+ * Returns true if the place is in the USA by comparing the place DCID format
+ * only.
+ */
+export function isPlaceDcidInUsa(dcid: string): boolean {
+  // TODO(gmechali): We should expose an endpoint to fetch only the parent
+  // place DCIDs and use isPlaceInUsa.
+  const regex = /^(geoId\/\d{2}|\d{5}|\d{7})|(zip\/\d{5})$/;
+  return regex.test(dcid);
+}
 /**
  * Given a list of parent places, return true if the place is in USA.
  */


### PR DESCRIPTION
The Geometry coordinates for detailed Google maps boundaries is only available for places contained in the USA (not even the USA country), so we only want to show that component for the places contained within the USA.
