### PR TITLE
Add logging to understand flaky python test

### DIFF
--- a/nl_server/store/memory.py
+++ b/nl_server/store/memory.py
@@ -66,8 +66,8 @@ class MemoryEmbeddingsStore(EmbeddingsStore):
     logging.info('Loading embeddings file: %s', embeddings_path)
     try:
       ds = load_dataset('csv', data_files=embeddings_path)
-    except:
-      error_str = f'No embedding could be loaded for {embeddings_path}'
+    except Exception as e:
+      error_str = f'No embedding could be loaded for {embeddings_path}: {e}'
       logging.error(error_str)
       raise Exception(error_str)
 

--- a/nl_server/store/memory.py
+++ b/nl_server/store/memory.py
@@ -67,9 +67,9 @@ class MemoryEmbeddingsStore(EmbeddingsStore):
     try:
       ds = load_dataset('csv', data_files=embeddings_path)
     except:
-      error_str = "No embedding could be loaded."
+      error_str = f'No embedding could be loaded for {embeddings_path}'
       logging.error(error_str)
-      raise Exception("No embedding could be loaded.")
+      raise Exception(error_str)
 
     df = ds["train"].to_pandas()
     self.dcids = df['dcid'].values.tolist()


### PR DESCRIPTION
The python cloudbuild has been seeing transient errors having to do with embeddings file being empty ([example](https://pantheon.corp.google.com/cloud-build/builds;region=global/eaf1afc5-d2cd-4625-b650-2ed1bf7dc6a6;step=1?e=13803378&inv=1&invt=AbnIfg&mods=-monitoring_api_staging&project=datcom-ci)). However, I have not been able to trigger the error after re-building the cloudbuild multiple times: https://screenshot.googleplex.com/6TBMmvmyLCUT8fA

Adding an extra line in the logging to use to debug if the transient error shows up again.