### PR TITLE
[Dynamic Placeholder] Improve Google Analytics for dynamic placeholders

### DIFF
--- a/static/js/apps/base/components/header_bar/header_bar_search.tsx
+++ b/static/js/apps/base/components/header_bar/header_bar_search.tsx
@@ -82,7 +82,7 @@ const HeaderBarSearch = ({
     showDynamicPlaceholdersBase && !isMobileByWidth(theme);
 
   useEffect(() => {
-      triggerGAEvent(GA_EVENT_RENDER_NL_SEARCH_BAR, {});
+    triggerGAEvent(GA_EVENT_RENDER_NL_SEARCH_BAR, {});
   }, []);
 
   return (
@@ -94,7 +94,9 @@ const HeaderBarSearch = ({
           if (searchBarHashMode) {
             triggerGAEvent(GA_EVENT_NL_SEARCH, {
               [GA_PARAM_QUERY]: q,
-              [GA_PARAM_DYNAMIC_PLACEHOLDER]: String(dynamicPlaceholdersEnabled),
+              [GA_PARAM_DYNAMIC_PLACEHOLDER]: String(
+                dynamicPlaceholdersEnabled
+              ),
               [GA_PARAM_SOURCE]:
                 gaValueSearchSource ?? GA_VALUE_SEARCH_SOURCE_HOMEPAGE,
             });
@@ -107,7 +109,9 @@ const HeaderBarSearch = ({
           } else {
             triggerGAEvent(GA_EVENT_NL_SEARCH, {
               [GA_PARAM_QUERY]: q,
-              [GA_PARAM_DYNAMIC_PLACEHOLDER]: String(dynamicPlaceholdersEnabled),
+              [GA_PARAM_DYNAMIC_PLACEHOLDER]: String(
+                dynamicPlaceholdersEnabled
+              ),
               [GA_PARAM_SOURCE]:
                 gaValueSearchSource ?? GA_VALUE_SEARCH_SOURCE_HOMEPAGE,
             });

--- a/static/js/apps/base/components/header_bar/header_bar_search.tsx
+++ b/static/js/apps/base/components/header_bar/header_bar_search.tsx
@@ -90,11 +90,11 @@ const HeaderBarSearch = ({
       <NlSearchBar
         variant="header-inline"
         inputId={inputId}
-        onSearch={(q): void => {
+        onSearch={(q, dynamicPlaceholdersEnabled): void => {
           if (searchBarHashMode) {
             triggerGAEvent(GA_EVENT_NL_SEARCH, {
               [GA_PARAM_QUERY]: q,
-              [GA_PARAM_DYNAMIC_PLACEHOLDER]: String(showDynamicPlaceholders),
+              [GA_PARAM_DYNAMIC_PLACEHOLDER]: String(dynamicPlaceholdersEnabled),
               [GA_PARAM_SOURCE]:
                 gaValueSearchSource ?? GA_VALUE_SEARCH_SOURCE_HOMEPAGE,
             });
@@ -107,7 +107,7 @@ const HeaderBarSearch = ({
           } else {
             triggerGAEvent(GA_EVENT_NL_SEARCH, {
               [GA_PARAM_QUERY]: q,
-              [GA_PARAM_DYNAMIC_PLACEHOLDER]: String(showDynamicPlaceholders),
+              [GA_PARAM_DYNAMIC_PLACEHOLDER]: String(dynamicPlaceholdersEnabled),
               [GA_PARAM_SOURCE]:
                 gaValueSearchSource ?? GA_VALUE_SEARCH_SOURCE_HOMEPAGE,
             });

--- a/static/js/apps/base/components/header_bar/header_bar_search.tsx
+++ b/static/js/apps/base/components/header_bar/header_bar_search.tsx
@@ -17,7 +17,7 @@
 /* A wrapping component to render the header bar version of the search */
 
 import { useTheme } from "@emotion/react";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 
 import { NlSearchBar } from "../../../../components/nl_search_bar";
 import {
@@ -80,9 +80,10 @@ const HeaderBarSearch = ({
   const theme: Theme = useTheme();
   const showDynamicPlaceholders =
     showDynamicPlaceholdersBase && !isMobileByWidth(theme);
-  triggerGAEvent(GA_EVENT_RENDER_NL_SEARCH_BAR, {
-    [GA_PARAM_DYNAMIC_PLACEHOLDER]: String(showDynamicPlaceholders),
-  });
+
+  useEffect(() => {
+      triggerGAEvent(GA_EVENT_RENDER_NL_SEARCH_BAR, {});
+  }, []);
 
   return (
     <div className="header-search">

--- a/static/js/components/nl_search_bar.tsx
+++ b/static/js/components/nl_search_bar.tsx
@@ -27,7 +27,7 @@ interface NlSearchBarPropType {
   variant?: "standard" | "header-inline";
   allowEmptySearch?: boolean;
   inputId: string;
-  onSearch: (q: string) => void;
+  onSearch: (q: string, dynamicPlaceholdersEnabled: boolean) => void;
   initialValue: string;
   placeholder?: string;
   shouldAutoFocus?: boolean;
@@ -46,7 +46,7 @@ export interface NlSearchBarImplementationProps {
   //the change event (used to trigger appropriate state changes in this parent)
   onChange: (newValue: string) => void;
   //a function to be called once a search is run
-  onSearch: () => void;
+  onSearch: (dynamicPlaceholdersEnabled) => void;
   //the autofocus attribute of the input will be set to shouldAutoFocus
   shouldAutoFocus?: boolean;
   //an optional feedback link
@@ -63,13 +63,13 @@ export function NlSearchBar(props: NlSearchBarPropType): ReactElement {
     setInvalid(false);
   }, [props.initialValue]);
 
-  function handleSearch(): void {
+  function handleSearch(dynamicPlaceholdersEnabled: boolean): void {
     if (!props.allowEmptySearch && !value) {
       setInvalid(true);
       return;
     }
 
-    props.onSearch(value);
+    props.onSearch(value, dynamicPlaceholdersEnabled);
   }
 
   const commonProps: NlSearchBarImplementationProps = {

--- a/static/js/components/nl_search_bar.tsx
+++ b/static/js/components/nl_search_bar.tsx
@@ -46,7 +46,7 @@ export interface NlSearchBarImplementationProps {
   //the change event (used to trigger appropriate state changes in this parent)
   onChange: (newValue: string) => void;
   //a function to be called once a search is run
-  onSearch: (dynamicPlaceholdersEnabled) => void;
+  onSearch: (dynamicPlaceholdersEnabled: boolean) => void;
   //the autofocus attribute of the input will be set to shouldAutoFocus
   shouldAutoFocus?: boolean;
   //an optional feedback link

--- a/static/js/components/nl_search_bar/auto_complete_input.tsx
+++ b/static/js/components/nl_search_bar/auto_complete_input.tsx
@@ -125,7 +125,7 @@ export function AutoCompleteInput(
     lang = urlParams.has("hl") ? urlParams.get("hl") : "en";
 
     // Start cycling through sample questions when the component mounts.
-    if (props.enableDynamicPlaceholders) {
+    if (!inputText && props.enableDynamicPlaceholders) {
       enableDynamicPlacehoder(
         setSampleQuestionText,
         setDynamicPlaceholdersEnabled

--- a/static/js/components/nl_search_bar/auto_complete_input.tsx
+++ b/static/js/components/nl_search_bar/auto_complete_input.tsx
@@ -99,9 +99,9 @@ export function AutoCompleteInput(
   const [hoveredIdx, setHoveredIdx] = useState(-1);
   const [triggerSearch, setTriggerSearch] = useState("");
   const [inputActive, setInputActive] = useState(false);
-  const [dynamicPlaceholdersDone, setDynamicPlaceholdersDone] =
+  const [dynamicPlaceholdersDone, setDynamicPlaceholdersDone] = useState(false);
+  const [dynamicPlaceholdersEnabled, setDynamicPlaceholdersEnabled] =
     useState(false);
-  const [dynamicPlaceholdersEnabled, setDynamicPlaceholdersEnabled] = useState(false);
   const [sampleQuestionText, setSampleQuestionText] = useState("");
   const [lastAutoCompleteSelection, setLastAutoCompleteSelection] =
     useState("");

--- a/static/js/components/nl_search_bar/auto_complete_input.tsx
+++ b/static/js/components/nl_search_bar/auto_complete_input.tsx
@@ -69,7 +69,7 @@ interface AutoCompleteInputPropType {
   invalid: boolean;
   inputId: string;
   onChange: (query: string) => void;
-  onSearch: () => void;
+  onSearch: (dynamicPlaceholdersEnabled: boolean) => void;
   feedbackLink: string;
   shouldAutoFocus: boolean;
   barType: string;
@@ -99,8 +99,9 @@ export function AutoCompleteInput(
   const [hoveredIdx, setHoveredIdx] = useState(-1);
   const [triggerSearch, setTriggerSearch] = useState("");
   const [inputActive, setInputActive] = useState(false);
-  const [dynamicPlaceholdersEnabled, setDynamicPlaceholdersEnabled] =
+  const [dynamicPlaceholdersDone, setDynamicPlaceholdersDone] =
     useState(false);
+  const [dynamicPlaceholdersEnabled, setDynamicPlaceholdersEnabled] = useState(false);
   const [sampleQuestionText, setSampleQuestionText] = useState("");
   const [lastAutoCompleteSelection, setLastAutoCompleteSelection] =
     useState("");
@@ -128,13 +129,14 @@ export function AutoCompleteInput(
     if (!inputText && props.enableDynamicPlaceholders) {
       enableDynamicPlacehoder(
         setSampleQuestionText,
-        setDynamicPlaceholdersEnabled
+        setDynamicPlaceholdersEnabled,
+        setDynamicPlaceholdersDone
       );
     }
   }, []);
 
   const placeholderText =
-    !inputActive && dynamicPlaceholdersEnabled
+    !inputActive && dynamicPlaceholdersEnabled && !dynamicPlaceholdersDone
       ? intl.formatMessage(placeholderMessages.exploreDataPlaceholder, {
           sampleQuestion: sampleQuestionText,
         })
@@ -182,7 +184,7 @@ export function AutoCompleteInput(
     setResults({ placeResults: [], svResults: [] });
     setHoveredIdx(-1);
     controller.current.abort(); // Ensure autocomplete responses can't come back.
-    props.onSearch();
+    props.onSearch(dynamicPlaceholdersEnabled);
   }
 
   function onInputChange(e: React.ChangeEvent<HTMLInputElement>): void {

--- a/static/js/components/nl_search_bar/dynamic_placeholder_helper.ts
+++ b/static/js/components/nl_search_bar/dynamic_placeholder_helper.ts
@@ -19,6 +19,10 @@
  */
 import { SetStateAction } from "react";
 import { defineMessages } from "react-intl";
+import {
+  GA_EVENT_RENDER_NL_SEARCH_BAR_WITH_PLACEHOLDERS,
+  triggerGAEvent,
+} from "../../shared/ga_events";
 
 const TYPING_SPEED = 50; // milliseconds per character
 const TYPING_SPEED_DELETE = 30; // milliseconds per character
@@ -39,6 +43,7 @@ export const enableDynamicPlacehoder = (
   setSampleQuestionText: (arg0: SetStateAction<string>) => void,
   setDynamicPlaceholdersEnabled: (arg0: SetStateAction<boolean>) => void
 ): void => {
+  triggerGAEvent(GA_EVENT_RENDER_NL_SEARCH_BAR_WITH_PLACEHOLDERS, {});
   const sampleQuestions = loadSampleQuestions();
   if (sampleQuestions.length == 0) {
     return;

--- a/static/js/components/nl_search_bar/dynamic_placeholder_helper.ts
+++ b/static/js/components/nl_search_bar/dynamic_placeholder_helper.ts
@@ -19,6 +19,7 @@
  */
 import { SetStateAction } from "react";
 import { defineMessages } from "react-intl";
+
 import {
   GA_EVENT_RENDER_NL_SEARCH_BAR_WITH_PLACEHOLDERS,
   triggerGAEvent,

--- a/static/js/components/nl_search_bar/dynamic_placeholder_helper.ts
+++ b/static/js/components/nl_search_bar/dynamic_placeholder_helper.ts
@@ -41,7 +41,8 @@ export const placeholderMessages = defineMessages({
 
 export const enableDynamicPlacehoder = (
   setSampleQuestionText: (arg0: SetStateAction<string>) => void,
-  setDynamicPlaceholdersEnabled: (arg0: SetStateAction<boolean>) => void
+  setDynamicPlaceholdersEnabled: (arg0: SetStateAction<boolean>) => void,
+  setDynamicPlaceholdersDone: (arg0: SetStateAction<boolean>) => void
 ): void => {
   triggerGAEvent(GA_EVENT_RENDER_NL_SEARCH_BAR_WITH_PLACEHOLDERS, {});
   const sampleQuestions = loadSampleQuestions();
@@ -56,12 +57,13 @@ export const enableDynamicPlacehoder = (
   // Add a 0.5-second delay before starting the cycle
   const timerId = setTimeout(() => {
     setDynamicPlaceholdersEnabled(true);
+    setDynamicPlaceholdersDone(false);
     cycleSampleQuestions(
       sampleQuestions,
       sampleQuestionStartIndex,
       0,
       setSampleQuestionText,
-      setDynamicPlaceholdersEnabled
+      setDynamicPlaceholdersDone
     );
   }, 800);
 
@@ -101,11 +103,11 @@ export const cycleSampleQuestions = (
   index: number,
   questionCount: number,
   setSampleQuestionText: (arg0: SetStateAction<string>) => void,
-  setDynamicPlaceholdersEnabled: (arg0: SetStateAction<boolean>) => void
+  setDynamicPlaceholdersDone: (arg0: SetStateAction<boolean>) => void
 ): void => {
   if (questionCount == sampleQuestions.length) {
     setSampleQuestionText("");
-    setDynamicPlaceholdersEnabled(false);
+    setDynamicPlaceholdersDone(true);
     return;
   }
 
@@ -129,7 +131,7 @@ export const cycleSampleQuestions = (
               nextQuestionIndex,
               questionCount + 1,
               setSampleQuestionText,
-              setDynamicPlaceholdersEnabled
+              setDynamicPlaceholdersDone
             );
           }
         };

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -107,7 +107,8 @@ export const GA_EVENT_RENDER_NL_SEARCH_BAR = "nl_search_bar_render";
 /**
  * Triggered when the NL Search bar is rendered with dynamic placeholders enabled.
  */
-export const GA_EVENT_RENDER_NL_SEARCH_BAR_WITH_PLACEHOLDERS = "nl_search_bar_render_with_placeholders";
+export const GA_EVENT_RENDER_NL_SEARCH_BAR_WITH_PLACEHOLDERS =
+  "nl_search_bar_render_with_placeholders";
 
 /**
  * Triggered when detection results are returned in NL search.

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -105,6 +105,11 @@ export const GA_EVENT_NL_SEARCH = "explore_search_q";
 export const GA_EVENT_RENDER_NL_SEARCH_BAR = "nl_search_bar_render";
 
 /**
+ * Triggered when the NL Search bar is rendered with dynamic placeholders enabled.
+ */
+export const GA_EVENT_RENDER_NL_SEARCH_BAR_WITH_PLACEHOLDERS = "nl_search_bar_render_with_placeholders";
+
+/**
  * Triggered when detection results are returned in NL search.
  * Parameters:
  *   "query": search query


### PR DESCRIPTION
Make a new event for rendering the search bar with dynamic placeholders since the text value matters on whether it's enabled.

This way we can actually compare the # of events for the search bar being rendered , and the number of events being rendered with dynamic placeholders. And we can compare that ratio to the number of explore_search_q events.

This also propagates whether the dynamic placeholders are enabled all the way to the onSearch trigger such that we don't miscount when the placeholder is hidden due to the query. 