### PR TITLE
Updated cdc data Dockerfile to install dependencies before copying over source files

### DIFF
--- a/build/cdc_data/Dockerfile
+++ b/build/cdc_data/Dockerfile
@@ -14,51 +14,25 @@
 
 
 # #### Stage 1: Download base dc model from GCS. ####
-FROM google/cloud-sdk:slim as model-downloader
+FROM google/cloud-sdk:slim AS model-downloader
 
 # Copy model.
 RUN mkdir -p /tmp/datcom-nl-models \
     && gsutil -m cp -R gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/
 
 
-# #### Stage 2: Copy required files. ####
-FROM python:3.11.4-slim as file-copier
+# #### Stage 2: Install python dependencies. ####
+FROM python:3.11.4-slim AS file-copier
 
 WORKDIR /workspace
 
 # Copy simple importer requirements.
 COPY import/simple/requirements.txt ./import/simple/requirements.txt
 
-# Copy simple importer.
-COPY import/simple/ ./import/simple/
-
 # Copy embeddings builder requirements.
 # Copy nl_requirements.txt since it is referenced by embeddings requirements.txt
 COPY tools/nl/embeddings/requirements.txt ./tools/nl/embeddings/requirements.txt
 COPY nl_requirements.txt ./nl_requirements.txt
-
-# Copy the embeddings builder module.
-COPY tools/nl/embeddings/. ./tools/nl/embeddings/
-# Copy the shared module.
-COPY shared/. ./shared/
-# Copy nl_server module. Some scripts from here are used by the embeddings builder.
-COPY nl_server/. /workspace/nl_server/
-# Copy yaml files used by the embeddings builder.
-COPY deploy/nl/. /datacommons/nl/
-
-
-# #### Stage 3: Runtime env. ####
-FROM python:3.11.4-slim as runner
-
-ARG ENV
-ENV ENV=${ENV}
-
-WORKDIR /workspace
-
-# Copy scripts, dependencies and files from the build stages.
-COPY --from=file-copier /workspace/ .
-COPY --from=file-copier /datacommons/ /datacommons
-COPY --from=model-downloader /tmp/datcom-nl-models /tmp/datcom-nl-models
 
 ARG PIP_DISABLE_PIP_VERSION_CHECK=1
 ARG PIP_NO_CACHE_DIR=1
@@ -72,11 +46,39 @@ RUN sed -i'' '/lancedb/d' /workspace/nl_requirements.txt \
     && pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu \
     && pip3 install -r ./tools/nl/embeddings/requirements.txt
 
+
+# #### Stage 3: Runtime env. ####
+FROM python:3.11.4-slim AS runner
+
+ARG ENV
+ENV ENV=${ENV}
+
+WORKDIR /workspace
+
+# Copy models and dependencies.
+COPY --from=file-copier /workspace/ .
+COPY --from=file-copier /workspace/venv /workspace/venv
+COPY --from=model-downloader /tmp/datcom-nl-models /tmp/datcom-nl-models
+
+# Copy the embeddings builder module.
+COPY tools/nl/embeddings/. ./tools/nl/embeddings/
+# Copy the shared module.
+COPY shared/. ./shared/
+# Copy nl_server module. Some scripts from here are used by the embeddings builder.
+COPY nl_server/. /workspace/nl_server/
+# Copy yaml files used by the embeddings builder.
+COPY deploy/nl/. /datacommons/nl/
+# Copy simple importer.
+COPY import/simple/ ./import/simple/
+
 # Copy executable script.
 COPY build/cdc_data/run.sh .
 
 # Make script executable.
 RUN chmod +x run.sh
+
+# Activate the virtual env.
+ENV PATH="/workspace/venv/bin:$PATH"
 
 # Set the default command to run the script.
 CMD ./run.sh

--- a/build/cdc_data/Dockerfile
+++ b/build/cdc_data/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p /tmp/datcom-nl-models \
 
 
 # #### Stage 2: Install python dependencies. ####
-FROM python:3.11.4-slim AS file-copier
+FROM python:3.11.4-slim AS dependencies-installer
 
 WORKDIR /workspace
 
@@ -56,8 +56,8 @@ ENV ENV=${ENV}
 WORKDIR /workspace
 
 # Copy models and dependencies.
-COPY --from=file-copier /workspace/ .
-COPY --from=file-copier /workspace/venv /workspace/venv
+COPY --from=dependencies-installer /workspace/ .
+COPY --from=dependencies-installer /workspace/venv /workspace/venv
 COPY --from=model-downloader /tmp/datcom-nl-models /tmp/datcom-nl-models
 
 # Copy the embeddings builder module.

--- a/build/cdc_data/Dockerfile
+++ b/build/cdc_data/Dockerfile
@@ -81,4 +81,4 @@ RUN chmod +x run.sh
 ENV PATH="/workspace/venv/bin:$PATH"
 
 # Set the default command to run the script.
-CMD ./run.sh
+CMD ["./run.sh"]


### PR DESCRIPTION
Previously during local development, code changes would for pip dependencies to be reinstalled. With this change, pip dependencies are only reinstalled if the actual requirements.txt files change.