### PR TITLE
[Feature Cleanup] Remove references in the code to the scroll to top button

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -18,6 +18,7 @@
 },
 {
     "name": "scroll_to_top_button",
+    "deprecated": true,
     "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable the scroll to top button on the explore and place pages."

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -18,6 +18,7 @@
 },
 {
     "name": "scroll_to_top_button",
+    "deprecated": true,
     "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable the scroll to top button on the explore and place pages."

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -18,6 +18,7 @@
 },
 {
     "name": "scroll_to_top_button",
+    "deprecated": true,
     "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable the scroll to top button on the explore and place pages."

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -18,6 +18,7 @@
 },
 {
     "name": "scroll_to_top_button",
+    "deprecated": true,
     "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable the scroll to top button on the explore and place pages."

--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -18,6 +18,7 @@
 },
 {
     "name": "scroll_to_top_button",
+    "deprecated": true,
     "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable the scroll to top button on the explore and place pages."

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -18,6 +18,7 @@
 },
 {
     "name": "scroll_to_top_button",
+    "deprecated": true,
     "enabled": true,
     "owner": "gmechali",
     "description": "Feature flag to enable the scroll to top button on the explore and place pages."

--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -35,10 +35,6 @@ import {
   NlSessionContext,
   RankingUnitUrlFuncContext,
 } from "../../shared/context";
-import {
-  isFeatureEnabled,
-  SCROLL_TO_TOP_FEATURE_FLAG,
-} from "../../shared/feature_flags/util";
 import { QueryResult, UserMessageInfo } from "../../types/app/explore_types";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import {
@@ -195,9 +191,7 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
                     svgChartHeight={SVG_CHART_HEIGHT}
                     showExploreMore={true}
                   />
-                  {isFeatureEnabled(SCROLL_TO_TOP_FEATURE_FLAG) && (
-                    <ScrollToTopButton />
-                  )}
+                  <ScrollToTopButton />
                 </ExploreContext.Provider>
               </NlSessionContext.Provider>
             </RankingUnitUrlFuncContext.Provider>

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -29,10 +29,6 @@ import { ScrollToTopButton } from "../components/elements/scroll_to_top_button";
 import { SubjectPageMainPane } from "../components/subject_page/main_pane";
 import { intl, LocalizedLink } from "../i18n/i18n";
 import { pageMessages } from "../i18n/i18n_place_messages";
-import {
-  isFeatureEnabled,
-  SCROLL_TO_TOP_FEATURE_FLAG,
-} from "../shared/feature_flags/util";
 import { useQueryStore } from "../shared/stores/query_store_hook";
 import { NamedTypedPlace } from "../shared/types";
 import theme from "../theme/theme";
@@ -430,7 +426,7 @@ export const DevPlaceMain = (): React.JSX.Element => {
         {isOverview && childPlaces.length > 0 && (
           <RelatedPlaces place={place} childPlaces={childPlaces} />
         )}
-        {isFeatureEnabled(SCROLL_TO_TOP_FEATURE_FLAG) && <ScrollToTopButton />}
+        <ScrollToTopButton />
       </RawIntlProvider>
     </ThemeProvider>
   );

--- a/static/js/shared/feature_flags/util.ts
+++ b/static/js/shared/feature_flags/util.ts
@@ -18,7 +18,6 @@ export const FEATURE_FLAGS = globalThis.FEATURE_FLAGS;
 export const AUTOCOMPLETE_FEATURE_FLAG = "autocomplete";
 export const PLACE_PAGE_EXPERIMENT_FEATURE_FLAG = "autocomplete";
 export const PLACE_PAGE_GA_FEATURE_FLAG = "autocomplete";
-export const SCROLL_TO_TOP_FEATURE_FLAG = "scroll_to_top_button";
 
 /**
  * Helper method to interact with feature flags.


### PR DESCRIPTION
This PR removes references in the code to gate the scroll to top button behind a feature.
I also mark the feature flag in all environments as deprecated in order to highlight that it can be removed. But I do not remove it yet because we need this PR to be included in a release first.

If we remove the flags right now, we would end up disabling the feature until this PR makes it to production. So we ll keep the flags in for just a couple more weeks.