### PR TITLE
rollback of i18n quote fix

### DIFF
--- a/static/js/components/nl_search_bar/dynamic_placeholder_helper.ts
+++ b/static/js/components/nl_search_bar/dynamic_placeholder_helper.ts
@@ -29,7 +29,7 @@ const MAX_SAMPLE_COUNTRY_CYCLE = 5;
 export const placeholderMessages = defineMessages({
   exploreDataPlaceholder: {
     id: "explore_data_on",
-    defaultMessage: 'Explore data on... \\"{sampleQuestion}\\"',
+    defaultMessage: 'Explore data on... "{sampleQuestion}"',
     description:
       "Used for the dynamic placeholders in the search bar, gives an example of a query to type.",
   },

--- a/static/js/i18n/i18n_place_messages.ts
+++ b/static/js/i18n/i18n_place_messages.ts
@@ -212,7 +212,7 @@ export const pageMessages = defineMessages({
   },
   placeNotFound: {
     id: "place_not_found",
-    defaultMessage: 'Place \\"{placeDcid}\\" not found.',
+    defaultMessage: 'Place "{placeDcid}" not found.',
     description:
       'Text to display on a 404 page when a place ID is not found. Example: "Place "dcid:geoId/04" not found.". Please leave the {placeDcid} variable unchanged in the resulting translation.',
   },

--- a/static/js/i18n/strings/en/place.json
+++ b/static/js/i18n/strings/en/place.json
@@ -116,7 +116,7 @@
     "description": "Link to explore the chart in a specific tool"
   },
   "explore_data_on": {
-    "defaultMessage": "Explore data on... \\\"{sampleQuestion}\\\"",
+    "defaultMessage": "Explore data on... \"{sampleQuestion}\"",
     "description": "Used for the dynamic placeholders in the search bar, gives an example of a query to type."
   },
   "header-overview": {
@@ -160,7 +160,7 @@
     "description": "Gives context for where this place is located. E.g. on the Tokyo place page, we say \"{City} in {Japan, Asia}\"."
   },
   "place_not_found": {
-    "defaultMessage": "Place \\\"{placeDcid}\\\" not found.",
+    "defaultMessage": "Place \"{placeDcid}\" not found.",
     "description": "Text to display on a 404 page when a place ID is not found. Example: \"Place \"dcid:geoId/04\" not found.\". Please leave the {placeDcid} variable unchanged in the resulting translation."
   },
   "place_page_ranking_table-ranking_in": {


### PR DESCRIPTION
Rollback of quote fix from https://github.com/datacommonsorg/website/pull/5035 - it was causing a literal "\\" to show up in the page. 