### PR TITLE
Tweaks to new place page for the no data state

### DIFF
--- a/server/templates/dev_place.html
+++ b/server/templates/dev_place.html
@@ -14,6 +14,8 @@
   limitations under the License.
   #}
   {%- extends BASE_HTML -%}
+
+  {% from 'macros/icons.html' import inline_svg %}
   
   {% set main_id = 'dc-places' %}
   {% set page_id = 'page-dc-places' %}
@@ -52,6 +54,11 @@
     ></div>
     <div id="plage-page-main" class="container">
       <div id="place-page-content" class="page-content-container">
+      </div>
+      <div id="page-loading" class="mt-4" style="display:none;">
+        {{ inline_svg('progress_activity') }}
+        {# TRANSLATORS: A message shown on the page while the content is loading. #}
+        <p>{% trans %}Loading{% endtrans %}</p>
       </div>
     </div>
   </div>

--- a/static/css/place/dev_place_page.scss
+++ b/static/css/place/dev_place_page.scss
@@ -173,3 +173,25 @@ main {
     padding-top: 16px;
   }
 }
+
+#page-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  svg {
+    font-size: 24px;
+    animation: rotating 2s linear infinite;
+  }
+  p {
+    margin: 3px 0 0 0;
+  }
+}
+
+@keyframes rotating {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -26,7 +26,6 @@ import { RawIntlProvider } from "react-intl";
 
 import { GoogleMap } from "../components/google_map";
 import { SubjectPageMainPane } from "../components/subject_page/main_pane";
-import { LoadingHeader } from "../components/tiles/loading_header";
 import { intl } from "../i18n/i18n";
 import { NamedTypedPlace, StatVarSpec } from "../shared/types";
 import {
@@ -562,6 +561,14 @@ export const DevPlaceMain = (): React.JSX.Element => {
   }, []);
 
   /**
+   * Set the visibility on the loading indicator on loading changes.
+   */
+  useEffect(() => {
+    const loadingElem = document.getElementById("page-loading");
+    loadingElem.style.display = isLoading ? '' : 'none';
+  }, [isLoading, setIsLoading]);
+
+  /**
    * Once we have place data, fetch chart and related places data from the API.
    * Updates state with API responses and derived data.
    */
@@ -637,7 +644,6 @@ export const DevPlaceMain = (): React.JSX.Element => {
       {isOverview && childPlaces.length > 0 && (
         <RelatedPlaces place={place} childPlaces={childPlaces} />
       )}
-      {isLoading && <LoadingHeader isLoading={true} />}
       {hasPlaceCharts && (
         <PlaceCharts
           place={place}

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -20,7 +20,7 @@ import {
   PlaceChartsApiResponse,
   RelatedPlacesApiResponse,
 } from "@datacommonsorg/client/dist/data_commons_web_client_types";
-import _, { over } from "lodash";
+import _ from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 import { RawIntlProvider } from "react-intl";
 
@@ -562,7 +562,7 @@ export const DevPlaceMain = (): React.JSX.Element => {
       console.error("Error loading place page metadata element");
       return;
     }
-    if (
+    if (!isLoading &&
       pageMetadata.dataset.placeDcid != "" &&
       pageMetadata.dataset.placeName === ""
     ) {

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -565,7 +565,7 @@ export const DevPlaceMain = (): React.JSX.Element => {
    */
   useEffect(() => {
     const loadingElem = document.getElementById("page-loading");
-    loadingElem.style.display = isLoading ? '' : 'none';
+    loadingElem.style.display = isLoading ? "" : "none";
   }, [isLoading, setIsLoading]);
 
   /**

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -24,9 +24,9 @@ import _ from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 import { RawIntlProvider } from "react-intl";
 
-import { LoadingHeader } from "../components/tiles/loading_header";
 import { GoogleMap } from "../components/google_map";
 import { SubjectPageMainPane } from "../components/subject_page/main_pane";
+import { LoadingHeader } from "../components/tiles/loading_header";
 import { intl } from "../i18n/i18n";
 import { NamedTypedPlace, StatVarSpec } from "../shared/types";
 import {
@@ -525,7 +525,7 @@ const PlaceCharts = (props: {
  * related places, and chart data.
  */
 export const DevPlaceMain = (): React.JSX.Element => {
-  const overview_string = "Overview";
+  const overviewString = "Overview";
   // Core place data
   const [place, setPlace] = useState<NamedTypedPlace>();
   const [placeSummary, setPlaceSummary] = useState<string>();
@@ -546,11 +546,13 @@ export const DevPlaceMain = (): React.JSX.Element => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const urlParams = new URLSearchParams(window.location.search);
-  const category = urlParams.get("category") || overview_string;
-  const isOverview = category === overview_string;
+  const category = urlParams.get("category") || overviewString;
+  const isOverview = category === overviewString;
   const forceDevPlaces = urlParams.get("force_dev_places") === "true";
-  const hasPlaceCharts = place && pageConfig && pageConfig.categories.length > 0;
-  const hasNoCharts = place && pageConfig && pageConfig.categories.length == 0 && !isLoading;
+  const hasPlaceCharts =
+    place && pageConfig && pageConfig.categories.length > 0;
+  const hasNoCharts =
+    place && pageConfig && pageConfig.categories.length == 0 && !isLoading;
 
   /**
    * On initial load, get place metadata from the page's metadata element
@@ -562,7 +564,7 @@ export const DevPlaceMain = (): React.JSX.Element => {
       console.error("Error loading place page metadata element");
       return;
     }
-    if (!isLoading &&
+    if (
       pageMetadata.dataset.placeDcid != "" &&
       pageMetadata.dataset.placeName === ""
     ) {
@@ -609,7 +611,7 @@ export const DevPlaceMain = (): React.JSX.Element => {
       setPageConfig(pageConfig);
       setIsLoading(false);
     })();
-  }, [place]);
+  }, [place, category]);
 
   if (!place) {
     return <div>Loading...</div>;
@@ -649,7 +651,7 @@ export const DevPlaceMain = (): React.JSX.Element => {
       )}
       {hasNoCharts && (
         <div>
-          No {category === overview_string ? "" : category} data found for{" "}
+          No {category === overviewString ? "" : category} data found for{" "}
           {place.name}.
         </div>
       )}

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -597,7 +597,7 @@ export const DevPlaceMain = (): React.JSX.Element => {
       setChildPlaceType(relatedPlacesApiResponse.childPlaceType);
       setChildPlaces(relatedPlacesApiResponse.childPlaces);
       setParentPlaces(relatedPlacesApiResponse.parentPlaces);
-      setPageConfig(pageConfig);
+      setPageConfig(config);
       setIsLoading(false);
     })();
   }, [place, category]);
@@ -613,7 +613,7 @@ export const DevPlaceMain = (): React.JSX.Element => {
         )
       );
     }
-  }, [placeChartsApiResponse, setPlaceChartsApiResponse, setCategories]);
+  }, [placeChartsApiResponse, setPlaceChartsApiResponse]);
 
   if (!place) {
     return <div>Loading...</div>;


### PR DESCRIPTION
Hides the Overview panel when in another category (other than Overview): [screenshot](https://screenshot.googleplex.com/NanbV29seswndcw)
Hides the Overview panel when there is no summary. [before](https://screenshot.googleplex.com/5GHepNWgPWom9QZ), [after](https://screenshot.googleplex.com/7jaqgBeeRqdJavY)
Hides the child places when there are no child places. [after](https://screenshot.googleplex.com/BuniXa4CBeA6zFu)

Shows error message for invalid DCID: [after](https://screenshot.googleplex.com/AtVVbfJkFM3bZhB)
Shows missing data message when there is no data: [before](https://screenshot.googleplex.com/9mjJsnVZGq9v8x9) [after](https://screenshot.googleplex.com/573nHshTCnt8YfG)

Adds a loading spinner while the charts are loading: [after](https://screenshot.googleplex.com/7c6zo9Csw9ScGmE)