### PR TITLE
Added feature flag URL override

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -69,15 +69,14 @@ This script uploads the feature flag configuration files from the Github master 
 5. **Deploy & update GCS Flag files**: Once your code reaches production, you can enable your flags and run the script to update the GCS flag files.
 6. **Restart Kubernetes**: The script to update the GCS flag files will prompt you to restart Kubernetes, on restart the new flags will be applied and your feature will be enabled.
 
-## Manually override feature flags
+## Manually enable feature flags
 
-Feature flags can be overridden manually through the the URL with the following convention:
+Feature flags can be enabled manually on any datacommons.org page using the `enable_feature` URL parameter.
 
- - To enable a feature: add ?enable_<feature_name> to the URL
- - To disable a feature: add ?disable_<feature_name> to the URL
- 
-For example, to enable or disable the "autocomplete" feature:
- - Enable: https://datacommons.org/explore?enable_autocomplete
- - Disable: https://datacommons.org/explore?disable_autocomplete
+For example, to enable the "autocomplete" feature:
+ - Enable: https://datacommons.org/explore?enable_feature=autocomplete
+
+To enable both the autocomplete and metadata_modal features:
+ - Disable: https://datacommons.org/explore?enable_feature=autocomplete&enable_feature=metadata_modal
  
 These URL overrides take precedence over the environment-specific feature flag settings defined in server/config/feature_flag_configs/<environment>.json

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -68,3 +68,16 @@ This script uploads the feature flag configuration files from the Github master 
 4. **Check flag value and implement your feature**
 5. **Deploy & update GCS Flag files**: Once your code reaches production, you can enable your flags and run the script to update the GCS flag files.
 6. **Restart Kubernetes**: The script to update the GCS flag files will prompt you to restart Kubernetes, on restart the new flags will be applied and your feature will be enabled.
+
+## Manually override feature flags
+
+Feature flags can be overridden manually through the the URL with the following convention:
+
+ - To enable a feature: add ?enable_<feature_name> to the URL
+ - To disable a feature: add ?disable_<feature_name> to the URL
+ 
+For example, to enable or disable the "autocomplete" feature:
+ - Enable: https://datacommons.org/explore?enable_autocomplete
+ - Disable: https://datacommons.org/explore?disable_autocomplete
+ 
+These URL overrides take precedence over the environment-specific feature flag settings defined in server/config/feature_flag_configs/<environment>.json

--- a/static/js/shared/feature_flags/util.test.ts
+++ b/static/js/shared/feature_flags/util.test.ts
@@ -50,14 +50,16 @@ describe("isFeatureEnabled", () => {
       },
       writable: true,
     });
+    // Make a copy of the original FEATURE_FLAGS object
+    globalThis.FEATURE_FLAGS = { ...originalFeatureFlags };
   });
 
   afterEach(() => {
     // Restore window.location and FEATURE_FLAGS
     Object.defineProperty(window, "location", {
       value: originalLocation,
-      writable: true,
     });
+    // Restore the original FEATURE_FLAGS object
     globalThis.FEATURE_FLAGS = originalFeatureFlags;
   });
 

--- a/static/js/shared/feature_flags/util.test.ts
+++ b/static/js/shared/feature_flags/util.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import {
+  DISABLE_FEATURE_FLAG_PREFIX,
+  ENABLE_FEATURE_FLAG_PREFIX,
+  isFeatureEnabled,
+} from "./util";
+
+describe("isFeatureEnabled", () => {
+  const featureName = "testFeature";
+  const enableParam = `${ENABLE_FEATURE_FLAG_PREFIX}${featureName}`;
+  const disableParam = `${DISABLE_FEATURE_FLAG_PREFIX}${featureName}`;
+
+  // Store original window.location and FEATURE_FLAGS
+  const originalLocation = window.location;
+  const originalFeatureFlags = globalThis.FEATURE_FLAGS;
+
+  beforeEach(() => {
+    // Mock window.location
+    Object.defineProperty(window, "location", {
+      value: {
+        ...originalLocation,
+        search: "",
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    // Restore window.location and FEATURE_FLAGS
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+    });
+    globalThis.FEATURE_FLAGS = originalFeatureFlags;
+  });
+
+  test("returns true when enable param is present", () => {
+    window.location.search = `?${enableParam}`;
+    expect(isFeatureEnabled(featureName)).toBe(true);
+  });
+
+  test("returns false when disable param is present", () => {
+    window.location.search = `?${disableParam}`;
+    expect(isFeatureEnabled(featureName)).toBe(false);
+  });
+
+  test("returns false when no URL params are present", () => {
+    window.location.search = "";
+    expect(isFeatureEnabled(featureName)).toBe(false);
+  });
+
+  test("returns false when different URL params are present", () => {
+    window.location.search = "?someOtherParam=true";
+    expect(isFeatureEnabled(featureName)).toBe(false);
+  });
+
+  test("returns true when feature flag is enabled in FEATURE_FLAGS", () => {
+    window.location.search = "";
+    globalThis.FEATURE_FLAGS = { [featureName]: true };
+    expect(isFeatureEnabled(featureName)).toBe(true);
+  });
+
+  test("returns false when feature flag is disabled in FEATURE_FLAGS", () => {
+    window.location.search = "";
+    globalThis.FEATURE_FLAGS = { [featureName]: false };
+    expect(isFeatureEnabled(featureName)).toBe(false);
+  });
+});

--- a/static/js/shared/feature_flags/util.test.ts
+++ b/static/js/shared/feature_flags/util.test.ts
@@ -13,6 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * Tests for the feature flag system.
+ *
+ * Feature flags are set for each environment in
+ * server/config/feature_flag_configs/<environment>.json
+ *
+ * Feature flags can be overridden manually through URL parameters:
+ * - To enable a feature: add ?enable_<feature_name> to the URL
+ * - To disable a feature: add ?disable_<feature_name> to the URL
+ *
+ * Example URLs:
+ * - https://datacommons.org/explore?enable_autocomplete
+ * - https://datacommons.org/explore?disable_autocomplete
+ *
+ * These URL overrides take precedence over the environment-specific flag settings
+ */
 import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 import {
   DISABLE_FEATURE_FLAG_PREFIX,
@@ -49,6 +66,7 @@ describe("isFeatureEnabled", () => {
     globalThis.FEATURE_FLAGS = originalFeatureFlags;
   });
 
+  // Test URL parameter overrides
   test("returns true when enable param is present", () => {
     window.location.search = `?${enableParam}`;
     expect(isFeatureEnabled(featureName)).toBe(true);
@@ -69,6 +87,7 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(featureName)).toBe(false);
   });
 
+  // Test environment-specific feature flag settings
   test("returns true when feature flag is enabled in FEATURE_FLAGS", () => {
     window.location.search = "";
     globalThis.FEATURE_FLAGS = { [featureName]: true };

--- a/static/js/shared/feature_flags/util.test.ts
+++ b/static/js/shared/feature_flags/util.test.ts
@@ -31,6 +31,7 @@
  * These URL overrides take precedence over the environment-specific flag settings
  */
 import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
 import {
   DISABLE_FEATURE_FLAG_PREFIX,
   ENABLE_FEATURE_FLAG_PREFIX,

--- a/static/js/shared/feature_flags/util.ts
+++ b/static/js/shared/feature_flags/util.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-export function getFeatureFlags() {
-  return globalThis.FEATURE_FLAGS;
-}
-
 // Feature flag names
 export const AUTOCOMPLETE_FEATURE_FLAG = "autocomplete";
 export const METADATA_FEATURE_FLAG = "metadata_modal";
@@ -37,17 +33,25 @@ export function getFeatureOverride(featureName: string): boolean {
 }
 
 /**
+ * Returns the feature flags for the current environment.
+ * @returns
+ */
+export function getFeatureFlags(): Record<string, boolean> {
+  return globalThis.FEATURE_FLAGS as Record<string, boolean>;
+}
+
+/**
  * Helper method to check if a feature is enabled with feature flags.
  *
  * Feature flags are set for each environment in
  * server/config/feature_flag_configs/<environment>.json
  *
- * Feature flags can be overridden and enabled or disabled manually
- * by adding ?enable_<feature_name> or ?disable_<feature_name> to the URL.
+ * Feature flags can be overridden and enabled manually
+ * by adding ?enable_feature=<feature_name> to the URL.
  *
  * Example:
- * https://datacommons.org/explore?enable_autocomplete will enable the autocomplete feature.
- * https://datacommons.org/explore?disable_autocomplete will disable the autocomplete feature.
+ * https://datacommons.org/explore?enable_feature=autocomplete will enable the autocomplete feature.
+ * https://datacommons.org/explore?enable_feature=autocomplete&enable_feature=metadata_modal will enable both the autocomplete and metadata_modal features.
  *
  * @param featureName name of feature for which we want status.
  * @returns Bool describing if the feature is enabled

--- a/static/js/shared/feature_flags/util.ts
+++ b/static/js/shared/feature_flags/util.ts
@@ -18,10 +18,23 @@ export function getFeatureFlags() {
   return globalThis.FEATURE_FLAGS;
 }
 
+// Feature flag names
 export const AUTOCOMPLETE_FEATURE_FLAG = "autocomplete";
 export const METADATA_FEATURE_FLAG = "metadata_modal";
-export const ENABLE_FEATURE_FLAG_PREFIX = "enable_";
-export const DISABLE_FEATURE_FLAG_PREFIX = "disable_";
+
+// Feature flag URL parameters
+export const ENABLE_FEATURE_URL_PARAM = "enable_feature";
+
+/**
+ * Returns true if the feature is enabled by the URL parameter.
+ * @param featureName name of feature for which we want status.
+ * @returns true if the feature is enabled by the URL parameter, false otherwise.
+ */
+export function getFeatureOverride(featureName: string): boolean {
+  const urlParams = new URLSearchParams(window.location.search);
+  const enabledFeatures = urlParams.getAll(ENABLE_FEATURE_URL_PARAM);
+  return enabledFeatures.includes(featureName);
+}
 
 /**
  * Helper method to check if a feature is enabled with feature flags.
@@ -41,15 +54,10 @@ export const DISABLE_FEATURE_FLAG_PREFIX = "disable_";
  */
 export function isFeatureEnabled(featureName: string): boolean {
   // Check URL params for feature flag overrides
-  const urlParams = new URLSearchParams(window.location.search);
-  const enableParam = `${ENABLE_FEATURE_FLAG_PREFIX}${featureName}`;
-  const disableParam = `${DISABLE_FEATURE_FLAG_PREFIX}${featureName}`;
-  if (urlParams.has(enableParam)) {
+  if (getFeatureOverride(featureName)) {
     return true;
   }
-  if (urlParams.has(disableParam)) {
-    return false;
-  }
+  // Check if the feature flag is enabled in server config
   const featureFlags = getFeatureFlags();
   if (featureFlags && featureName in featureFlags) {
     return featureFlags[featureName];

--- a/static/js/shared/feature_flags/util.ts
+++ b/static/js/shared/feature_flags/util.ts
@@ -14,18 +14,45 @@
  * limitations under the License.
  */
 
-export const FEATURE_FLAGS = globalThis.FEATURE_FLAGS;
+export function getFeatureFlags() {
+  return globalThis.FEATURE_FLAGS;
+}
+
 export const AUTOCOMPLETE_FEATURE_FLAG = "autocomplete";
 export const METADATA_FEATURE_FLAG = "metadata_modal";
+export const ENABLE_FEATURE_FLAG_PREFIX = "enable_";
+export const DISABLE_FEATURE_FLAG_PREFIX = "disable_";
 
 /**
- * Helper method to interact with feature flags.
+ * Helper method to check if a feature is enabled with feature flags.
+ *
+ * Feature flags are set for each environment in
+ * server/config/feature_flag_configs/<environment>.json
+ *
+ * Feature flags can be overridden and enabled or disabled manually
+ * by adding ?enable_<feature_name> or ?disable_<feature_name> to the URL.
+ *
+ * Example:
+ * https://datacommons.org/explore?enable_autocomplete will enable the autocomplete feature.
+ * https://datacommons.org/explore?disable_autocomplete will disable the autocomplete feature.
+ *
  * @param featureName name of feature for which we want status.
  * @returns Bool describing if the feature is enabled
  */
 export function isFeatureEnabled(featureName: string): boolean {
-  if (FEATURE_FLAGS && featureName in FEATURE_FLAGS) {
-    return FEATURE_FLAGS[featureName];
+  // Check URL params for feature flag overrides
+  const urlParams = new URLSearchParams(window.location.search);
+  const enableParam = `${ENABLE_FEATURE_FLAG_PREFIX}${featureName}`;
+  const disableParam = `${DISABLE_FEATURE_FLAG_PREFIX}${featureName}`;
+  if (urlParams.has(enableParam)) {
+    return true;
+  }
+  if (urlParams.has(disableParam)) {
+    return false;
+  }
+  const featureFlags = getFeatureFlags();
+  if (featureFlags && featureName in featureFlags) {
+    return featureFlags[featureName];
   }
   return false;
 }


### PR DESCRIPTION
Added ability to manually enable feature flags using a new `enable_feature` URL parameter.

From the updated `docs/feature_flags.md`:

Feature flags can be enabled manually on any datacommons.org page using the `enable_feature` URL parameter.

For example, to enable the "autocomplete" feature:
 - Enable: https://datacommons.org/explore?enable_feature=autocomplete

To enable both the autocomplete and metadata_modal features:
 - Disable: https://datacommons.org/explore?enable_feature=autocomplete&enable_feature=metadata_modal
 
These URL overrides take precedence over the environment-specific feature flag settings defined in server/config/feature_flag_configs/<environment>.json
