### PR TITLE
Resolve lint warnings

### DIFF
--- a/static/js/apps/explore/debug_info.tsx
+++ b/static/js/apps/explore/debug_info.tsx
@@ -57,8 +57,8 @@ const svToSentences = (
                           <li key={sentence.score + sentence.sentence}>
                             {sentence.sentence} (cosine:
                             {sentence.score.toFixed(4)}
-                            {sentence.rerank_score
-                              ? " - rerank:" + sentence.rerank_score.toFixed(4)
+                            {sentence.rerankScore
+                              ? " - rerank:" + sentence.rerankScore.toFixed(4)
                               : ""}
                             )
                           </li>

--- a/static/js/apps/visualization/selector_wrapper.tsx
+++ b/static/js/apps/visualization/selector_wrapper.tsx
@@ -18,7 +18,6 @@
  * Wrapper for selectors used in the selector pane.
  */
 
-import _ from "lodash";
 import React from "react";
 
 interface SelectorWrapperPropType {

--- a/static/js/apps/visualization/vis_type_configs/scatter_config.tsx
+++ b/static/js/apps/visualization/vis_type_configs/scatter_config.tsx
@@ -76,7 +76,7 @@ function getDisplayInputs(appContext: AppContextType): InputInfo[] {
   return [
     {
       isChecked: appContext.displayOptions.scatterQuadrants,
-      onUpdated: (isChecked: boolean) => {
+      onUpdated: (isChecked: boolean): void => {
         const newDisplayOptions = _.cloneDeep(appContext.displayOptions);
         newDisplayOptions.scatterQuadrants = isChecked;
         appContext.setDisplayOptions(newDisplayOptions);
@@ -86,7 +86,7 @@ function getDisplayInputs(appContext: AppContextType): InputInfo[] {
     },
     {
       isChecked: appContext.displayOptions.scatterPlaceLabels,
-      onUpdated: (isChecked: boolean) => {
+      onUpdated: (isChecked: boolean): void => {
         const newDisplayOptions = _.cloneDeep(appContext.displayOptions);
         newDisplayOptions.scatterPlaceLabels = isChecked;
         appContext.setDisplayOptions(newDisplayOptions);
@@ -122,7 +122,7 @@ function getFacetSelector(appContext: AppContextType): JSX.Element {
       };
     });
   });
-  const onSvFacetIdUpdated = (svFacetId: Record<string, string>) => {
+  const onSvFacetIdUpdated = (svFacetId: Record<string, string>): void => {
     const facetsChanged = statVars.filter(
       (sv) => sv.facetId !== svFacetId[sv.dcid]
     );

--- a/static/js/biomedical/landing/card.tsx
+++ b/static/js/biomedical/landing/card.tsx
@@ -43,7 +43,7 @@ const CardContainer = styled.a`
 `;
 
 const Text = styled.div`
-  color: ${(props) => props.theme.textColor || "#146C2E"};
+  color: ${(props: CardProps): string => props.theme.textColor || "#146C2E"};
   font-size: 24px;
   font-weight: 400;
   line-height: 32px;
@@ -57,9 +57,11 @@ const Text = styled.div`
 
 const Tag = styled.div`
   align-items: center;
-  background-color: ${(props) => props.theme.tagBackgroundColor || "#C4EED0"};
+  background-color: ${(props: CardProps): string =>
+    props.theme.tagBackgroundColor || "#C4EED0"};
   border-radius: 28px;
-  color: ${(props) => props.theme.tagLabelColor || "#072711"};
+  color: ${(props: CardProps): string =>
+    props.theme.tagLabelColor || "#072711"};
   display: flex;
   font-size: 12px;
   font-weight: 500;

--- a/static/js/shared/util.test.ts
+++ b/static/js/shared/util.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-disable camelcase */
+
 import { MAX_DATE, MAX_YEAR } from "./constants";
 import { getCappedStatVarDate, isDateTooFar } from "./util";
 

--- a/static/js/tools/download/mock_functions.ts
+++ b/static/js/tools/download/mock_functions.ts
@@ -16,6 +16,8 @@
 
 /* mocked axios calls for Page test for download tool. */
 
+/* eslint-disable camelcase */
+
 jest.mock("axios");
 import axios from "axios";
 import { when } from "jest-when";

--- a/static/js/tools/scatter/app.test.tsx
+++ b/static/js/tools/scatter/app.test.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-disable camelcase */
+
 jest.mock("axios");
 
 import { act, waitFor } from "@testing-library/react";

--- a/static/js/tools/scatter/place_and_type_options.tsx
+++ b/static/js/tools/scatter/place_and_type_options.tsx
@@ -107,7 +107,7 @@ function PlaceAndTypeOptions(props: PlaceAndTypeOptionsProps): JSX.Element {
               ? "selected-chart-option"
               : "chart-type-option"
           }`}
-          onClick={() => display.setChartType(ScatterChartType.SCATTER)}
+          onClick={(): void => display.setChartType(ScatterChartType.SCATTER)}
         >
           <i className="material-icons-outlined">scatter_plot</i>
         </div>
@@ -117,7 +117,7 @@ function PlaceAndTypeOptions(props: PlaceAndTypeOptionsProps): JSX.Element {
               ? "selected-chart-option"
               : "chart-type-option"
           }`}
-          onClick={() => display.setChartType(ScatterChartType.MAP)}
+          onClick={(): void => display.setChartType(ScatterChartType.MAP)}
         >
           <i className="material-icons-outlined">public</i>
         </div>

--- a/static/js/tools/scatter/plot_options.tsx
+++ b/static/js/tools/scatter/plot_options.tsx
@@ -19,12 +19,10 @@
  * lower and upper bounds for populations.
  */
 
-import _ from "lodash";
 import React, { useContext, useState } from "react";
 import { Button, Card, FormGroup, Input, Label } from "reactstrap";
 import { Container } from "reactstrap";
 
-import { DENOM_INPUT_PLACEHOLDER } from "../../shared/constants";
 import {
   GA_EVENT_TOOL_CHART_OPTION_CLICK,
   GA_PARAM_TOOL_CHART_OPTION,
@@ -63,18 +61,6 @@ function swapAxes(x: AxisWrapper, y: AxisWrapper): void {
   const [xValue, yValue] = [x.value, y.value];
   x.set(yValue);
   y.set(xValue);
-}
-
-/**
- * Toggles whether to plot per capita values for an axis.
- * @param axis
- * @param event
- */
-function checkPerCapita(
-  axis: AxisWrapper,
-  event: React.ChangeEvent<HTMLInputElement>
-): void {
-  axis.setPerCapita(event.target.checked);
 }
 
 /**
@@ -178,8 +164,6 @@ function PlotOptions(): JSX.Element {
   const [upperBound, setUpperBound] = useState(
     place.value.upperBound.toString()
   );
-  const [xDenomInput, setXDenomInput] = useState(x.value.denom);
-  const [yDenomInput, setYDenomInput] = useState(y.value.denom);
   const yAxisLabel =
     display.chartType === ScatterChartType.SCATTER
       ? "Y-axis"
@@ -217,7 +201,7 @@ function PlotOptions(): JSX.Element {
                     id="per-capita-y"
                     type="checkbox"
                     checked={y.value.perCapita}
-                    onChange={(e) => {
+                    onChange={(e): void => {
                       y.setPerCapita(e.target.checked);
                       if (!y.value.perCapita) {
                         triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -237,7 +221,7 @@ function PlotOptions(): JSX.Element {
                   id="log-y"
                   type="checkbox"
                   checked={y.value.log}
-                  onChange={(e) => {
+                  onChange={(e): void => {
                     checkLog(y, e);
                     if (!y.value.log) {
                       triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -264,7 +248,7 @@ function PlotOptions(): JSX.Element {
                     id="per-capita-x"
                     type="checkbox"
                     checked={x.value.perCapita}
-                    onChange={(e) => {
+                    onChange={(e): void => {
                       x.setPerCapita(e.target.checked);
                       if (!x.value.perCapita) {
                         triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -284,7 +268,7 @@ function PlotOptions(): JSX.Element {
                   id="log-x"
                   type="checkbox"
                   checked={x.value.log}
-                  onChange={(e) => {
+                  onChange={(e): void => {
                     checkLog(x, e);
                     if (!x.value.log) {
                       triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -309,7 +293,7 @@ function PlotOptions(): JSX.Element {
                     id="swap-axes"
                     size="sm"
                     color="light"
-                    onClick={() => {
+                    onClick={(): void => {
                       swapAxes(x, y);
                       triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
                         [GA_PARAM_TOOL_CHART_OPTION]:
@@ -328,7 +312,7 @@ function PlotOptions(): JSX.Element {
                         id="quadrants"
                         type="checkbox"
                         checked={display.showQuadrants}
-                        onChange={(e) => {
+                        onChange={(e): void => {
                           checkQuadrants(display, e);
                           if (!display.showQuadrants) {
                             triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -349,7 +333,7 @@ function PlotOptions(): JSX.Element {
                         id="quadrants"
                         type="checkbox"
                         checked={display.showLabels}
-                        onChange={(e) => {
+                        onChange={(e): void => {
                           checkLabels(display, e);
                           if (!display.showLabels) {
                             triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -370,7 +354,7 @@ function PlotOptions(): JSX.Element {
                         id="density"
                         type="checkbox"
                         checked={display.showDensity}
-                        onChange={(e) => {
+                        onChange={(e): void => {
                           checkDensity(display, e);
                           if (!display.showDensity) {
                             triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -396,7 +380,7 @@ function PlotOptions(): JSX.Element {
                     <Input
                       checked={display.showPopulation === SHOW_POPULATION_OFF}
                       id="show-population-off"
-                      onChange={(e) => {
+                      onChange={(e): void => {
                         selectShowPopulation(display, e);
                         if (display.showPopulation !== SHOW_POPULATION_OFF) {
                           triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -416,7 +400,7 @@ function PlotOptions(): JSX.Element {
                         display.showPopulation === SHOW_POPULATION_LINEAR
                       }
                       id="show-population-linear"
-                      onChange={(e) => {
+                      onChange={(e): void => {
                         selectShowPopulation(display, e);
                         if (display.showPopulation !== SHOW_POPULATION_LINEAR) {
                           triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -434,7 +418,7 @@ function PlotOptions(): JSX.Element {
                     <Input
                       checked={display.showPopulation === SHOW_POPULATION_LOG}
                       id="show-population-log"
-                      onChange={(e) => {
+                      onChange={(e): void => {
                         selectShowPopulation(display, e);
                         if (display.showPopulation !== SHOW_POPULATION_LOG) {
                           triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -459,11 +443,11 @@ function PlotOptions(): JSX.Element {
                     <Input
                       className="pop-filter-input"
                       type="number"
-                      onChange={(e) =>
+                      onChange={(e): void =>
                         selectLowerBound(place, e, setLowerBound)
                       }
                       value={lowerBound}
-                      onBlur={() => {
+                      onBlur={(): void => {
                         setLowerBound(place.value.lowerBound.toString());
                         triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
                           [GA_PARAM_TOOL_CHART_OPTION]:
@@ -479,11 +463,11 @@ function PlotOptions(): JSX.Element {
                     <Input
                       className="pop-filter-input"
                       type="number"
-                      onChange={(e) =>
+                      onChange={(e): void =>
                         selectUpperBound(place, e, setUpperBound)
                       }
                       value={upperBound}
-                      onBlur={() => {
+                      onBlur={(): void => {
                         setUpperBound(place.value.upperBound.toString());
                         triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
                           [GA_PARAM_TOOL_CHART_OPTION]:

--- a/static/js/tools/scatter/statvar.tsx
+++ b/static/js/tools/scatter/statvar.tsx
@@ -90,7 +90,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
     );
     setSamplePlaces(samplePlaces);
   }, [place.value.enclosedPlaces]);
-  const closeModal = () => {
+  const closeModal = (): void => {
     setThirdStatVar(emptyStatVar);
     setModalOpen(false);
   };
@@ -155,13 +155,15 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
         collapsible={true}
         svHierarchyType={StatVarHierarchyType.SCATTER}
         sampleEntities={samplePlaces}
-        deselectSVs={(svList: string[]) =>
+        deselectSVs={(svList: string[]): void =>
           svList.forEach((sv) => {
             removeStatVar(x, y, sv);
           })
         }
         selectedSVs={selectedSvs}
-        selectSV={(sv) => addStatVar(x, y, sv, setThirdStatVar, setModalOpen)}
+        selectSV={(sv): void =>
+          addStatVar(x, y, sv, setThirdStatVar, setModalOpen)
+        }
       />
       {/* Modal for selecting 2 stat vars when a third is selected */}
       <Modal isOpen={modalOpen} backdrop="static" id="statvar-modal">
@@ -181,7 +183,9 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
                     type="radio"
                     name="statvar"
                     defaultChecked={modalSelected.x}
-                    onClick={() => setModalSelected({ x: true, y: false })}
+                    onClick={(): void =>
+                      setModalSelected({ x: true, y: false })
+                    }
                   />
                   {xTitle}
                 </Label>
@@ -193,7 +197,9 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
                     type="radio"
                     name="statvar"
                     defaultChecked={modalSelected.y}
-                    onClick={() => setModalSelected({ x: false, y: true })}
+                    onClick={(): void =>
+                      setModalSelected({ x: false, y: true })
+                    }
                   />
                   {yTitle}
                 </Label>
@@ -204,7 +210,7 @@ export function StatVarChooser(props: StatVarChooserProps): JSX.Element {
         <ModalFooter>
           <Button
             color="primary"
-            onClick={() =>
+            onClick={(): void =>
               confirmStatVars(
                 x,
                 y,
@@ -241,7 +247,7 @@ function addStatVar(
   svDcid: string,
   setThirdStatVar: (statVar: StatVar) => void,
   setModalOpen: (open: boolean) => void
-) {
+): void {
   getStatVarInfo([svDcid])
     .then((info) => {
       const svInfo = info[svDcid] ? info[svDcid] : {};
@@ -298,7 +304,7 @@ function addStatVarHelper(
  * @param statVar
  * @param nodePath
  */
-function removeStatVar(x: AxisWrapper, y: AxisWrapper, svDcid: string) {
+function removeStatVar(x: AxisWrapper, y: AxisWrapper, svDcid: string): void {
   const statVarX = x.value.statVarDcid;
   const statVarY = y.value.statVarDcid;
   if (statVarX === svDcid) {

--- a/static/js/tools/scatter/util.test.ts
+++ b/static/js/tools/scatter/util.test.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { ContextType, SHOW_POPULATION_LINEAR } from "./context";
+import {
+  Axis,
+  ContextType,
+  PlaceInfo,
+  PointScaleState,
+  SHOW_POPULATION_LINEAR,
+} from "./context";
 import { applyHash, ScatterChartType, updateHash } from "./util";
 
 const TestContext = {
@@ -87,17 +93,20 @@ test("updateHash", () => {
 
 test("applyHash", () => {
   const context = { x: {}, y: {}, place: {}, display: {} } as ContextType;
-  context.x.set = (value) => (context.x.value = value);
-  context.y.set = (value) => (context.y.value = value);
-  context.place.set = (value) => (context.place.value = value);
-  context.display.setQuadrants = (value) =>
+  context.x.set = (value): Axis => (context.x.value = value);
+  context.y.set = (value): Axis => (context.y.value = value);
+  context.place.set = (value): PlaceInfo => (context.place.value = value);
+  context.display.setQuadrants = (value): boolean =>
     (context.display.showQuadrants = value);
-  context.display.setLabels = (value) => (context.display.showLabels = value);
-  context.display.setChartType = (value) => (context.display.chartType = value);
-  context.display.setDensity = (value) => (context.display.showDensity = value);
-  context.display.setRegression = (value) =>
+  context.display.setLabels = (value): boolean =>
+    (context.display.showLabels = value);
+  context.display.setChartType = (value): ScatterChartType =>
+    (context.display.chartType = value);
+  context.display.setDensity = (value): boolean =>
+    (context.display.showDensity = value);
+  context.display.setRegression = (value): boolean =>
     (context.display.showRegression = value);
-  context.display.setPopulation = (value) =>
+  context.display.setPopulation = (value): PointScaleState =>
     (context.display.showPopulation = value);
   location.hash = Hash;
   applyHash(context);

--- a/static/js/tools/scatter/util.ts
+++ b/static/js/tools/scatter/util.ts
@@ -150,7 +150,7 @@ export async function getStatAllWithinPlace(
  * @param key
  * @param isX
  */
-function addSuffix(key: string, isX: boolean) {
+function addSuffix(key: string, isX: boolean): string {
   return `${key}${isX ? "x" : "y"}`;
 }
 
@@ -368,7 +368,7 @@ export function updateHashPlace(hash: string, place: PlaceInfo): string {
 function updateHashDisplayOptions(
   hash: string,
   display: DisplayOptionsWrapper
-) {
+): string {
   hash = updateHashBoolean(
     hash,
     FieldToAbbreviation.showQuadrant,

--- a/static/js/tools/shared/stat_var_widget.tsx
+++ b/static/js/tools/shared/stat_var_widget.tsx
@@ -55,7 +55,6 @@ interface StatVarWidgetPropsType {
 export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
   // Set up refs for sv widget modal. Widget is tied to the LHS menu but
   // reattached to the modal when it is opened on small screens.
-  const svHierarchyModalRef = createRef<HTMLDivElement>();
   const svHierarchyContainerRef = createRef<HTMLDivElement>();
   const sidebarRef = useRef<HTMLDivElement>(null);
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -127,7 +126,7 @@ export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
             selectedSVs={Object.keys(props.selectedSVs)}
             selectSV={props.selectSV}
             searchLabel={"Statistical variables"}
-            deselectSV={(sv) => props.deselectSVs([sv])}
+            deselectSV={(sv): void => props.deselectSVs([sv])}
             numEntitiesExistence={getNumEntitiesExistence()}
           />
         </div>
@@ -157,7 +156,7 @@ export function StatVarWidget(props: StatVarWidgetPropsType): JSX.Element {
             selectedSVs={Object.keys(props.selectedSVs)}
             selectSV={props.selectSV}
             searchLabel={"Statistical variables"}
-            deselectSV={(sv) => props.deselectSVs([sv])}
+            deselectSV={(sv): void => props.deselectSVs([sv])}
             numEntitiesExistence={getNumEntitiesExistence()}
           />
         </ModalBody>

--- a/static/js/tools/shared/tile_metadata_modal.tsx
+++ b/static/js/tools/shared/tile_metadata_modal.tsx
@@ -66,7 +66,7 @@ export function TileMetadataModal(
   const [modalOpen, setModalOpen] = useState(false);
   const [statVarNames, setStatVarNames] = useState<DcidNameTuple[]>([]);
   const dcids = new Set<string>();
-  const toggleModal = () => setModalOpen(!modalOpen);
+  const toggleModal = (): void => setModalOpen(!modalOpen);
   const dataCommonsClient = getDataCommonsClient(props.apiRoot);
   if (props.statVarSpecs) {
     for (const spec of props.statVarSpecs) {
@@ -81,7 +81,7 @@ export function TileMetadataModal(
     // Only fetch data once the modal is opened.
     if (!modalOpen) return;
     if (dcids.size == statVarNames.length) return;
-    (async () => {
+    (async (): Promise<void> => {
       const responseObj = await dataCommonsClient.getFirstNodeValues({
         dcids: [...dcids],
         prop: "name",
@@ -100,7 +100,7 @@ export function TileMetadataModal(
     <>
       <a
         href="#"
-        onClick={(e) => {
+        onClick={(e): void => {
           e.preventDefault();
           setModalOpen(true);
         }}
@@ -147,7 +147,7 @@ export function TileMetadataModal(
           <ModalFooter>
             <Button
               className="modal-close"
-              onClick={() => {
+              onClick={(): void => {
                 setModalOpen(false);
               }}
             >

--- a/static/js/tools/shared/tool_chart_footer.tsx
+++ b/static/js/tools/shared/tool_chart_footer.tsx
@@ -93,7 +93,7 @@ export function ToolChartFooter(props: ToolChartFooterPropType): JSX.Element {
           )}
         </div>
         <div
-          onClick={() => setChartOptionsOpened(!chartOptionsOpened)}
+          onClick={(): void => setChartOptionsOpened(!chartOptionsOpened)}
           className={`${SELECTOR_PREFIX}-options-button`}
         >
           <span>Chart Options</span>
@@ -110,7 +110,7 @@ export function ToolChartFooter(props: ToolChartFooterPropType): JSX.Element {
                     id={ratioCheckboxId}
                     type="checkbox"
                     checked={props.isPerCapita}
-                    onChange={() => {
+                    onChange={(): void => {
                       props.onIsPerCapitaUpdated(!props.isPerCapita);
                       if (!props.isPerCapita) {
                         triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -129,7 +129,7 @@ export function ToolChartFooter(props: ToolChartFooterPropType): JSX.Element {
           <FacetSelector
             svFacetId={props.svFacetId}
             facetListPromise={Promise.resolve(props.facetList)}
-            onSvFacetIdUpdated={(svFacetId) => {
+            onSvFacetIdUpdated={(svFacetId): void => {
               props.onSvFacetIdUpdated(svFacetId);
               triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
                 [GA_PARAM_TOOL_CHART_OPTION]:

--- a/static/js/tools/stat_var/dataset_selector.tsx
+++ b/static/js/tools/stat_var/dataset_selector.tsx
@@ -49,7 +49,7 @@ export function DatasetSelector(props: DatasetSelectorProps): JSX.Element {
             className={`${CSS_PREFIX}-custom-input`}
             type="select"
             value={props.source}
-            onChange={(e) => {
+            onChange={(e): void => {
               const dcid = e.currentTarget.value ? e.currentTarget.value : "";
               updateHash({
                 [SV_URL_PARAMS.SOURCE]: dcid,
@@ -75,7 +75,7 @@ export function DatasetSelector(props: DatasetSelectorProps): JSX.Element {
             className={`${CSS_PREFIX}-custom-input`}
             type="select"
             value={props.dataset}
-            onChange={(e) => {
+            onChange={(e): void => {
               const dcid = e.currentTarget.value ? e.currentTarget.value : "";
               updateHash({ [SV_URL_PARAMS.DATASET]: dcid });
             }}

--- a/static/js/tools/stat_var/page.tsx
+++ b/static/js/tools/stat_var/page.tsx
@@ -82,7 +82,7 @@ class Page extends Component<unknown, PageStateType> {
     this.toggleSvHierarchyModal = this.toggleSvHierarchyModal.bind(this);
   }
 
-  private handleHashChange = () => {
+  private handleHashChange = (): void => {
     const dataset = getUrlToken(SV_URL_PARAMS.DATASET);
     const source = getUrlToken(SV_URL_PARAMS.SOURCE);
     const sv = getUrlToken(SV_URL_PARAMS.STAT_VAR);
@@ -117,9 +117,9 @@ class Page extends Component<unknown, PageStateType> {
           collapsible={false}
           svHierarchyType={StatVarHierarchyType.STAT_VAR}
           sampleEntities={entities}
-          deselectSVs={() => updateHash({ [SV_URL_PARAMS.STAT_VAR]: "" })}
+          deselectSVs={(): void => updateHash({ [SV_URL_PARAMS.STAT_VAR]: "" })}
           selectedSVs={svs}
-          selectSV={(sv) => updateHash({ [SV_URL_PARAMS.STAT_VAR]: sv })}
+          selectSV={(sv): void => updateHash({ [SV_URL_PARAMS.STAT_VAR]: sv })}
           disableAlert={true}
         />
         <div id="plot-container">

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -131,7 +131,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
                   title={this.props.statVarInfos[statVar].title}
                   color={color}
                   removeChip={this.props.removeStatVar}
-                  onTextClick={(): void =>
+                  onTextClick={(): WindowProxy | null =>
                     window.open(`/tools/statvar#sv=${statVar}`)
                   }
                 />

--- a/static/js/tools/timeline/chart.tsx
+++ b/static/js/tools/timeline/chart.tsx
@@ -131,7 +131,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
                   title={this.props.statVarInfos[statVar].title}
                   color={color}
                   removeChip={this.props.removeStatVar}
-                  onTextClick={() =>
+                  onTextClick={(): void =>
                     window.open(`/tools/statvar#sv=${statVar}`)
                   }
                 />
@@ -152,10 +152,10 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
           }
           svFacetId={svFacetId}
           facetList={facetList}
-          onSvFacetIdUpdated={(svFacetId) => setMetahash(svFacetId)}
+          onSvFacetIdUpdated={(svFacetId): void => setMetahash(svFacetId)}
           hideIsRatio={false}
           isPerCapita={this.props.pc}
-          onIsPerCapitaUpdated={(isPerCapita: boolean) =>
+          onIsPerCapitaUpdated={(isPerCapita: boolean): void =>
             setChartOption(this.props.chartId, "pc", isPerCapita)
           }
         >
@@ -167,7 +167,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
                   className="is-delta-input"
                   type="checkbox"
                   checked={this.props.delta}
-                  onChange={() => {
+                  onChange={(): void => {
                     setChartOption(
                       this.props.chartId,
                       "delta",
@@ -247,7 +247,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
     this.processData();
   }
 
-  private handleWindowResize() {
+  private handleWindowResize(): void {
     if (!this.svgContainer.current) {
       return;
     }
@@ -271,7 +271,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
     });
   }
 
-  private loadRawData() {
+  private loadRawData(): void {
     const places = Object.keys(this.props.placeNameMap);
     const statVars = Object.keys(this.props.statVarInfos);
     fetchRawData(places, statVars, this.props.denom)
@@ -284,7 +284,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
       });
   }
 
-  private processData() {
+  private processData(): void {
     if (!this.state.rawData) {
       return;
     }
@@ -351,7 +351,7 @@ class Chart extends Component<ChartPropsType, ChartStateType> {
   /**
    * Draw chart in current svg container based on stats data.
    */
-  private drawChart() {
+  private drawChart(): void {
     const dataGroupsDict = {};
     if (!this.state.statData) {
       return;

--- a/static/js/tools/timeline/chart_region.tsx
+++ b/static/js/tools/timeline/chart_region.tsx
@@ -67,7 +67,7 @@ class ChartRegion extends Component<ChartRegionPropsType> {
       "download-link"
     ) as HTMLAnchorElement;
     if (this.downloadLink) {
-      this.downloadLink.onclick = () => {
+      this.downloadLink.onclick = (): void => {
         saveToFile("export.csv", this.createDataCsv(this.props.placeName));
       };
     }
@@ -75,7 +75,7 @@ class ChartRegion extends Component<ChartRegionPropsType> {
       "bulk-download-link"
     ) as HTMLAnchorElement;
     if (this.bulkDownloadLink) {
-      this.bulkDownloadLink.onclick = () => {
+      this.bulkDownloadLink.onclick = (): void => {
         // Carry over hash params, which is used by the bulk download tool for
         // stat var parsing.
         window.location.href = window.location.href.replace(
@@ -114,7 +114,7 @@ class ChartRegion extends Component<ChartRegionPropsType> {
               denom={chartGroupInfo.chartIdToOptions[mprop].denom}
               delta={chartGroupInfo.chartIdToOptions[mprop].delta}
               onDataUpdate={this.onDataUpdate.bind(this)}
-              removeStatVar={(statVar) => {
+              removeStatVar={(statVar): void => {
                 removeToken("statsVar", statVarSep, statVar);
                 setMetahash({ [statVar]: "" });
               }}
@@ -122,7 +122,7 @@ class ChartRegion extends Component<ChartRegionPropsType> {
                 getMetahash(),
                 chartGroupInfo.chartIdToStatVars[mprop]
               )}
-              onMetadataMapUpdate={(metadataMap) => {
+              onMetadataMapUpdate={(metadataMap): void => {
                 this.metadataMap = { ...this.metadataMap, ...metadataMap };
               }}
             ></Chart>
@@ -132,7 +132,7 @@ class ChartRegion extends Component<ChartRegionPropsType> {
     );
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     if (this.downloadLink) {
       this.downloadLink.style.display = "none";
     }
@@ -141,7 +141,7 @@ class ChartRegion extends Component<ChartRegionPropsType> {
     }
   }
 
-  private onDataUpdate(groupId: string, data: StatData) {
+  private onDataUpdate(groupId: string, data: StatData): void {
     this.allStatData[groupId] = data;
     const displayStyle =
       Object.keys(this.allStatData).length > 0 ? "inline-block" : "none";
@@ -184,7 +184,7 @@ class ChartRegion extends Component<ChartRegionPropsType> {
     };
   }
 
-  private createDataCsv(placeNames: Record<string, string>) {
+  private createDataCsv(placeNames: Record<string, string>): string {
     // Get all the dates
     let allDates = new Set<string>();
     for (const mprop in this.allStatData) {

--- a/static/js/tools/timeline/data_fetcher.test.ts
+++ b/static/js/tools/timeline/data_fetcher.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-disable camelcase */
+
 import { expect } from "@jest/globals";
 import axios from "axios";
 import { when } from "jest-when";

--- a/static/js/tools/timeline/mock_functions.tsx
+++ b/static/js/tools/timeline/mock_functions.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-disable camelcase */
+
 jest.mock("axios");
 
 import { expect } from "@jest/globals";

--- a/static/js/tools/timeline/page.test.tsx
+++ b/static/js/tools/timeline/page.test.tsx
@@ -38,7 +38,7 @@ beforeEach(() => {
   window.infoConfig = {};
 });
 
-async function waitForComponentUpdates(wrapper: ReactWrapper) {
+async function waitForComponentUpdates(wrapper: ReactWrapper): Promise<void> {
   // Wait for state updates
   await waitFor(() => {
     expect(wrapper.text()).toContain("");

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -111,7 +111,7 @@ class Page extends Component<unknown, PageStateType> {
     });
   }
 
-  private onSvHierarchyModalOpened() {
+  private onSvHierarchyModalOpened(): void {
     if (
       this.svHierarchyModalRef.current &&
       this.svHierarchyContainerRef.current
@@ -122,7 +122,7 @@ class Page extends Component<unknown, PageStateType> {
     }
   }
 
-  private onSvHierarchyModalClosed() {
+  private onSvHierarchyModalClosed(): void {
     document
       .getElementById("explore")
       .appendChild(this.svHierarchyContainerRef.current);
@@ -142,7 +142,7 @@ class Page extends Component<unknown, PageStateType> {
       sv.includes("|") ? sv.split("|")[0] : sv
     );
 
-    const deselectSVs = (svList: string[]) => {
+    const deselectSVs = (svList: string[]): void => {
       const availableSVs = statVars.filter((sv) => svList.indexOf(sv) === -1);
       const statVarTokenInfo = {
         name: TIMELINE_URL_PARAM_KEYS.STAT_VAR,
@@ -167,7 +167,7 @@ class Page extends Component<unknown, PageStateType> {
           sampleEntities={namedPlaces}
           deselectSVs={deselectSVs}
           selectedSVs={svToSvInfo}
-          selectSV={(sv) =>
+          selectSV={(sv): void =>
             addToken(TIMELINE_URL_PARAM_KEYS.STAT_VAR, statVarSep, sv)
           }
         />
@@ -189,13 +189,13 @@ class Page extends Component<unknown, PageStateType> {
                 <Col sm={12}>
                   <SearchBar
                     places={this.state.placeName}
-                    addPlace={(place) => {
+                    addPlace={(place): void => {
                       addToken(TIMELINE_URL_PARAM_KEYS.PLACE, placeSep, place);
                       triggerGAEvent(GA_EVENT_TOOL_PLACE_ADD, {
                         [GA_PARAM_PLACE_DCID]: place,
                       });
                     }}
-                    removePlace={(place) => {
+                    removePlace={(place): void => {
                       removeToken(
                         TIMELINE_URL_PARAM_KEYS.PLACE,
                         placeSep,

--- a/static/js/types/app/explore_types.ts
+++ b/static/js/types/app/explore_types.ts
@@ -61,7 +61,7 @@ export interface SVScores {
 export interface SentenceScore {
   sentence: string;
   score: number;
-  rerank_score: number;
+  rerankScore: number;
 }
 
 export interface DebugInfo {

--- a/static/js/utils/app/visualization_utils.tsx
+++ b/static/js/utils/app/visualization_utils.tsx
@@ -189,7 +189,7 @@ export function getFooterOptions(
                   <Input
                     type="checkbox"
                     checked={pcInput.isChecked}
-                    onChange={() => {
+                    onChange={(): void => {
                       pcInput.onUpdated(!pcInput.isChecked);
                       if (!pcInput.isChecked) {
                         triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {
@@ -215,7 +215,7 @@ export function getFooterOptions(
                   <Input
                     type="checkbox"
                     checked={logInput.isChecked}
-                    onChange={() => {
+                    onChange={(): void => {
                       logInput.onUpdated(!logInput.isChecked);
                       if (!logInput.isChecked) {
                         triggerGAEvent(GA_EVENT_TOOL_CHART_OPTION_CLICK, {

--- a/static/js/utils/axios.ts
+++ b/static/js/utils/axios.ts
@@ -16,11 +16,11 @@
 
 import { stringify } from "qs";
 
-export const stringifyFn = (params) => {
+export const stringifyFn = (params): string => {
   return stringify(params, { arrayFormat: "repeat" });
 };
 
-export const getRoot = () => {
+export const getRoot = (): string => {
   if (globalThis.datacommons) {
     return globalThis.datacommons.root || "";
   }

--- a/static/js/utils/data_commons_client.ts
+++ b/static/js/utils/data_commons_client.ts
@@ -41,7 +41,7 @@ export const defaultDataCommonsClient = new DataCommonsClient({
  * @param apiRoot
  * @returns DataCommonsClient instance
  */
-export function getDataCommonsClient(apiRoot?: string) {
+export function getDataCommonsClient(apiRoot?: string): DataCommonsClient {
   if (apiRoot) {
     return new DataCommonsClient({
       apiRoot,

--- a/static/js/utils/disaster_event_map_utils.tsx
+++ b/static/js/utils/disaster_event_map_utils.tsx
@@ -176,7 +176,7 @@ function getGeoJsonFeature(
   eventDcid: string,
   geoJsonProp: string,
   propVals: { [prop: string]: { vals: string[] } }
-) {
+): string {
   let geoJson = null;
   if (propVals[geoJsonProp] && !_.isEmpty(propVals[geoJsonProp].vals)) {
     // Remove any extra backslashes that that are in the prop val string.
@@ -465,7 +465,9 @@ export function onPointClicked(
   const infoCard = d3.select(infoCardElement);
   ReactDOM.render(
     <DisasterEventMapInfoCard
-      onClose={() => d3.select(infoCardElement).style("visibility", "hidden")}
+      onClose={(): d3.Selection<HTMLDivElement, unknown, null, undefined> =>
+        d3.select(infoCardElement).style("visibility", "hidden")
+      }
       eventData={point}
     />,
     infoCardElement

--- a/static/js/utils/place_utils.ts
+++ b/static/js/utils/place_utils.ts
@@ -201,8 +201,7 @@ export function getPlaceNames(
  */
 export async function getPlaceType(
   dcid: string,
-  apiRoot?: string,
-  prop?: string
+  apiRoot?: string
 ): Promise<string> {
   if (!dcid) {
     return THING_PLACE_TYPE;

--- a/static/js/utils/stat_metadata_utils.test.ts
+++ b/static/js/utils/stat_metadata_utils.test.ts
@@ -53,5 +53,5 @@ test("getUnit", () => {
     unit: testUnit,
     unitDisplayName: shortUnit,
   };
-  expect(getUnit(sourceSeriesWithUnitAndScalingFactor) === shortUnit);
+  expect(getUnit(sourceSeriesWithUnitDisplayName) === shortUnit);
 });

--- a/static/library/index.ts
+++ b/static/library/index.ts
@@ -60,7 +60,7 @@ globalThis.datacommons = {
  * Web components can't load external fonts directly, so instead add them
  * directly to the parent page
  */
-function loadStyles() {
+function loadStyles(): void {
   const googleSansEl = document.createElement("link");
   googleSansEl.href =
     "https://fonts.googleapis.com/css2?family=Google+Sans:wght@300;400;500;700&family=Google+Sans+Text:wght@300;400;500;700&display=swap";

--- a/static/library/slider_component.ts
+++ b/static/library/slider_component.ts
@@ -463,22 +463,15 @@ export class DatacommonsSliderComponent extends LitElement {
     `;
   }
 
-  private defaultHeader() {
+  private defaultHeader(): TemplateResult {
     return html`<h4 part="header">Explore trends over time</h4>`;
   }
 
-  private getDateText() {
+  private getDateText(): string {
     if (this._value < 0 || this._value >= this._dates.length) {
       return "Unknown";
     }
     return this._dates[this._value];
-  }
-
-  private getEndDateText() {
-    if (this._dates.length === 0) {
-      return "Unknown";
-    }
-    return this._dates[this._dates.length - 1];
   }
 
   private onSliderChange(e: Event): void {
@@ -523,7 +516,7 @@ export class DatacommonsSliderComponent extends LitElement {
     );
   }
 
-  private async fetchObservationDates() {
+  private async fetchObservationDates(): Promise<void> {
     const apiRoot = getApiRoot(this.apiRoot);
     const dataCommonsWebClient = new DataCommonsWebClient({ apiRoot });
     if (


### PR DESCRIPTION
This resolves around 200 lint warning (803 to 606) by disabling camel-case check when unnecessary, adding a return type to functions, or removing some unused code.
