### PR TITLE
Update model version used for llm fallback

### DIFF
--- a/server/lib/nl/detection/llm_api.py
+++ b/server/lib/nl/detection/llm_api.py
@@ -23,7 +23,7 @@ import requests
 
 from server.lib.nl.common import counters
 
-_GEMINI_PRO_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent"
+_GEMINI_PRO_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent"
 _API_HEADER = {'content-type': 'application/json'}
 
 # TODO: Consider tweaking this. And maybe consider passing as url param.


### PR DESCRIPTION
The llm api call started getting this error complaining about the model version we were trying to use: https://screenshot.googleplex.com/B9gXbaNpz2FqCuT