### PR TITLE
update nodejs endpoint to be able to specify detector

### DIFF
--- a/static/nodejs_server/query.test.ts
+++ b/static/nodejs_server/query.test.ts
@@ -220,7 +220,8 @@ test("getQueryResult", async () => {
       "bard",
       "",
       "",
-      false
+      false,
+      ""
     );
     try {
       expect(result.charts).toStrictEqual(c.expectedCharts);

--- a/static/nodejs_server/query.ts
+++ b/static/nodejs_server/query.ts
@@ -61,8 +61,8 @@ const TOOLFORMER_RIG_ALLOWED_CHARTS = new Set(["LINE", "HIGHLIGHT"]);
 // The root to use to form the dc link in the tile results
 // TODO: update this to use bard.datacommons.org
 const DC_URL_ROOT = "https://datacommons.org/explore#q=";
-// Detector to use when handling nl queries
-const QUERY_DETECTOR = "heuristic";
+// Default detector type to use when handling nl queries
+const DEFAULT_QUERY_DETECTOR = "heuristic";
 // Number of related questions to return
 const NUM_RELATED_QUESTIONS = 6;
 
@@ -292,6 +292,7 @@ export async function getQueryResult(
   mode: string,
   varThreshold: string,
   wantRelatedQuestions: boolean,
+  detector: string,
   idx?: string
 ): Promise<QueryResult> {
   const startTime = process.hrtime.bigint();
@@ -308,7 +309,9 @@ export async function getQueryResult(
   // Get the nl detect-and-fulfill result for the query
   // TODO: only generate related things when we need to generate related question
   let nlResp = null;
-  let url = `${apiRoot}/api/explore/detect-and-fulfill?q=${query}&detector=${QUERY_DETECTOR}`;
+  let url = `${apiRoot}/api/explore/detect-and-fulfill?q=${query}&detector=${
+    detector || DEFAULT_QUERY_DETECTOR
+  }`;
   const params = {
     client,
     idx,

--- a/static/src/server.ts
+++ b/static/src/server.ts
@@ -309,6 +309,7 @@ app.get("/nodejs/query", (req: Request, res: Response) => {
   const wantRelatedQuestions =
     req.query.relatedQuestions === URL_PARAM_VALUE_TRUTHY;
   const idx = (req.query.idx as string) || "";
+  const detector = (req.query.detector as string) || "";
   getQueryResult(
     query,
     useChartUrl,
@@ -320,6 +321,7 @@ app.get("/nodejs/query", (req: Request, res: Response) => {
     mode,
     varThreshold,
     wantRelatedQuestions,
+    detector,
     idx
   ).then((result) => {
     res.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
Update the nodejs endpoint to allow users to specify the detector type for NL detection.

This came up because "What is the most populous state in the US" works on Data Commons website which uses detector=hybrid, but does not work through the nodejs endpoint which uses detector=heuristic. We want to keep the default behavior, but allow a user to specify if they want to use the hybrid detection.

With this change:
- default: [/nodejs/query?q=what%20is%20the%20most%20populous%20state%20in%20the%20us](https://screenshot.googleplex.com/4B6nP8cqA5JznGD)
- with hybrid detection: [/nodejs/query?q=what%20is%20the%20most%20populous%20state%20in%20the%20us&detector=hybrid](https://screenshot.googleplex.com/3ofpz3qK6yHL2mo)