### PR TITLE
Launch place page experiment, autocomplete and scroll to top

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -1,12 +1,12 @@
 [{
     "name": "autocomplete",
-    "enabled": false,
+    "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable place autocomplete."
 },
 {
     "name": "dev_place_experiment",
-    "enabled": false,
+    "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable the V2 place page only for the experiment places."
 },
@@ -18,7 +18,7 @@
 },
 {
     "name": "scroll_to_top_button",
-    "enabled": false,
+    "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable the scroll to top button on the explore and place pages."
 }]


### PR DESCRIPTION
About to run the script to update the files in prod. The file checked in has to match staging feature flags.

This will allow me to launch autocomplete, place page experiment and scroll to top button.