### PR TITLE
Fixed bug where place page header link was keeping the category param instead of redirecting to the overview page

### DIFF
--- a/server/webdriver/tests/place_explorer_test.py
+++ b/server/webdriver/tests/place_explorer_test.py
@@ -98,6 +98,20 @@ class TestPlaceExplorer(PlaceExplorerTestMixin, BaseDcWebdriverTest):
         len(find_elems(map_geo_regions, by=By.TAG_NAME, value='path')),
         238)  # country count.
 
+  def test_dev_place_overview_world_redirect(self):
+    """Ensure click on place link from the demographics page redirects to the overview page"""
+    self.driver.get(self.url_ + '/place/Earth?category=Demographics')
+
+    # Click the place link and verify it takes us to the overview page
+    place_link = find_elem(self.driver,
+                           by=By.CSS_SELECTOR,
+                           value='.place-info-link')
+    place_link.click()
+
+    # Wait for URL change and page load
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
+        EC.url_to_be(self.url_ + '/place/Earth'))
+
   def test_dev_place_overview_california(self):
     """Ensure experimental dev place page content loads"""
     self.driver.get(self.url_ + '/place/geoId/06?force_dev_places=true')

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -73,6 +73,12 @@ const PlaceHeader = (props: {
     );
   });
 
+  const placeHref = createPlacePageCategoryHref(
+    "Overview",
+    forceDevPlaces,
+    place
+  );
+
   return (
     <div className="title-section">
       <div className="place-info">
@@ -81,11 +87,9 @@ const PlaceHeader = (props: {
             {selectedCategory.name === "Overview" ? (
               place.name
             ) : (
-              <LocalizedLink
-                className="place-info-link"
-                href={`/place/${place.dcid}`}
-                text={place.name}
-              />
+              <a className="place-info-link" href={placeHref}>
+                {place.name}
+              </a>
             )}
             {selectedCategory.name != "Overview"
               ? ` • ${selectedCategory.translatedName}`

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -73,12 +73,6 @@ const PlaceHeader = (props: {
     );
   });
 
-  const placeHref = createPlacePageCategoryHref(
-    selectedCategory.name,
-    forceDevPlaces,
-    place
-  );
-
   return (
     <div className="title-section">
       <div className="place-info">
@@ -87,9 +81,11 @@ const PlaceHeader = (props: {
             {selectedCategory.name === "Overview" ? (
               place.name
             ) : (
-              <a className="place-info-link" href={placeHref}>
-                {place.name}
-              </a>
+              <LocalizedLink
+                className="place-info-link"
+                href={`/place/${place.dcid}`}
+                text={place.name}
+              />
             )}
             {selectedCategory.name != "Overview"
               ? ` • ${selectedCategory.translatedName}`


### PR DESCRIPTION
Screenshot fixes this:

![place-header](https://github.com/user-attachments/assets/8645bfe9-c10e-4051-bc44-333276f5abae)
