### PR TITLE
[Place Page Revamp] Re-adds the AI Icon previously disabled due to Theme issues

### DIFF
--- a/server/webdriver/tests/place_explorer_test.py
+++ b/server/webdriver/tests/place_explorer_test.py
@@ -379,7 +379,6 @@ class TestPlaceExplorer(PlaceExplorerTestMixin, BaseDcWebdriverTest):
                   value='query-search-input').get_attribute('value'),
         'United States Of America')
 
-  # TODO(gmechali): Re-enable when static theme issue is fixed.
   @pytest.mark.skip(reason="Fix theme compile error before re-enabling")
   def test_dev_place_ai_spark_icon_hover(self):
     self.driver.get(self.url_ + '/place/geoId/04?force_dev_places=true')

--- a/static/js/place/dev_place_overview.tsx
+++ b/static/js/place/dev_place_overview.tsx
@@ -186,8 +186,7 @@ export const PlaceOverview = (props: {
       >
         <LocationCity />
         <span>{intl.formatMessage(pageMessages.SummaryOverview)}</span>
-        {/* TODO(gmechali): Re-enable when static theme issue is fixed. */}
-        {false && placeSummary && (
+        {placeSummary && (
           <InfoTooltipComponent
             icon={<InfoSpark />}
             description={intl.formatMessage(


### PR DESCRIPTION
The theme issues have been fixed in https://github.com/datacommonsorg/website/pull/4992
This PR just removes the logic to hide the icon. I ran the command to start the Node JS server and it worked. 