### PR TITLE
Disable web crawlers (GoogleBot) on dev

### DIFF
--- a/server/app_env/_base.py
+++ b/server/app_env/_base.py
@@ -98,3 +98,5 @@ class Config:
   # Whether to enable BigQuery for instance. This is primarily used for
   # accessing the observation browser pages.
   ENABLE_BQ = False
+  # Whether to block all crawlers like GoogleBot from access to entire site
+  DISABLE_CRAWLERS = False

--- a/server/app_env/dev.py
+++ b/server/app_env/dev.py
@@ -24,3 +24,4 @@ class Config(_base.Config):
   HIDE_DEBUG = False
   USE_MEMCACHE = False
   ENABLE_BQ = True
+  DISABLE_CRAWLERS = True

--- a/server/routes/static.py
+++ b/server/routes/static.py
@@ -21,10 +21,12 @@ from flask import Blueprint
 from flask import current_app
 from flask import redirect
 from flask import render_template
-from flask import send_from_directory
 from flask import request
+from flask import send_from_directory
 
+from server.lib.cache import cache
 import server.lib.render as lib_render
+from server.routes import TIMEOUT
 from server.services import datacommons as dc
 
 bp = Blueprint('static', __name__)
@@ -119,6 +121,7 @@ def version():
 
 
 @bp.route('/robots.txt')
+@cache.cached(timeout=TIMEOUT)
 def robots_config():
   if current_app.config.get('DISABLE_CRAWLERS', False):
     return "User-agent: *<br>Disallow: /"

--- a/server/routes/static.py
+++ b/server/routes/static.py
@@ -22,6 +22,7 @@ from flask import current_app
 from flask import redirect
 from flask import render_template
 from flask import request
+from flask import Response
 from flask import send_from_directory
 
 from server.lib.cache import cache
@@ -124,6 +125,6 @@ def version():
 @cache.cached(timeout=TIMEOUT)
 def robots_config():
   if current_app.config.get('DISABLE_CRAWLERS', False):
-    return "User-agent: *<br>Disallow: /"
+    return Response("User-agent: *\nDisallow: /", mimetype="text/plain")
   else:
     return send_from_directory("dist", "robots.txt")

--- a/server/routes/static.py
+++ b/server/routes/static.py
@@ -21,6 +21,7 @@ from flask import Blueprint
 from flask import current_app
 from flask import redirect
 from flask import render_template
+from flask import send_from_directory
 from flask import request
 
 import server.lib.render as lib_render
@@ -115,3 +116,11 @@ def version():
       bigquery=mixer_version.get('bigquery', ''),
       featureFlags=current_app.config.get('FEATURE_FLAGS', []),
       remote_mixer_domain=mixer_version.get('remoteMixerDomain', ''))
+
+
+@bp.route('/robots.txt')
+def robots_config():
+  if current_app.config.get('DISABLE_CRAWLERS', False):
+    return "User-agent: *<br>Disallow: /"
+  else:
+    return send_from_directory("dist", "robots.txt")


### PR DESCRIPTION
Adds a new config variable (DISABLE_CRAWLERS) which disables all crawlers access to content within the entire site. 
This is set to False by default in the Base Config and only set to True for the Dev Config.

Screenshots of robots.txt when running locally: 

DISABLE_CRAWLERS == False: 
![image](https://github.com/user-attachments/assets/0271ebce-3941-4a0a-91fd-9aa9d2c0c22c)

DISABLE_CRAWLERS == True:
![image](https://github.com/user-attachments/assets/3dd6dac0-40f7-4541-8a74-f9f3f6783a72)
