### PR TITLE
[Attribution] Re-adds ability to inject chart to highlight, with the query fix. 

### DIFF
--- a/packages/client/src/data_commons_client.ts
+++ b/packages/client/src/data_commons_client.ts
@@ -457,7 +457,7 @@ class DataCommonsClient {
     dcids: string[];
     prop: string;
   }): Promise<Record<string, string | null>> {
-    const nodePropvals = await this.webClient.getNodePropvals(params);
+    const nodePropvals = await this.webClient.getNodePropvalsOut(params);
     const nodeValues: Record<string, string | null> = {};
     Object.keys(nodePropvals).forEach((nodeDcid) => {
       nodeValues[nodeDcid] =

--- a/packages/client/src/data_commons_web_client.ts
+++ b/packages/client/src/data_commons_web_client.ts
@@ -50,11 +50,36 @@ class DataCommonsWebClient {
    * @param params.dcids List of DCIDs to fetch property values for
    * @param params.prop Property name to fetch
    */
-  async getNodePropvals(params: {
+  async getNodePropvalsOut(params: {
     dcids: string[];
     prop: string;
   }): Promise<ApiNodePropvalOutResponse> {
     const url = `${this.apiRoot || ""}/api/node/propvals/out`;
+    const response = await fetch(url, {
+      body: JSON.stringify({
+        dcids: params.dcids,
+        prop: params.prop,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "post",
+    });
+
+    return (await response.json()) as ApiNodePropvalOutResponse;
+  }
+
+  /**
+   * Fetches all node property values for the given property name
+   * Uses /api/node/propvals/in endpoint
+   * @param params.dcids List of DCIDs to fetch property values for
+   * @param params.prop Property name to fetch
+   */
+  async getNodePropvalsIn(params: {
+    dcids: string[];
+    prop: string;
+  }): Promise<ApiNodePropvalOutResponse> {
+    const url = `${this.apiRoot || ""}/api/node/propvals/in`;
     const response = await fetch(url, {
       body: JSON.stringify({
         dcids: params.dcids,

--- a/server/lib/nl/common/utterance.py
+++ b/server/lib/nl/common/utterance.py
@@ -82,6 +82,14 @@ class ChartType(IntEnum):
   ANSWER = 8
   ENTITY_OVERVIEW = 9
 
+  @staticmethod
+  def from_string(chart_type_str: str):
+    """Fetch the ChartType from a string with the same value."""
+    try:
+      return ChartType[chart_type_str]
+    except KeyError:
+      raise ValueError(f"Invalid ChartType string: {chart_type_str}")
+
 
 class FulfillmentResult(str, Enum):
   """Where is a variable or place from?"""

--- a/server/lib/nl/config_builder/base.py
+++ b/server/lib/nl/config_builder/base.py
@@ -63,11 +63,11 @@ class Builder:
       main_place = uttr.rankedCharts[0].places[0]
       metadata.place_dcid.append(main_place.dcid)
       for ch in uttr.rankedCharts:
-        if (ch.chart_type == ChartType.MAP_CHART or
-            ch.chart_type == ChartType.RANKING_WITH_MAP or
-            ch.chart_type == ChartType.SCATTER_CHART):
-          metadata.contained_place_types[main_place.place_type] = \
-            ch.place_type
+        if ch.chart_type in [
+            ChartType.MAP_CHART, ChartType.RANKING_WITH_MAP,
+            ChartType.SCATTER_CHART
+        ]:
+          metadata.contained_place_types[main_place.place_type] = ch.place_type
           break
 
     self.category = self.page_config.categories.add()

--- a/server/lib/nl/explore/params.py
+++ b/server/lib/nl/explore/params.py
@@ -59,6 +59,8 @@ class Params(str, Enum):
   MAX_TOPICS = 'maxTopics'
   # The maximum number of charts blocks to return in the resulting chart config
   MAX_CHARTS = 'maxCharts'
+  # The type of the chart to return in the resulting chart config
+  CHART_TYPE = 'chartType'
 
 
 class DCNames(str, Enum):

--- a/server/lib/nl/fulfillment/comparison.py
+++ b/server/lib/nl/fulfillment/comparison.py
@@ -56,8 +56,7 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
     dcids = [p.dcid for p in places]
     state.uttr.counters.info('comparison_place_candidates', dcids)
 
-  chart_type = state.uttr.insight_ctx.get(Params.CHART_TYPE,
-                                          'BAR_CHART') or 'BAR_CHART'
+  chart_type = state.uttr.insight_ctx.get(Params.CHART_TYPE, '')
 
   found = False
   if not chart_vars.is_topic_peer_group:
@@ -78,7 +77,7 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
       cv.svs = [sv]
       sv_place_latest_date = ext.get_sv_place_latest_date([sv], places, None,
                                                           state.exist_checks)
-      found |= add_chart_to_utterance(ChartType.from_string(chart_type),
+      found |= add_chart_to_utterance(ChartType.from_string(chart_type) if chart_type else ChartType.BAR_CHART,
                                       state,
                                       cv,
                                       exist_places,

--- a/server/lib/nl/fulfillment/comparison.py
+++ b/server/lib/nl/fulfillment/comparison.py
@@ -77,7 +77,8 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
       cv.svs = [sv]
       sv_place_latest_date = ext.get_sv_place_latest_date([sv], places, None,
                                                           state.exist_checks)
-      found |= add_chart_to_utterance(ChartType.from_string(chart_type) if chart_type else ChartType.BAR_CHART,
+      found |= add_chart_to_utterance(ChartType.from_string(chart_type)
+                                      if chart_type else ChartType.BAR_CHART,
                                       state,
                                       cv,
                                       exist_places,

--- a/server/lib/nl/fulfillment/comparison.py
+++ b/server/lib/nl/fulfillment/comparison.py
@@ -20,6 +20,7 @@ import server.lib.nl.common.existence_util as ext
 from server.lib.nl.common.utterance import ChartOriginType
 from server.lib.nl.common.utterance import ChartType
 from server.lib.nl.detection.types import Place
+from server.lib.nl.explore.params import Params
 from server.lib.nl.fulfillment.types import ChartVars
 from server.lib.nl.fulfillment.types import PopulateState
 from server.lib.nl.fulfillment.utils import add_chart_to_utterance
@@ -55,6 +56,9 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
     dcids = [p.dcid for p in places]
     state.uttr.counters.info('comparison_place_candidates', dcids)
 
+  chart_type = state.uttr.insight_ctx.get(Params.CHART_TYPE,
+                                          'BAR_CHART') or 'BAR_CHART'
+
   found = False
   if not chart_vars.is_topic_peer_group:
     for i, sv in enumerate(chart_vars.svs):
@@ -74,7 +78,7 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
       cv.svs = [sv]
       sv_place_latest_date = ext.get_sv_place_latest_date([sv], places, None,
                                                           state.exist_checks)
-      found |= add_chart_to_utterance(ChartType.BAR_CHART,
+      found |= add_chart_to_utterance(ChartType.from_string(chart_type),
                                       state,
                                       cv,
                                       exist_places,

--- a/server/routes/explore/helpers.py
+++ b/server/routes/explore/helpers.py
@@ -274,15 +274,15 @@ def update_insight_ctx_for_chart_fulfill(request: Dict,
   utterance.insight_ctx[params.Params.DC.value] = dc_name
   # iterate through numeric parameters and set in the insight context
   for p in [
-      params.Params.MAX_TOPIC_SVS, params.Params.MAX_TOPICS,
-      params.Params.MAX_CHARTS
+      params.Params.MAX_TOPIC_SVS,
+      params.Params.MAX_TOPICS,
+      params.Params.MAX_CHARTS,
+      params.Params.CHART_TYPE,
   ]:
     param_val = request.args.get(p, None)
     if param_val != None:
       if param_val.isnumeric():
         param_val = int(param_val)
-      else:
-        param_val = None
     utterance.insight_ctx[p] = param_val
 
 

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -191,10 +191,11 @@ export function App(props: AppProps): ReactElement {
     return hasPlace || fulfillData["entities"];
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable @typescript-eslint/no-explicit-any
   function extractMainPlaceAndMetadata(
     fulfillData: any
   ): [any, SubjectPageMetadata] {
+    // eslint-enable @typescript-eslint/no-explicit-any
     const mainPlace = {
       dcid: fulfillData["place"]["dcid"],
       name: fulfillData["place"]["name"],
@@ -230,8 +231,8 @@ export function App(props: AppProps): ReactElement {
    * @param fulfillData The fulfill data from the search API response
    * @param userQuery The user's search query
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function processFulfillData(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fulfillData: any,
     setPageConfig: (config: SubjectPageMetadata) => void,
     userQuery?: string,

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -191,11 +191,11 @@ export function App(props: AppProps): ReactElement {
     return hasPlace || fulfillData["entities"];
   }
 
-  // eslint-disable @typescript-eslint/no-explicit-any
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   function extractMainPlaceAndMetadata(
     fulfillData: any
   ): [any, SubjectPageMetadata] {
-    // eslint-enable @typescript-eslint/no-explicit-any
+    /* eslint-enable @typescript-eslint/no-explicit-any */
     const mainPlace = {
       dcid: fulfillData["place"]["dcid"],
       name: fulfillData["place"]["name"],
@@ -232,7 +232,7 @@ export function App(props: AppProps): ReactElement {
    * @param userQuery The user's search query
    */
   function processFulfillData(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     fulfillData: any,
     setPageConfig: (config: SubjectPageMetadata) => void,
     userQuery?: string,
@@ -334,7 +334,7 @@ export function App(props: AppProps): ReactElement {
       places = [urlHashParams.place];
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     let fulfillmentPromise: Promise<unknown>;
     let highlightPromise: Promise<unknown>;
 

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -233,8 +233,8 @@ export function App(props: AppProps): ReactElement {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function processFulfillData(
     fulfillData: any,
+    setPageConfig: (config: SubjectPageMetadata) => void,
     userQuery?: string,
-    setPageConfig?: (config: SubjectPageMetadata) => void,
     isHighlight?: boolean
   ): void {
     setDebugData(fulfillData["debug"]);
@@ -371,7 +371,7 @@ export function App(props: AppProps): ReactElement {
         urlHashParams.maxCharts
       )
         .then((resp) => {
-          processFulfillData(resp, query);
+          processFulfillData(resp, setPageMetadata, query);
         })
         .catch(() => {
           setLoadingStatus(LoadingStatus.FAILED);
@@ -431,11 +431,11 @@ export function App(props: AppProps): ReactElement {
 
       Promise.all([highlightPromise, fulfillmentPromise]).then(
         ([highlightResponse, fulfillResponse]) => {
-          processFulfillData(fulfillResponse, undefined, setPageMetadata);
+          processFulfillData(fulfillResponse, setPageMetadata, undefined);
           processFulfillData(
             highlightResponse,
-            undefined,
             setHighlightPageMetadata,
+            undefined,
             true
           );
         }

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -191,11 +191,11 @@ export function App(props: AppProps): ReactElement {
     return hasPlace || fulfillData["entities"];
   }
 
-  /* eslint-disable @typescript-eslint/no-explicit-any */
+  /* eslint-disable */
   function extractMainPlaceAndMetadata(
     fulfillData: any
   ): [any, SubjectPageMetadata] {
-    /* eslint-enable @typescript-eslint/no-explicit-any */
+    /* eslint-enable */
     const mainPlace = {
       dcid: fulfillData["place"]["dcid"],
       name: fulfillData["place"]["name"],
@@ -232,7 +232,7 @@ export function App(props: AppProps): ReactElement {
    * @param userQuery The user's search query
    */
   function processFulfillData(
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    /* eslint-disable-next-line */
     fulfillData: any,
     setPageConfig: (config: SubjectPageMetadata) => void,
     userQuery?: string,
@@ -334,7 +334,6 @@ export function App(props: AppProps): ReactElement {
       places = [urlHashParams.place];
     }
 
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     let fulfillmentPromise: Promise<unknown>;
     let highlightPromise: Promise<unknown>;
 

--- a/static/js/apps/explore/highlight_result.tsx
+++ b/static/js/apps/explore/highlight_result.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { SubjectPageMainPane } from "../../components/subject_page/main_pane";
+import { SubjectPageMetadata } from "../../types/subject_page_types";
+import { trimCategory } from "../../utils/subject_page_utils";
+
+/**
+ * Component to show the Subject Page for the highlight only.
+ */
+
+const PAGE_ID = "highlight-result";
+
+interface HighlightResultProps {
+  highlightPageMetadata: SubjectPageMetadata;
+  maxBlock: number;
+}
+
+export function HighlightResult(
+  props: HighlightResultProps
+): React.ReactElement {
+  return (
+    <div>
+      <SubjectPageMainPane
+        id={PAGE_ID}
+        place={props.highlightPageMetadata.place}
+        pageConfig={trimCategory(
+          props.highlightPageMetadata.pageConfig,
+          props.maxBlock
+        )}
+        showExploreMore={false}
+      />
+    </div>
+  );
+}

--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -44,6 +44,7 @@ import { getPlaceTypePlural } from "../../utils/string_utils";
 import { trimCategory } from "../../utils/subject_page_utils";
 import { getUpdatedHash } from "../../utils/url_utils";
 import { DebugInfo } from "./debug_info";
+import { HighlightResult } from "./highlight_result";
 import { RelatedPlace } from "./related_place";
 import { ResultHeaderSection } from "./result_header_section";
 import { SearchSection } from "./search_section";
@@ -67,6 +68,8 @@ interface SuccessResultPropType {
   //if true, there is no header bar search, and so we display search inline
   //if false, there is a header bar search, and so we do not display search inline
   hideHeaderSearchBar: boolean;
+  // Object containing the highlight page metadata only.
+  highlightPageMetadata?: SubjectPageMetadata;
 }
 
 export function SuccessResult(props: SuccessResultPropType): ReactElement {
@@ -179,6 +182,12 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
                   placeType: props.exploreContext.childEntityType || "",
                 }}
               >
+                {props.highlightPageMetadata && (
+                  <HighlightResult
+                    highlightPageMetadata={props.highlightPageMetadata}
+                    maxBlock={maxBlock}
+                  />
+                )}
                 <SubjectPageMainPane
                   id={PAGE_ID}
                   place={props.pageMetadata.place}

--- a/static/js/components/subject_page/block_container.tsx
+++ b/static/js/components/subject_page/block_container.tsx
@@ -54,6 +54,7 @@ export interface BlockContainerPropType {
   place?: NamedTypedPlace;
   commonSVSpec?: StatVarSpec[];
   infoMessage?: string;
+  disableExploreMore?: boolean;
 }
 
 export function BlockContainer(props: BlockContainerPropType): JSX.Element {
@@ -133,7 +134,7 @@ export function BlockContainer(props: BlockContainerPropType): JSX.Element {
           <ReactMarkdown>{footnote}</ReactMarkdown>
         </footer>
       )}
-      {exploreSVSpec.length > 0 && (
+      {!props.disableExploreMore && exploreSVSpec.length > 0 && (
         <div id="explore-more-section">
           {exploreSVSpec.slice(0, 1).map((spec) => {
             // Only show 1 explore section now.

--- a/static/js/components/subject_page/category.tsx
+++ b/static/js/components/subject_page/category.tsx
@@ -155,6 +155,7 @@ function renderBlocks(
               place={props.place}
               commonSVSpec={commonSVSpec}
               infoMessage={block.infoMessage}
+              disableExploreMore={!props.showExploreMore}
             >
               <Block
                 id={id}

--- a/static/js/constants/app/explore_constants.ts
+++ b/static/js/constants/app/explore_constants.ts
@@ -21,6 +21,7 @@
 // URL hash param keys
 export const URL_HASH_PARAMS = {
   PLACE: "p",
+  STAT_VAR: "sv",
   TOPIC: "t",
   QUERY: "q",
   DC: "dc",
@@ -46,6 +47,7 @@ export const URL_HASH_PARAMS = {
   MAX_TOPICS: "maxTopics",
   MAX_TOPIC_SVS: "maxTopicSvs",
   MAX_CHARTS: "maxCharts",
+  CHART_TYPE: "chartType",
 };
 export const CLIENT_TYPES = {
   // User typed in a p=X&t=Y URL

--- a/static/js/utils/app/explore_utils.ts
+++ b/static/js/utils/app/explore_utils.ts
@@ -58,6 +58,8 @@ export function getTopics(
           [URL_HASH_PARAMS.PLACE]: placeUrlVal,
           [URL_HASH_PARAMS.QUERY]: "",
           [URL_HASH_PARAMS.CLIENT]: CLIENT_TYPES.RELATED_TOPIC,
+          [URL_HASH_PARAMS.STAT_VAR]: "",
+          [URL_HASH_PARAMS.CHART_TYPE]: "",
         })}`,
       });
     }

--- a/static/js/utils/url_utils.ts
+++ b/static/js/utils/url_utils.ts
@@ -18,6 +18,10 @@
  * URL related helpers shared across components.
  */
 
+import queryString from "query-string";
+
+import { URL_HASH_PARAMS } from "../constants/app/explore_constants";
+
 /**
  * Returns token for URL param.
  * @param param URL param
@@ -80,4 +84,94 @@ export function updateHash(params: Record<string, string | string[]>): void {
  */
 export function apiRootToHostname(apiRoot?: string): string {
   return apiRoot ? apiRoot.replace(/\/$/, "") : "";
+}
+
+export function getSingleParam(input: string | string[]): string {
+  // If the input is an array, convert it to a single string
+  if (Array.isArray(input)) {
+    return input[0];
+  }
+  if (!input) {
+    // Return empty instead of letting it be undefined.
+    return "";
+  }
+  return input;
+}
+
+/**
+ * Extracts all the const parameters from the URL hash parameters within the Explore.
+ * @param hashParams parameters.
+ * @returns string array of all parrams.
+ */
+export interface UrlHashParams {
+  query: string;
+  place: string;
+  topic: string;
+  statVars: string;
+  dc: string;
+  idx: string;
+  disableExploreMore: string;
+  detector: string;
+  testMode: string;
+  i18n: string;
+  includeStopWords: string;
+  defaultPlace: string;
+  mode: string;
+  reranker: string;
+  maxTopics: string;
+  maxTopicSvs: string;
+  maxCharts: string;
+  chartType: string;
+}
+
+export function extractUrlHashParams(
+  hashParams: queryString.ParsedQuery<string>
+): UrlHashParams {
+  const query =
+    getSingleParam(hashParams[URL_HASH_PARAMS.QUERY]) ||
+    getSingleParam(hashParams[URL_HASH_PARAMS.DEPRECATED_QUERY]);
+  const place = getSingleParam(hashParams[URL_HASH_PARAMS.PLACE]);
+  const topic = getSingleParam(hashParams[URL_HASH_PARAMS.TOPIC]);
+  const statVars = getSingleParam(hashParams[URL_HASH_PARAMS.STAT_VAR]);
+  const dc = getSingleParam(hashParams[URL_HASH_PARAMS.DC]);
+  const idx = getSingleParam(hashParams[URL_HASH_PARAMS.IDX]);
+  const disableExploreMore = getSingleParam(
+    hashParams[URL_HASH_PARAMS.DISABLE_EXPLORE_MORE]
+  );
+  const detector = getSingleParam(hashParams[URL_HASH_PARAMS.DETECTOR]);
+  const testMode = getSingleParam(hashParams[URL_HASH_PARAMS.TEST_MODE]);
+  const i18n = getSingleParam(hashParams[URL_HASH_PARAMS.I18N]);
+  const includeStopWords = getSingleParam(
+    hashParams[URL_HASH_PARAMS.INCLUDE_STOP_WORDS]
+  );
+  const defaultPlace = getSingleParam(
+    hashParams[URL_HASH_PARAMS.DEFAULT_PLACE]
+  );
+  const mode = getSingleParam(hashParams[URL_HASH_PARAMS.MODE]);
+  const reranker = getSingleParam(hashParams[URL_HASH_PARAMS.RERANKER]);
+  const maxTopics = getSingleParam(hashParams[URL_HASH_PARAMS.MAX_TOPICS]);
+  const maxTopicSvs = getSingleParam(hashParams[URL_HASH_PARAMS.MAX_TOPIC_SVS]);
+  const maxCharts = getSingleParam(hashParams[URL_HASH_PARAMS.MAX_CHARTS]);
+  const chartType = getSingleParam(hashParams[URL_HASH_PARAMS.CHART_TYPE]);
+
+  return {
+    query,
+    place,
+    topic,
+    statVars,
+    dc,
+    idx,
+    disableExploreMore,
+    detector,
+    testMode,
+    i18n,
+    includeStopWords,
+    defaultPlace,
+    mode,
+    reranker,
+    maxTopics,
+    maxTopicSvs,
+    maxCharts,
+    chartType,
+  };
 }


### PR DESCRIPTION
https://github.com/datacommonsorg/website/pull/5114 was reverted in https://github.com/datacommonsorg/website/pull/5141 following a bug being noticed where the query was correct processed but the results were no longer displayed. This was a bug tied to the changes in processFulfillData which is now resolved. I made the SetPageMetadata parameter non-optional to ensure it doesn't happen again.

This PR uses the URL Hash Params to add the ability to pass in multiple places, and pass in one statistical variable.
We inject the chart for the one stat var, and issue a second call to fetch the Topic of said SV, then issue another fulfill call to with the associated topic.

Adds support for multiple StatVars, and multiple Topics on the fulfill call.
Does a very basic merging of the responses.

In this state, here's what the page looks like, while passing in:

Rhode Island and Arizona
Median_Income_Household, Area_Farm, Count_Person
TIMELINE_WITH_HIGHLIGHT for chartType
http://localhost:8080/explore/#sv=Median_Income_Household___Area_Farm___Count_Person&p=geoId%2F48___geoId%2F06&client=ui_related_topic&chartType=TIMELINE_WITH_HIGHLIGHT

https://screencast.googleplex.com/cast/NDg2NDE3MjA1ODczODY4OHwyODllMGExYS0wMQ

Note that the first 3 charts are for each of the StatVars passed in. The remaining come from the 3 topics identified for the statVars
dc/topic/Income, dc/topic/Agriculture, dc/topic/Demographics

Next Up: Allow injecting provenance, unit and timerange. more Code Cleanup. Testing.