### PR TITLE
Add usage metrics for StatVar browsing

### DIFF
--- a/static/js/shared/ga_events.test.tsx
+++ b/static/js/shared/ga_events.test.tsx
@@ -84,6 +84,7 @@ import { Chart as TimelineToolChart } from "../tools/timeline/chart";
 import * as dataFetcher from "../tools/timeline/data_fetcher";
 import { axiosMock } from "../tools/timeline/mock_functions";
 import {
+  GA_EVENT_STATVAR_HIERARCHY_CLICK,
   GA_EVENT_STATVAR_SEARCH_TRIGGERED,
   GA_EVENT_TOOL_CHART_OPTION_CLICK,
   GA_EVENT_TOOL_CHART_PLOT,
@@ -92,6 +93,7 @@ import {
   GA_EVENT_TOOL_STAT_VAR_SEARCH_NO_RESULT,
   GA_PARAM_PLACE_DCID,
   GA_PARAM_SEARCH_TERM,
+  GA_PARAM_SOURCE,
   GA_PARAM_STAT_VAR,
   GA_PARAM_TOOL_CHART_OPTION,
   GA_VALUE_TOOL_CHART_OPTION_DELTA,
@@ -103,6 +105,7 @@ import {
   GA_VALUE_TOOL_CHART_OPTION_SHOW_LABELS,
   GA_VALUE_TOOL_CHART_OPTION_SHOW_QUADRANTS,
   GA_VALUE_TOOL_CHART_OPTION_SWAP,
+  GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY
 } from "./ga_events";
 import { PlaceSelector } from "./place_selector";
 import { StatVarInfo } from "./stat_var";
@@ -608,13 +611,20 @@ describe("test ga event tool stat var click", () => {
       target: { checked: true },
     });
     await waitFor(() => {
-      // Check gtag is called once.
-      expect(mockgtag.mock.calls.length).toEqual(1);
+      // Check gtag is called.
+      expect(mockgtag.mock.calls.length).toEqual(2);
+      // Check that the first event called is GA_EVENT_STATVAR_HIERARCHY_CLICK
+      expect(mockgtag.mock.calls[0]).toEqual([
+        "event",
+        GA_EVENT_STATVAR_HIERARCHY_CLICK,
+        {},
+      ]);
       // Check the parameters passed to the gtag.
       expect(mockgtag.mock.lastCall).toEqual([
         "event",
         GA_EVENT_TOOL_STAT_VAR_CLICK,
         {
+          [GA_PARAM_SOURCE]: GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY,
           [GA_PARAM_STAT_VAR]: STAT_VAR_3,
         },
       ]);

--- a/static/js/shared/ga_events.test.tsx
+++ b/static/js/shared/ga_events.test.tsx
@@ -105,7 +105,7 @@ import {
   GA_VALUE_TOOL_CHART_OPTION_SHOW_LABELS,
   GA_VALUE_TOOL_CHART_OPTION_SHOW_QUADRANTS,
   GA_VALUE_TOOL_CHART_OPTION_SWAP,
-  GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY
+  GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY,
 } from "./ga_events";
 import { PlaceSelector } from "./place_selector";
 import { StatVarInfo } from "./stat_var";

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -63,10 +63,10 @@ export const GA_EVENT_TOOL_CHART_PLOT = "tool_chart_plot";
 /**
  * Event name: tool_stat_var_click
  * Triggered when: a stat var is selected in the stat var hierarchy.
- * Parameters with value: { 
+ * Parameters with value: {
  *                         source: "sv_search" | "sv_hierarchy",
  *                         stat_var: "Median_Income_Household",
- *                        }     
+ *                        }
  */
 export const GA_EVENT_TOOL_STAT_VAR_CLICK = "tool_stat_var_click";
 /**

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -63,7 +63,10 @@ export const GA_EVENT_TOOL_CHART_PLOT = "tool_chart_plot";
 /**
  * Event name: tool_stat_var_click
  * Triggered when: a stat var is selected in the stat var hierarchy.
- * Parameters with value: { stat_var: "Median_Income_Household" }
+ * Parameters with value: { 
+ *                         source: "sv_search" | "sv_hierarchy",
+ *                         stat_var: "Median_Income_Household",
+ *                        }     
  */
 export const GA_EVENT_TOOL_STAT_VAR_CLICK = "tool_stat_var_click";
 /**
@@ -220,6 +223,12 @@ export const GA_EVENT_STATVAR_SEARCH_TRIGGERED = "statvar_search_trigger";
  */
 export const GA_EVENT_STATVAR_SEARCH_SELECTION = "statvar_search_select";
 
+/**
+ * Triggered when any node on the StatVar hierarchy is clicked.
+ * Parameters: None
+ */
+export const GA_EVENT_STATVAR_HIERARCHY_CLICK = "statvar_hierarchy_click";
+
 // GA event parameters
 export const GA_PARAM_PLACE_CATEGORY_CLICK_SOURCE =
   "place_category_click_source";
@@ -270,3 +279,5 @@ export const GA_VALUE_SEARCH_SOURCE_EXPLORE = "explore";
 export const GA_VALUE_SEARCH_SOURCE_EXPLORE_LANDING = "explore_landing";
 export const GA_VALUE_SEARCH_SOURCE_HOMEPAGE = "homepage";
 export const GA_VALUE_SEARCH_SOURCE_PLACE_PAGE = "place";
+export const GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY = "sv_hierarchy";
+export const GA_VALUE_TOOL_STAT_VAR_OPTION_SEARCH = "sv_search";

--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -26,6 +26,10 @@ import Collapsible from "react-collapsible";
 import { ASYNC_ELEMENT_HOLDER_CLASS } from "../constants/css_constants";
 import { Context, ContextType } from "../shared/context";
 import {
+  GA_EVENT_STATVAR_HIERARCHY_CLICK,
+  triggerGAEvent,
+} from "../shared/ga_events";
+import {
   NamedNode,
   RADIO_BUTTON_TYPES,
   StatVarGroupInfo,
@@ -216,6 +220,7 @@ export class StatVarGroupNode extends React.Component<
           triggerWhenOpen={getTrigger(true)}
           open={shouldOpen}
           handleTriggerClick={(): void => {
+            triggerGAEvent(GA_EVENT_STATVAR_HIERARCHY_CLICK, {});
             this.setState({ isOpen: !this.state.isOpen });
           }}
           transitionTime={200}

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -27,7 +27,10 @@ import React from "react";
 import { Context } from "../shared/context";
 import {
   GA_EVENT_TOOL_STAT_VAR_CLICK,
+  GA_PARAM_SOURCE,
   GA_PARAM_STAT_VAR,
+  GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY,
+  GA_VALUE_TOOL_STAT_VAR_OPTION_SEARCH,
   triggerGAEvent,
 } from "../shared/ga_events";
 import {
@@ -344,12 +347,12 @@ export class StatVarHierarchy extends React.Component<
         searchSelectionCleared,
         expandedPath: searchSelectionCleared ? this.state.focusPath : [],
       });
-      this.togglePath(selection, path);
+      this.togglePath(selection, path, true);
     });
   }
 
   // Add or remove a stat var and its path from the state.
-  private togglePath(sv: string, path?: string[]): void {
+  private togglePath(sv: string, path?: string[], searchSelection: boolean = false): void {
     if (sv in this.state.svPath) {
       const tmp = _.cloneDeep(this.state.svPath);
       delete tmp[sv];
@@ -360,9 +363,16 @@ export class StatVarHierarchy extends React.Component<
     } else {
       if (this.props.selectSV) {
         this.props.selectSV(sv);
-        triggerGAEvent(GA_EVENT_TOOL_STAT_VAR_CLICK, {
-          [GA_PARAM_STAT_VAR]: sv,
-        });
+        console.log("Stat var selected: ", sv);
+        // Trigger GA event if sv is not empty
+        if (sv) {
+          console.log("triggering GA event");
+          triggerGAEvent(GA_EVENT_TOOL_STAT_VAR_CLICK, {
+            [GA_PARAM_SOURCE]: searchSelection ? GA_VALUE_TOOL_STAT_VAR_OPTION_SEARCH 
+            : GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY,
+            [GA_PARAM_STAT_VAR]: sv,
+          });
+        }
       }
       const svPath = RADIO_BUTTON_TYPES.has(this.props.type)
         ? { [sv]: path }

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -355,7 +355,7 @@ export class StatVarHierarchy extends React.Component<
   private togglePath(
     sv: string,
     path?: string[],
-    isSearchSelection = false
+    isSearchSelection?: boolean
   ): void {
     if (sv in this.state.svPath) {
       const tmp = _.cloneDeep(this.state.svPath);

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -355,7 +355,7 @@ export class StatVarHierarchy extends React.Component<
   private togglePath(
     sv: string,
     path?: string[],
-    isSearchSelection: boolean = false
+    isSearchSelection = false
   ): void {
     if (sv in this.state.svPath) {
       const tmp = _.cloneDeep(this.state.svPath);

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -347,7 +347,7 @@ export class StatVarHierarchy extends React.Component<
         searchSelectionCleared,
         expandedPath: searchSelectionCleared ? this.state.focusPath : [],
       });
-      this.togglePath(selection, path, true);
+      this.togglePath(selection, path, /*isSearchSelection=*/ true);
     });
   }
 
@@ -355,7 +355,7 @@ export class StatVarHierarchy extends React.Component<
   private togglePath(
     sv: string,
     path?: string[],
-    searchSelection = false
+    isSearchSelection: boolean = false
   ): void {
     if (sv in this.state.svPath) {
       const tmp = _.cloneDeep(this.state.svPath);
@@ -367,12 +367,10 @@ export class StatVarHierarchy extends React.Component<
     } else {
       if (this.props.selectSV) {
         this.props.selectSV(sv);
-        console.log("Stat var selected: ", sv);
         // Trigger GA event if sv is not empty
         if (sv) {
-          console.log("triggering GA event");
           triggerGAEvent(GA_EVENT_TOOL_STAT_VAR_CLICK, {
-            [GA_PARAM_SOURCE]: searchSelection
+            [GA_PARAM_SOURCE]: isSearchSelection
               ? GA_VALUE_TOOL_STAT_VAR_OPTION_SEARCH
               : GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY,
             [GA_PARAM_STAT_VAR]: sv,

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -352,7 +352,11 @@ export class StatVarHierarchy extends React.Component<
   }
 
   // Add or remove a stat var and its path from the state.
-  private togglePath(sv: string, path?: string[], searchSelection: boolean = false): void {
+  private togglePath(
+    sv: string,
+    path?: string[],
+    searchSelection = false
+  ): void {
     if (sv in this.state.svPath) {
       const tmp = _.cloneDeep(this.state.svPath);
       delete tmp[sv];
@@ -368,8 +372,9 @@ export class StatVarHierarchy extends React.Component<
         if (sv) {
           console.log("triggering GA event");
           triggerGAEvent(GA_EVENT_TOOL_STAT_VAR_CLICK, {
-            [GA_PARAM_SOURCE]: searchSelection ? GA_VALUE_TOOL_STAT_VAR_OPTION_SEARCH 
-            : GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY,
+            [GA_PARAM_SOURCE]: searchSelection
+              ? GA_VALUE_TOOL_STAT_VAR_OPTION_SEARCH
+              : GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY,
             [GA_PARAM_STAT_VAR]: sv,
           });
         }


### PR DESCRIPTION
Adds Google Analytics events to track user browsing StatVar. 

- One event is fired when the user clicks on any toggles in the StatVar hierarchy. Note that this fires both when the toggle is opened OR closed (I thought it would be relevant to track both opening and closing the toggle since they both reflect user browsing, but lmk if you disagree with this). 
- The other change updates the existing event `GA_EVENT_TOOL_STAT_VAR_CLICK` which currently fires whenever a stat var is selected. I added a parameter here to track whether the stat var was selected directly from the hierarchy or through searching. 
   - While testing this change I also noticed that the event is currently also fired whenever the user clears the current search query ([example](http://screencast/cast/NTAyNTIyOTcwODQ2MDAzMnw2Yjg1NjAyOC1kZQ)), I believe because of [this](https://github.com/datacommonsorg/website/blob/master/static/js/stat_var_hierarchy/stat_var_search.tsx#L256) line which calls `onSelectionChange` with an empty string, which down the line ends up calling `togglePath` with `sv` as an empty string. So I also added a check to see if `sv` is non-empty before firing the event. 

Tested by using console logs & manually verifying that code is reached during expected events. Also modified an existing client test to test this change. 