### PR TITLE
Skip failing custom dc tests.

### DIFF
--- a/server/webdriver/cdc_tests/autopush/cdc_base_webdriver.py
+++ b/server/webdriver/cdc_tests/autopush/cdc_base_webdriver.py
@@ -14,6 +14,10 @@
 from server.webdriver.base import WebdriverBaseTest
 from server.webdriver.cdc_tests.base import CDC_AUTOPUSH_URL
 
+# Shared tests that don't work in custom DC are skipped with this reason.
+# Any skipped test should be noted in b/386405593, fixed and unskipped subsequently.
+SKIPPED_TEST_REASON = "Not working in custom DC. See b/386405593"
+
 
 class CdcAutopushTestBase(WebdriverBaseTest):
   """Base class for CDC Autopush webdriver tests."""

--- a/server/webdriver/cdc_tests/autopush/place_explorer_i18n_test.py
+++ b/server/webdriver/cdc_tests/autopush/place_explorer_i18n_test.py
@@ -11,11 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import unittest
+
 from server.webdriver.cdc_tests.autopush.cdc_base_webdriver import \
     CdcAutopushTestBase
+from server.webdriver.cdc_tests.autopush.cdc_base_webdriver import \
+    SKIPPED_TEST_REASON
 from server.webdriver.shared_tests.place_explorer_i18n_test import \
     PlaceI18nExplorerTestMixin
 
 
 class TestPlaceExplorerI18n(PlaceI18nExplorerTestMixin, CdcAutopushTestBase):
   """Class to test the i18n place explorer page for Custom DC. Tests come from PlaceI18nExplorerTestMixin."""
+
+  @unittest.skip(reason=SKIPPED_TEST_REASON)
+  def test_explorer_redirect_place_explorer_keeps_locale(self):
+    super().test_explorer_redirect_place_explorer_keeps_locale()

--- a/server/webdriver/cdc_tests/autopush/place_explorer_test.py
+++ b/server/webdriver/cdc_tests/autopush/place_explorer_test.py
@@ -11,11 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import unittest
+
 from server.webdriver.cdc_tests.autopush.cdc_base_webdriver import \
     CdcAutopushTestBase
+from server.webdriver.cdc_tests.autopush.cdc_base_webdriver import \
+    SKIPPED_TEST_REASON
 from server.webdriver.shared_tests.place_explorer_test import \
     PlaceExplorerTestMixin
 
 
 class TestPlaceExplorer(PlaceExplorerTestMixin, CdcAutopushTestBase):
   """Class to test the place explorer page for Custom DC. Tests come from PlaceExplorerTestMixin."""
+
+  @unittest.skip(reason=SKIPPED_TEST_REASON)
+  def test_explorer_redirect_place_explorer(self):
+    super().test_explorer_redirect_place_explorer()


### PR DESCRIPTION
* Certain place explorer tests are failing on custom DC autopush. This PR skips those tests for now.
* The failures are likely due to recent place explorer page changes that have probably not been ported to custom DC.
* Filed b/386405593 to fix and unskip them subsequently.
* Also filed b/386405338 to run these tests on each PR so they are caught at the outset.