### PR TITLE
Set default env values in the run_servers script.

### DIFF
--- a/run_servers.sh
+++ b/run_servers.sh
@@ -30,6 +30,16 @@ if [[ "$1" == "--verbose" ]]; then
   VERBOSE=true
 fi
 
+export FLASK_ENV="${FLASK_ENV:-integration_test}"
+export ENV_PREFIX="${ENV_PREFIX:-Staging}"
+export GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT:-datcom-website-staging}"
+export ENABLE_MODEL="${ENABLE_MODEL:-true}"
+
+echo "FLASK_ENV=$FLASK_ENV"
+echo "ENV_PREFIX=$ENV_PREFIX"
+echo "GOOGLE_CLOUD_PROJECT=$GOOGLE_CLOUD_PROJECT"
+echo "ENABLE_MODEL=$ENABLE_MODEL"
+
 exit_with=0
 
 # Kill forked processes, then exit with the status code stored in a variable.


### PR DESCRIPTION
* This PR sets default values for env variables that are used for running servers.
* The defaults are used if the corresponding variables are not specified.
* This makes it easier to use the `run_servers.sh` script.