### PR TITLE
Flake Fix for Custom DC webdriver test

### DIFF
--- a/server/webdriver/shared_tests/scatter_test.py
+++ b/server/webdriver/shared_tests/scatter_test.py
@@ -92,7 +92,7 @@ class ScatterTestMixin():
     find_elem(self.driver, by=By.CSS_SELECTOR,
               value='.pac-item:nth-child(1)').click()
     shared.wait_for_loading(self.driver)
-    self.assertIsNotNone(wait_elem(self.driver, value='chip'))
+    self.assertIsNotNone(wait_elem(self.driver, value='place-selector-place-type'))
 
     # Choose place type
     Select(


### PR DESCRIPTION
Uses the ID for the component we are directly going to click on rather than a proxy. 