### PR TITLE
Updated data sources link to point to datacommons.org/data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo hosts code for the Data Commons website.
 
 [Data Commons](https://datacommons.org/) is an open knowledge graph that
 provides a unified view across multiple public data sets and statistics. We've
-bootstrapped the graph with lots of [data](https://docs.datacommons.org/datasets/)
+bootstrapped the graph with lots of [data](https://datacommons.org/data)
 from US Census, CDC, NOAA, etc., and through collaborations with the New York
 Botanical Garden, Opportunity Insights, and more. However, Data Commons is meant
 to be for community, by the community. We are excited to work with you to make

--- a/server/config/base/header.json
+++ b/server/config/base/header.json
@@ -73,7 +73,7 @@
         "label": "Blog"
       },
       {
-        "href": "https://docs.datacommons.org/datasets/",
+        "href": "{static.data}",
         "label": "Data Sources"
       },
       {

--- a/server/config/base/header_v2.json
+++ b/server/config/base/header_v2.json
@@ -107,7 +107,7 @@
           },
           {
             "title": "Data Sources",
-            "url": "https://docs.datacommons.org/datasets/",
+            "url": "{static.data}",
             "description": "Get familiar with the data available in Data Commons"
           }
         ]

--- a/server/routes/redirects.py
+++ b/server/routes/redirects.py
@@ -69,7 +69,7 @@ def nlnext():
 
 @bp.route('/datasets')
 def datasets():
-  return redirect('https://docs.datacommons.org/datasets/', code=302)
+  return redirect(url_for('static.data'), code=301)
 
 
 @bp.route('/documentation')

--- a/server/routes/static.py
+++ b/server/routes/static.py
@@ -59,9 +59,9 @@ def build():
       partners=json.dumps(current_app.config.get('HOMEPAGE_PARTNERS', [])))
 
 
-@bp.route("/data", defaults={"path": ""})
+@bp.route("/data", defaults={"path": ""}, strict_slashes=False)
 @bp.route("/data/<path:path>")
-def data_page(path):
+def data(path):
   return lib_render.render_page("static/data.html", "data.html")
 
 

--- a/server/templates/custom_dc/stanford/base.html
+++ b/server/templates/custom_dc/stanford/base.html
@@ -140,7 +140,7 @@
                     %}</a>
                   <a class="dropdown-item" href="https://blog.datacommons.org">{% trans %}Blog{% endtrans
                     %}</a>
-                  <a class="dropdown-item" href="https://docs.datacommons.org/datasets/">{% trans %}Data Sources{%
+                  <a class="dropdown-item" href="https://datacommons.org/data">{% trans %}Data Sources{%
                     endtrans %}</a>
                   <a class="dropdown-item" href="{{ url_for('static.faq') }}">{% trans %}FAQ{% endtrans %}</a>
                   <a class="dropdown-item" href="{{ url_for('static.feedback') }}">{% trans %}Feedback{% endtrans %}</a>
@@ -210,7 +210,7 @@
             {# TRANSLATORS: The label for a link to the project's blog. #}
             <a href="https://blog.datacommons.org/">{% trans %}Blog{% endtrans %}</a>
             {# TRANSLATORS: The label for a link to data sources included in the Data Commons knowledge graph. #}
-            <a href="https://docs.datacommons.org/datasets/">{% trans %}Data Sources{% endtrans %}</a>
+            <a href="https://datacommons.org/data">{% trans %}Data Sources{% endtrans %}</a>
             {# TRANSLATORS: The label for a link to instructions about sending feedback. #}
             <a href="{{ url_for('static.feedback') }}">{% trans %}Feedback{% endtrans %}</a>
             {# TRANSLATORS: The label for a link to project FAQ page. #}

--- a/server/templates/metadata/routes.html
+++ b/server/templates/metadata/routes.html
@@ -32,6 +32,7 @@ limitations under the License.
   'tools.download',
   'static.about',
   'static.build',
+  'static.data',
   'static.feedback',
   'static.faq'
 ] %}

--- a/static/js/apps/about/components/stay_in_touch.tsx
+++ b/static/js/apps/about/components/stay_in_touch.tsx
@@ -48,7 +48,7 @@ export const StayInTouch = ({ routes }: StayInTouchProps): ReactElement => {
         <h3>See Also</h3>
         <ul>
           <li>
-            <a href="https://docs.datacommons.org/datasets/">Data Sources</a>
+            <a href={routes["static.data"]}>Data Sources</a>
           </li>
           <li>
             <a href={routes["static.faq"]}>Frequently Asked Questions</a>

--- a/static/js/apps/homepage/app.tsx
+++ b/static/js/apps/homepage/app.tsx
@@ -69,7 +69,7 @@ export function App({
   return (
     <ThemeProvider theme={theme}>
       <Section colorVariant="light" variant="large">
-        <HomeHero linkChips={topicLinkChips} />
+        <HomeHero linkChips={topicLinkChips} routes={routes} />
       </Section>
 
       <Section>

--- a/static/js/apps/homepage/components/home_hero.tsx
+++ b/static/js/apps/homepage/components/home_hero.tsx
@@ -26,19 +26,24 @@ import React, { ReactElement } from "react";
 import { HeroColumns } from "../../../components/content/hero_columns";
 import { LinkChips } from "../../../components/content/link_chips";
 import { Link } from "../../../components/elements/link_chip";
-
+import { Routes } from "../../../shared/types/base";
 interface HomeHeroProps {
   //an array of links to be rendered by the component
   linkChips: Link[];
+  //the routes dictionary - this is used to convert routes to resolved urls
+  routes: Routes;
 }
 
-export const HomeHero = ({ linkChips }: HomeHeroProps): ReactElement => {
+export const HomeHero = ({
+  linkChips,
+  routes,
+}: HomeHeroProps): ReactElement => {
   const theme = useTheme();
 
   linkChips.push({
     id: "data-sources",
     title: "See all available data sources",
-    url: "https://docs.datacommons.org/datasets/",
+    url: routes["static.data"],
     variant: "flat",
   });
 

--- a/static/js/biomedical/landing/data_sources_section.tsx
+++ b/static/js/biomedical/landing/data_sources_section.tsx
@@ -46,7 +46,7 @@ export function DataSourcesSection(): JSX.Element {
           <p>
             The Biomedical Data Commons is a comprehensive repository that
             integrates data from over{" "}
-            <UnderlinedLink href="https://docs.datacommons.org/datasets/Biomedical.html">
+            <UnderlinedLink href="https://datacommons.org/data/biomedical">
               18 different trusted sources
             </UnderlinedLink>{" "}
             like NIH NCBI and EMBL-EBI. Including commonly used open-source

--- a/static/js/biomedical/landing/header_and_search_section.tsx
+++ b/static/js/biomedical/landing/header_and_search_section.tsx
@@ -119,7 +119,7 @@ export function HeaderAndSearchBox(): JSX.Element {
           <h3>
             Find relationships between{" "}
             <a href="/browser/bio">25 biomedical categories</a> sourced from{" "}
-            <a href="https://docs.datacommons.org/datasets/Biomedical.html">
+            <a href="https://datacommons.org/data/biomedical">
               18 trusted sources
             </a>
             , including NIH NCBI and EMBL-EBI


### PR DESCRIPTION
* Removed links to https://docs.datacommons.org/datasets/ and replaced them with links to https://datacommons.org/data
* Updated legacy https://datacommons.org/datasets/ redirect to point to https://datacommons.org/data