### PR TITLE
Update build embeddings logger to match format from the stats importer

### DIFF
--- a/tools/nl/embeddings/build_embeddings.py
+++ b/tools/nl/embeddings/build_embeddings.py
@@ -36,12 +36,22 @@ flags.DEFINE_string(
 
 
 def _init_logger():
+  # Remove existing handlers from root handler that were set by absl library
+  for handler in logging.root.handlers:
+    logging.root.removeHandler(handler)
+
   # Log to stdout for easy redirect of the output text.
   # This enables the logs to be captured by the admin tool.
   logger = logging.getLogger()
-  logger.setLevel(logging.INFO)
   handler = logging.StreamHandler(sys.stdout)
   handler.setLevel(logging.INFO)
+
+  # Create a formatter to format the log messages
+  formatter = logging.Formatter(
+      "[%(asctime)s %(levelname)s %(filename)s:%(lineno)d] %(message)s")
+  handler.setFormatter(formatter)
+
+  # Add the handler to the logger
   logger.addHandler(handler)
 
 


### PR DESCRIPTION
- Removed duplicate log messages
- Updated the log format to match that in https://github.com/datacommonsorg/import/pull/355

Before:
```
I1202 18:24:38.316821 140552371297152 utils.py:72] Loading model
Loading model
I1202 18:24:38.317865 140552371297152 SentenceTransformer.py:66] Load pretrained SentenceTransformer: /tmp/datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2
Load pretrained SentenceTransformer: /tmp/datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2
I1202 18:24:40.600165 140552371297152 SentenceTransformer.py:105] Use pytorch device: cpu
Use pytorch device: cpu
```

After:


```
[2024-12-18 23:47:08,350 INFO utils.py:72] Loading model
[2024-12-18 23:47:08,350 INFO SentenceTransformer.py:66] Load pretrained SentenceTransformer: /tmp/datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2
[2024-12-18 23:47:08,542 INFO SentenceTransformer.py:105] Use pytorch device: cpu
```