### PR TITLE
Skip empty embeddings in custom DC

### DIFF
--- a/nl_server/embeddings.py
+++ b/nl_server/embeddings.py
@@ -95,3 +95,8 @@ class Embeddings:
 
     # Turn this into a map:
     return {k: v for k, v in zip(queries, results)}
+
+
+class NoEmbeddingsException(Exception):
+  """Custom exception raised when no embeddings are found in the embeddings csv."""
+  pass


### PR DESCRIPTION
* Some custom DCs may not have SVs or topics, hence the embeddings file will be empty.
* Prior to this fix, starting up a service with such files failed.
* With this fix, in custom DC mode, we'll log a warning in such instances and skip that index.
* In base DC mode, it will continue to fail.