### PR TITLE
Reduce flake in cdc test that blocked autopush

### DIFF
--- a/run_cdc_tests.sh
+++ b/run_cdc_tests.sh
@@ -23,6 +23,7 @@ export FLASK_ENV=webdriver
 # Like run_test.sh, use flag -g for updating goldens.
 if [[ "$1" == "-g" ]]; then
   export TEST_MODE=write
+  shift # Remove -g from arguments, so pytest doesn't see it.
 fi
 
-python3 -m pytest -n auto --reruns 2 server/webdriver/cdc_tests/
+python3 -m pytest -n auto --reruns 2 server/webdriver/cdc_tests/ "$@"

--- a/server/webdriver/shared_tests/download_test.py
+++ b/server/webdriver/shared_tests/download_test.py
@@ -14,7 +14,6 @@
 import os
 import tempfile
 
-
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select

--- a/server/webdriver/shared_tests/download_test.py
+++ b/server/webdriver/shared_tests/download_test.py
@@ -14,6 +14,7 @@
 import os
 import tempfile
 
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select

--- a/server/webdriver/shared_tests/scatter_test.py
+++ b/server/webdriver/shared_tests/scatter_test.py
@@ -95,9 +95,11 @@ class ScatterTestMixin():
     self.assertIsNotNone(wait_elem(self.driver, value='chip'))
 
     # Choose place type
-    Select(
-        find_elem(self.driver, by=By.ID,
-                  value='place-selector-place-type')).select_by_value('County')
+    shared.wait_for_loading(self.driver)
+    place_selector_place_type = find_elem(self.driver,
+                                          by=By.ID,
+                                          value='place-selector-place-type')
+    Select(place_selector_place_type).select_by_value('County')
 
     # Choose stat vars
     shared.wait_for_loading(self.driver)


### PR DESCRIPTION
Adds the ability to run a single test file at a time in cdc test. 

I think this change deflaked a test a little but not too sure why...