### PR TITLE
Added cdc data loading job timeout variable

### DIFF
--- a/deploy/terraform-custom-datacommons/modules/main.tf
+++ b/deploy/terraform-custom-datacommons/modules/main.tf
@@ -383,6 +383,7 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
 
       execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
       service_account       = google_service_account.datacommons_service_account.email
+      timeout               = var.dc_data_job_timeout
     }
   }
 

--- a/deploy/terraform-custom-datacommons/modules/variables.tf
+++ b/deploy/terraform-custom-datacommons/modules/variables.tf
@@ -200,6 +200,12 @@ variable "dc_data_job_memory" {
   default     = "8G"
 }
 
+variable "dc_data_job_timeout" {
+  description = "Timeout for the Data Commons data loading job"
+  type        = string
+  default     = "600s"
+}
+
 # Data Commons Cloud VPC Network variables
 
 variable "vpc_network_name" {


### PR DESCRIPTION
Tested in my local gcp account with a 5s timeout, and the job 'successfully' failed with a timeout error