### PR TITLE
Enable datagemma based on an env variable.

### DIFF
--- a/deploy/helm_charts/dc_website/templates/deployment.yaml
+++ b/deploy/helm_charts/dc_website/templates/deployment.yaml
@@ -135,6 +135,8 @@ spec:
               value: {{ .Values.nl.enabled | quote }}
             - name: ENABLE_EVAL_TOOL
               value: {{ .Values.website.evalTool.enabled | quote }}
+            - name: ENABLE_DATAGEMMA
+              value: {{ .Values.website.dataGemma.enabled | quote }}
             - name: INGRESS_CONFIG_PATH
               value: /datacommons/ingress/rules
             # A dummy config used to bounce the server without any docker image

--- a/deploy/helm_charts/dc_website/values.yaml
+++ b/deploy/helm_charts/dc_website/values.yaml
@@ -41,6 +41,9 @@ website:
   evalTool:
     enabled: false
 
+  dataGemma:
+    enabled: false
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/deploy/helm_charts/envs/autopush.yaml
+++ b/deploy/helm_charts/envs/autopush.yaml
@@ -29,6 +29,8 @@ website:
   nodePool: "default-pool"
   evalTool:
     enabled: true
+  dataGemma:
+    enabled: true
   redis:
     enabled: true
     configFile: |

--- a/run_server.sh
+++ b/run_server.sh
@@ -70,6 +70,7 @@ while getopts ":e:p:m?d?l?xg" OPTION; do
 done
 
 export GOOGLE_CLOUD_PROJECT=datcom-website-dev
+export ENABLE_DATAGEMMA=true
 
 # Set flask env
 if [[ $FLASK_ENV == "" ]]; then

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -75,6 +75,13 @@ def _get_api_key(env_keys=[], gcp_project='', gcp_path=''):
   return ''
 
 
+def _enable_datagemma() -> bool:
+  """Returns whether to enable the DataGemma UI for this instance. 
+  This UI should only be enabled for internal instances.
+  """
+  return os.environ.get('ENABLE_DATAGEMMA') == 'true'
+
+
 def register_routes_base_dc(app):
   # apply the blueprints for all apps
   from server.routes.dev import html as dev_html
@@ -329,7 +336,7 @@ def create_app(nl_root=DEFAULT_NL_ROOT):
   if cfg.SHOW_SUSTAINABILITY:
     register_routes_sustainability(app)
 
-  if cfg.ENABLE_DATAGEMMA:
+  if _enable_datagemma():
     register_routes_datagemma(app, cfg)
 
   # Load topic page config

--- a/server/app_env/_base.py
+++ b/server/app_env/_base.py
@@ -98,6 +98,3 @@ class Config:
   # Whether to enable BigQuery for instance. This is primarily used for
   # accessing the observation browser pages.
   ENABLE_BQ = False
-  # Whether to enable the DataGemma UI for this instance. This UI should only be
-  # enabled for internal instances.
-  ENABLE_DATAGEMMA = False

--- a/server/app_env/autopush.py
+++ b/server/app_env/autopush.py
@@ -25,4 +25,3 @@ class Config(_base.Config):
   HIDE_DEBUG = False
   USE_MEMCACHE = False
   ENABLE_BQ = True
-  ENABLE_DATAGEMMA = True

--- a/server/app_env/local.py
+++ b/server/app_env/local.py
@@ -21,7 +21,6 @@ class Config(_base.Config):
   SCHEME = 'http'
   USE_MEMCACHE = False
   ENABLE_BQ = True
-  ENABLE_DATAGEMMA = True
 
 
 class DCConfig(Config):


### PR DESCRIPTION
* The current approach configures this variable in code. Making it an env variable makes it configurable at runtime.
* Also, custom dcs [inherit](https://github.com/ONEcampaign/one-datacommons-website/blob/master/server/app_env/one.py#L29) from some of the base configs, so enabling it in base level configs like `local.Config` is problematic for custom dcs.
* Another approach could be to explicitly disable it for custom DCs. However, we want to slowly phase out python based configs over time so that they can be a pure runtime artifact. So implementing this as an env variable.