### PR TITLE
[custom dc] Added resource to run the schema init job on terraform apply operations before deploying the web service

### DIFF
--- a/deploy/terraform-custom-datacommons/modules/main.tf
+++ b/deploy/terraform-custom-datacommons/modules/main.tf
@@ -413,12 +413,8 @@ resource "null_resource" "run_db_init" {
       gcloud run jobs execute ${var.namespace}-datacommons-data-job \
         --update-env-vars DATA_RUN_MODE=schemaupdate \
         --region=${var.region} \
-        --project=${var.project_id}
-
-      # 2) Wait for the job to complete
-      gcloud run jobs wait ${var.namespace}-datacommons-data-job \
-        --region=${var.region} \
-        --project=${var.project_id}
+        --project=${var.project_id} \
+        --wait
     EOT
   }
 }

--- a/deploy/terraform-custom-datacommons/modules/main.tf
+++ b/deploy/terraform-custom-datacommons/modules/main.tf
@@ -409,7 +409,7 @@ resource "null_resource" "run_db_init" {
 
   provisioner "local-exec" {
     command = <<EOT
-      # 1) Execute the schema update / initializationjob
+      # 1) Execute the schema update / initialization job
       gcloud run jobs execute ${var.namespace}-datacommons-data-job \
         --update-env-vars DATA_RUN_MODE=schemaupdate \
         --region=${var.region} \

--- a/deploy/terraform-custom-datacommons/modules/variables.tf
+++ b/deploy/terraform-custom-datacommons/modules/variables.tf
@@ -182,11 +182,11 @@ variable "make_dc_web_service_public" {
 }
 
 #  Data Commons Cloud Run job variables
-
+# TODO: Change to stable after the next release
 variable "dc_data_job_image" {
   description = "The container image for the data job"
   type        = string
-  default     = "gcr.io/datcom-ci/datacommons-data:stable"
+  default     = "gcr.io/datcom-ci/datacommons-data:latest"
 }
 
 variable "dc_data_job_cpu" {

--- a/nl_server/requirements.txt
+++ b/nl_server/requirements.txt
@@ -5,7 +5,7 @@ Flask==2.3.2
 google-cloud-logging==3.10.0
 gunicorn==22.0.0
 markupsafe==2.1.2
-Werkzeug==3.0.1
+Werkzeug==3.0.6
 # Downloading the named-entity recognition (NER) library spacy and the large EN model
 # using the guidelines here: https://spacy.io/usage/models#production
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl


### PR DESCRIPTION
Requires "gcr.io/datcom-ci/datacommons-data:latest" to run since the input bucket won't have a config file yet.

I'll switch it back to gcr.io/datcom-ci/datacommons-data:stable after the next release.