### PR TITLE
Disable dev place pages in production.

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -7,7 +7,7 @@
   },
   {
     "name": "dev_place_experiment",
-    "enabled": true,
+    "enabled": false,
     "owner": "gmechali",
     "description": "Feature flag to enable the V2 place page only for the experiment places."
   },


### PR DESCRIPTION
This is temporary while we fix the Paris related places issue.