### PR TITLE
Parameterize the env file used to run the custom dc dev script.

### DIFF
--- a/.run_cdc_dev.env
+++ b/.run_cdc_dev.env
@@ -14,11 +14,14 @@
 
 # Env variables for running run_cdc_dev.sh
 
-# The 3 keys / passwords below are not checked in.
-# Either uncomment these lines and set them here or set them separately as environment variables.
-# DC_API_KEY=
-# MAPS_API_KEY=
-# DB_PASS=
+# The 3 keys / passwords below must be specified before the script can be run.
+# Either specify them here or better still is to 
+# copy this file, specify the values in the copy and set the env variable RUN_CDC_DEV_ENV_FILE to that file's path before running the script.
+# e.g. if the copied file is at tmp/cdc.env, you can run the script as follows:
+# RUN_CDC_DEV_ENV_FILE=tmp/cdc.env ./run_cdc_dev.sh
+DC_API_KEY=
+MAPS_API_KEY=
+DB_PASS=
 
 # If your DC_API_KEY is for autopush, change this to https://autopush.api.datacommons.org
 DC_API_ROOT=https://api.datacommons.org

--- a/run_cdc_dev.sh
+++ b/run_cdc_dev.sh
@@ -27,7 +27,9 @@ set -e
 # Kill forked processes on exit.
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
-source .run_cdc_dev.env && export $(sed '/^#/d' .run_cdc_dev.env | cut -d= -f1)
+ENV_FILE=${RUN_CDC_DEV_ENV_FILE:-.run_cdc_dev.env}
+echo "Using environment file: $ENV_FILE"
+source $ENV_FILE && export $(sed '/^#/d' $ENV_FILE | cut -d= -f1)
 
 # Print commit hashes.
 echo -e "\033[0;32m" # Set different color.
@@ -60,7 +62,7 @@ fi
 
 # Validate api root and key by making an API call.
 echo
-url="${DC_API_ROOT}/v2/node?key=${DC_API_KEY}&nodes=geoId/06&property=<-"
+url="${DC_API_ROOT}/v2/node?key=${DC_API_KEY}&nodes=geoId/06&property=%3C-"
 echo "Calling API to validate key: $url"
 # Perform the request and capture both output and HTTP status code
 response=$(curl --silent --output /dev/null --write-out "%{http_code}" "$url")


### PR DESCRIPTION
* This allows devs to have multiple env files referencing different custom dc backends and then run a local setup connecting to those backends quickly.
* This also fixes a bug where a curl command in the script failed due to an unescaped url character.