### PR TITLE
Updated workflows to use default permission Read repository contents and packages permissions to align with org policies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: "30 7 * * 3"
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/release-branch-checks.yml
+++ b/.github/workflows/release-branch-checks.yml
@@ -2,10 +2,14 @@ name: Release branch checks
 
 on:
   pull_request:
-    branches: [ "customdc_stable" ]
+    branches: ["customdc_stable"]
   # Required for merge queue to work: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
   merge_group:
-    branches: [ "customdc_stable" ]
+    branches: ["customdc_stable"]
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   verify_all_commits_are_already_in_master:


### PR DESCRIPTION
Our github enterprise policy will soon start enforcing that workflows have read repository and package permissions instead of read-write.

This update makes the change ahead of the enterprise policy update.