### PR TITLE
Place revamp - minor bug fixes

### DIFF
--- a/server/routes/dev_place/utils.py
+++ b/server/routes/dev_place/utils.py
@@ -27,7 +27,7 @@ import server.routes.shared_api.place as place_api
 from server.services import datacommons as dc
 
 # Parent place types to include in listing of containing places at top of page
-PARENT_PLACE_TYPES_TO_HIGHLIGHT = {
+PARENT_PLACE_TYPES_TO_HIGHLIGHT = [
     'County',
     'AdministrativeArea2',
     'EurostatNUTS2',
@@ -36,7 +36,7 @@ PARENT_PLACE_TYPES_TO_HIGHLIGHT = {
     'EurostatNUTS1',
     'Country',
     'Continent',
-}
+]
 
 
 def get_place_html_link(place_dcid: str, place_name: str) -> str:
@@ -94,6 +94,15 @@ def get_place_type_with_parent_places_links(dcid: str) -> str:
       parent for parent in all_parents
       if parent.types in PARENT_PLACE_TYPES_TO_HIGHLIGHT
   ]
+
+  # Create a dictionary mapping parent types to their order in the highlight list
+  type_order = {
+      parent_type: i
+      for i, parent_type in enumerate(PARENT_PLACE_TYPES_TO_HIGHLIGHT)
+  }
+
+  # Sort the parents_to_include list using the type_order dictionary
+  parents_to_include.sort(key=lambda parent: type_order.get(parent.types))
 
   # Fetch the localized names of the parents
   parent_dcids = [parent.dcid for parent in parents_to_include]

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -232,8 +232,6 @@ def get_place_type_with_parent_places_links(dcid: str) -> str:
 
   # Sort the parents_to_include list using the type_order dictionary
   parents_to_include.sort(key=lambda parent: type_order.get(parent['type']))
-  print("So now we have\n")
-  print(parents_to_include)
 
   parent_dcids = [parent['dcid'] for parent in parents_to_include]
   localized_names = place_api.get_i18n_name(parent_dcids)
@@ -483,8 +481,6 @@ def place_landing(error_msg=''):
 def dev_place(place_dcid=None):
   place_type_with_parent_places_links = utils.get_place_type_with_parent_places_links(
       place_dcid)
-  print("HELLOW ORLDDDD\n\n\n")
-  print(place_type_with_parent_places_links)
   place_names = place_api.get_i18n_name([place_dcid]) or {}
   place_name = place_names.get(place_dcid, place_dcid)
   # Place summaries are currently only supported in English

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -232,6 +232,8 @@ def get_place_type_with_parent_places_links(dcid: str) -> str:
 
   # Sort the parents_to_include list using the type_order dictionary
   parents_to_include.sort(key=lambda parent: type_order.get(parent['type']))
+  print("So now we have\n")
+  print(parents_to_include)
 
   parent_dcids = [parent['dcid'] for parent in parents_to_include]
   localized_names = place_api.get_i18n_name(parent_dcids)
@@ -481,6 +483,8 @@ def place_landing(error_msg=''):
 def dev_place(place_dcid=None):
   place_type_with_parent_places_links = utils.get_place_type_with_parent_places_links(
       place_dcid)
+  print("HELLOW ORLDDDD\n\n\n")
+  print(place_type_with_parent_places_links)
   place_names = place_api.get_i18n_name([place_dcid]) or {}
   place_name = place_names.get(place_dcid, place_dcid)
   # Place summaries are currently only supported in English

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -61,7 +61,8 @@ CANONICAL_DOMAIN = 'datacommons.org'
 PLACE_SUMMARY_DIR = "/datacommons/place-summary/"
 
 # Parent place types to include in listing of containing places at top of page
-PARENT_PLACE_TYPES_TO_HIGHLIGHT = {
+# Keep sorted!
+PARENT_PLACE_TYPES_TO_HIGHLIGHT = [
     'County',
     'AdministrativeArea2',
     'EurostatNUTS2',
@@ -70,7 +71,7 @@ PARENT_PLACE_TYPES_TO_HIGHLIGHT = {
     'EurostatNUTS1',
     'Country',
     'Continent',
-}
+]
 
 # Location of manually written templates for SEO experimentation in GCS bucket
 SEO_EXPERIMENT_HTML_GCS_DIR = "seo_experiments/active"
@@ -222,6 +223,13 @@ def get_place_type_with_parent_places_links(dcid: str) -> str:
       parent for parent in all_parents
       if parent['type'] in PARENT_PLACE_TYPES_TO_HIGHLIGHT
   ]
+
+  # Create a dictionary mapping parent types to their order in the highlight list
+  type_order = {parent_type: i for i, parent_type in enumerate(PARENT_PLACE_TYPES_TO_HIGHLIGHT)}
+
+  # Sort the parents_to_include list using the type_order dictionary
+  parents_to_include.sort(key=lambda parent: type_order.get(parent['type']))
+
   parent_dcids = [parent['dcid'] for parent in parents_to_include]
   localized_names = place_api.get_i18n_name(parent_dcids)
   places_with_names = [

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -225,7 +225,10 @@ def get_place_type_with_parent_places_links(dcid: str) -> str:
   ]
 
   # Create a dictionary mapping parent types to their order in the highlight list
-  type_order = {parent_type: i for i, parent_type in enumerate(PARENT_PLACE_TYPES_TO_HIGHLIGHT)}
+  type_order = {
+      parent_type: i
+      for i, parent_type in enumerate(PARENT_PLACE_TYPES_TO_HIGHLIGHT)
+  }
 
   # Sort the parents_to_include list using the type_order dictionary
   parents_to_include.sort(key=lambda parent: type_order.get(parent['type']))

--- a/static/css/place/dev_place_page.scss
+++ b/static/css/place/dev_place_page.scss
@@ -19,6 +19,8 @@
 @use "../base.scss";
 @use "../explore";
 
+@import "../shared/tiles.scss";
+
 // Left/right spacing shared across elements to ensure all text on the page
 // is left-justified to the same visual line, including the NL search bar text
 $text-alignment-spacing: 24px;
@@ -94,7 +96,7 @@ main {
 }
 .summary-text {
   color: var(--gm-3-ref-neutral-neutral-20);
-  font-size: 14px;
+  font-size: 5px;
   font-style: normal;
   font-weight: 400;
   line-height: 20px;
@@ -130,7 +132,7 @@ main {
       }
 
       a {
-        font-size: 14px;
+        font-size: 55px;
         font-style: normal;
         font-weight: 500;
         line-height: 20px;

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -21,7 +21,7 @@ import {
   RelatedPlacesApiResponse,
 } from "@datacommonsorg/client/dist/data_commons_web_client_types";
 import _ from "lodash";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { RawIntlProvider } from "react-intl";
 
 import { GoogleMap } from "../components/google_map";
@@ -37,6 +37,7 @@ import {
   defaultDataCommonsClient,
   defaultDataCommonsWebClient,
 } from "../utils/data_commons_client";
+import { TileSources } from "../utils/tile_utils";
 import { isPlaceContainedInUsa } from "./util";
 
 /**
@@ -309,6 +310,7 @@ const PlaceTopicTabs = ({
 const PlaceOverviewTable = (props: { placeDcid: string }) => {
   const { placeDcid } = props;
   const [dataRows, setDataRows] = useState<DataRow[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
   // Fetch key demographic statistics for the place when it changes
   useEffect(() => {
     (async () => {
@@ -329,6 +331,11 @@ const PlaceOverviewTable = (props: { placeDcid: string }) => {
   if (!dataRows) {
     return null;
   }
+  const sourceUrls = new Set(
+    dataRows.map((dataRow) => {
+      return dataRow.variable.observation.metadata.provenanceUrl;
+    })
+  );
   return (
     <table className="table">
       <thead>
@@ -357,6 +364,15 @@ const PlaceOverviewTable = (props: { placeDcid: string }) => {
             </tr>
           );
         })}
+        {dataRows && (
+          <tr>
+            <td>
+              <TileSources containerRef={containerRef} sources={sourceUrls} />
+            </td>
+            <td></td>
+            <td></td>
+          </tr>
+        )}
       </tbody>
     </table>
   );

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -367,7 +367,9 @@ const PlaceOverviewTable = (props: { placeDcid: string }) => {
         {dataRows && (
           <tr>
             <td>
-              <TileSources containerRef={containerRef} sources={sourceUrls} />
+              <div className="chart-container">
+                <TileSources containerRef={containerRef} sources={sourceUrls} />
+              </div>
             </td>
             <td></td>
             <td></td>

--- a/static/js/utils/tile_utils.tsx
+++ b/static/js/utils/tile_utils.tsx
@@ -380,7 +380,8 @@ export function TileSources(props: {
   });
   return (
     <div className="sources" {...{ part: "source" }}>
-      {sourcesJsx.length > 1 ? "Sources" : "Source"}: <span {...{ part: "source-links" }}>{sourcesJsx}</span>
+      {sourcesJsx.length > 1 ? "Sources" : "Source"}:{" "}
+      <span {...{ part: "source-links" }}>{sourcesJsx}</span>
       {statVarSpecs && statVarSpecs.length > 0 && (
         <>
           <span {...{ part: "source-separator" }}> • </span>

--- a/static/js/utils/tile_utils.tsx
+++ b/static/js/utils/tile_utils.tsx
@@ -380,7 +380,7 @@ export function TileSources(props: {
   });
   return (
     <div className="sources" {...{ part: "source" }}>
-      Source: <span {...{ part: "source-links" }}>{sourcesJsx}</span>
+      {sourcesJsx.length > 1 ? "Sources" : "Source"}: <span {...{ part: "source-links" }}>{sourcesJsx}</span>
       {statVarSpecs && statVarSpecs.length > 0 && (
         <>
           <span {...{ part: "source-separator" }}> • </span>


### PR DESCRIPTION
Sorts the parent places according to the parent place type in both old and new place page.
Before: https://screenshot.googleplex.com/73zetb4iETK6D7p
After: https://screenshot.googleplex.com/4KQ4baSMN64ZNS6

Adds source tile to the bottom of the key demographics in the overview:
https://screenshot.googleplex.com/57gfbASDD62Jx5y

Replaces the source tile from "Source" to "Sources" when there are multiple.
Before: https://screenshot.googleplex.com/8i94e76fpnWRStE
After: https://screenshot.googleplex.com/HfKwv3zrbDsHxK9