### PR TITLE
Refactor place page routes, various redirect fixes

### DIFF
--- a/server/config/base/footer.json
+++ b/server/config/base/footer.json
@@ -3,7 +3,7 @@
     "label": "Tools",
     "subMenu": [
       {
-        "href": "{place.place}",
+        "href": "{place.place_explorer}",
         "label": "Place Explorer"
       },
       {

--- a/server/config/base/header.json
+++ b/server/config/base/header.json
@@ -4,7 +4,7 @@
     "ariaLabel": "Show exploration tools",
     "subMenu": [
       {
-        "href": "{place.place}",
+        "href": "{place.place_explorer}",
         "label": "Place Explorer"
       },
       {

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -289,58 +289,9 @@ def is_dev_place_ga_enabled(request_args: MultiDict[str, str]) -> bool:
   ) and not request_args.get("disable_dev_places") == "true"
 
 
-@bp.route('', strict_slashes=False)
-@bp.route('/<path:place_dcid>')
-@cache.cached(query_string=True)
-def place(place_dcid=None):
-  if place_dcid is not None and is_dev_place_ga_enabled(flask.request.args):
-    place_category = flask.request.args.get('category', None)
-    return dev_place(place_dcid=place_dcid, place_category=place_category)
-  redirect_args = dict(flask.request.args)
-
-  # Strip trailing slashes from place dcids
-  should_redirect = False
-  if place_dcid and place_dcid.endswith('/'):
-    place_dcid = place_dcid.rstrip('/')
-    should_redirect = True
-
-  # Rename legacy "topic" request argument to "category"
-  if 'topic' in flask.request.args:
-    redirect_args['category'] = flask.request.args.get('topic', '')
-    del redirect_args['topic']
-    should_redirect = True
-
-  # Rename legacy category request arguments
-  category = redirect_args.get('category', None)
-  if category in CATEGORY_REDIRECTS:
-    redirect_args['category'] = CATEGORY_REDIRECTS[category]
-    should_redirect = True
-
-  if should_redirect:
-    redirect_args['place_dcid'] = place_dcid
-    return flask.redirect(flask.url_for('place.place', **redirect_args),
-                          code=301)
-
-  dcid = flask.request.args.get('dcid', None)
-  if dcid:
-    # Traffic from "explore more" in Search. Forward along all parameters,
-    # except for dcid, to the new URL format.
-    redirect_args = dict(flask.request.args)
-    redirect_args['place_dcid'] = dcid
-    del redirect_args['dcid']
-    redirect_args['category'] = category
-    url = flask.url_for('place.place',
-                        **redirect_args,
-                        _external=True,
-                        _scheme=current_app.config.get('SCHEME', 'https'))
-    return flask.redirect(url)
-
-  if not place_dcid:
-    return place_landing()
-
+def legacy_place(place_dcid: str, category: str):
+  """Render legacy place page"""
   place_type = place_api.api_place_type(place_dcid)
-  if not place_type:
-    return place_landing(error_msg=f'Place "{place_dcid}" not found')
 
   place_type_with_parent_places_links = get_place_type_with_parent_places_links(
       place_dcid)
@@ -434,26 +385,6 @@ def place(place_dcid=None):
   return response
 
 
-def place_landing(error_msg=''):
-  """Returns filled template for the place landing page."""
-  template_file = os.path.join('custom_dc', g.env, 'place_landing.html')
-  dcid_json = os.path.join('custom_dc', g.env, 'place_landing_dcids.json')
-  if not os.path.exists(
-      os.path.join(current_app.root_path, 'templates', template_file)):
-    template_file = 'place_landing.html'
-    dcid_json = 'place_landing_dcids.json'
-
-  with open(os.path.join(current_app.root_path, 'templates', dcid_json)) as f:
-    landing_dcids = json.load(f)
-    # Use display names (including state, if applicable) for the static page
-    place_names = place_api.get_display_name(landing_dcids)
-    return flask.render_template(
-        template_file,
-        error_msg=error_msg,
-        place_names=place_names,
-        maps_api_key=current_app.config['MAPS_API_KEY'])
-
-
 def get_canonical_links(place_dcid: str, place_category: str) -> List[str]:
   """Returns canonical and alternate language header links for the place page
 
@@ -514,8 +445,84 @@ def get_canonical_links(place_dcid: str, place_category: str) -> List[str]:
   return links
 
 
-# Dev place experiment route
-def dev_place(place_dcid=None, place_category=None):
+@bp.route('', strict_slashes=False)
+@cache.cached(query_string=True)
+def place_explorer():
+  """Renders the place explorer landing page.
+
+  Also handles redirects from Google Search to individual place pages if the
+  request includes a dcid.
+  """
+  dcid = flask.request.args.get('dcid', None)
+  if dcid:
+    # Handle redirects from Google Search using old URL format
+    # URLS from the search "Explore More" link look like:
+    # https://datacommons.org/place?utm_medium=explore&dcid=geoId/06&mprop=count&popt=Person&hl=en
+    # Forward along all parameters, except for dcid, to the new URL format.
+    redirect_args = dict(flask.request.args)
+    redirect_args['place_dcid'] = dcid
+    del redirect_args['dcid']
+    url = flask.url_for('place.place',
+                        **redirect_args,
+                        _external=True,
+                        _scheme=current_app.config.get('SCHEME', 'https'))
+    return flask.redirect(url)
+
+  # Otherwise, render the place explorer landing page
+  template_file = os.path.join('custom_dc', g.env, 'place_landing.html')
+  dcid_json = os.path.join('custom_dc', g.env, 'place_landing_dcids.json')
+  if not os.path.exists(
+      os.path.join(current_app.root_path, 'templates', template_file)):
+    template_file = 'place_landing.html'
+    dcid_json = 'place_landing_dcids.json'
+
+  with open(os.path.join(current_app.root_path, 'templates', dcid_json)) as f:
+    landing_dcids = json.load(f)
+    # Use display names (including state, if applicable) for the static page
+    place_names = place_api.get_display_name(landing_dcids)
+    return flask.render_template(
+        template_file,
+        place_names=place_names,
+        maps_api_key=current_app.config['MAPS_API_KEY'])
+
+
+@bp.route('/<path:place_dcid>', strict_slashes=False)
+@cache.cached(query_string=True)
+def place(place_dcid):
+  """
+  Renders place page with the given DCID.
+
+  Args:
+    place_dcid: DCID of the place to redirect to
+  """
+  redirect_args = dict(flask.request.args)
+  # Strip trailing slashes from place dcids
+  should_redirect = False
+  if place_dcid and place_dcid.endswith('/'):
+    place_dcid = place_dcid.rstrip('/')
+    should_redirect = True
+
+  # Rename legacy "topic" request argument to "category"
+  if 'topic' in flask.request.args:
+    redirect_args['category'] = flask.request.args.get('topic', '')
+    del redirect_args['topic']
+    should_redirect = True
+
+  # Rename legacy category request arguments
+  category = redirect_args.get('category', None)
+  if category in CATEGORY_REDIRECTS:
+    redirect_args['category'] = CATEGORY_REDIRECTS[category]
+    should_redirect = True
+
+  if should_redirect:
+    redirect_args['place_dcid'] = place_dcid
+    return flask.redirect(flask.url_for('place.place', **redirect_args),
+                          code=301)
+
+  # Render legacy place page if dev place ga is not enabled
+  if not is_dev_place_ga_enabled(flask.request.args):
+    return legacy_place(place_dcid=place_dcid, category=category)
+
   place_names = place_api.get_i18n_name([place_dcid]) or {}
   place_name = place_names.get(place_dcid, place_dcid)
   # Place summaries are currently only supported in English
@@ -525,7 +532,7 @@ def dev_place(place_dcid=None, place_category=None):
   else:
     place_summary = ""
 
-  canonical_links = get_canonical_links(place_dcid, place_category)
+  canonical_links = get_canonical_links(place_dcid, category)
   return flask.render_template('dev_place.html',
                                canonical_links=canonical_links,
                                maps_api_key=current_app.config['MAPS_API_KEY'],

--- a/server/routes/place/html.py
+++ b/server/routes/place/html.py
@@ -306,9 +306,6 @@ def legacy_place(place_dcid: str, category: str):
   if locale not in AVAILABLE_LANGUAGES:
     locale = 'en'
 
-  if category not in CATEGORIES:
-    category = None
-
   is_overview = (not category) or (category == 'Overview')
 
   place_summary = {}
@@ -513,6 +510,10 @@ def place(place_dcid):
   if category in CATEGORY_REDIRECTS:
     redirect_args['category'] = CATEGORY_REDIRECTS[category]
     should_redirect = True
+  elif category is not None and category not in CATEGORIES:
+    # Redirect to the overview page if the category is invalid
+    redirect_args['category'] = None
+    should_redirect = True
 
   if should_redirect:
     redirect_args['place_dcid'] = place_dcid
@@ -535,6 +536,7 @@ def place(place_dcid):
   canonical_links = get_canonical_links(place_dcid, category)
   return flask.render_template('dev_place.html',
                                canonical_links=canonical_links,
+                               category=category,
                                maps_api_key=current_app.config['MAPS_API_KEY'],
                                place_dcid=place_dcid,
                                place_name=place_name,

--- a/server/templates/custom_dc/stanford/base.html
+++ b/server/templates/custom_dc/stanford/base.html
@@ -98,7 +98,7 @@
                 </a>
                 <div class="dropdown-menu" aria-labelledby="nav-explore-dropdown">
                   <a class="dropdown-item" href="{{ url_for('disasters.disaster_dashboard') }}">Natural Disaster Dashboard</a>
-                  <a class="dropdown-item" href="{{ url_for('place.place') }}">{% trans %}Place Explorer{% endtrans
+                  <a class="dropdown-item" href="{{ url_for('place.place_explorer') }}">{% trans %}Place Explorer{% endtrans
                     %}</a>
                   <a class="dropdown-item" href="{{ url_for('browser.browser_main') }}">{% trans %}Knowledge Graph{%
                     endtrans %}</a>
@@ -171,7 +171,7 @@
             {# TRANSLATORS: The label for a collection of exploration tools. #}
             <h6>{% trans %}Explore{% endtrans %}</h6>
             {# TRANSLATORS: The name of a tool to browse statistics about a place. #}
-            <a href="{{ url_for('place.place') }}">{% trans %}Place Explorer{% endtrans %}</a>
+            <a href="{{ url_for('place.place_explorer') }}">{% trans %}Place Explorer{% endtrans %}</a>
             {# TRANSLATORS: The name of a tool to browse the Data Commons knowledge graph. #}
             <a href="{{ url_for('browser.browser_main') }}">{% trans %}Knowledge Graph{% endtrans %}</a>
             {# TRANSLATORS: The name of a tool to explore timeline charts of statistical variables for places. #}

--- a/server/templates/dev_place.html
+++ b/server/templates/dev_place.html
@@ -23,7 +23,7 @@
     {% set title = place_name %}
     {% set description = _('Statistics about economics, health, equity, crime, education, demographics, housing, and environment in {place_name}.'.format(place_name=place_name)) %}
   {% else %}
-    {% set title = place_name + ' - ' + _(category) %}
+    {% set title = place_name + ' - ' + _('CHART_TITLE-CHART_CATEGORY-{category}'.format(category=category)) %}
     {% set description = _('Statistics about {category} in {place_name}.'.format(category=category, place_name=place_name)) %}
   {% endif %}
   {% set place_category = category %}

--- a/server/templates/dev_place.html
+++ b/server/templates/dev_place.html
@@ -19,17 +19,17 @@
   
   {% set main_id = 'dc-places' %}
   {% set page_id = 'page-dc-places' %}
-  {% if category == '' %}
-    {% set title = place_name + ' ' +  _('Statistics') %}
+  {% if category == None %}
+    {% set title = place_name %}
     {% set description = _('Statistics about economics, health, equity, crime, education, demographics, housing, and environment in {place_name}.'.format(place_name=place_name)) %}
   {% else %}
-    {% set title = place_name + ' ' + _(category) %}
+    {% set title = place_name + ' - ' + _(category) %}
     {% set description = _('Statistics about {category} in {place_name}.'.format(category=category, place_name=place_name)) %}
   {% endif %}
   {% set place_category = category %}
   {% set is_show_header_search_bar = true %}
   {% set new_place_page = true %}
-  
+
   {% block head %}
     {%- for link in canonical_links %}
       {{ link|safe }}

--- a/server/templates/metadata/routes.html
+++ b/server/templates/metadata/routes.html
@@ -25,7 +25,7 @@ limitations under the License.
 
 {% set routes = [
   'static.homepage',
-  'place.place',
+  'place.place_explorer',
   'browser.browser_main',
   'tools.visualization',
   'tools.stat_var',

--- a/server/templates/place_landing.html
+++ b/server/templates/place_landing.html
@@ -33,10 +33,6 @@
 
 {% block content %}
 <div id="body" class="container">
-  {%- if error_msg %}
-    <p class="mb-4">{{error_msg}}</p>
-  {% endif -%}
-
   <h1 class="mb-4">{% trans %}Place Explorer{% endtrans %}</h1>
 
   <div class="search border mb-4">

--- a/server/tests/routes/place_test.py
+++ b/server/tests/routes/place_test.py
@@ -322,3 +322,41 @@ class TestPlacePageHeaders(unittest.TestCase):
     # Test empty list returned for invalid category
     links = get_canonical_links('geoId/06', 'InvalidCategory')
     assert links == []
+
+
+class TestRedirectToPlacePage(unittest.TestCase):
+  """Tests for the redirect_to_place_page function."""
+
+  @patch('flask.url_for')
+  @patch('flask.redirect')
+  def test_redirect_to_place_page(self, mock_redirect, mock_url_for):
+    """Test that redirect_to_place_page properly formats the redirect URL."""
+    from werkzeug.datastructures import MultiDict
+
+    from server.routes.place.html import redirect_to_place_page
+
+    # Setup test data
+    dcid = 'geoId/06'
+    request_args = MultiDict([('dcid', 'geoId/06'), ('category', 'Health'),
+                              ('hl', 'en'), ('utm_medium', 'explore')])
+
+    # Mock url_for to return a specific URL
+    mock_url_for.return_value = '/place/geoId/06?category=Health&hl=en&utm_medium=explore'
+
+    # Need to run within app context
+    with app.app_context():
+      # Call the function
+      redirect_to_place_page(dcid, request_args)
+
+      # Verify url_for was called with correct arguments
+      mock_url_for.assert_called_once_with('place.place',
+                                           category='Health',
+                                           hl='en',
+                                           utm_medium='explore',
+                                           place_dcid='geoId/06',
+                                           _external=True,
+                                           _scheme='http')
+
+      # Verify redirect was called with the URL from url_for
+      mock_redirect.assert_called_once_with(
+          '/place/geoId/06?category=Health&hl=en&utm_medium=explore')

--- a/server/tests/routes/place_test.py
+++ b/server/tests/routes/place_test.py
@@ -69,7 +69,6 @@ class TestPlacePage(unittest.TestCase):
   @patch('server.routes.shared_api.place.parent_places')
   def test_place(self, mock_parent_places, mock_get_place_type_i18n_name,
                  mock_api_place_type, mock_get_i18n_name):
-    mock_feature_flags(app, ['dev_place_ga'], False)
     mock_parent_places.return_value = {
         'geoId/06': [{
             'dcid': 'country/USA',
@@ -137,6 +136,11 @@ class TestPlacePage(unittest.TestCase):
     assert response.status_code == 200
     assert b"<title>California - Environment" in response.data
 
+    response = app.test_client().get('/place/geoId/06/?category=InvalidCategory',
+                                     follow_redirects=True)
+    assert response.status_code == 200
+    assert b"<title>California - Data Commons" in response.data
+
     # TODO(beets): construct a better test that doesn't rely on prod.
     response = app.test_client().get('/explore/place?dcid=geoId/06',
                                      follow_redirects=False)
@@ -180,7 +184,7 @@ class TestPlacePageHeaders(unittest.TestCase):
         'Link')
 
     # Test "Overview" page gives canonical without query parameters
-    response = app.test_client().get('/place/geoId/06?category=Overview',
+    response = app.test_client().get('/place/geoId/06',
                                      follow_redirects=False)
     assert response.status_code == 200
     assert 'Link' in response.headers

--- a/server/tests/routes/place_test.py
+++ b/server/tests/routes/place_test.py
@@ -136,8 +136,8 @@ class TestPlacePage(unittest.TestCase):
     assert response.status_code == 200
     assert b"<title>California - Environment" in response.data
 
-    response = app.test_client().get('/place/geoId/06/?category=InvalidCategory',
-                                     follow_redirects=True)
+    response = app.test_client().get(
+        '/place/geoId/06/?category=InvalidCategory', follow_redirects=True)
     assert response.status_code == 200
     assert b"<title>California - Data Commons" in response.data
 
@@ -184,8 +184,7 @@ class TestPlacePageHeaders(unittest.TestCase):
         'Link')
 
     # Test "Overview" page gives canonical without query parameters
-    response = app.test_client().get('/place/geoId/06',
-                                     follow_redirects=False)
+    response = app.test_client().get('/place/geoId/06', follow_redirects=False)
     assert response.status_code == 200
     assert 'Link' in response.headers
     assert '<https://datacommons.org/place/geoId/06>; rel="canonical"' in response.headers.get(
@@ -225,7 +224,7 @@ class TestPlacePageHeaders(unittest.TestCase):
 
     # Test bad category input gives a canonical without category
     response = app.test_client().get('/place/geoId/06?category=foobar',
-                                     follow_redirects=False)
+                                     follow_redirects=True)
     assert response.status_code == 200
     assert 'Link' in response.headers
     assert '<https://datacommons.org/place/geoId/06>; rel="canonical"' in response.headers.get(
@@ -233,7 +232,7 @@ class TestPlacePageHeaders(unittest.TestCase):
 
     # Test bad locale input gives a canonical without locale
     response = app.test_client().get('/place/geoId/06?hl=foobar',
-                                     follow_redirects=False)
+                                     follow_redirects=True)
     assert response.status_code == 200
     assert 'Link' in response.headers
     assert '<https://datacommons.org/place/geoId/06>; rel="canonical"' in response.headers.get(

--- a/server/webdriver/shared_tests/place_explorer_i18n_test.py
+++ b/server/webdriver/shared_tests/place_explorer_i18n_test.py
@@ -138,3 +138,8 @@ class PlaceI18nExplorerTestMixin():
     # Assert localized page title is correct for the locale.
     WebDriverWait(self.driver,
                   self.TIMEOUT_SEC).until(EC.title_contains('États-Unis'))
+
+  def test_localized_place_page_title(self):
+    """Test localized place page title is correct for the locale."""
+    self.driver.get(self.url_ + '/place/country/USA?hl=ja&category=Demographics')
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(EC.title_contains('アメリカ合衆国 - 人口統計'))

--- a/server/webdriver/shared_tests/place_explorer_i18n_test.py
+++ b/server/webdriver/shared_tests/place_explorer_i18n_test.py
@@ -141,5 +141,7 @@ class PlaceI18nExplorerTestMixin():
 
   def test_localized_place_page_title(self):
     """Test localized place page title is correct for the locale."""
-    self.driver.get(self.url_ + '/place/country/USA?hl=ja&category=Demographics')
-    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(EC.title_contains('アメリカ合衆国 - 人口統計'))
+    self.driver.get(self.url_ +
+                    '/place/country/USA?hl=ja&category=Demographics')
+    WebDriverWait(self.driver,
+                  self.TIMEOUT_SEC).until(EC.title_contains('アメリカ合衆国 - 人口統計'))

--- a/server/webdriver/shared_tests/place_explorer_test.py
+++ b/server/webdriver/shared_tests/place_explorer_test.py
@@ -388,3 +388,21 @@ class PlaceExplorerTestMixin():
     no_data_present = EC.text_to_be_present_in_element(
         (By.CLASS_NAME, 'page-content-container'), 'No data found for')
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(no_data_present)
+
+  def test_place_category_placeholder(self):
+    """Test that the place category placeholder is correct."""
+    # Load CA housing page
+    ca_housing_url = CA_URL + "?category=Housing"
+    self.driver.get(self.url_ + ca_housing_url)
+
+    # Wait for search input to be present
+    search_input_present = EC.presence_of_element_located(
+        (By.ID, "query-search-input"))
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(search_input_present)
+
+    # Wait for placeholder text to update to expected value
+    def placeholder_has_text(driver):
+      element = driver.find_element(By.ID, "query-search-input")
+      return element.get_attribute("placeholder") == "Housing in California"
+
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(placeholder_has_text)

--- a/static/js/place/dev_place_main.tsx
+++ b/static/js/place/dev_place_main.tsx
@@ -408,7 +408,7 @@ export const DevPlaceMain = (): React.JSX.Element => {
           setStorePlaceholderString(
             intl.formatMessage(pageMessages.categoryInPlace, {
               placeName: pageMetadata.dataset.placeName,
-              category: selectedCategory.translatedName,
+              category: newSelectedCategory.translatedName,
             })
           );
         }


### PR DESCRIPTION
- Added a new route to handle the place explorer landing page and google search redirects
- Updated logic flow handle new place page rendering first, and legacy place page by exception
- Added redirect handling to new place page to:
  - strip trailing slashes (`/place/Earth/` redirects to `/place/Earth`)
  - redirect legacy categories to new categories (`?category=Climate` redirects to `?category=Environment`)
  - to redirect legacy 'topic' param to use new 'category' param (we still get quite a bit of traffic using the legacy `topic=` param in prod - @beets any idea why?)
  - Strip out invalid `category=abcdefg` params and redirect to the overview page
- Updated place_test.py redirect test case to use the new dev place page
- Fixed issue where place page "category" wasn't showing up in the title. Now the title reads:
  - `/place/country/USA?category=Demographics`: `<title>アメリカ合衆国 - 人口統計 - Data Commons</title>`
  - `/place/country/USA?hl=ja&category=Demographics`: `<title>United States of America - Demographics - Data Commons</title>`