### PR TITLE
Update webdriver-chrome Docker image

### DIFF
--- a/build/ci/cloudbuild.cdc_autopush.yaml
+++ b/build/ci/cloudbuild.cdc_autopush.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-substitutions:
-  _VERS: "2025-01-15"
-
 steps:
-  - name: "gcr.io/cloud-builders/docker"
+  - id: run_tests
+    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
+    entrypoint: /bin/sh
+    waitFor: ["-"]
     args:
-      - build
-      - "--build-arg=VERS=${_VERS}"
-      - --tag=gcr.io/datcom-ci/webdriver-chrome:${_VERS}
-      - --tag=gcr.io/datcom-ci/webdriver-chrome:latest
-      - "."
+      - -c
+      - |
+        ./run_cdc_tests.sh
 
-images:
-  - "gcr.io/datcom-ci/webdriver-chrome:${_VERS}"
-  - "gcr.io/datcom-ci/webdriver-chrome:latest"
+timeout: 1800s # 30 minutes
+
+options:
+  machineType: "E2_HIGHCPU_32"

--- a/build/ci/cloudbuild.sdg_sanity.yaml
+++ b/build/ci/cloudbuild.sdg_sanity.yaml
@@ -14,7 +14,7 @@
 
 steps:
   - id: sdg_sanity
-    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
+    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
     entrypoint: /bin/bash
     args:
       - -c

--- a/build/ci/cloudbuild.webdriver.yaml
+++ b/build/ci/cloudbuild.webdriver.yaml
@@ -42,7 +42,7 @@ steps:
 
   # Run the webdriver tests
   - id: flask_webdriver_test
-    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
+    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
     entrypoint: /bin/sh
     waitFor: ["package_js", "setup_python"]
     args:

--- a/build/ci/cloudbuild.website_sanity.yaml
+++ b/build/ci/cloudbuild.website_sanity.yaml
@@ -14,7 +14,7 @@
 
 steps:
   - id: website_sanity
-    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
+    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
     entrypoint: /bin/bash
     args:
       - -c

--- a/build/ci/cloudbuild.website_testing.yaml
+++ b/build/ci/cloudbuild.website_testing.yaml
@@ -24,7 +24,7 @@ steps:
 
   # Run Website screenshot
   - id: screenshot
-    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
+    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
     entrypoint: /bin/bash
     args:
       - -c
@@ -36,7 +36,7 @@ steps:
 
   # Run Website sanity
   - id: website_sanity
-    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
+    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
     entrypoint: /bin/bash
     args:
       - -c
@@ -48,7 +48,7 @@ steps:
 
   # Run Website adversarial
   - id: website_adversarial
-    name: gcr.io/datcom-ci/webdriver-chrome:2024-06-05
+    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
     entrypoint: /bin/bash
     args:
       - -c

--- a/build/webdriver-chrome/README.md
+++ b/build/webdriver-chrome/README.md
@@ -9,8 +9,10 @@ This is a Docker image based on python:3.11, but comes with some other tools:
 
 ## How to update the Docker image
 
-To generate the Docker image and push it to GCS, change the version number
-in cloudbuild.yaml, then run:
+To generate the Docker image and push it to GCS:
+
+1. Change the version date in cloudbuild.yaml
+2. Run (from this directory):
 
 ```bash
 gcloud config set project datcom-ci

--- a/build/website_cron_testing/Dockerfile
+++ b/build/website_cron_testing/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/datcom-ci/webdriver-chrome:2024-06-05
+FROM gcr.io/datcom-ci/webdriver-chrome:2025-01-15
 
 WORKDIR /resources
 

--- a/build/website_cron_testing/README.md
+++ b/build/website_cron_testing/README.md
@@ -8,7 +8,9 @@ This is a Docker image based on gcr.io/datcom-ci/webdriver-chrome, but comes wit
 
 ## How to update the Docker image
 
-To generate the Docker image and push it to GCS, run the following from the root directory:
+Generally you shouldn't have to do this manually since it happens as part of the website autopush pipeline (see build/ci/cloudbuild.push.yaml).
+
+If you can't wait for the next autopush build, you can run a script to generate this image as well as some others that are usually autopushed and push them all to GCS as latest:
 
 ```bash
 .scripts/push_image.sh


### PR DESCRIPTION
This might resolve an issue where website-cron-testing is running with a vulnerable image (e.g. b/390115448)