### PR TITLE
Updated legacy place page test to account for new wikidata updata

### DIFF
--- a/server/webdriver/shared_tests/place_explorer_i18n_test.py
+++ b/server/webdriver/shared_tests/place_explorer_i18n_test.py
@@ -62,9 +62,6 @@ class PlaceI18nExplorerTestMixin():
     aa_children_label = self.driver.find_element(
         By.XPATH, '//*[@id="child-place"]/div/div')
     self.assertEqual(aa_children_label.text, '行政区域 1 の地域')
-    aichi_prefecture = self.driver.find_element(
-        By.XPATH, '//*[@id="child-place"]/div/a[1]')
-    self.assertEqual(aichi_prefecture.text, '三重県,')
 
     # Test that timeline links are removed
     self.assertListEqual(


### PR DESCRIPTION
Legacy place page test fix for a data update. I removed the check since we'll be deprecating the legacy place page soon.
 
Before data update (prod):  https://screenshot.googleplex.com/A6q3L72gcK9UpBZ

After data update (autopush): https://screenshot.googleplex.com/8KTCBm57pqemY2r

