### PR TITLE
Moving place revamp test to Base DC only.

### DIFF
--- a/server/webdriver/base_utils.py
+++ b/server/webdriver/base_utils.py
@@ -25,7 +25,7 @@ DEFAULT_WIDTH = 1200
 def create_driver(preferences=None):
   # These options are needed to run ChromeDriver inside a Docker without a UI.
   chrome_options = Options()
-  chrome_options.add_argument('--headless=new')
+  # chrome_options.add_argument('--headless=new')
   chrome_options.add_argument('--no-sandbox')
   chrome_options.add_argument('--disable-dev-shm-usage')
   chrome_options.add_argument('--hide-scrollbars')

--- a/server/webdriver/base_utils.py
+++ b/server/webdriver/base_utils.py
@@ -25,7 +25,7 @@ DEFAULT_WIDTH = 1200
 def create_driver(preferences=None):
   # These options are needed to run ChromeDriver inside a Docker without a UI.
   chrome_options = Options()
-  # chrome_options.add_argument('--headless=new')
+  chrome_options.add_argument('--headless=new')
   chrome_options.add_argument('--no-sandbox')
   chrome_options.add_argument('--disable-dev-shm-usage')
   chrome_options.add_argument('--hide-scrollbars')

--- a/server/webdriver/shared_tests/place_explorer_test.py
+++ b/server/webdriver/shared_tests/place_explorer_test.py
@@ -289,29 +289,3 @@ class PlaceExplorerTestMixin():
     # Check the title text
     page_title = self.driver.find_element(By.ID, 'place-name').text
     self.assertEqual(page_title, place_name_text)
-
-  def test_dev_place_overview_california(self):
-    """Ensure experimental dev place page content loads"""
-    self.driver.get(self.url_ + '/place/geoId/06?force_dev_places=true')
-
-    # For the dev place page, the related places callout is under the
-    # .related-places-callout div.
-    related_places_callout_el_present = EC.presence_of_element_located(
-        (By.CLASS_NAME, 'related-places-callout'))
-    related_places_callout_el = WebDriverWait(
-        self.driver, self.TIMEOUT_SEC).until(related_places_callout_el_present)
-    self.assertEqual(related_places_callout_el.text, 'Places in California')
-
-    # Assert the "Download" link is present in charts
-    download_link_present = EC.presence_of_element_located(
-        (By.CLASS_NAME, 'download-outlink'))
-    download_link_el = WebDriverWait(
-        self.driver, self.TIMEOUT_SEC).until(download_link_present)
-    self.assertTrue('Download' in download_link_el.text)
-
-    # Assert the "Explore in ... Tool" link is present in charts
-    explore_in_link_present = EC.presence_of_element_located(
-        (By.CLASS_NAME, 'explore-in-outlink'))
-    explore_in_link_el = WebDriverWait(
-        self.driver, self.TIMEOUT_SEC).until(explore_in_link_present)
-    self.assertTrue('Explore in' in explore_in_link_el.text)

--- a/server/webdriver/tests/place_explorer_test.py
+++ b/server/webdriver/tests/place_explorer_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -30,7 +28,6 @@ class TestPlaceExplorer(PlaceExplorerTestMixin, BaseDcWebdriverTest):
     """Ensure experimental dev place page content loads"""
     self.driver.get(self.url_ + '/place/geoId/06?force_dev_places=true')
 
-    time.sleep(1000)
     # For the dev place page, the related places callout is under the
     # .related-places-callout div.
     related_places_callout_el_present = EC.presence_of_element_located(
@@ -52,4 +49,3 @@ class TestPlaceExplorer(PlaceExplorerTestMixin, BaseDcWebdriverTest):
     explore_in_link_el = WebDriverWait(
         self.driver, self.TIMEOUT_SEC).until(explore_in_link_present)
     self.assertTrue('Explore in' in explore_in_link_el.text)
-    time.sleep(100000)

--- a/server/webdriver/tests/place_explorer_test.py
+++ b/server/webdriver/tests/place_explorer_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -24,10 +26,11 @@ from server.webdriver.shared_tests.place_explorer_test import \
 class TestPlaceExplorer(PlaceExplorerTestMixin, BaseDcWebdriverTest):
   """Class to test place explorer page. Tests come from PlaceExplorerTestMixin."""
 
-def test_dev_place_overview_california(self):
+  def test_dev_place_overview_california(self):
     """Ensure experimental dev place page content loads"""
     self.driver.get(self.url_ + '/place/geoId/06?force_dev_places=true')
 
+    time.sleep(1000)
     # For the dev place page, the related places callout is under the
     # .related-places-callout div.
     related_places_callout_el_present = EC.presence_of_element_located(
@@ -49,3 +52,4 @@ def test_dev_place_overview_california(self):
     explore_in_link_el = WebDriverWait(
         self.driver, self.TIMEOUT_SEC).until(explore_in_link_present)
     self.assertTrue('Explore in' in explore_in_link_el.text)
+    time.sleep(100000)

--- a/server/webdriver/tests/place_explorer_test.py
+++ b/server/webdriver/tests/place_explorer_test.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
 from server.webdriver.base_dc_webdriver import BaseDcWebdriverTest
 from server.webdriver.shared_tests.place_explorer_test import \
     PlaceExplorerTestMixin
@@ -19,3 +23,29 @@ from server.webdriver.shared_tests.place_explorer_test import \
 
 class TestPlaceExplorer(PlaceExplorerTestMixin, BaseDcWebdriverTest):
   """Class to test place explorer page. Tests come from PlaceExplorerTestMixin."""
+
+def test_dev_place_overview_california(self):
+    """Ensure experimental dev place page content loads"""
+    self.driver.get(self.url_ + '/place/geoId/06?force_dev_places=true')
+
+    # For the dev place page, the related places callout is under the
+    # .related-places-callout div.
+    related_places_callout_el_present = EC.presence_of_element_located(
+        (By.CLASS_NAME, 'related-places-callout'))
+    related_places_callout_el = WebDriverWait(
+        self.driver, self.TIMEOUT_SEC).until(related_places_callout_el_present)
+    self.assertEqual(related_places_callout_el.text, 'Places in California')
+
+    # Assert the "Download" link is present in charts
+    download_link_present = EC.presence_of_element_located(
+        (By.CLASS_NAME, 'download-outlink'))
+    download_link_el = WebDriverWait(
+        self.driver, self.TIMEOUT_SEC).until(download_link_present)
+    self.assertTrue('Download' in download_link_el.text)
+
+    # Assert the "Explore in ... Tool" link is present in charts
+    explore_in_link_present = EC.presence_of_element_located(
+        (By.CLASS_NAME, 'explore-in-outlink'))
+    explore_in_link_el = WebDriverWait(
+        self.driver, self.TIMEOUT_SEC).until(explore_in_link_present)
+    self.assertTrue('Explore in' in explore_in_link_el.text)


### PR DESCRIPTION
The revampled place page experiment should not be tested against CDC autopush. Extracting that test back out to the Based DC tests only.
Once the revampled place page is fully enabled, we should update all the place page tests to be for the new page.