### PR TITLE
Fixed issue where places with no 'name' attribute were showing a generic 'no data found' issue

### DIFF
--- a/server/webdriver/shared_tests/place_explorer_test.py
+++ b/server/webdriver/shared_tests/place_explorer_test.py
@@ -23,6 +23,7 @@ MTV_URL = '/place/geoId/0649670'
 USA_URL = '/place/country/USA'
 CA_URL = '/place/geoId/06'
 PLACE_SEARCH = 'California, USA'
+NO_DATA_NEIGHBORHOOD_URL = '/place/wikidataId/Q995366'
 
 
 def element_has_text(driver, locator):
@@ -325,3 +326,18 @@ class PlaceExplorerTestMixin():
     entity_dcid_present = EC.text_to_be_present_in_element(
         (By.CLASS_NAME, "copy-svg"), "Entity DCID")
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(entity_dcid_present)
+
+  def test_neighborhood_no_data(self):
+    """Test that neighborhood place page shows correct type and no data message."""
+    # Load neighborhood page
+    self.driver.get(self.url_ + NO_DATA_NEIGHBORHOOD_URL)
+
+    # Wait for subheader to load and contain "Neighborhood in"
+    subheader_present = EC.text_to_be_present_in_element(
+        (By.CLASS_NAME, 'subheader'), 'Neighborhood in')
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(subheader_present)
+
+    # Wait for no data message to appear
+    no_data_present = EC.text_to_be_present_in_element(
+        (By.CLASS_NAME, 'page-content-container'), 'No data found for')
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(no_data_present)

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -24,6 +24,7 @@ import { ThemeProvider } from "@emotion/react";
 import React, { useEffect, useState } from "react";
 import { RawIntlProvider } from "react-intl";
 
+import styled from "@emotion/styled";
 import { Loading } from "../components/elements/loading";
 import { ScrollToTopButton } from "../components/elements/scroll_to_top_button";
 import { SubjectPageMainPane } from "../components/subject_page/main_pane";
@@ -40,6 +41,11 @@ import {
   displayNameForPlaceType,
   placeChartsApiResponsesToPageConfig,
 } from "./util";
+
+const PlaceWarning = styled.div`
+  padding: 24px;
+  font-size: ${(p) => p.theme.typography.text.md};
+`;
 
 /**
  * Component that renders the header section of a place page.
@@ -338,15 +344,15 @@ export const DevPlaceMain = (): React.JSX.Element => {
       console.error("Error loading place page metadata element");
       return;
     }
-    if (
-      pageMetadata.dataset.placeDcid != "" &&
-      pageMetadata.dataset.placeName === ""
-    ) {
+    if (pageMetadata.dataset.placeDcid == "") {
       console.error("Error loading place page metadata element");
       setHasError(true);
     }
+    // Get place name from page metadata. Use placeDcid if placeName is not set.
+    const placeName =
+      pageMetadata.dataset.placeName || pageMetadata.dataset.placeDcid;
     setPlace({
-      name: pageMetadata.dataset.placeName,
+      name: placeName,
       dcid: pageMetadata.dataset.placeDcid,
       types: [],
     });
@@ -487,12 +493,12 @@ export const DevPlaceMain = (): React.JSX.Element => {
           />
         )}
         {hasNoCharts && (
-          <div>
+          <PlaceWarning>
             {intl.formatMessage(pageMessages.noCharts, {
               category: selectedCategory.translatedName,
               place: place.name,
             })}
-          </div>
+          </PlaceWarning>
         )}
         {isOverview && childPlaces.length > 0 && (
           <RelatedPlaces place={place} childPlaces={childPlaces} />


### PR DESCRIPTION
Before:

![err-before](https://github.com/user-attachments/assets/ab0ac572-e4b1-4e1b-800f-2481017488b3)

After:
![err-after](https://github.com/user-attachments/assets/6f476c1a-ff72-4ea1-9efc-ff1ef1038ba4)



