### PR TITLE
[Chart Injection] Adds support for "?" as URL parameter separator

### DIFF
--- a/server/webdriver/shared_tests/explore_test.py
+++ b/server/webdriver/shared_tests/explore_test.py
@@ -48,6 +48,17 @@ class ExplorePageTestMixin():
                                    'place-callout-link')
     self.assertEqual(place_callout_link.text, 'France')
 
+  def test_highlight_chart_as_url_params(self):
+    """Test the highlight chart for France GDP timeline."""
+    highlight_params = "?sv=Amount_EconomicActivity_GrossDomesticProduction_Nominal&p=country%2FFRA&chartType=TIMELINE_WITH_HIGHLIGHT"
+    self.driver.get(self.url_ + EXPLORE_URL + highlight_params)
+
+    shared.wait_for_loading(self.driver)
+
+    place_callout_link = find_elem(self.driver, By.CLASS_NAME,
+                                   'place-callout-link')
+    self.assertEqual(place_callout_link.text, 'France')
+
   def test_highlight_chart_france_italy_gdp_timeline(self):
     """Test the highlight chart for France GDP timeline."""
     highlight_params = "#sv=Amount_EconomicActivity_GrossDomesticProduction_Nominal&p=country%2FFRA___country%2FITA&chartType=TIMELINE_WITH_HIGHLIGHT"

--- a/server/webdriver/shared_tests/explore_test.py
+++ b/server/webdriver/shared_tests/explore_test.py
@@ -59,6 +59,11 @@ class ExplorePageTestMixin():
                                    'place-callout-link')
     self.assertEqual(place_callout_link.text, 'France')
 
+    highlight_div = find_elem(self.driver, By.CLASS_NAME,
+                              'highlight-result-title')
+    line_chart = find_elem(highlight_div, By.CLASS_NAME, 'line-chart')
+    self.assertIsNotNone(line_chart)
+
   def test_highlight_chart_france_italy_gdp_timeline(self):
     """Test the highlight chart for France GDP timeline."""
     highlight_params = "#sv=Amount_EconomicActivity_GrossDomesticProduction_Nominal&p=country%2FFRA___country%2FITA&chartType=TIMELINE_WITH_HIGHLIGHT"

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -299,7 +299,15 @@ export function App(props: AppProps): ReactElement {
 
   async function handleHashChange(): Promise<void> {
     setLoadingStatus(LoadingStatus.LOADING);
-    const hashParams = queryString.parse(window.location.hash);
+    let hashParams: Record<string, string | string[]>;
+    if (window.location.hash) {
+      hashParams = queryString.parse(window.location.hash);
+    } else {
+      hashParams = Object.fromEntries(
+        new URLSearchParams(window.location.search)
+      );
+    }
+
     let client = getSingleParam(hashParams[URL_HASH_PARAMS.CLIENT]);
     const urlHashParams: UrlHashParams = extractUrlHashParams(hashParams);
     const query = urlHashParams.query;


### PR DESCRIPTION
Allow the hashparams to be provided as URL parameters. The "?" separator is the preferred standard today, we plan on supporting both for now and trying to migrate everything to the using URL params over hash params in the future.