### PR TITLE
Update NL Goldens

### DIFF
--- a/server/integration_tests/test_data/demo_feb2023/query_2/chart_config.json
+++ b/server/integration_tests/test_data/demo_feb2023/query_2/chart_config.json
@@ -40,7 +40,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2023"
+                      "startDate": "2024"
                     },
                     "statVarKey": [
                       "Count_FireEvent_285042123"
@@ -102,7 +102,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2023"
+                      "startDate": "2024"
                     },
                     "statVarKey": [
                       "Count_WildfireEvent_2519150620"
@@ -126,45 +126,9 @@
               }
             ],
             "title": "Wildfires"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 10,
-                      "showHighest": true
-                    },
-                    "statVarKey": [
-                      "Annual_ExpectedLoss_NaturalHazardImpact_WildfireEvent"
-                    ],
-                    "title": "Annual Expected Loss From Natural Hazard Impact: Wildfire in Counties of California (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Annual_ExpectedLoss_NaturalHazardImpact_WildfireEvent"
-                    ],
-                    "title": "Annual Expected Loss From Natural Hazard Impact: Wildfire in Counties of California (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Annual Expected Loss From Natural Hazard Impact: Wildfire in Counties of California"
           }
         ],
         "statVarSpec": {
-          "Annual_ExpectedLoss_NaturalHazardImpact_WildfireEvent": {
-            "name": "Annual Expected Loss from Natural Hazard Impact: Wildfire",
-            "statVar": "Annual_ExpectedLoss_NaturalHazardImpact_WildfireEvent"
-          },
           "Count_FireEvent": {
             "name": "Count of Fire Event",
             "statVar": "Count_FireEvent"

--- a/server/integration_tests/test_data/detection_api_multivar/comparemalepopulationwithfemalepopulation/debug_info.json
+++ b/server/integration_tests/test_data/detection_api_multivar/comparemalepopulationwithfemalepopulation/debug_info.json
@@ -121,7 +121,7 @@
             },
             {
               "CosineScore": [
-                0.917032,
+                0.917033,
                 0.873019
               ],
               "QueryPart": "population female population",

--- a/server/integration_tests/test_data/detection_api_multivar/showmetheimpactofclimatechangeondrought/debug_info.json
+++ b/server/integration_tests/test_data/detection_api_multivar/showmetheimpactofclimatechangeondrought/debug_info.json
@@ -66,7 +66,7 @@
             {
               "CosineScore": [
                 0.794237,
-                0.792901
+                0.792902
               ],
               "QueryPart": "show climate",
               "SV": [

--- a/server/integration_tests/test_data/e2e_date_range/lifeexpectancyinusstatesinthelast5years/chart_config.json
+++ b/server/integration_tests/test_data/e2e_date_range/lifeexpectancyinusstatesinthelast5years/chart_config.json
@@ -41,7 +41,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2019"
+                      "startDate": "2020"
                     },
                     "statVarKey": [
                       "LifeExpectancy_Person_3563600999"
@@ -71,72 +71,8 @@
               {
                 "tiles": [
                   {
-                    "statVarKey": [
-                      "LifeExpectancy_Person_Female"
-                    ],
-                    "title": "Female Life Expectancy in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "LifeExpectancy_Person_Female"
-                    ],
-                    "title": "Female Life Expectancy in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "description": "Life expectancy at birth indicates the number of years a newborn infant would live if prevailing patterns of mortality at the time of its birth were to stay the same throughout its life. (1) united nations population division. World population prospects: 2019 revision. (2) census reports and other statistical publications from national statistical offices, (3) eurostat: demographic statistics, (4) united nations statistical division. Population and vital statistics report (various years), (5) u.S. Census bureau: international database, and (6) secretariat of the pacific community: statistics and demography programme.",
-            "title": "Female Life Expectancy in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "LifeExpectancy_Person_Male"
-                    ],
-                    "title": "Male Life Expectancy in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "LifeExpectancy_Person_Male"
-                    ],
-                    "title": "Male Life Expectancy in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "description": "Life expectancy at birth indicates the number of years a newborn infant would live if prevailing patterns of mortality at the time of its birth were to stay the same throughout its life. (1) united nations population division. World population prospects: 2019 revision. (2) census reports and other statistical publications from national statistical offices, (3) eurostat: demographic statistics, (4) united nations statistical division. Population and vital statistics report (various years), (5) u.S. Census bureau: international database, and (6) secretariat of the pacific community: statistics and demography programme.",
-            "title": "Male Life Expectancy in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
                     "lineTileSpec": {
-                      "startDate": "2019"
+                      "startDate": "2020"
                     },
                     "statVarKey": [
                       "LifeExpectancy_Person_Female_2776657033",
@@ -188,7 +124,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2019"
+                      "startDate": "2020"
                     },
                     "statVarKey": [
                       "Count_Death_1437305810"
@@ -220,7 +156,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2019"
+                      "startDate": "2020"
                     },
                     "statVarKey": [
                       "Count_Death_AsAFractionOfCount_Person_1113810078"
@@ -282,6 +218,38 @@
               {
                 "tiles": [
                   {
+                    "statVarKey": [
+                      "Count_Death_CertainConditionsOriginatingInThePerinatalPeriod"
+                    ],
+                    "title": "Deaths Due to Certain Conditions Originating in the Perinatal Period in States of United States (${date})",
+                    "type": "MAP"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "rankingTileSpec": {
+                      "rankingCount": 5,
+                      "showHighestLowest": true
+                    },
+                    "statVarKey": [
+                      "Count_Death_CertainConditionsOriginatingInThePerinatalPeriod"
+                    ],
+                    "title": "Deaths Due to Certain Conditions Originating in the Perinatal Period in States of United States (${date})",
+                    "type": "RANKING"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Deaths Due to Certain Conditions Originating in the Perinatal Period in States of United States"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
                     "barTileSpec": {
                       "maxPlaces": 15,
                       "maxVariables": 15,
@@ -292,7 +260,6 @@
                     ],
                     "statVarKey": [
                       "Count_Death_DiseasesOfTheCirculatorySystem_multiple_place_bar_block",
-                      "Count_Death_IntentionalSelfHarm_AsFractionOf_Count_Person_multiple_place_bar_block",
                       "Count_Death_CertainConditionsOriginatingInThePerinatalPeriod_multiple_place_bar_block",
                       "Count_Death_CertainInfectiousParasiticDiseases_multiple_place_bar_block",
                       "Count_Death_Neoplasms_multiple_place_bar_block",
@@ -308,71 +275,8 @@
                 ]
               }
             ],
+            "denom": "Count_Person",
             "title": "Causes of Death"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Death_Female"
-                    ],
-                    "title": "Count of Mortality Event: Female in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Death_Female"
-                    ],
-                    "title": "Count of Mortality Event: Female in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Count of Mortality Event: Female in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2019"
-                    },
-                    "statVarKey": [
-                      "Count_Death_Female_1437305810"
-                    ],
-                    "title": "Count of Mortality Event: Female in United States",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Count of Mortality Event: Female in United States",
-                    "statVarKey": [
-                      "Count_Death_Female"
-                    ],
-                    "title": "Count of Mortality Event: Female in United States",
-                    "type": "HIGHLIGHT"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Count of Mortality Event: Female"
           },
           {
             "columns": [
@@ -476,7 +380,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2019"
+                      "startDate": "2020"
                     },
                     "statVarKey": [
                       "sdg/SH_DYN_NMRT.AGE--M0_2966989201"
@@ -602,7 +506,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2019"
+                      "startDate": "2020"
                     },
                     "statVarKey": [
                       "sdg/SH_DYN_IMRT.AGE--Y0__SEX--F_2966989201",
@@ -653,7 +557,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2019"
+                      "startDate": "2020"
                     },
                     "statVarKey": [
                       "Count_Death_AgeAdjusted_AsAFractionOf_Count_Person_1151455814"
@@ -715,7 +619,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2019"
+                      "startDate": "2020"
                     },
                     "statVarKey": [
                       "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth_606064963"
@@ -809,7 +713,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2019"
+                      "startDate": "2020"
                     },
                     "statVarKey": [
                       "Median_Age_Person_3357919774"
@@ -884,6 +788,10 @@
             "name": "Deaths Per Capita",
             "statVar": "Count_Death_AsAFractionOfCount_Person"
           },
+          "Count_Death_CertainConditionsOriginatingInThePerinatalPeriod": {
+            "name": "Deaths Due To Certain Conditions Originating in The Perinatal Period",
+            "statVar": "Count_Death_CertainConditionsOriginatingInThePerinatalPeriod"
+          },
           "Count_Death_CertainConditionsOriginatingInThePerinatalPeriod_Female": {
             "name": "Female Deaths Due To Certain Conditions Originating in The Perinatal Period",
             "statVar": "Count_Death_CertainConditionsOriginatingInThePerinatalPeriod_Female"
@@ -931,19 +839,6 @@
           "Count_Death_DiseasesOfTheCirculatorySystem_multiple_place_bar_block": {
             "name": "Deaths From Diseases of the Circulatory System",
             "statVar": "Count_Death_DiseasesOfTheCirculatorySystem"
-          },
-          "Count_Death_Female": {
-            "name": "Count of Mortality Event: Female",
-            "statVar": "Count_Death_Female"
-          },
-          "Count_Death_Female_1437305810": {
-            "facetId": "1437305810",
-            "name": "Count of Mortality Event: Female",
-            "statVar": "Count_Death_Female"
-          },
-          "Count_Death_IntentionalSelfHarm_AsFractionOf_Count_Person_multiple_place_bar_block": {
-            "name": "% of Suicide Events",
-            "statVar": "Count_Death_IntentionalSelfHarm_AsFractionOf_Count_Person"
           },
           "Count_Death_LessThan1Year_AsAFractionOf_Count_BirthEvent": {
             "name": "Count of Mortality Event: 1 Years or Less (As Fraction of Count Birth Event)",
@@ -1010,18 +905,10 @@
             "name": "Life Expectancy",
             "statVar": "LifeExpectancy_Person"
           },
-          "LifeExpectancy_Person_Female": {
-            "name": "Female Life Expectancy",
-            "statVar": "LifeExpectancy_Person_Female"
-          },
           "LifeExpectancy_Person_Female_2776657033": {
             "facetId": "2776657033",
             "name": "Female Life Expectancy",
             "statVar": "LifeExpectancy_Person_Female"
-          },
-          "LifeExpectancy_Person_Male": {
-            "name": "Male Life Expectancy",
-            "statVar": "LifeExpectancy_Person_Male"
           },
           "LifeExpectancy_Person_Male_2776657033": {
             "facetId": "2776657033",
@@ -1462,7 +1349,6 @@
       },
       "Count_Death_AsAFractionOfCount_Person": {
         "causeOfDeath": [
-          "Count_Death_IntentionalSelfHarm_AsFractionOf_Count_Person",
           "Count_MortalityEvent_Assault(Homicide)_AsAFractionOf_Count_Person",
           "Count_MortalityEvent_ICD10/A00-B99_AsAFractionOf_Count_Person",
           "Count_MortalityEvent_ICD10/C00-D48_AsAFractionOf_Count_Person",
@@ -1472,18 +1358,6 @@
           "Count_MortalityEvent_ICD10/Q00-Q99_AsAFractionOf_Count_Person",
           "Count_MortalityEvent_ICD10/R00-R99_AsAFractionOf_Count_Person",
           "Count_MortalityEvent_Suicide_AsAFractionOf_Count_Person"
-        ]
-      },
-      "Count_Death_Female": {
-        "causeOfDeath": [
-          "Count_Death_AbnormalNotClassfied_Female",
-          "Count_Death_CertainConditionsOriginatingInThePerinatalPeriod_Female",
-          "Count_Death_CertainInfectiousParasiticDiseases_Female",
-          "Count_Death_CongenitalMalformationsDeformationsChromosomalAbnormalities_Female",
-          "Count_Death_DiseasesOfBloodAndBloodFormingOrgansAndImmuneDisorders_Female",
-          "Count_Death_DiseasesOfTheCirculatorySystem_Female",
-          "Count_Death_Neoplasms_Female",
-          "Count_MortalityEvent_Assault(Homicide)_Female"
         ]
       },
       "LifeExpectancy_Person": {

--- a/server/integration_tests/test_data/e2e_date_range/whichcountriesinafricahavehadthegreatestincreaseinelectricityaccessoverthelast10years/chart_config.json
+++ b/server/integration_tests/test_data/e2e_date_range/whichcountriesinafricahavehadthegreatestincreaseinelectricityaccessoverthelast10years/chart_config.json
@@ -11,18 +11,18 @@
                   {
                     "comparisonPlaces": [
                       "country/KEN",
+                      "country/UGA",
                       "country/RWA",
                       "country/ETH",
-                      "country/UGA",
                       "country/TZA",
                       "country/MLI",
                       "country/ZMB",
-                      "country/SDN",
                       "country/ZWE",
-                      "country/AGO"
+                      "country/SDN",
+                      "country/BEN"
                     ],
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS10_3629701879"
@@ -42,7 +42,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/KEN",
                     "statVarKey": [
@@ -57,37 +57,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
-                    },
-                    "placeDcidOverride": "country/RWA",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_abs_3629701879"
-                    ],
-                    "title": "Rwanda",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2014"
-                    },
-                    "placeDcidOverride": "country/ETH",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_abs_3629701879"
-                    ],
-                    "title": "Ethiopia",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/UGA",
                     "statVarKey": [
@@ -102,7 +72,37 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
+                    },
+                    "placeDcidOverride": "country/RWA",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_abs_3629701879"
+                    ],
+                    "title": "Rwanda",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "lineTileSpec": {
+                      "startDate": "2015"
+                    },
+                    "placeDcidOverride": "country/ETH",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_abs_3629701879"
+                    ],
+                    "title": "Ethiopia",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "lineTileSpec": {
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/TZA",
                     "statVarKey": [
@@ -117,7 +117,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/MLI",
                     "statVarKey": [
@@ -132,7 +132,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/ZMB",
                     "statVarKey": [
@@ -147,22 +147,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
-                    },
-                    "placeDcidOverride": "country/SDN",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_abs_3629701879"
-                    ],
-                    "title": "Sudan",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/ZWE",
                     "statVarKey": [
@@ -177,13 +162,28 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
-                    "placeDcidOverride": "country/AGO",
+                    "placeDcidOverride": "country/SDN",
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS_growth_abs_3629701879"
                     ],
-                    "title": "Angola",
+                    "title": "Sudan",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "lineTileSpec": {
+                      "startDate": "2015"
+                    },
+                    "placeDcidOverride": "country/BEN",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_abs_3629701879"
+                    ],
+                    "title": "Benin",
                     "type": "LINE"
                   }
                 ]
@@ -198,22 +198,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
-                    },
-                    "placeDcidOverride": "country/RWA",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_pct_3629701879"
-                    ],
-                    "title": "Rwanda",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/UGA",
                     "statVarKey": [
@@ -228,13 +213,13 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
-                    "placeDcidOverride": "country/KEN",
+                    "placeDcidOverride": "country/RWA",
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS_growth_pct_3629701879"
                     ],
-                    "title": "Kenya",
+                    "title": "Rwanda",
                     "type": "LINE"
                   }
                 ]
@@ -243,7 +228,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/ETH",
                     "statVarKey": [
@@ -258,7 +243,22 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
+                    },
+                    "placeDcidOverride": "country/KEN",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_pct_3629701879"
+                    ],
+                    "title": "Kenya",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "lineTileSpec": {
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/TZA",
                     "statVarKey": [
@@ -273,7 +273,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/SSD",
                     "statVarKey": [
@@ -288,7 +288,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/ZMB",
                     "statVarKey": [
@@ -303,43 +303,43 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2014"
-                    },
-                    "placeDcidOverride": "country/MLI",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_pct_3629701879"
-                    ],
-                    "title": "Mali",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2014"
-                    },
-                    "placeDcidOverride": "country/COD",
-                    "statVarKey": [
-                      "worldBank/EG_ELC_ACCS_ZS_growth_pct_3629701879"
-                    ],
-                    "title": "Congo [DRC]",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2014"
+                      "startDate": "2015"
                     },
                     "placeDcidOverride": "country/MDG",
                     "statVarKey": [
                       "worldBank/EG_ELC_ACCS_ZS_growth_pct_3629701879"
                     ],
                     "title": "Madagascar",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "lineTileSpec": {
+                      "startDate": "2015"
+                    },
+                    "placeDcidOverride": "country/TCD",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_pct_3629701879"
+                    ],
+                    "title": "Chad",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "lineTileSpec": {
+                      "startDate": "2015"
+                    },
+                    "placeDcidOverride": "country/ZWE",
+                    "statVarKey": [
+                      "worldBank/EG_ELC_ACCS_ZS_growth_pct_3629701879"
+                    ],
+                    "title": "Zimbabwe",
                     "type": "LINE"
                   }
                 ]

--- a/server/integration_tests/test_data/e2e_single_date/populationintheusinthelastyear/chart_config.json
+++ b/server/integration_tests/test_data/e2e_single_date/populationintheusinthelastyear/chart_config.json
@@ -10,717 +10,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2023"
-                    },
-                    "statVarKey": [
-                      "Count_Person_2176550201"
-                    ],
-                    "title": "Population in United States",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Population in United States",
-                    "statVarKey": [
-                      "Count_Person"
-                    ],
-                    "title": "Population in United States",
-                    "type": "HIGHLIGHT"
-                  }
-                ]
-              }
-            ],
-            "title": "Population"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person"
-                    ],
-                    "title": "Population in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person"
-                    ],
-                    "title": "Population in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "title": "Population in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2023"
-                    },
-                    "statVarKey": [
-                      "Count_Person_PerArea_1151455814"
-                    ],
-                    "title": "Population Density in United States",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Population Density in United States",
-                    "statVarKey": [
-                      "Count_Person_PerArea"
-                    ],
-                    "title": "Population Density in United States",
-                    "type": "HIGHLIGHT"
-                  }
-                ]
-              }
-            ],
-            "title": "Population Density"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_PerArea"
-                    ],
-                    "title": "Population Density in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_PerArea"
-                    ],
-                    "title": "Population Density in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "title": "Population Density in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2023"
-                    },
-                    "statVarKey": [
-                      "GrowthRate_Count_Person_3981252704"
-                    ],
-                    "title": "Rate of Population Growth in United States",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Rate of Population Growth in United States",
-                    "statVarKey": [
-                      "GrowthRate_Count_Person"
-                    ],
-                    "title": "Rate of Population Growth in United States",
-                    "type": "HIGHLIGHT"
-                  }
-                ]
-              }
-            ],
-            "title": "Rate of Population Growth"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_85OrMoreYears_Female"
-                    ],
-                    "title": "Women Over 85 in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_85OrMoreYears_Female"
-                    ],
-                    "title": "Women Over 85 in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Women Over 85 in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_85OrMoreYears_Male"
-                    ],
-                    "title": "Men Over 85 in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_85OrMoreYears_Male"
-                    ],
-                    "title": "Men Over 85 in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Men Over 85 in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2023"
-                    },
-                    "statVarKey": [
-                      "Count_Person_Female_3999249536",
-                      "Count_Person_Male_3999249536"
-                    ],
-                    "title": "Population by Gender in United States",
-                    "type": "LINE"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Population by Gender"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_Female"
-                    ],
-                    "title": "Women in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_Female"
-                    ],
-                    "title": "Women in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Women in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_Male"
-                    ],
-                    "title": "Men in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_Male"
-                    ],
-                    "title": "Men in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Men in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2023"
-                    },
-                    "statVarKey": [
-                      "Count_Person_WhiteAlone_3935616881",
-                      "Count_Person_BlackOrAfricanAmericanAlone_3935616881",
-                      "Count_Person_HispanicOrLatino_2317674805",
-                      "Count_Person_AsianAlone_3935616881",
-                      "Count_Person_AmericanIndianAndAlaskaNativeAlone_3935616881"
-                    ],
-                    "title": "Monoracial Breakdown in United States",
-                    "type": "LINE"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Monoracial Breakdown"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_WhiteAlone"
-                    ],
-                    "title": "White Monoracial Population in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_WhiteAlone"
-                    ],
-                    "title": "White Monoracial Population in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "White Monoracial Population in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_BlackOrAfricanAmericanAlone"
-                    ],
-                    "title": "Black Monoracial Population in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_BlackOrAfricanAmericanAlone"
-                    ],
-                    "title": "Black Monoracial Population in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Black Monoracial Population in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2023"
-                    },
-                    "statVarKey": [
-                      "Count_Person_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881",
-                      "Count_Person_AsianAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881",
-                      "Count_Person_BlackOrAfricanAmericanAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881",
-                      "Count_Person_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881",
-                      "Count_Person_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881"
-                    ],
-                    "title": "Monoracial/multiracial Breakdown in United States",
-                    "type": "LINE"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Monoracial/multiracial Breakdown"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces"
-                    ],
-                    "title": "American Indian and Alaska Native Population, Monoracial/Multiracial in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces"
-                    ],
-                    "title": "American Indian and Alaska Native Population, Monoracial/Multiracial in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "American Indian and Alaska Native Population, Monoracial/Multiracial in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_AsianAloneOrInCombinationWithOneOrMoreOtherRaces"
-                    ],
-                    "title": "Asian Population, Monoracial/Multiracial in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_AsianAloneOrInCombinationWithOneOrMoreOtherRaces"
-                    ],
-                    "title": "Asian Population, Monoracial/Multiracial in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Asian Population, Monoracial/Multiracial in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "barTileSpec": {
-                      "maxPlaces": 15,
-                      "maxVariables": 15,
-                      "sort": "DESCENDING"
-                    },
-                    "comparisonPlaces": [
-                      "country/USA"
-                    ],
-                    "statVarKey": [
-                      "Count_Person_HispanicOrLatino_AmericanIndianOrAlaskaNativeAlone_multiple_place_bar_block",
-                      "Count_Person_HispanicOrLatino_AsianAlone_multiple_place_bar_block",
-                      "Count_Person_HispanicOrLatino_BlackOrAfricanAmericanAlone_multiple_place_bar_block",
-                      "Count_Person_HispanicOrLatino_NativeHawaiianOrOtherPacificIslanderAlone_multiple_place_bar_block",
-                      "Count_Person_HispanicOrLatino_TwoOrMoreRaces_multiple_place_bar_block",
-                      "Count_Person_HispanicOrLatino_WhiteAlone_multiple_place_bar_block",
-                      "Count_Person_HispanicOrLatino_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block",
-                      "Count_Person_HispanicOrLatino_AsianAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block",
-                      "Count_Person_HispanicOrLatino_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block",
-                      "Count_Person_HispanicOrLatino_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block"
-                    ],
-                    "title": "Racial Breakdown With Hispanic Consideration in United States (${date})",
-                    "type": "BAR"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Racial Breakdown With Hispanic Consideration"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_HispanicOrLatino_AmericanIndianOrAlaskaNativeAlone"
-                    ],
-                    "title": "Hispanic American Indian Population in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_HispanicOrLatino_AmericanIndianOrAlaskaNativeAlone"
-                    ],
-                    "title": "Hispanic American Indian Population in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Hispanic American Indian Population in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_HispanicOrLatino_AsianAlone"
-                    ],
-                    "title": "Hispanic Asian Population in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_HispanicOrLatino_AsianAlone"
-                    ],
-                    "title": "Hispanic Asian Population in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Hispanic Asian Population in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "barTileSpec": {
-                      "maxPlaces": 15,
-                      "maxVariables": 15,
-                      "sort": "DESCENDING"
-                    },
-                    "comparisonPlaces": [
-                      "country/USA"
-                    ],
-                    "statVarKey": [
-                      "Count_Person_WhiteAloneNotHispanicOrLatino_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_AmericanIndianOrAlaskaNativeAlone_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_AsianAlone_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_BlackOrAfricanAmericanAlone_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_NativeHawaiianOrOtherPacificIslanderAlone_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_AsianAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_BlackOrAfricanAmericanAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_TwoOrMoreRaces_multiple_place_bar_block",
-                      "Count_Person_NotHispanicOrLatino_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block"
-                    ],
-                    "title": "Racial Breakdown With Non Hispanic Consideration in United States (${date})",
-                    "type": "BAR"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Racial Breakdown With Non Hispanic Consideration"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_WhiteAloneNotHispanicOrLatino"
-                    ],
-                    "title": "White Hispanic Monoracial Population in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_WhiteAloneNotHispanicOrLatino"
-                    ],
-                    "title": "White Hispanic Monoracial Population in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "White Hispanic Monoracial Population in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Person_NotHispanicOrLatino_AmericanIndianOrAlaskaNativeAlone"
-                    ],
-                    "title": "Non Hispanic Population Identifying as American Indian or Alaska Native Alone in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Person_NotHispanicOrLatino_AmericanIndianOrAlaskaNativeAlone"
-                    ],
-                    "title": "Non Hispanic Population Identifying as American Indian or Alaska Native Alone in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Non Hispanic Population Identifying as American Indian or Alaska Native Alone in States of United States"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2023"
-                    },
-                    "statVarKey": [
-                      "Count_Person_Urban_3615161630"
-                    ],
-                    "title": "Population Living in Urban Areas in United States",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Population Living in Urban Areas in United States",
-                    "statVarKey": [
-                      "Count_Person_Urban"
-                    ],
-                    "title": "Population Living in Urban Areas in United States",
-                    "type": "HIGHLIGHT"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "description": "Urban population refers to people living in urban areas as defined by national statistical offices. It is calculated using world bank population estimates and urban ratios from the united nations world urbanization prospects. Aggregation of urban and rural population may not add up to total population because of different country coverages. World bank staff estimates based on the united nations population Division's world urbanization prospects: 2018 revision.",
-            "title": "Population Living in Urban Areas"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2023"
+                      "startDate": "2024"
                     },
                     "statVarKey": [
                       "Count_Person_Employed_3707913853"
@@ -784,40 +74,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2023"
-                    },
-                    "statVarKey": [
-                      "Count_Person_Rural_3615161630"
-                    ],
-                    "title": "Population Living in Rural Areas in United States",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Population Living in Rural Areas in United States",
-                    "statVarKey": [
-                      "Count_Person_Rural"
-                    ],
-                    "title": "Population Living in Rural Areas in United States",
-                    "type": "HIGHLIGHT"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "description": "Rural population refers to people living in rural areas as defined by national statistical offices. It is calculated as the difference between total population and urban population. Aggregation of urban and rural population may not add up to total population because of different country coverages. World bank staff estimates based on the united nations population Division's world urbanization prospects: 2018 revision.",
-            "title": "Population Living in Rural Areas"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2023"
+                      "startDate": "2024"
                     },
                     "statVarKey": [
                       "Count_Person_InLaborForce_3707913853"
@@ -881,7 +138,7 @@
                 "tiles": [
                   {
                     "lineTileSpec": {
-                      "startDate": "2023"
+                      "startDate": "2024"
                     },
                     "statVarKey": [
                       "Count_Person_ResidesInHousehold_1926704588"
@@ -906,141 +163,9 @@
             ],
             "denom": "Count_Person",
             "title": "Population: Household"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "lineTileSpec": {
-                      "startDate": "2023"
-                    },
-                    "statVarKey": [
-                      "Count_Death_1437305810"
-                    ],
-                    "title": "Number of Deaths in United States",
-                    "type": "LINE"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "description": "Number of Deaths in United States",
-                    "statVarKey": [
-                      "Count_Death"
-                    ],
-                    "title": "Number of Deaths in United States",
-                    "type": "HIGHLIGHT"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Number of Deaths"
-          },
-          {
-            "columns": [
-              {
-                "tiles": [
-                  {
-                    "statVarKey": [
-                      "Count_Death"
-                    ],
-                    "title": "Number of Deaths in States of United States (${date})",
-                    "type": "MAP"
-                  }
-                ]
-              },
-              {
-                "tiles": [
-                  {
-                    "rankingTileSpec": {
-                      "rankingCount": 5,
-                      "showHighestLowest": true
-                    },
-                    "statVarKey": [
-                      "Count_Death"
-                    ],
-                    "title": "Number of Deaths in States of United States (${date})",
-                    "type": "RANKING"
-                  }
-                ]
-              }
-            ],
-            "denom": "Count_Person",
-            "title": "Number of Deaths in States of United States"
           }
         ],
         "statVarSpec": {
-          "Count_Death": {
-            "name": "Number of Deaths",
-            "statVar": "Count_Death"
-          },
-          "Count_Death_1437305810": {
-            "facetId": "1437305810",
-            "name": "Number of Deaths",
-            "statVar": "Count_Death"
-          },
-          "Count_Person": {
-            "name": "Population",
-            "statVar": "Count_Person"
-          },
-          "Count_Person_2176550201": {
-            "facetId": "2176550201",
-            "name": "Population",
-            "statVar": "Count_Person"
-          },
-          "Count_Person_85OrMoreYears_Female": {
-            "name": "Women over 85",
-            "statVar": "Count_Person_85OrMoreYears_Female"
-          },
-          "Count_Person_85OrMoreYears_Male": {
-            "name": "Men over 85",
-            "statVar": "Count_Person_85OrMoreYears_Male"
-          },
-          "Count_Person_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces": {
-            "name": "American Indian and Alaska Native Population, Monoracial/Multiracial",
-            "statVar": "Count_Person_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881": {
-            "facetId": "3935616881",
-            "name": "American Indian and Alaska Native Population, Monoracial/Multiracial",
-            "statVar": "Count_Person_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_AmericanIndianAndAlaskaNativeAlone_3935616881": {
-            "facetId": "3935616881",
-            "name": "Population American Indian or Alaska Native Alone",
-            "statVar": "Count_Person_AmericanIndianAndAlaskaNativeAlone"
-          },
-          "Count_Person_AsianAloneOrInCombinationWithOneOrMoreOtherRaces": {
-            "name": "Asian Population, Monoracial/Multiracial",
-            "statVar": "Count_Person_AsianAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_AsianAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881": {
-            "facetId": "3935616881",
-            "name": "Asian Population, Monoracial/Multiracial",
-            "statVar": "Count_Person_AsianAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_AsianAlone_3935616881": {
-            "facetId": "3935616881",
-            "name": "Population Asian Alone",
-            "statVar": "Count_Person_AsianAlone"
-          },
-          "Count_Person_BlackOrAfricanAmericanAlone": {
-            "name": "Black Monoracial Population",
-            "statVar": "Count_Person_BlackOrAfricanAmericanAlone"
-          },
-          "Count_Person_BlackOrAfricanAmericanAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881": {
-            "facetId": "3935616881",
-            "name": "Black Population, Monoracial/Multiracial",
-            "statVar": "Count_Person_BlackOrAfricanAmericanAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_BlackOrAfricanAmericanAlone_3935616881": {
-            "facetId": "3935616881",
-            "name": "Black Monoracial Population",
-            "statVar": "Count_Person_BlackOrAfricanAmericanAlone"
-          },
           "Count_Person_Employed": {
             "name": "Population With Current Employment",
             "statVar": "Count_Person_Employed"
@@ -1049,68 +174,6 @@
             "facetId": "3707913853",
             "name": "Population With Current Employment",
             "statVar": "Count_Person_Employed"
-          },
-          "Count_Person_Female": {
-            "name": "Women",
-            "statVar": "Count_Person_Female"
-          },
-          "Count_Person_Female_3999249536": {
-            "facetId": "3999249536",
-            "name": "Women",
-            "statVar": "Count_Person_Female"
-          },
-          "Count_Person_HispanicOrLatino_2317674805": {
-            "facetId": "2317674805",
-            "name": "Hispanic Population",
-            "statVar": "Count_Person_HispanicOrLatino"
-          },
-          "Count_Person_HispanicOrLatino_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block": {
-            "name": "Hispanic American Indian Population",
-            "statVar": "Count_Person_HispanicOrLatino_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_HispanicOrLatino_AmericanIndianOrAlaskaNativeAlone": {
-            "name": "Hispanic American Indian Population",
-            "statVar": "Count_Person_HispanicOrLatino_AmericanIndianOrAlaskaNativeAlone"
-          },
-          "Count_Person_HispanicOrLatino_AmericanIndianOrAlaskaNativeAlone_multiple_place_bar_block": {
-            "name": "Hispanic American Indian Population",
-            "statVar": "Count_Person_HispanicOrLatino_AmericanIndianOrAlaskaNativeAlone"
-          },
-          "Count_Person_HispanicOrLatino_AsianAlone": {
-            "name": "Hispanic Asian Population",
-            "statVar": "Count_Person_HispanicOrLatino_AsianAlone"
-          },
-          "Count_Person_HispanicOrLatino_AsianAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block": {
-            "name": "Hispanic Asian Population",
-            "statVar": "Count_Person_HispanicOrLatino_AsianAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_HispanicOrLatino_AsianAlone_multiple_place_bar_block": {
-            "name": "Hispanic Asian Population",
-            "statVar": "Count_Person_HispanicOrLatino_AsianAlone"
-          },
-          "Count_Person_HispanicOrLatino_BlackOrAfricanAmericanAlone_multiple_place_bar_block": {
-            "name": "Hispanic African American Population",
-            "statVar": "Count_Person_HispanicOrLatino_BlackOrAfricanAmericanAlone"
-          },
-          "Count_Person_HispanicOrLatino_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block": {
-            "name": "Hispanic Native Hawaiian/Other Pacific Islander Population. Monoracial/Multiracial",
-            "statVar": "Count_Person_HispanicOrLatino_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_HispanicOrLatino_NativeHawaiianOrOtherPacificIslanderAlone_multiple_place_bar_block": {
-            "name": "Hispanic Native Hawaiian/Other Pacific Islander Alone Population",
-            "statVar": "Count_Person_HispanicOrLatino_NativeHawaiianOrOtherPacificIslanderAlone"
-          },
-          "Count_Person_HispanicOrLatino_TwoOrMoreRaces_multiple_place_bar_block": {
-            "name": "Hispanic Multiracial Population",
-            "statVar": "Count_Person_HispanicOrLatino_TwoOrMoreRaces"
-          },
-          "Count_Person_HispanicOrLatino_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block": {
-            "name": "White Hispanic Population, Monoracial/Multiracial",
-            "statVar": "Count_Person_HispanicOrLatino_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_HispanicOrLatino_WhiteAlone_multiple_place_bar_block": {
-            "name": "White Hispanic Monoracial Population",
-            "statVar": "Count_Person_HispanicOrLatino_WhiteAlone"
           },
           "Count_Person_InLaborForce": {
             "name": "Population in the Labor Force",
@@ -1121,73 +184,6 @@
             "name": "Population in the Labor Force",
             "statVar": "Count_Person_InLaborForce"
           },
-          "Count_Person_Male": {
-            "name": "Men",
-            "statVar": "Count_Person_Male"
-          },
-          "Count_Person_Male_3999249536": {
-            "facetId": "3999249536",
-            "name": "Men",
-            "statVar": "Count_Person_Male"
-          },
-          "Count_Person_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881": {
-            "facetId": "3935616881",
-            "name": "Native Hawaiian and Other Pacific Islander Population, Monoracial/Multiracial",
-            "statVar": "Count_Person_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_NotHispanicOrLatino_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block": {
-            "name": "Non Hispanic Population Identifying as American Indian and Alaska Native, Monoracial/Multiracial",
-            "statVar": "Count_Person_NotHispanicOrLatino_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_NotHispanicOrLatino_AmericanIndianOrAlaskaNativeAlone": {
-            "name": "Non Hispanic Population Identifying as American Indian or Alaska Native Alone",
-            "statVar": "Count_Person_NotHispanicOrLatino_AmericanIndianOrAlaskaNativeAlone"
-          },
-          "Count_Person_NotHispanicOrLatino_AmericanIndianOrAlaskaNativeAlone_multiple_place_bar_block": {
-            "name": "Non Hispanic Population Identifying as American Indian or Alaska Native Alone",
-            "statVar": "Count_Person_NotHispanicOrLatino_AmericanIndianOrAlaskaNativeAlone"
-          },
-          "Count_Person_NotHispanicOrLatino_AsianAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block": {
-            "name": "Non Hispanic Population Identifying as Asian",
-            "statVar": "Count_Person_NotHispanicOrLatino_AsianAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_NotHispanicOrLatino_AsianAlone_multiple_place_bar_block": {
-            "name": "Non Hispanic Population Identifying as Asian Alone",
-            "statVar": "Count_Person_NotHispanicOrLatino_AsianAlone"
-          },
-          "Count_Person_NotHispanicOrLatino_BlackOrAfricanAmericanAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block": {
-            "name": "Non Hispanic Population Identifying as Black or African American",
-            "statVar": "Count_Person_NotHispanicOrLatino_BlackOrAfricanAmericanAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_NotHispanicOrLatino_BlackOrAfricanAmericanAlone_multiple_place_bar_block": {
-            "name": "Non Hispanic Population Identifying as Black or African American Alone",
-            "statVar": "Count_Person_NotHispanicOrLatino_BlackOrAfricanAmericanAlone"
-          },
-          "Count_Person_NotHispanicOrLatino_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block": {
-            "name": "Non Hispanic Population Identifying as Native Hawaiian and Other Pacific Islander",
-            "statVar": "Count_Person_NotHispanicOrLatino_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_NotHispanicOrLatino_NativeHawaiianOrOtherPacificIslanderAlone_multiple_place_bar_block": {
-            "name": "Non Hispanic Population Identifying as Native Hawaiian or Other Pacific Islander Alone",
-            "statVar": "Count_Person_NotHispanicOrLatino_NativeHawaiianOrOtherPacificIslanderAlone"
-          },
-          "Count_Person_NotHispanicOrLatino_TwoOrMoreRaces_multiple_place_bar_block": {
-            "name": "Non Hispanic Multiracial Population",
-            "statVar": "Count_Person_NotHispanicOrLatino_TwoOrMoreRaces"
-          },
-          "Count_Person_NotHispanicOrLatino_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces_multiple_place_bar_block": {
-            "name": "Non Hispanic White Population, Monoracial/Multiracial",
-            "statVar": "Count_Person_NotHispanicOrLatino_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_PerArea": {
-            "name": "Population Density",
-            "statVar": "Count_Person_PerArea"
-          },
-          "Count_Person_PerArea_1151455814": {
-            "facetId": "1151455814",
-            "name": "Population Density",
-            "statVar": "Count_Person_PerArea"
-          },
           "Count_Person_ResidesInHousehold": {
             "name": "Population: Household",
             "statVar": "Count_Person_ResidesInHousehold"
@@ -1196,55 +192,6 @@
             "facetId": "1926704588",
             "name": "Population: Household",
             "statVar": "Count_Person_ResidesInHousehold"
-          },
-          "Count_Person_Rural": {
-            "name": "Population Living in Rural Areas",
-            "statVar": "Count_Person_Rural"
-          },
-          "Count_Person_Rural_3615161630": {
-            "facetId": "3615161630",
-            "name": "Population Living in Rural Areas",
-            "statVar": "Count_Person_Rural"
-          },
-          "Count_Person_Urban": {
-            "name": "Population Living in Urban Areas",
-            "statVar": "Count_Person_Urban"
-          },
-          "Count_Person_Urban_3615161630": {
-            "facetId": "3615161630",
-            "name": "Population Living in Urban Areas",
-            "statVar": "Count_Person_Urban"
-          },
-          "Count_Person_WhiteAlone": {
-            "name": "White Monoracial Population",
-            "statVar": "Count_Person_WhiteAlone"
-          },
-          "Count_Person_WhiteAloneNotHispanicOrLatino": {
-            "name": "White Hispanic Monoracial Population",
-            "statVar": "Count_Person_WhiteAloneNotHispanicOrLatino"
-          },
-          "Count_Person_WhiteAloneNotHispanicOrLatino_multiple_place_bar_block": {
-            "name": "White Hispanic Monoracial Population",
-            "statVar": "Count_Person_WhiteAloneNotHispanicOrLatino"
-          },
-          "Count_Person_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces_3935616881": {
-            "facetId": "3935616881",
-            "name": "White Population, Monoracial/Multiracial",
-            "statVar": "Count_Person_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces"
-          },
-          "Count_Person_WhiteAlone_3935616881": {
-            "facetId": "3935616881",
-            "name": "White Monoracial Population",
-            "statVar": "Count_Person_WhiteAlone"
-          },
-          "GrowthRate_Count_Person": {
-            "name": "Rate of Population Growth",
-            "statVar": "GrowthRate_Count_Person"
-          },
-          "GrowthRate_Count_Person_3981252704": {
-            "facetId": "3981252704",
-            "name": "Rate of Population Growth",
-            "statVar": "GrowthRate_Count_Person"
           }
         }
       }
@@ -1633,103 +580,32 @@
     },
     "childTopics": [
       {
-        "dcid": "dc/topic/Age",
-        "name": "Age",
+        "dcid": "dc/topic/Jobs",
+        "name": "Jobs",
         "types": [
           "Topic"
         ]
       },
       {
-        "dcid": "dc/topic/Gender",
-        "name": "Gender",
+        "dcid": "dc/topic/UnemploymentRate",
+        "name": "Unemployment Rate",
         "types": [
           "Topic"
         ]
       },
       {
-        "dcid": "dc/topic/Race",
-        "name": "Population by Race",
-        "types": [
-          "Topic"
-        ]
-      },
-      {
-        "dcid": "dc/topic/Language",
-        "name": "Language Spoken At Home",
-        "types": [
-          "Topic"
-        ]
-      },
-      {
-        "dcid": "dc/topic/MaritalStatus",
-        "name": "Marital Status",
-        "types": [
-          "Topic"
-        ]
-      },
-      {
-        "dcid": "dc/topic/Nationality",
-        "name": "Nationality",
-        "types": [
-          "Topic"
-        ]
-      },
-      {
-        "dcid": "dc/topic/Veterans",
-        "name": "Veterans",
+        "dcid": "dc/topic/UnpaidFamilyWorkers",
+        "name": "Unpaid Family Workers",
         "types": [
           "Topic"
         ]
       }
     ],
-    "exploreMore": {
-      "Count_Person": {
-        "gender": [
-          "Count_Person_Female",
-          "Count_Person_Male"
-        ],
-        "placeOfResidenceClassification": [
-          "Count_Person_Rural",
-          "Count_Person_Urban"
-        ],
-        "race": [
-          "Count_Person_AmericanIndianAndAlaskaNativeAlone",
-          "Count_Person_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_AsianAlone",
-          "Count_Person_AsianAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_BlackOrAfricanAmericanAlone",
-          "Count_Person_BlackOrAfricanAmericanAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_HispanicOrLatino",
-          "Count_Person_HispanicOrLatino_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_HispanicOrLatino_AmericanIndianOrAlaskaNativeAlone",
-          "Count_Person_HispanicOrLatino_AsianAlone",
-          "Count_Person_HispanicOrLatino_AsianAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_HispanicOrLatino_BlackOrAfricanAmericanAlone",
-          "Count_Person_HispanicOrLatino_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_HispanicOrLatino_NativeHawaiianOrOtherPacificIslanderAlone",
-          "Count_Person_HispanicOrLatino_TwoOrMoreRaces",
-          "Count_Person_HispanicOrLatino_WhiteAlone",
-          "Count_Person_HispanicOrLatino_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_NotHispanicOrLatino_AmericanIndianAndAlaskaNativeAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_NotHispanicOrLatino_AmericanIndianOrAlaskaNativeAlone",
-          "Count_Person_NotHispanicOrLatino_AsianAlone",
-          "Count_Person_NotHispanicOrLatino_AsianAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_NotHispanicOrLatino_BlackOrAfricanAmericanAlone",
-          "Count_Person_NotHispanicOrLatino_BlackOrAfricanAmericanAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_NotHispanicOrLatino_NativeHawaiianAndOtherPacificIslanderAloneOrInCombinationWithOneOrMoreOtherRaces",
-          "Count_Person_NotHispanicOrLatino_NativeHawaiianOrOtherPacificIslanderAlone",
-          "Count_Person_NotHispanicOrLatino_TwoOrMoreRaces",
-          "Count_Person_WhiteAlone",
-          "Count_Person_WhiteAloneNotHispanicOrLatino",
-          "Count_Person_WhiteAloneOrInCombinationWithOneOrMoreOtherRaces"
-        ]
-      }
-    },
+    "exploreMore": {},
     "mainTopics": [
       {
-        "dcid": "dc/topic/Demographics",
-        "name": "Demographics",
+        "dcid": "dc/topic/Employment",
+        "name": "Employment",
         "types": [
           "Topic"
         ]
@@ -1738,8 +614,8 @@
     "parentPlaces": [],
     "parentTopics": [
       {
-        "dcid": "dc/topic/Root",
-        "name": "Statistics",
+        "dcid": "dc/topic/Economy",
+        "name": "Economy",
         "types": [
           "Topic"
         ]
@@ -1847,36 +723,43 @@
     ],
     "peerTopics": [
       {
-        "dcid": "dc/topic/Health",
-        "name": "Health",
+        "dcid": "dc/topic/Businesses",
+        "name": "Businesses",
         "types": [
           "Topic"
         ]
       },
       {
-        "dcid": "dc/topic/Economy",
-        "name": "Economy",
+        "dcid": "dc/topic/EconomicActivity",
+        "name": "Economic Activity",
         "types": [
           "Topic"
         ]
       },
       {
-        "dcid": "dc/topic/EducationHousingAndCommute",
-        "name": "Education, Housing and Commute",
+        "dcid": "dc/topic/GlobalEconomicActivity",
+        "name": "Global Economic Activity",
         "types": [
           "Topic"
         ]
       },
       {
-        "dcid": "dc/topic/Equity",
-        "name": "Equity",
+        "dcid": "dc/topic/Income",
+        "name": "Income",
         "types": [
           "Topic"
         ]
       },
       {
-        "dcid": "dc/topic/Sustainability",
-        "name": "Sustainability",
+        "dcid": "dc/topic/Poverty",
+        "name": "Poverty",
+        "types": [
+          "Topic"
+        ]
+      },
+      {
+        "dcid": "dc/topic/Agriculture",
+        "name": "Agriculture",
         "types": [
           "Topic"
         ]

--- a/server/integration_tests/test_data/e2e_single_date/whatwastheaveragehousepricefor2brhouseinmountainviewdecadeago/chart_config.json
+++ b/server/integration_tests/test_data/e2e_single_date/whatwastheaveragehousepricefor2brhouseinmountainviewdecadeago/chart_config.json
@@ -9,6 +9,38 @@
               {
                 "tiles": [
                   {
+                    "lineTileSpec": {
+                      "highlightDate": "2015"
+                    },
+                    "statVarKey": [
+                      "Count_HousingUnit_HomeValue2000000OrMoreUSDollar_2015_1145703171"
+                    ],
+                    "title": "Homes Valued at $2,000,000 or More in Mountain View",
+                    "type": "LINE"
+                  }
+                ]
+              },
+              {
+                "tiles": [
+                  {
+                    "description": "Homes Valued at $2,000,000 or More in Mountain View",
+                    "statVarKey": [
+                      "Count_HousingUnit_HomeValue2000000OrMoreUSDollar_2015"
+                    ],
+                    "title": "Homes Valued at $2,000,000 or More in Mountain View",
+                    "type": "HIGHLIGHT"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Homes Valued at $2,000,000 or More"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
                     "barTileSpec": {
                       "maxPlaces": 15,
                       "maxVariables": 15
@@ -17,12 +49,14 @@
                       "geoId/0649670"
                     ],
                     "statVarKey": [
-                      "Count_HousingUnit_HomeValueUpto49999USDollar_multiple_place_bar_block_2014",
-                      "Count_HousingUnit_HomeValue50000To99999USDollar_multiple_place_bar_block_2014",
-                      "Count_HousingUnit_HomeValue100000To199999USDollar_multiple_place_bar_block_2014",
-                      "Count_HousingUnit_HomeValue200000To299999USDollar_multiple_place_bar_block_2014",
-                      "Count_HousingUnit_HomeValue300000To499999USDollar_multiple_place_bar_block_2014",
-                      "Count_HousingUnit_HomeValue500000To999999USDollar_multiple_place_bar_block_2014"
+                      "Count_HousingUnit_HomeValueUpto49999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue50000To99999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue100000To199999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue200000To299999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue300000To499999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue500000To999999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue1000000To1499999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue1500000To1999999USDollar_multiple_place_bar_block_2015"
                     ],
                     "title": "Home Value of Houses in Mountain View (${date})",
                     "type": "BAR"
@@ -32,36 +66,156 @@
             ],
             "denom": "Count_Person",
             "title": "Home Value of Houses"
+          },
+          {
+            "columns": [
+              {
+                "tiles": [
+                  {
+                    "barTileSpec": {
+                      "maxPlaces": 15,
+                      "maxVariables": 15
+                    },
+                    "comparisonPlaces": [
+                      "geoId/0649670"
+                    ],
+                    "statVarKey": [
+                      "Count_HousingUnit_HomeValue2000000OrMoreUSDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue1000000To1499999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue100000To124999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue100000To199999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue10000To14999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue125000To149999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue1500000To1999999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue150000To174999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue15000To19999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue175000To199999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue200000To249999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue200000To299999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue20000To24999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue250000To299999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue25000To29999USDollar_multiple_place_bar_block_2015",
+                      "Count_HousingUnit_HomeValue300000To399999USDollar_multiple_place_bar_block_2015"
+                    ],
+                    "title": "Homes Valued at $2,000,000 or More and More in Mountain View (${date})",
+                    "type": "BAR"
+                  }
+                ]
+              }
+            ],
+            "denom": "Count_Person",
+            "title": "Related: Homes Valued at $2,000,000 or More and More"
           }
         ],
         "statVarSpec": {
-          "Count_HousingUnit_HomeValue100000To199999USDollar_multiple_place_bar_block_2014": {
-            "date": "2014",
+          "Count_HousingUnit_HomeValue1000000To1499999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $1,000,000 and $1,499,999",
+            "statVar": "Count_HousingUnit_HomeValue1000000To1499999USDollar"
+          },
+          "Count_HousingUnit_HomeValue100000To124999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $100,000 and $124,999",
+            "statVar": "Count_HousingUnit_HomeValue100000To124999USDollar"
+          },
+          "Count_HousingUnit_HomeValue100000To199999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
             "name": "Count of Housing Unit: 100,000 - 199,999 USD",
             "statVar": "Count_HousingUnit_HomeValue100000To199999USDollar"
           },
-          "Count_HousingUnit_HomeValue200000To299999USDollar_multiple_place_bar_block_2014": {
-            "date": "2014",
+          "Count_HousingUnit_HomeValue10000To14999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $10,000 and $14,999",
+            "statVar": "Count_HousingUnit_HomeValue10000To14999USDollar"
+          },
+          "Count_HousingUnit_HomeValue125000To149999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $125,000 and $149,999",
+            "statVar": "Count_HousingUnit_HomeValue125000To149999USDollar"
+          },
+          "Count_HousingUnit_HomeValue1500000To1999999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $1,500,000 and $1,999,999",
+            "statVar": "Count_HousingUnit_HomeValue1500000To1999999USDollar"
+          },
+          "Count_HousingUnit_HomeValue150000To174999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $150,000 and $174,999",
+            "statVar": "Count_HousingUnit_HomeValue150000To174999USDollar"
+          },
+          "Count_HousingUnit_HomeValue15000To19999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $15,000 to $19,999",
+            "statVar": "Count_HousingUnit_HomeValue15000To19999USDollar"
+          },
+          "Count_HousingUnit_HomeValue175000To199999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $175,000 to $199,999",
+            "statVar": "Count_HousingUnit_HomeValue175000To199999USDollar"
+          },
+          "Count_HousingUnit_HomeValue2000000OrMoreUSDollar_2015": {
+            "date": "2015",
+            "name": "Homes Valued at $2,000,000 or More",
+            "statVar": "Count_HousingUnit_HomeValue2000000OrMoreUSDollar"
+          },
+          "Count_HousingUnit_HomeValue2000000OrMoreUSDollar_2015_1145703171": {
+            "date": "2015",
+            "facetId": "1145703171",
+            "name": "Homes Valued at $2,000,000 or More",
+            "statVar": "Count_HousingUnit_HomeValue2000000OrMoreUSDollar"
+          },
+          "Count_HousingUnit_HomeValue2000000OrMoreUSDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued at $2,000,000 or More",
+            "statVar": "Count_HousingUnit_HomeValue2000000OrMoreUSDollar"
+          },
+          "Count_HousingUnit_HomeValue200000To249999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $200,000 to $249,999",
+            "statVar": "Count_HousingUnit_HomeValue200000To249999USDollar"
+          },
+          "Count_HousingUnit_HomeValue200000To299999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
             "name": "Count of Housing Unit: 200,000 - 299,999 USD",
             "statVar": "Count_HousingUnit_HomeValue200000To299999USDollar"
           },
-          "Count_HousingUnit_HomeValue300000To499999USDollar_multiple_place_bar_block_2014": {
-            "date": "2014",
+          "Count_HousingUnit_HomeValue20000To24999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $20,000 to $24,999",
+            "statVar": "Count_HousingUnit_HomeValue20000To24999USDollar"
+          },
+          "Count_HousingUnit_HomeValue250000To299999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $250,000 to $299,999",
+            "statVar": "Count_HousingUnit_HomeValue250000To299999USDollar"
+          },
+          "Count_HousingUnit_HomeValue25000To29999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Homes Valued Between $25,000 to $29,999",
+            "statVar": "Count_HousingUnit_HomeValue25000To29999USDollar"
+          },
+          "Count_HousingUnit_HomeValue300000To399999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
+            "name": "Housing Units Valued at $300,000-$399,999",
+            "statVar": "Count_HousingUnit_HomeValue300000To399999USDollar"
+          },
+          "Count_HousingUnit_HomeValue300000To499999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
             "name": "Count of Housing Unit: 300,000 - 499,999 USD",
             "statVar": "Count_HousingUnit_HomeValue300000To499999USDollar"
           },
-          "Count_HousingUnit_HomeValue500000To999999USDollar_multiple_place_bar_block_2014": {
-            "date": "2014",
+          "Count_HousingUnit_HomeValue500000To999999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
             "name": "Count of Housing Unit: 500,000 - 999,999 USD",
             "statVar": "Count_HousingUnit_HomeValue500000To999999USDollar"
           },
-          "Count_HousingUnit_HomeValue50000To99999USDollar_multiple_place_bar_block_2014": {
-            "date": "2014",
+          "Count_HousingUnit_HomeValue50000To99999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
             "name": "Count of Housing Unit: 50,000 - 99,999 USD",
             "statVar": "Count_HousingUnit_HomeValue50000To99999USDollar"
           },
-          "Count_HousingUnit_HomeValueUpto49999USDollar_multiple_place_bar_block_2014": {
-            "date": "2014",
+          "Count_HousingUnit_HomeValueUpto49999USDollar_multiple_place_bar_block_2015": {
+            "date": "2015",
             "name": "Count of Housing Unit: 49,999 USD or Less",
             "statVar": "Count_HousingUnit_HomeValueUpto49999USDollar"
           }

--- a/server/lib/util.py
+++ b/server/lib/util.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import csv
-from datetime import date
-from datetime import datetime
+import datetime
 from functools import wraps
 import gzip
 import hashlib
@@ -472,11 +471,11 @@ def hash_id(user_id):
 def parse_date(date_string):
   parts = date_string.split("-")
   if len(parts) == 1:
-    return datetime.strptime(date_string, "%Y")
+    return datetime.datetime.strptime(date_string, "%Y")
   elif len(parts) == 2:
-    return datetime.strptime(date_string, "%Y-%m")
+    return datetime.datetime.strptime(date_string, "%Y-%m")
   elif len(parts) == 3:
-    return datetime.strptime(date_string, "%Y-%m-%d")
+    return datetime.datetime.strptime(date_string, "%Y-%m-%d")
   else:
     raise ValueError("Invalid date: %s", date_string)
 
@@ -808,7 +807,7 @@ def _get_recent_date_counts(observation_entity_counts_by_date,
   # TODO: Remove this check once data is corrected in b/327667797
   if observation_entity_counts_by_date[
       'variable'] in FILTER_FUTURE_OBSERVATIONS_FROM_VARIABLES:
-    todays_date = str(date.today())
+    todays_date = str(datetime.date.today())
     descending_observation_dates = [
         observation_date for observation_date in descending_observation_dates
         if observation_date['date'] < todays_date
@@ -818,7 +817,7 @@ def _get_recent_date_counts(observation_entity_counts_by_date,
   # Heuristic to fetch the "max_dates_to_check" most recent
   # observation dates or observation dates going back
   # "max_years_to_check" years, whichever is greater
-  cutoff_year = str(date.today().year - max_years_to_check)
+  cutoff_year = str(datetime.date.today().year - max_years_to_check)
   latest_observation_dates_from_year = [
       o for o in descending_observation_dates if o['date'] > cutoff_year
   ]

--- a/server/tests/lib/nl/date_parser_test.py
+++ b/server/tests/lib/nl/date_parser_test.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """Tests for quantity_parser."""
 
+from datetime import date as datetime_date  # Rename to avoid conflict
 import unittest
+from unittest import mock
 
 from parameterized import parameterized
 
@@ -41,7 +43,9 @@ class TestDateParser(unittest.TestCase):
       ("Female population in California a decade ago", [Date('in', 2014)]),
       ('Female population in California 15 years ago', [Date('in', 2009)])
   ])
-  def test_main(self, query, expected):
+  @mock.patch('datetime.date')
+  def test_main(self, query, expected, mock_date):
+    mock_date.today.return_value = datetime_date(2024, 12, 1)
     ctr = Counters()
     attr = date.parse_date(query, ctr)
     if attr:

--- a/server/tests/lib/util_test.py
+++ b/server/tests/lib/util_test.py
@@ -1482,10 +1482,12 @@ class TestFetchHighestCoverage(unittest.TestCase):
                                     entities=entities)
     mock_point_core.assert_called_with(entities, variables, '2021', False)
 
+  @patch('server.lib.util.datetime.date')
   @patch('server.lib.fetch.point_core')
   @patch('server.services.datacommons.obs_series')
   def test_fetch_highest_coverage_with_entities_multi_variable(
-      self, mock_obs_series, mock_point_core):
+      self, mock_obs_series, mock_point_core, mock_date):
+    mock_date.today.return_value = datetime.date(2024, 12, 1)
     variables = ['Count_Person_InLaborForce', 'sdg/SI_POV_DAY1']
     entities = ['country/USA', 'country/RUS', 'country/MEX']
     mock_obs_series_response = {


### PR DESCRIPTION
Tests started failing because our NL goldens hardcode exact year that rely on the real date. So tests like "Population over the last 5 years" now excludes the year 2020. 

A couple of the python unit tests also did the same thing, now they have the date mocked.