### PR TITLE
Increase website container memory from 3G to 4G

### DIFF
--- a/deploy/helm_charts/dc_website/templates/deployment.yaml
+++ b/deploy/helm_charts/dc_website/templates/deployment.yaml
@@ -100,9 +100,9 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              memory: "3G"
+              memory: "4G"
             requests:
-              memory: "3G"
+              memory: "4G"
           volumeMounts:
             - name: ingress-config
               mountPath: /datacommons/ingress


### PR DESCRIPTION
Verified that autopush and prod node pools have enough memory to support this increase. 