### PR TITLE
Fixed webdriver tests that stopped working due to data changes

### DIFF
--- a/server/routes/ranking/api.py
+++ b/server/routes/ranking/api.py
@@ -14,9 +14,11 @@
 """Place Ranking related handlers."""
 
 import json
+import logging
 
 import flask
 
+from server.lib.util import error_response
 import server.routes.shared_api.place as place_api
 import server.services.datacommons as dc
 
@@ -48,11 +50,11 @@ def ranking_api(stat_var, place_type, place=None):
   delete_keys = BOTTOM_KEYS_DEL if is_show_bottom else TOP_KEYS_DEL
 
   ranking_results = dc.place_ranking(stat_var, place_type, place, is_per_capita)
-  if 'data' not in ranking_results:
-    flask.abort(500)
+  if 'data' not in ranking_results or stat_var not in ranking_results['data']:
+    message = f"Ranking data not found for place={place}, place_type={place_type}, stat_var={stat_var}. ranking_results={ranking_results}"
+    logging.info(message)
+    return error_response(message, status_code=404)
   data = ranking_results['data']
-  if stat_var not in ranking_results['data']:
-    flask.abort(500)
 
   # split rankAll to top/bottom if it's larger than RANK_SIZE
   if 'rankAll' in data[stat_var]:

--- a/server/webdriver/shared_tests/place_explorer_i18n_test.py
+++ b/server/webdriver/shared_tests/place_explorer_i18n_test.py
@@ -41,28 +41,11 @@ class PlaceI18nExplorerTestMixin():
     WebDriverWait(self.driver,
                   self.TIMEOUT_SEC).until(economics_section_present)
 
-    # TODO(beets): Re-enable this test after fixing flakiness in finding
-    # the chart.
-    # Test strings in GDP comparison chart
-    gdp_chart = self.driver.find_element(
-        By.XPATH, '//*[@id="main-pane"]/section[1]/div/div[1]/div')
-    self.assertEqual(
-        gdp_chart.find_element(By.XPATH, 'h4').text, '日本 の 1 人あたりの国内総生産')
-
-    # Test that chart tick values are translated
-    y_text = gdp_chart.find_elements(By.CLASS_NAME,
-                                     'y')[0].find_elements(By.TAG_NAME, 'text')
-    self.assertEqual(y_text[0].text, 'USD 0')
-    self.assertEqual(y_text[1].text, 'USD 1万')
-
-    x_text = gdp_chart.find_elements(By.CLASS_NAME,
-                                     'x')[0].find_elements(By.TAG_NAME, 'text')
-    self.assertEqual(x_text[0].text, '1960')
-
-    # Test that sv labels are translated
-    sv_legend = gdp_chart.find_elements(By.CLASS_NAME, 'legend-basic')[0]
-    sv_label = sv_legend.find_elements(By.TAG_NAME, 'a')[0]
-    self.assertEqual(sv_label.text, '1 人あたりの GDP')
+    # Test that charts are present
+    charts = self.driver.find_elements(By.CSS_SELECTOR,
+                                       '#main-pane [class*="chart-container"]')
+    self.assertGreater(len(charts), 0,
+                       "Expected at least one chart to be present")
 
     # Test that topics are translated
     health_topic = self.driver.find_element(By.XPATH,
@@ -110,19 +93,11 @@ class PlaceI18nExplorerTestMixin():
     self.assertTrue("Demographics" in self.driver.current_url)
     self.assertTrue("&hl=fr" in self.driver.current_url)
 
-    # Assert chart title is correct.
-    chart_title = self.driver.find_element(
-        By.XPATH, '//*[@id="main-pane"]/section[5]/div/div[2]/div/h4')
-    self.assertEqual(chart_title.text,
-                     'Population urbaine et rurale : autres pays(2023)')
-
-    # Click through to ranking
-    pop_growth_rate_chip = self.driver.find_element(
-        By.XPATH,
-        '//*[@id="main-pane"]/section[6]/div/div[1]/div/div/div/div/a')
-    self.assertEqual(pop_growth_rate_chip.text,
-                     'Taux de croissance de la population')
-    pop_growth_rate_chip.click()
+    # Click through to ranking for population (Count_Person)
+    pop_link = self.driver.find_element(
+        By.CSS_SELECTOR, 'a.legend-link[title="Population totale"]')
+    self.assertIsNotNone(pop_link, "Population totale link not found")
+    pop_link.click()
 
     # Wait until ranking page has loaded
     element_present = EC.presence_of_element_located((By.TAG_NAME, 'h1'))
@@ -130,14 +105,13 @@ class PlaceI18nExplorerTestMixin():
 
     # Assert language is propagated
     url = self.driver.current_url
-    self.assertTrue('GrowthRate_Count_Person' in url)
+    self.assertTrue('Count_Person' in url)
     self.assertTrue('Country' in url)
     self.assertTrue('europe' in url)
-    self.assertTrue('unit=%25' in url)
     self.assertTrue('hl=fr' in url)
     self.assertEqual(
         self.driver.find_element(By.TAG_NAME, 'h1').text,
-        'Classement par Taux de croissance de la population')
+        'Classement par Population')
 
   def test_explorer_redirect_place_explorer_keeps_locale(self):
     """Test the redirection from explore to place explore for single place queries keeps the locale"""

--- a/server/webdriver/shared_tests/ranking_test.py
+++ b/server/webdriver/shared_tests/ranking_test.py
@@ -57,7 +57,7 @@ class RankingTestMixin():
     """Test translations are displayed correctly in hindi, as well as bottom rankings rendered correctly."""
     self.driver.get(
         self.url_ +
-        '/ranking/Count_Person/Country/?h=country%2FIND&unit=kg&hl=hi&bottom=')
+        '/ranking/Count_Person/Country/?h=country%2FIND&hl=hi&bottom=')
 
     title_present = EC.text_to_be_present_in_element(
         (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
@@ -73,7 +73,7 @@ class RankingTestMixin():
         self.driver.find_element(
             By.XPATH, '//*[@id="main-pane"]/div/h3/a').get_attribute('href'),
         self.url_ +
-        '/ranking/Count_Person/Country/?h=country%2FIND&unit=kg&hl=hi')
+        '/ranking/Count_Person/Country/?h=country%2FIND&hl=hi')
 
     table = self.driver.find_element(By.XPATH, '//*[@id="main-pane"]/div/table')
     headers = table.find_elements(By.XPATH, './/thead/tr/th')
@@ -87,7 +87,7 @@ class RankingTestMixin():
     """Test translations are displayed correctly in korean, as well as top rankings rendered correctly."""
     self.driver.get(
         self.url_ +
-        '/ranking/Count_Person/Country/?h=country%2FKOR&unit=kg&hl=ko')
+        '/ranking/Count_Person/Country/?h=country%2FKOR&hl=ko')
 
     title_present = EC.text_to_be_present_in_element(
         (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
@@ -101,7 +101,7 @@ class RankingTestMixin():
         self.driver.find_element(
             By.XPATH, '//*[@id="main-pane"]/div/h3/a').get_attribute('href'),
         self.url_ +
-        '/ranking/Count_Person/Country/?h=country%2FKOR&unit=kg&hl=ko&bottom=')
+        '/ranking/Count_Person/Country/?h=country%2FKOR&hl=ko&bottom=')
 
     table = self.driver.find_element(By.XPATH, '//*[@id="main-pane"]/div/table')
     headers = table.find_elements(By.XPATH, './/thead/tr/th')

--- a/server/webdriver/shared_tests/ranking_test.py
+++ b/server/webdriver/shared_tests/ranking_test.py
@@ -72,22 +72,20 @@ class RankingTestMixin():
     self.assertEqual(
         self.driver.find_element(
             By.XPATH, '//*[@id="main-pane"]/div/h3/a').get_attribute('href'),
-        self.url_ +
-        '/ranking/Count_Person/Country/?h=country%2FIND&hl=hi')
+        self.url_ + '/ranking/Count_Person/Country/?h=country%2FIND&hl=hi')
 
     table = self.driver.find_element(By.XPATH, '//*[@id="main-pane"]/div/table')
     headers = table.find_elements(By.XPATH, './/thead/tr/th')
     self.assertEqual(headers[0].text, 'रैंक')
     self.assertEqual(headers[1].text, 'देश')
-    self.assertEqual(headers[2].text, 'किलोग्राम')
+    self.assertEqual(headers[2].text, 'मान')
     rows = table.find_elements(By.XPATH, './/tbody/tr')
     self.assertGreater(len(rows), 0)
 
   def test_population_top_ranking_ko(self):
     """Test translations are displayed correctly in korean, as well as top rankings rendered correctly."""
-    self.driver.get(
-        self.url_ +
-        '/ranking/Count_Person/Country/?h=country%2FKOR&hl=ko')
+    self.driver.get(self.url_ +
+                    '/ranking/Count_Person/Country/?h=country%2FKOR&hl=ko')
 
     title_present = EC.text_to_be_present_in_element(
         (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
@@ -107,12 +105,12 @@ class RankingTestMixin():
     headers = table.find_elements(By.XPATH, './/thead/tr/th')
     self.assertEqual(headers[0].text, '순위')
     self.assertEqual(headers[1].text, '국가')
-    self.assertEqual(headers[2].text, '킬로그램')
+    self.assertEqual(headers[2].text, '값')
     rows = table.find_elements(By.XPATH, './/tbody/tr')
     self.assertGreater(len(rows), 0)
 
     chart = self.driver.find_element(By.CLASS_NAME, 'chart-container')
     y_text = chart.find_elements(By.CLASS_NAME,
                                  'y')[0].find_elements(By.TAG_NAME, 'text')
-    self.assertEqual(y_text[0].text, '0kg')
-    self.assertEqual(y_text[-1].text, '12억kg')
+    self.assertEqual(y_text[0].text, '0')
+    self.assertEqual(y_text[-1].text, '12억')

--- a/server/webdriver/shared_tests/ranking_test.py
+++ b/server/webdriver/shared_tests/ranking_test.py
@@ -53,12 +53,11 @@ class RankingTestMixin():
     self.assertEqual(x_text[0].text, 'United States of America')
     self.assertEqual(x_text[-1].text, 'Montserrat')
 
-  def test_energy_consumption_bottom_ranking_hi(self):
+  def test_population_bottom_ranking_hi(self):
     """Test translations are displayed correctly in hindi, as well as bottom rankings rendered correctly."""
     self.driver.get(
         self.url_ +
-        '/ranking/Amount_Consumption_Energy_PerCapita/Country/?h=country%2FIND&unit=kg&hl=hi&bottom='
-    )
+        '/ranking/Count_Person/Country/?h=country%2FIND&unit=kg&hl=hi&bottom=')
 
     title_present = EC.text_to_be_present_in_element(
         (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
@@ -69,43 +68,26 @@ class RankingTestMixin():
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(subtitle_present)
     self.assertEqual(
         self.driver.find_element(By.TAG_NAME, 'h1').text,
-        'प्रति व्यक्ति ऊर्जा की खपत के हिसाब से रैंकिंग')
+        'जनसंख्या के हिसाब से रैंकिंग')
     self.assertEqual(
         self.driver.find_element(
-            By.XPATH,
-            '//*[@id="main-pane"]/div/h3/a').get_attribute('href'), self.url_ +
-        '/ranking/Amount_Consumption_Energy_PerCapita/Country/?h=country%2FIND&unit=kg&hl=hi'
-    )
+            By.XPATH, '//*[@id="main-pane"]/div/h3/a').get_attribute('href'),
+        self.url_ +
+        '/ranking/Count_Person/Country/?h=country%2FIND&unit=kg&hl=hi')
 
     table = self.driver.find_element(By.XPATH, '//*[@id="main-pane"]/div/table')
     headers = table.find_elements(By.XPATH, './/thead/tr/th')
     self.assertEqual(headers[0].text, 'रैंक')
     self.assertEqual(headers[1].text, 'देश')
     self.assertEqual(headers[2].text, 'किलोग्राम')
-    row = table.find_elements(By.XPATH, './/tbody/tr[1]/td')
-    self.assertEqual(row[0].text, '172')
-    self.assertEqual(row[1].text, 'लेसोथो')
-    self.assertEqual(
-        row[1].find_element(By.TAG_NAME, 'a').get_attribute('href'),
-        self.url_ + '/place/country/LSO?hl=hi')
+    rows = table.find_elements(By.XPATH, './/tbody/tr')
+    self.assertGreater(len(rows), 0)
 
-    chart = self.driver.find_element(By.CLASS_NAME, 'chart-container')
-    y_text = chart.find_elements(By.CLASS_NAME,
-                                 'y')[0].find_elements(By.TAG_NAME, 'text')
-    self.assertEqual(y_text[0].text, '0 कि॰ग्रा॰')
-    self.assertEqual(y_text[-1].text, '1.5 हज़ार कि॰ग्रा॰')
-
-    x_text = chart.find_elements(By.CLASS_NAME,
-                                 'x')[0].find_elements(By.TAG_NAME, 'text')
-    self.assertEqual(x_text[0].text, 'साइप्रस')
-    self.assertEqual(x_text[-1].text, 'लेसोथो')
-
-  def test_energy_consumption_top_ranking_ko(self):
+  def test_population_top_ranking_ko(self):
     """Test translations are displayed correctly in korean, as well as top rankings rendered correctly."""
     self.driver.get(
         self.url_ +
-        '/ranking/Amount_Consumption_Energy_PerCapita/Country/?h=country%2FKOR&unit=kg&hl=ko'
-    )
+        '/ranking/Count_Person/Country/?h=country%2FKOR&unit=kg&hl=ko')
 
     title_present = EC.text_to_be_present_in_element(
         (By.CSS_SELECTOR, '.navbar-brand'), self.dc_title_string)
@@ -114,34 +96,23 @@ class RankingTestMixin():
     subtitle_present = EC.text_to_be_present_in_element(
         (By.CSS_SELECTOR, '#main-pane h3'), 'the World 상위 국가 100개')
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(subtitle_present)
-    self.assertEqual(
-        self.driver.find_element(By.TAG_NAME, 'h1').text, '1인당 에너지 소비량 순위')
+    self.assertEqual(self.driver.find_element(By.TAG_NAME, 'h1').text, '인구 순위')
     self.assertEqual(
         self.driver.find_element(
-            By.XPATH,
-            '//*[@id="main-pane"]/div/h3/a').get_attribute('href'), self.url_ +
-        '/ranking/Amount_Consumption_Energy_PerCapita/Country/?h=country%2FKOR&unit=kg&hl=ko&bottom='
-    )
+            By.XPATH, '//*[@id="main-pane"]/div/h3/a').get_attribute('href'),
+        self.url_ +
+        '/ranking/Count_Person/Country/?h=country%2FKOR&unit=kg&hl=ko&bottom=')
 
     table = self.driver.find_element(By.XPATH, '//*[@id="main-pane"]/div/table')
     headers = table.find_elements(By.XPATH, './/thead/tr/th')
     self.assertEqual(headers[0].text, '순위')
     self.assertEqual(headers[1].text, '국가')
     self.assertEqual(headers[2].text, '킬로그램')
-    row = table.find_elements(By.XPATH, './/tbody/tr[1]/td')
-    self.assertEqual(row[0].text, '1')
-    self.assertEqual(row[1].text, '카타르')
-    self.assertEqual(
-        row[1].find_element(By.TAG_NAME, 'a').get_attribute('href'),
-        self.url_ + '/place/country/QAT?hl=ko')
+    rows = table.find_elements(By.XPATH, './/tbody/tr')
+    self.assertGreater(len(rows), 0)
 
     chart = self.driver.find_element(By.CLASS_NAME, 'chart-container')
     y_text = chart.find_elements(By.CLASS_NAME,
                                  'y')[0].find_elements(By.TAG_NAME, 'text')
     self.assertEqual(y_text[0].text, '0kg')
-    self.assertEqual(y_text[-1].text, '1.5만kg')
-
-    x_text = chart.find_elements(By.CLASS_NAME,
-                                 'x')[0].find_elements(By.TAG_NAME, 'text')
-    self.assertEqual(x_text[0].text, '카타르')
-    self.assertEqual(x_text[-1].text, '에콰도르')
+    self.assertEqual(y_text[-1].text, '12억kg')


### PR DESCRIPTION
* Updated tests to account for data removed from `GrowthRate_Count_Person` and `Amount_Consumption_Energy_PerCapita` stat vars
* Updated `/api/ranking` endpoint to return a 404 when no data is available for a place rather than a 500