### PR TITLE
Updated standalone 'sanity' test to skip data sources page

### DIFF
--- a/server/webdriver/tests/standalone/sanity.py
+++ b/server/webdriver/tests/standalone/sanity.py
@@ -164,9 +164,9 @@ class WebsiteSanityTest:
             ))
         return
 
-      # There is a button in the topic section that leads to the docs site,
-      # don't include it as an explore landing page.
-      if topic_url_elem.get_attribute("href").startswith(_DOCSITE_URL):
+      # There is a button in the topic section that leads to the data sources
+      # page. don't include it as an explore landing page.
+      if topic_url_elem.get_attribute("href").endswith("/data"):
         continue
 
       explore_landing_pages.append(

--- a/server/webdriver/tests/standalone/sanity.py
+++ b/server/webdriver/tests/standalone/sanity.py
@@ -49,7 +49,6 @@ flags.DEFINE_string(
 flags.DEFINE_string("url", None, "URL to start testing from.", required=True)
 
 _TEST_PARAM = "test=sanity"
-_DOCSITE_URL = "https://docs.datacommons.org"
 
 
 def url_with_test_param(url: str):


### PR DESCRIPTION
Fixes issue where website sanity test was failing when it landed on the new data sources (datacommons.org/data) page.

Updates sanity check to continue skipping the data sources page using its new URL.

![5SVdZaFxEGkajx3](https://github.com/user-attachments/assets/a116b38b-9165-4d4e-8e11-ff4a0eda1af7)
