### PR TITLE
Refactor, deflake, and unskip place explorer redirect tests

### DIFF
--- a/server/webdriver/cdc_tests/autopush/place_explorer_i18n_test.py
+++ b/server/webdriver/cdc_tests/autopush/place_explorer_i18n_test.py
@@ -11,19 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 
 from server.webdriver.cdc_tests.autopush.cdc_base_webdriver import \
     CdcAutopushTestBase
-from server.webdriver.cdc_tests.autopush.cdc_base_webdriver import \
-    SKIPPED_TEST_REASON
 from server.webdriver.shared_tests.place_explorer_i18n_test import \
     PlaceI18nExplorerTestMixin
 
 
 class TestPlaceExplorerI18n(PlaceI18nExplorerTestMixin, CdcAutopushTestBase):
   """Class to test the i18n place explorer page for Custom DC. Tests come from PlaceI18nExplorerTestMixin."""
-
-  @unittest.skip(reason=SKIPPED_TEST_REASON)
-  def test_explorer_redirect_place_explorer_keeps_locale(self):
-    super().test_explorer_redirect_place_explorer_keeps_locale()

--- a/server/webdriver/cdc_tests/autopush/place_explorer_test.py
+++ b/server/webdriver/cdc_tests/autopush/place_explorer_test.py
@@ -11,19 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 
 from server.webdriver.cdc_tests.autopush.cdc_base_webdriver import \
     CdcAutopushTestBase
-from server.webdriver.cdc_tests.autopush.cdc_base_webdriver import \
-    SKIPPED_TEST_REASON
 from server.webdriver.shared_tests.place_explorer_test import \
     PlaceExplorerTestMixin
 
 
 class TestPlaceExplorer(PlaceExplorerTestMixin, CdcAutopushTestBase):
   """Class to test the place explorer page for Custom DC. Tests come from PlaceExplorerTestMixin."""
-
-  @unittest.skip(reason=SKIPPED_TEST_REASON)
-  def test_explorer_redirect_place_explorer(self):
-    super().test_explorer_redirect_place_explorer()

--- a/server/webdriver/shared_tests/place_explorer_i18n_test.py
+++ b/server/webdriver/shared_tests/place_explorer_i18n_test.py
@@ -113,8 +113,8 @@ class PlaceI18nExplorerTestMixin():
         self.driver.find_element(By.TAG_NAME, 'h1').text,
         'Classement par Population')
 
-  def test_explorer_redirect_place_explorer_keeps_locale(self):
-    """Test the redirection from explore to place explore for single place queries keeps the locale"""
+  def test_explorer_redirect_place_explorer(self):
+    """Test the redirection from explore to place explore for single place queries keeps the locale and query string"""
     usa_explore_fr_locale = '/explore?hl=fr#q=United%20States%20Of%20America'
 
     start_url = self.url_ + usa_explore_fr_locale
@@ -123,12 +123,15 @@ class PlaceI18nExplorerTestMixin():
     # Assert 200 HTTP code: successful page load.
     self.assertEqual(shared.safe_url_open(self.driver.current_url), 200)
 
-    # Assert localized page title is correct, and that the query string is set in the url.
-    WebDriverWait(self.driver, 3).until(EC.title_contains('États-Unis'))
-    self.assertTrue("place/country/USA?q=United+States+Of+America&hl=fr" in
+    # Wait for redirect and page load.
+    redirect_finished = EC.url_changes(start_url)
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(redirect_finished)
+    shared.wait_for_loading(self.driver)
+
+    # Assert redirected URL is correct and contains the locale and query string.
+    self.assertTrue('place/country/USA?q=United+States+Of+America&hl=fr' in
                     self.driver.current_url)
 
-    # Ensure the query string is set in the NL Search Bar.
-    search_bar = self.driver.find_element(By.ID, "query-search-input")
-    self.assertEqual(search_bar.get_attribute("value"),
-                     "United States Of America")
+    # Assert localized page title is correct for the locale.
+    WebDriverWait(self.driver,
+                  self.TIMEOUT_SEC).until(EC.title_contains('États-Unis'))

--- a/server/webdriver/shared_tests/place_explorer_test.py
+++ b/server/webdriver/shared_tests/place_explorer_test.py
@@ -180,16 +180,18 @@ class PlaceExplorerTestMixin():
     # Assert 200 HTTP code: successful page load.
     self.assertEqual(shared.safe_url_open(self.driver.current_url), 200)
 
-    # Assert page title is correct, and that the query string is set in the url.
-    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
-        EC.title_contains('United States of America'))
-    self.assertTrue("place/country/USA?q=United+States+Of+America" in
+    # Wait for redirect and page load.
+    redirect_finished = EC.url_changes(start_url)
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(redirect_finished)
+    shared.wait_for_loading(self.driver)
+
+    # Assert redirected URL is correct and contains the query string.
+    self.assertTrue('place/country/USA?q=United+States+Of+America' in
                     self.driver.current_url)
 
-    # Ensure the query string is set in the NL Search Bar.
-    search_bar = self.driver.find_element(By.ID, "query-search-input")
-    self.assertEqual(search_bar.get_attribute("value"),
-                     "United States Of America")
+    # Assert page title is correct.
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
+        EC.title_contains('United States of America'))
 
   def test_ranking_chart_present(self):
     """Test basic ranking chart."""

--- a/server/webdriver/tests/place_explorer_i18n_test.py
+++ b/server/webdriver/tests/place_explorer_i18n_test.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from server.webdriver import shared
 from server.webdriver.base_dc_webdriver import BaseDcWebdriverTest
 from server.webdriver.shared_tests.place_explorer_i18n_test import \
     PlaceI18nExplorerTestMixin
@@ -19,3 +24,26 @@ from server.webdriver.shared_tests.place_explorer_i18n_test import \
 
 class TestPlaceI18nExplorer(PlaceI18nExplorerTestMixin, BaseDcWebdriverTest):
   """Class to test i18n place explorer page. Tests come from PlaceI18nExplorerTestMixin."""
+
+  def test_explorer_redirect_place_explorer_populates_search_bar(self):
+    """Test the redirection from explore to place explore for single place queries populates the search bar from the URL query"""
+    usa_explore_fr_locale = '/explore?hl=fr#q=United%20States%20Of%20America'
+
+    start_url = self.url_ + usa_explore_fr_locale
+    self.driver.get(start_url)
+
+    # Assert 200 HTTP code: successful page load.
+    self.assertEqual(shared.safe_url_open(self.driver.current_url), 200)
+
+    # Wait for redirect and page load
+    redirect_finished = EC.url_changes(start_url)
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(redirect_finished)
+    shared.wait_for_loading(self.driver)
+
+    # Ensure the query string is set in the NL Search Bar.
+    search_bar_present = EC.presence_of_element_located(
+        (By.ID, 'query-search-input'))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(search_bar_present)
+    search_bar = self.driver.find_element(By.ID, 'query-search-input')
+    self.assertEqual(search_bar.get_attribute('value'),
+                     'United States Of America')

--- a/server/webdriver/tests/place_explorer_test.py
+++ b/server/webdriver/tests/place_explorer_test.py
@@ -16,6 +16,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
+from server.webdriver import shared
 from server.webdriver.base_dc_webdriver import BaseDcWebdriverTest
 from server.webdriver.shared_tests.place_explorer_test import \
     PlaceExplorerTestMixin
@@ -49,3 +50,26 @@ class TestPlaceExplorer(PlaceExplorerTestMixin, BaseDcWebdriverTest):
     explore_in_link_el = WebDriverWait(
         self.driver, self.TIMEOUT_SEC).until(explore_in_link_present)
     self.assertTrue('Explore in' in explore_in_link_el.text)
+
+  def test_explorer_redirect_place_explorer_populates_search_bar(self):
+    """Test the redirection from explore to place explore for single place queries populates the search bar from the URL query"""
+    usa_explore = '/explore#q=United%20States%20Of%20America'
+
+    start_url = self.url_ + usa_explore
+    self.driver.get(start_url)
+
+    # Assert 200 HTTP code: successful page load.
+    self.assertEqual(shared.safe_url_open(self.driver.current_url), 200)
+
+    # Wait for redirect and page load
+    redirect_finished = EC.url_changes(start_url)
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(redirect_finished)
+    shared.wait_for_loading(self.driver)
+
+    # Ensure the query string is set in the NL Search Bar.
+    search_bar_present = EC.presence_of_element_located(
+        (By.ID, 'query-search-input'))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(search_bar_present)
+    search_bar = self.driver.find_element(By.ID, 'query-search-input')
+    self.assertEqual(search_bar.get_attribute('value'),
+                     'United States Of America')


### PR DESCRIPTION
- Separate out tests for the search bar's contents into a non-shared test since Custom DC doesn't have a search bar in the header.
- Ensure the redirect has completed before checking the URL. I used pytest-flakefinder with 100 runs per test to verify this eliminates test flakiness.
- Re-enable the shared portion of the tests for Custom DC