### PR TITLE
Enabled Cross-Origin Resource Sharing (CORS) for Custom DC mixer api endpoint (/core/*)

### DIFF
--- a/build/cdc_services/nginx.conf
+++ b/build/cdc_services/nginx.conf
@@ -12,6 +12,18 @@ http {
 
     # Make mixer api available at /core/api/
     location /core/api/ {
+        # Handle preflight (OPTIONS) requests
+        if ($request_method = OPTIONS) {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,X-Requested-With' always;
+            add_header 'Access-Control-Max-Age' 3600;
+            
+            # Respond with 204 No Content for OPTIONS requests
+            add_header 'Content-Length' 0;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            return 204;
+        }
         rewrite /core/api/(.*) /$1 break;
         proxy_pass http://localhost:8081;
         proxy_http_version 1.1;
@@ -19,6 +31,11 @@ http {
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $http_host;
         proxy_read_timeout 3600;
+        
+        # Add CORS headers to normal (non-OPTIONS) responses as well
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,X-Requested-With' always;
     }
     error_log /dev/stderr;
   }


### PR DESCRIPTION
This change enables cross-origin requests for the Custom DC mixer api endpoint. This allows customers like the UN to make api requests from their static site. 
(The website api endpoint already has CORS enabled)