### PR TITLE
Reverted bootstrap back to 4.5 to align with website version

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@rollup/plugin-typescript": "^11.1.3",
-    "bootstrap": "^5.0.0",
+    "bootstrap": "^4.5.2",
     "lodash": "^4.17.21",
     "raw-loader": "^4.0.2",
     "sass": "^1.68.0",


### PR DESCRIPTION
I saw bootstrap in the web components (5.0.0) was out of sync with bootstrap in the website (4.5.2). When i tried to upgrade the website to 5.0.0, i saw some errors:

```
ERROR in ./css/about.scss
Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: $color: var(--link-color) is not a color.
    ╷
185 │     "r": red($color),
    │          ^^^^^^^^^^^
    ╵
  node_modules/bootstrap/scss/_functions.scss 185:10  luminance()
  node_modules/bootstrap/scss/_functions.scss 174:8   contrast-ratio()
  node_modules/bootstrap/scss/_functions.scss 159:22  color-contrast()
  node_modules/bootstrap/scss/_variables.scss 846:42  @import
  node_modules/bootstrap/scss/bootstrap.scss 8:9      @import
  css/base.scss 66:9                                  @import
  /Users/dwnoble/Projects/datacommons/website/static/css/about.scss 20:9                                          root stylesheet

```


I think this will require a modest refactoring to how we define CSS variables, so i think for now we should downgrade back to 4.5.2