### PR TITLE
[Chart Injection] Make the highlight Response only show the highlighted chart + Remove the matching chart from the non-highlight response.

### DIFF
--- a/server/lib/nl/fulfillment/basic.py
+++ b/server/lib/nl/fulfillment/basic.py
@@ -76,6 +76,7 @@ def _populate_explore(state: PopulateState, chart_vars: ChartVars,
                       places: List[Place], chart_origin: ChartOriginType,
                       rank: int) -> bool:
   added = False
+  # TODO(gmechali): Consider making is_highlight a part of the utterance.
   is_highlight = bool(state.uttr.insight_ctx.get(params.Params.CHART_TYPE))
 
   # For peer-groups, add multi-line charts.
@@ -103,6 +104,8 @@ def _populate_explore(state: PopulateState, chart_vars: ChartVars,
     if state.place_type:
       # If this is SDG, unless user has asked for ranking, do not return!
       added_child_type_charts = False
+
+      # TODO(gmechali): Refactor this code for more explicit logic.
       if not is_highlight and not is_special_dc or state.ranking_types:
         ranking_orig = state.ranking_types
         if not state.ranking_types:

--- a/server/lib/nl/fulfillment/basic.py
+++ b/server/lib/nl/fulfillment/basic.py
@@ -77,6 +77,9 @@ def _populate_explore(state: PopulateState, chart_vars: ChartVars,
                       rank: int) -> bool:
   added = False
   # TODO(gmechali): Consider making is_highlight a part of the utterance.
+  # We use the chart type parameter as a proxy to determine if a specific chart
+  # was requested, and should be used as the highlight chart. On highlight chart
+  # cases, we don't want to show any other chart.
   is_highlight = bool(state.uttr.insight_ctx.get(params.Params.CHART_TYPE))
 
   # For peer-groups, add multi-line charts.
@@ -106,6 +109,8 @@ def _populate_explore(state: PopulateState, chart_vars: ChartVars,
       added_child_type_charts = False
 
       # TODO(gmechali): Refactor this code for more explicit logic.
+      # The is_highlight check is to avoid showing the related contained-in
+      # chart when the user has asked for a specific chart.
       if not is_highlight and not is_special_dc or state.ranking_types:
         ranking_orig = state.ranking_types
         if not state.ranking_types:

--- a/server/lib/nl/fulfillment/basic.py
+++ b/server/lib/nl/fulfillment/basic.py
@@ -76,6 +76,7 @@ def _populate_explore(state: PopulateState, chart_vars: ChartVars,
                       places: List[Place], chart_origin: ChartOriginType,
                       rank: int) -> bool:
   added = False
+  is_highlight = bool(state.uttr.insight_ctx.get(params.Params.CHART_TYPE))
 
   # For peer-groups, add multi-line charts.
   max_rank_and_map_charts = _get_max_rank_and_map_charts(chart_vars, state)
@@ -102,7 +103,7 @@ def _populate_explore(state: PopulateState, chart_vars: ChartVars,
     if state.place_type:
       # If this is SDG, unless user has asked for ranking, do not return!
       added_child_type_charts = False
-      if not is_special_dc or state.ranking_types:
+      if not is_highlight and not is_special_dc or state.ranking_types:
         ranking_orig = state.ranking_types
         if not state.ranking_types:
           state.ranking_types = [RankingType.HIGH, RankingType.LOW]

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -25,7 +25,6 @@ import queryString from "query-string";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
 import { RawIntlProvider } from "react-intl";
 import { Container } from "reactstrap";
-import { block } from "sharp";
 
 import { Spinner } from "../../components/spinner";
 import {
@@ -208,7 +207,6 @@ export function App(props: AppProps): ReactElement {
     /* eslint-disable-next-line */
     fulfillData: any,
     pageMetadata: SubjectPageMetadata,
-    // setPageConfig: (config: SubjectPageMetadata) => void,
     userQuery?: string,
     isHighlight?: boolean
   ): void {

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -417,19 +417,23 @@ export function App(props: AppProps): ReactElement {
       Promise.all([highlightPromise, fulfillmentPromise]).then(
         ([highlightResponse, fulfillResponse]) => {
           const mainPlace = extractMainPlace(fulfillResponse);
+          let mainPageMetadata = extractMetadata(fulfillResponse, mainPlace);
+
           const highlightPageMetadataResp = extractMetadata(
             highlightResponse,
             mainPlace
           );
-          setHighlightPageMetadata(highlightPageMetadataResp);
 
-          let mainPageMetadata = extractMetadata(fulfillResponse, mainPlace);
-          mainPageMetadata = filterBlocksFromPageMetadata(
-            mainPageMetadata,
-            highlightPageMetadataResp.pageConfig.categories.flatMap(
-              (category) => category.blocks || []
-            )
-          );
+          if (highlightPageMetadataResp) {
+            setHighlightPageMetadata(highlightPageMetadataResp);
+            mainPageMetadata = filterBlocksFromPageMetadata(
+              mainPageMetadata,
+              highlightPageMetadataResp.pageConfig.categories.flatMap(
+                (category) => category.blocks || []
+              )
+            );
+          }
+
           setPageMetadata(mainPageMetadata);
           processFulfillData(fulfillResponse, mainPageMetadata, query);
         }

--- a/static/js/apps/explore/explore_utils.ts
+++ b/static/js/apps/explore/explore_utils.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { BlockConfig } from "../../types/subject_page_proto_types";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
-
 /**
  * Checks if the fulfill data is valid.
  * @param fulfillData - The fulfill data to validate.

--- a/static/js/apps/explore/explore_utils.ts
+++ b/static/js/apps/explore/explore_utils.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BlockConfig } from "../../types/subject_page_proto_types";
+import { SubjectPageMetadata } from "../../types/subject_page_types";
+
+/**
+ * Checks if the fulfill data is valid.
+ * @param fulfillData - The fulfill data to validate.
+ * @returns boolean indicating if the fulfill data is valid.
+ */
+export function isFulfillDataValid(fulfillData: any): boolean {
+  if (!fulfillData) {
+    return false;
+  }
+  const hasPlace = fulfillData["place"] && fulfillData["place"]["dcid"];
+  // Fulfill data needs to have either a place or entities
+  return hasPlace || fulfillData["entities"];
+}
+
+/**
+ * Filters out blocks from the page metadata that are present in the highlight
+ * page metadata.
+ *
+ * @param pageMetadata - The original page metadata.
+ * @param highlightPageMetadata - The highlight page metadata.
+ * @returns The new page metadata with the blocks filtered out.
+ */
+export function filterBlocksFromPageMetadata(
+  pageMetadata: SubjectPageMetadata,
+  highlightPageMetadata: SubjectPageMetadata
+): SubjectPageMetadata {
+  const blocksToRemove: BlockConfig[] =
+    highlightPageMetadata.pageConfig.categories.flatMap(
+      (category) => category.blocks
+    );
+  // Filter out all blocks that exactly match the blocks in the page metadata
+  // and return the new page metadata.
+  const newPageMetadata = { ...pageMetadata };
+  newPageMetadata.pageConfig = {
+    ...pageMetadata.pageConfig,
+    categories: pageMetadata.pageConfig.categories.map((category) => {
+      const newCategory = { ...category };
+      newCategory.blocks = category.blocks.filter((block) => {
+        return !blocksToRemove.some((b) => {
+          return (
+            b.title === block.title &&
+            b.description === block.description &&
+            b.footnote === block.footnote &&
+            JSON.stringify(b.columns) === JSON.stringify(block.columns) &&
+            b.type === block.type &&
+            b.denom === block.denom &&
+            b.startWithDenom === block.startWithDenom &&
+            JSON.stringify(b.disasterBlockSpec) ===
+              JSON.stringify(block.disasterBlockSpec) &&
+            b.infoMessage === block.infoMessage
+          );
+        });
+      });
+      return newCategory;
+    }),
+  };
+  return newPageMetadata;
+}
+
+/* eslint-disable */
+/**
+ * Extracts the main place and metadata from the fulfill data.
+ *
+ * @param fulfillData - The fulfill data to extract from.
+ * @returns A tuple containing the main place and metadata.
+ */
+export function extractMainPlaceAndMetadata(
+    fulfillData: any
+  ): [any, SubjectPageMetadata] {
+    /* eslint-enable */
+  const mainPlace = {
+    dcid: fulfillData["place"]["dcid"],
+    name: fulfillData["place"]["name"],
+    types: [fulfillData["place"]["place_type"]],
+  };
+  const relatedThings = fulfillData["relatedThings"] || {};
+  const pageMetadata: SubjectPageMetadata = {
+    place: mainPlace,
+    places: fulfillData["places"],
+    pageConfig: fulfillData["config"],
+    childPlaces: relatedThings["childPlaces"],
+    peerPlaces: relatedThings["peerPlaces"],
+    parentPlaces: relatedThings["parentPlaces"],
+    parentTopics: relatedThings["parentTopics"],
+    childTopics: relatedThings["childTopics"],
+    peerTopics: relatedThings["peerTopics"],
+    exploreMore: relatedThings["exploreMore"],
+    mainTopics: relatedThings["mainTopics"],
+    sessionId: "session" in fulfillData ? fulfillData["session"]["id"] : "",
+    svSource: fulfillData["svSource"],
+  };
+  return [mainPlace, pageMetadata];
+}

--- a/static/js/apps/explore/explore_utils.ts
+++ b/static/js/apps/explore/explore_utils.ts
@@ -101,6 +101,9 @@ export function extractMetadata(
   mainPlace: any
 ): SubjectPageMetadata {
   /* eslint-enable */
+  if (!isFulfillDataValid(fulfillData)) {
+    return null;
+  }
   const relatedThings = fulfillData["relatedThings"] || {};
   const pageMetadata: SubjectPageMetadata = {
     place: mainPlace,

--- a/static/js/apps/explore/explore_utils.ts
+++ b/static/js/apps/explore/explore_utils.ts
@@ -41,12 +41,8 @@ export function isFulfillDataValid(fulfillData: any): boolean {
  */
 export function filterBlocksFromPageMetadata(
   pageMetadata: SubjectPageMetadata,
-  highlightPageMetadata: SubjectPageMetadata
+  blocksToRemove: BlockConfig[]
 ): SubjectPageMetadata {
-  const blocksToRemove: BlockConfig[] =
-    highlightPageMetadata.pageConfig.categories.flatMap(
-      (category) => category.blocks
-    );
   // Filter out all blocks that exactly match the blocks in the page metadata
   // and return the new page metadata.
   const newPageMetadata = { ...pageMetadata };
@@ -76,22 +72,33 @@ export function filterBlocksFromPageMetadata(
   return newPageMetadata;
 }
 
-/* eslint-disable */
+/**
+ * Extracts the main place from the fulfill data.
+ *
+ * @param fulfillData - The fulfill data to extract from.
+ * @returns The main place extracted from the fulfill data.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function extractMainPlace(fulfillData: any): any {
+  /* eslint-enable */
+  return {
+    dcid: fulfillData["place"]["dcid"],
+    name: fulfillData["place"]["name"],
+    types: [fulfillData["place"]["place_type"]],
+  };
+}
 /**
  * Extracts the main place and metadata from the fulfill data.
  *
  * @param fulfillData - The fulfill data to extract from.
  * @returns A tuple containing the main place and metadata.
  */
-export function extractMainPlaceAndMetadata(
-    fulfillData: any
-  ): [any, SubjectPageMetadata] {
-    /* eslint-enable */
-  const mainPlace = {
-    dcid: fulfillData["place"]["dcid"],
-    name: fulfillData["place"]["name"],
-    types: [fulfillData["place"]["place_type"]],
-  };
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function extractMetadata(
+  fulfillData: any,
+  mainPlace: any
+): SubjectPageMetadata {
+  /* eslint-enable */
   const relatedThings = fulfillData["relatedThings"] || {};
   const pageMetadata: SubjectPageMetadata = {
     place: mainPlace,
@@ -108,5 +115,5 @@ export function extractMainPlaceAndMetadata(
     sessionId: "session" in fulfillData ? fulfillData["session"]["id"] : "",
     svSource: fulfillData["svSource"],
   };
-  return [mainPlace, pageMetadata];
+  return pageMetadata;
 }

--- a/static/js/apps/explore/explore_utils.ts
+++ b/static/js/apps/explore/explore_utils.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-
 import { BlockConfig } from "../../types/subject_page_proto_types";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 /**
  * Checks if the fulfill data is valid.
  * @param fulfillData - The fulfill data to validate.
  * @returns boolean indicating if the fulfill data is valid.
-*/
+ */
 /* eslint-disable */
 export function isFulfillDataValid(fulfillData: any): boolean {
   /* eslint-enable */

--- a/static/js/apps/explore/explore_utils.ts
+++ b/static/js/apps/explore/explore_utils.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { BlockConfig } from "../../types/subject_page_proto_types";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
@@ -22,8 +21,10 @@ import { SubjectPageMetadata } from "../../types/subject_page_types";
  * Checks if the fulfill data is valid.
  * @param fulfillData - The fulfill data to validate.
  * @returns boolean indicating if the fulfill data is valid.
- */
+*/
+/* eslint-disable */
 export function isFulfillDataValid(fulfillData: any): boolean {
+  /* eslint-enable */
   if (!fulfillData) {
     return false;
   }
@@ -79,7 +80,7 @@ export function filterBlocksFromPageMetadata(
  * @param fulfillData - The fulfill data to extract from.
  * @returns The main place extracted from the fulfill data.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable */
 export function extractMainPlace(fulfillData: any): any {
   /* eslint-enable */
   return {
@@ -94,7 +95,7 @@ export function extractMainPlace(fulfillData: any): any {
  * @param fulfillData - The fulfill data to extract from.
  * @returns A tuple containing the main place and metadata.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable */
 export function extractMetadata(
   fulfillData: any,
   mainPlace: any

--- a/static/js/utils/app/explore_utils.ts
+++ b/static/js/utils/app/explore_utils.ts
@@ -60,6 +60,7 @@ export function getTopics(
           [URL_HASH_PARAMS.CLIENT]: CLIENT_TYPES.RELATED_TOPIC,
           [URL_HASH_PARAMS.STAT_VAR]: "",
           [URL_HASH_PARAMS.CHART_TYPE]: "",
+          [URL_HASH_PARAMS.IMPORT_NAME]: "",
         })}`,
       });
     }

--- a/static/js/utils/app/explore_utils.ts
+++ b/static/js/utils/app/explore_utils.ts
@@ -61,6 +61,8 @@ export function getTopics(
           [URL_HASH_PARAMS.STAT_VAR]: "",
           [URL_HASH_PARAMS.CHART_TYPE]: "",
           [URL_HASH_PARAMS.IMPORT_NAME]: "",
+          [URL_HASH_PARAMS.MEASUREMENT_METHOD]: "",
+          [URL_HASH_PARAMS.UNIT]: "",
         })}`,
       });
     }

--- a/static/js/utils/explore_utils.ts
+++ b/static/js/utils/explore_utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { BlockConfig } from "../types/subject_page_proto_types";
 import { SubjectPageMetadata } from "../types/subject_page_types";
 
 /**

--- a/static/js/utils/explore_utils.ts
+++ b/static/js/utils/explore_utils.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { BlockConfig } from "../types/subject_page_proto_types";
 import { SubjectPageMetadata } from "../types/subject_page_types";
 
 /**


### PR DESCRIPTION
This PR does two main things for improving the chart injection work:

For single chart injection, it would show the proper chart + a chart for the contained in places. This PR removes that part of the code. Whenever we have that chartType URL parameter, we filter out any additional contained_in logic for chart generation.

For all charts, since we duplicated the call to fulfill while restricting to a single stat var, that chart will appear in the highlight chart + the regular response. so I implemented the logic to remove any duplicate blocks from the non-highlight block.

Examples:
Before: https://screenshot.googleplex.com/BtvrNX3hHEGaBjv
After: https://screenshot.googleplex.com/9WF3EDSQLVtEZn9
Note the contained in block is gone, and the duplicate first chart is gone.