### PR TITLE
Update datagemma instance flask config

### DIFF
--- a/deploy/helm_charts/envs/datagemma.yaml
+++ b/deploy/helm_charts/envs/datagemma.yaml
@@ -23,7 +23,7 @@ cluster_prefix: "website"
 namespace:
   name: "website"
 website:
-  flaskEnv: custom
+  flaskEnv: datagemma
   replicas: 20
   redis:
     enabled: true

--- a/server/app_env/datagemma.py
+++ b/server/app_env/datagemma.py
@@ -1,0 +1,29 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from server.app_env import custom
+from server.app_env import local
+
+
+class Config(custom.Config):
+  USE_LLM = True
+  SECRET_PROJECT = 'datcom-datagemma'
+
+
+class LocalConfig(Config, local.Config):
+  pass
+
+
+class ComposeConfig(Config, local.Config):
+  pass


### PR DESCRIPTION
Recently made a change to allow the nodejs api to use hybrid/llm mode in the NL search (https://github.com/datacommonsorg/website/pull/5145). However, in order to actually use the llm mode, the instance needs to have a secret project defined and need to turn on the flag USE_LLM 