### PR TITLE
Added new place page dimension tracking to google analytics

### DIFF
--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -36,7 +36,7 @@
 <!DOCTYPE html>
 
 <html lang={{ locale }} id={{ page_id }}>
-{% set GOOGLE_ANALYTICS_TAG_ID = '123' %}
+
 <head>
   {# Enable Google Analytics with cookieless tracking. #}
   {% if GOOGLE_ANALYTICS_TAG_ID %}

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -48,6 +48,7 @@
     gtag('config', '{{ GOOGLE_ANALYTICS_TAG_ID }}', {
       client_storage: 'none',
       anonymize_ip: true,
+      {# TODO: Remove new_place_page custom dimension after full launch #}
       {{ ("new_place_page: {},"|safe).format('true' if new_place_page else 'false') if new_place_page is defined else "" }}
       {{ ("place_category: '{}',"|safe).format(place_category) if place_category is defined else "" }}
       {{ ("send_page_view: false,"|safe) if manual_ga_pageview else "" }}

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -36,7 +36,7 @@
 <!DOCTYPE html>
 
 <html lang={{ locale }} id={{ page_id }}>
-
+{% set GOOGLE_ANALYTICS_TAG_ID = '123' %}
 <head>
   {# Enable Google Analytics with cookieless tracking. #}
   {% if GOOGLE_ANALYTICS_TAG_ID %}
@@ -48,6 +48,7 @@
     gtag('config', '{{ GOOGLE_ANALYTICS_TAG_ID }}', {
       client_storage: 'none',
       anonymize_ip: true,
+      {{ ("new_place_page: {},"|safe).format('true' if new_place_page else 'false') if new_place_page is defined else "" }}
       {{ ("place_category: '{}',"|safe).format(place_category) if place_category is defined else "" }}
       {{ ("send_page_view: false,"|safe) if manual_ga_pageview else "" }}
     });

--- a/server/templates/dev_place.html
+++ b/server/templates/dev_place.html
@@ -28,6 +28,7 @@
   {% endif %}
   {% set place_category = category %}
   {% set is_show_header_search_bar = true %}
+  {% set new_place_page = true %}
   
   {% block head %}
   <link rel="stylesheet" href={{url_for('static', filename='css/dev_place_page.min.css' , t=config['VERSION'])}}>

--- a/server/templates/place.html
+++ b/server/templates/place.html
@@ -27,6 +27,7 @@ limitations under the License.
   {% set description = _('Statistics about {category} in {place_name}.'.format(category=category, place_name=place_name)) %}
 {% endif %}
 {% set place_category = category %}
+{% set new_place_page = false %}
 
 {% block head %}
 <link rel="stylesheet" href={{url_for('static', filename='css/place_page.min.css' , t=config['VERSION'])}}>


### PR DESCRIPTION
New place page:
```
  <script>
    window.dataLayer = window.dataLayer || [];
    function gtag() { dataLayer.push(arguments); }
    gtag('js', new Date());
    gtag('config', '123', {
      client_storage: 'none',
      anonymize_ip: true,
      new_place_page: true,
      place_category: '',
      
    });
  </script>
```

Old plage page:
```
  <script>
    window.dataLayer = window.dataLayer || [];
    function gtag() { dataLayer.push(arguments); }
    gtag('js', new Date());
    gtag('config', '123', {
      client_storage: 'none',
      anonymize_ip: true,
      new_place_page: false,
      
      
    });
  </script>
```

Other pages
```  <script>
    window.dataLayer = window.dataLayer || [];
    function gtag() { dataLayer.push(arguments); }
    gtag('js', new Date());
    gtag('config', '123', {
      client_storage: 'none',
      anonymize_ip: true,
      
      
      
    });
  </script>
```