### PR TITLE
[VisTool Fix] Fix facet selection in vis tools

### DIFF
--- a/server/webdriver/shared_tests/vis_timeline_test.py
+++ b/server/webdriver/shared_tests/vis_timeline_test.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 from server.webdriver.base_utils import find_elem
+from server.webdriver.base_utils import find_elems
 import server.webdriver.shared as shared
 
 TIMELINE_URL = '/tools/visualization#visType=timeline'
@@ -225,33 +228,44 @@ class VisTimelineTestMixin():
     """Test selecting a different facet of the metadata and verify the line changes."""
     self.driver.get(self.url_ + TIMELINE_URL + URL_HASH_1)
 
-    # Wait until the chart has loaded
     shared.wait_for_loading(self.driver)
 
-    original_source_text = find_elem(self.driver, value='source-links').text
+    original_source_text = find_elems(self.driver,
+                                      value='sources',
+                                      path_to_elem=['chart'])[0].text
+    self.assertEqual(original_source_text, 'Source: census.gov • Show metadata')
 
     # Click on the button to open the source selector modal
-    find_elem(self.driver, 'source-selector-open-modal-button').click()
+    find_elem(self.driver, value='source-selector-open-modal-button').click()
 
     shared.wait_for_loading(self.driver)
 
-    first_source_title = find_elems(self.driver, value='source-selector-trigger-title')[0]
-    self.assertIsNotNone(first_source_title)
-    first_source_title.click()
+    first_sv = find_elem(self.driver, value='source-selector-trigger').click()
 
-    # Find the div that contains the text "OECD" and click on it
-    oecd_option = find_elem(self.driver, by=By.XPATH,
-    value='//div[contains(@class, "source-selector-option-title") and contains(text(), "OECD")]'
-    )
-    oecd_option.click()
+    shared.wait_for_loading(self.driver)
+
+    source_options = find_elems(
+        self.driver,
+        value='source-selector-option-title',
+        path_to_elem=['source-selector-options-section'])
+    self.assertEqual(len(source_options), 18)
+
+    radio = find_elem(source_options[8], by=By.TAG_NAME, value='input')
+    radio.click()
 
     # Click the modal-footer button to apply the changes
-    modal_footer_button = find_element(self.driver, value='modal-footer')
+    modal_footer_button = find_elem(self.driver,
+                                    value='btn-primary',
+                                    path_to_elem=['modal-footer'])
     modal_footer_button.click()
 
     # Wait for the chart to reload
     shared.wait_for_loading(self.driver)
 
     # Verify the source text has changed
-    updated_source_text = find_elem(self.driver, value='source-links').text
-    self.assertNotEqual(original_source_text, updated_source_text)
+    updated_source_text = find_elem(self.driver,
+                                    value='sources',
+                                    path_to_elem=['chart']).text
+    self.assertEqual(
+        updated_source_text,
+        'Sources: census.gov, data-explorer.oecd.org • Show metadata')

--- a/static/js/components/tiles/line_tile.tsx
+++ b/static/js/components/tiles/line_tile.tsx
@@ -333,12 +333,13 @@ export const fetchData = async (
       );
     } else {
       const placeDcids = getPlaceDcids(props);
+      // Note that for now there are two ways to select the facet, via facetIds or highlightFacet. At most only one should be provided.
       dataPromises.push(
         getSeries(
           props.apiRoot,
           placeDcids,
           facetToVariable[facetId],
-          undefined,
+          facetIds,
           props.highlightFacet
         )
       );

--- a/static/js/utils/data_fetch_utils.ts
+++ b/static/js/utils/data_fetch_utils.ts
@@ -228,9 +228,14 @@ export function getPointWithin(
 
 /**
  * Gets the data from /api/observations/series endpoint.
+ *
+ * Note that for now there are two ways to fetch a single facet, either via facetIds or given a highlightFacet. Only one of the two should be provided.
  * @param apiRoot api root
  * @param entities list of enitites to get data for
  * @param variables list of variables to get data for
+ * @param facetIds list of facet ids to get data for
+ * @param highlightFacet the facet to highlight
+ * @returns The data for the given entities and variables, matching the provided facet if applicable.
  */
 export function getSeries(
   apiRoot: string,


### PR DESCRIPTION
This PR re-adds the facetIds parameter for fetching source series. these are still used by the web components from the viztools. Removing it previously broke the facet selection. 

Added a webdriver test to prevent future breakages.