### PR TITLE
[Feature Flags] Give custom DC their own checked in flags.

### DIFF
--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -1,0 +1,24 @@
+[{
+    "name": "autocomplete",
+    "enabled": false,
+    "owner": "gmechali",
+    "description": "Feature flag to enable place autocomplete."
+},
+{
+    "name": "dev_place_experiment",
+    "enabled": false,
+    "owner": "gmechali",
+    "description": "Feature flag to enable the V2 place page only for the experiment places."
+},
+{
+    "name": "dev_place_ga",
+    "enabled": false,
+    "owner": "dwnoble",
+    "description": "Feature flag to enable the V2 Place page to GA."
+},
+{
+    "name": "scroll_to_top_button",
+    "enabled": false,
+    "owner": "gmechali",
+    "description": "Feature flag to enable the scroll to top button on the explore and place pages."
+}]

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -18,7 +18,7 @@
 },
 {
     "name": "scroll_to_top_button",
-    "enabled": false,
+    "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable the scroll to top button on the explore and place pages."
 }]

--- a/server/lib/util.py
+++ b/server/lib/util.py
@@ -431,7 +431,7 @@ def load_feature_flags_from_gcs(environment: str):
 def load_fallback_feature_flags(environment: str):
   """Loads the fallback feature flags into the app config. We fallback to checked in flag configs per environment."""
   environments_with_local_files = set(
-      ['local', 'autopush', 'dev', 'staging', 'production'])
+      ['local', 'autopush', 'dev', 'staging', 'production', 'custom'])
   testing_environments = set(['integration_test', 'test', 'webdriver'])
 
   if environment in testing_environments:

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -342,12 +342,13 @@ def is_dev_place_experiment_enabled(place_dcid: str, locale: str,
   if not is_feature_enabled(PLACE_PAGE_EXPERIMENT_FEATURE_FLAG):
     return False
 
-  # Force dev place experiment for testing
-  if request_args.get("force_dev_places") == "true":
-    return True
   # Disable dev place experiment for testing
   if request_args.get("disable_dev_places") == "true":
     return False
+
+  # Force dev place experiment for testing
+  if request_args.get("force_dev_places") == "true":
+    return True
 
   # Experiment is enabled for English pages for countries and US states in the experiment group
   if locale == 'en' and place_dcid in DEV_PLACE_EXPERIMENT_DCIDS:

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -342,13 +342,12 @@ def is_dev_place_experiment_enabled(place_dcid: str, locale: str,
   if not is_feature_enabled(PLACE_PAGE_EXPERIMENT_FEATURE_FLAG):
     return False
 
-  # Disable dev place experiment for testing
-  if request_args.get("disable_dev_places") == "true":
-    return False
-
   # Force dev place experiment for testing
   if request_args.get("force_dev_places") == "true":
     return True
+  # Disable dev place experiment for testing
+  if request_args.get("disable_dev_places") == "true":
+    return False
 
   # Experiment is enabled for English pages for countries and US states in the experiment group
   if locale == 'en' and place_dcid in DEV_PLACE_EXPERIMENT_DCIDS:

--- a/server/templates/custom_dc/custom/base.html
+++ b/server/templates/custom_dc/custom/base.html
@@ -47,9 +47,11 @@
       {{ ("place_category: '{}',"|safe).format(place_category) if place_category is defined else "" }}
       {{ ("send_page_view: false,"|safe) if manual_ga_pageview else "" }}
     });
+    </script>
+  {% endif %}
+  <script>
     globalThis.FEATURE_FLAGS = {{ config['FEATURE_FLAGS'] | tojson }};
   </script>
-  {% endif %}
 
   <title>{{ title }} - Custom Data Commons</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/server/templates/custom_dc/custom/base.html
+++ b/server/templates/custom_dc/custom/base.html
@@ -47,6 +47,7 @@
       {{ ("place_category: '{}',"|safe).format(place_category) if place_category is defined else "" }}
       {{ ("send_page_view: false,"|safe) if manual_ga_pageview else "" }}
     });
+    globalThis.FEATURE_FLAGS = {{ config['FEATURE_FLAGS'] | tojson }};
   </script>
   {% endif %}
 

--- a/server/templates/custom_dc/custom/base.html
+++ b/server/templates/custom_dc/custom/base.html
@@ -47,7 +47,7 @@
       {{ ("place_category: '{}',"|safe).format(place_category) if place_category is defined else "" }}
       {{ ("send_page_view: false,"|safe) if manual_ga_pageview else "" }}
     });
-    </script>
+  </script>
   {% endif %}
   <script>
     globalThis.FEATURE_FLAGS = {{ config['FEATURE_FLAGS'] | tojson }};


### PR DESCRIPTION
Creates a local file with the feature flags to be used in Custom DC.
Sets autocomplete and place page flags to be disabled (note that the screenshot had place experiment enabled, but it's now disabled).

Starts reading the flags for custom DC from the local file, and injects them in the custom DC base.html file.

See how local custom DC now has the scroll to top button:
https://screenshot.googleplex.com/7dk4eim4LALCuVL