### PR TITLE
Add support for a skip_topics param to the search-vector endpoint.

### DIFF
--- a/server/routes/nl/api.py
+++ b/server/routes/nl/api.py
@@ -44,4 +44,6 @@ def search_vector():
   if not queries:
     flask.abort(400, 'Must provide a `queries` in POST data')
 
-  return dc.nl_search_vars(queries, idx.split(','))
+  return dc.nl_search_vars(queries,
+                           idx.split(','),
+                           skip_topics=request.args.get('skip_topics', ''))

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -389,12 +389,17 @@ def resolve(nodes, prop):
   return post(url, {'nodes': nodes, 'property': prop})
 
 
-def nl_search_vars(queries, index_types: List[str], reranker=''):
+def nl_search_vars(queries,
+                   index_types: List[str],
+                   reranker='',
+                   skip_topics=''):
   """Search sv from NL server."""
   idx_params = ','.join(index_types)
   url = f'{current_app.config["NL_ROOT"]}/api/search_vars?idx={idx_params}'
   if reranker:
     url = f'{url}&reranker={reranker}'
+  if skip_topics:
+    url = f'{url}&skip_topics={skip_topics}'
   return post(url, {'queries': queries})
 
 


### PR DESCRIPTION
* The `search-vector` endpoint currently returns a mix of topics and SVs. This change is to support a param that returns only the latter.
* Verified locally by bringing up the website and NL servers and making the `search-vector` call with and without `skip_topics`.