### PR TITLE
[Chart Injection] Add Metadata Text on chart highlight

### DIFF
--- a/server/webdriver/shared_tests/explore_test.py
+++ b/server/webdriver/shared_tests/explore_test.py
@@ -82,7 +82,7 @@ class ExplorePageTestMixin():
 
   def test_highlight_chart_france_italy_gdp_bar_chart(self):
     """Test the highlight chart for France GDP timeline."""
-    highlight_params = "#sv=Amount_EconomicActivity_GrossDomesticProduction_Nominal&p=country%2FFRA___country%2FITA&chartType=BAR_CHART"
+    highlight_params = "#sv=Amount_EconomicActivity_GrossDomesticProduction_Nominal&p=country%2FFRA___country%2FITA&chartType=BAR_CHART&imp=WorldDevelopmentIndicators"
     self.driver.get(self.url_ + EXPLORE_URL + highlight_params)
 
     shared.wait_for_loading(self.driver)
@@ -92,8 +92,14 @@ class ExplorePageTestMixin():
 
     highlight_div = find_elem(self.driver, By.CLASS_NAME,
                               'highlight-result-title')
-    line_chart = find_elem(highlight_div, By.CLASS_NAME, 'bar-chart')
-    self.assertIsNotNone(line_chart)
+    bar_chart = find_elem(highlight_div, By.CLASS_NAME, 'bar-chart')
+    self.assertIsNotNone(bar_chart)
+
+    block_description = find_elems(self.driver, value='block-desc')[0]
+    self.assertEqual(
+        block_description.text,
+        'World Bank, World Development Indicators, with minor processing by Data Commons'
+    )
 
   def test_highlight_chart_clears(self):
     """Test the highlight chart for France GDP timeline clears after topic selected."""

--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -49,7 +49,6 @@ import { useQueryStore } from "../../shared/stores/query_store_hook";
 import theme from "../../theme/theme";
 import { QueryResult, UserMessageInfo } from "../../types/app/explore_types";
 import { FacetMetadata } from "../../types/facet_metadata";
-import { BlockConfig } from "../../types/subject_page_proto_types";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import { defaultDataCommonsWebClient } from "../../utils/data_commons_client";
 import { shouldSkipPlaceOverview } from "../../utils/explore_utils";

--- a/static/js/apps/explore/highlight_result.tsx
+++ b/static/js/apps/explore/highlight_result.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 
 import { SubjectPageMainPane } from "../../components/subject_page/main_pane";
+import { StatMetadata } from "../../shared/stat_types";
+import { NamedNode, StatVarFacetMap } from "../../shared/types";
+import { StatVarMetadata } from "../../tools/shared/metadata/metadata";
+import { fetchMetadata } from "../../tools/shared/metadata/metadata_fetcher";
+import { TileMetadataModalContent } from "../../tools/shared/metadata/tile_metadata_modal_content";
 import { FacetMetadata } from "../../types/facet_metadata";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
+import { getDataCommonsClient } from "../../utils/data_commons_client";
 import { trimCategory } from "../../utils/subject_page_utils";
 
 /**
@@ -15,25 +21,96 @@ interface HighlightResultProps {
   highlightPageMetadata: SubjectPageMetadata;
   maxBlock: number;
   highlightFacet?: FacetMetadata;
+  apiRoot?: string;
 }
 
 export function HighlightResult(
   props: HighlightResultProps
 ): React.ReactElement {
+  const dataCommonsClient = getDataCommonsClient(props.apiRoot);
+
+  const statMetadataRecord: { [key: string]: StatMetadata } = {
+    Count_Person: {
+      provenanceUrl: props.highlightFacet?.importName || "",
+      measurementMethod: props.highlightFacet?.measurementMethod || "",
+      observationPeriod: props.highlightFacet?.observationPeriod || "",
+      scalingFactor: String(props.highlightFacet?.scalingFactor) || "",
+      unit: props.highlightFacet?.unit || "",
+    },
+  };
+
+  console.log("StatMetadata Record: ", statMetadataRecord);
+  console.log(props.highlightPageMetadata);
+
+  const svthing =
+    props.highlightPageMetadata.pageConfig.categories[0].statVarSpec[
+      "Count_Person2"
+    ].statVar;
+  console.log("Stat var thing: ", svthing);
+  const statVarFacetMap: StatVarFacetMap = {
+    [svthing]: new Set(["1"]),
+  };
+
+  const [metadataMap, setMetadataMap] = React.useState<
+    Record<string, StatVarMetadata[]>
+  >({});
+  const [statVarList, setStatVarList] = React.useState<NamedNode[]>([]);
+
+  React.useEffect(() => {
+    fetchMetadata(
+      new Set(svthing),
+      statMetadataRecord,
+      dataCommonsClient,
+      statVarFacetMap,
+      props.apiRoot
+    )
+      .then((response) => {
+        const { metadata, statVarList } = response;
+        setMetadataMap(metadata);
+        setStatVarList(statVarList);
+        console.log("Fetched metadata: ", metadata);
+        console.log("Fetched stat var list: ", statVarList);
+      })
+      .catch((error) => {
+        console.error("Error fetching metadata: ", error);
+      });
+  }, [props.highlightPageMetadata]);
+
+  // Extract Stat Var information, place information, source information.
+  // const svSource = props.highlightPageMetadata.svSource;
+  // console.log("SV SOURCE IS " + JSON.stringify(svSource));
+
+  // const places = props.highlightPageMetadata.places;
+  // console.log("PLACES ARE " + JSON.stringify(places));
+
+  // const facet = props.highlightFacet;
+  // console.log("Requested facet is " + JSON.stringify(facet));
   return (
     <div>
-      <div className="highlight-result-title">
-        <SubjectPageMainPane
-          id={PAGE_ID}
-          place={props.highlightPageMetadata.place}
-          pageConfig={trimCategory(
-            props.highlightPageMetadata.pageConfig,
-            props.maxBlock
-          )}
-          showExploreMore={false}
-          highlightFacet={props.highlightFacet}
-        />
+      <br></br>
+      <div id="place-callout">
+        <span>Highlighted Chart</span>
       </div>
+      <TileMetadataModalContent
+        statVars={statVarList}
+        metadataMap={metadataMap}
+        apiRoot={props.apiRoot}
+      />
+      <p>
+        This is the data that is being highlighted as requested. It comes frmo
+        the source X - [Add Provenance name and description] with minor
+        processing from datacommons.
+      </p>
+      <SubjectPageMainPane
+        id={PAGE_ID}
+        place={props.highlightPageMetadata.place}
+        pageConfig={trimCategory(
+          props.highlightPageMetadata.pageConfig,
+          props.maxBlock
+        )}
+        showExploreMore={false}
+        highlightFacet={props.highlightFacet}
+      />
     </div>
   );
 }

--- a/static/js/apps/explore/highlight_result.tsx
+++ b/static/js/apps/explore/highlight_result.tsx
@@ -9,6 +9,7 @@ import { TileMetadataModalContent } from "../../tools/shared/metadata/tile_metad
 import { FacetMetadata } from "../../types/facet_metadata";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import { getDataCommonsClient } from "../../utils/data_commons_client";
+import { getFacets } from "../../utils/data_fetch_utils";
 import { trimCategory } from "../../utils/subject_page_utils";
 
 /**
@@ -24,90 +25,115 @@ interface HighlightResultProps {
   apiRoot?: string;
 }
 
-export function HighlightResult(
-  props: HighlightResultProps
-): React.ReactElement {
-  const dataCommonsClient = getDataCommonsClient(props.apiRoot);
+async function doMetadataFetch(props: HighlightResultProps): Promise<{
+  metadata: Record<string, StatVarMetadata[]>;
+  statVarList: NamedNode[];
+}> {
+  const statVarSet = new Set<string>();
+  if (props.highlightPageMetadata.pageConfig.categories[0].statVarSpec) {
+    for (const spec of Object.values(
+      props.highlightPageMetadata.pageConfig.categories[0].statVarSpec
+    )) {
+      statVarSet.add(spec.statVar);
+      if (spec.denom) {
+        statVarSet.add(spec.denom);
+      }
+    }
+  }
 
+  const dataCommonsClient = getDataCommonsClient(props.apiRoot);
   const statMetadataRecord: { [key: string]: StatMetadata } = {
-    Count_Person: {
+    "1": {
       provenanceUrl: props.highlightFacet?.importName || "",
       measurementMethod: props.highlightFacet?.measurementMethod || "",
       observationPeriod: props.highlightFacet?.observationPeriod || "",
-      scalingFactor: String(props.highlightFacet?.scalingFactor) || "",
+      scalingFactor: "",
       unit: props.highlightFacet?.unit || "",
     },
   };
 
-  console.log("StatMetadata Record: ", statMetadataRecord);
-  console.log(props.highlightPageMetadata);
+  const statVarArray = Array.from(statVarSet);
+  const facets = await getFacets(
+    props.apiRoot,
+    [props.highlightPageMetadata.place.dcid],
+    statVarArray
+  );
+  console.log("facets", facets);
 
-  const svthing =
-    props.highlightPageMetadata.pageConfig.categories[0].statVarSpec[
-      "Count_Person2"
-    ].statVar;
-  console.log("Stat var thing: ", svthing);
+  const facetIds = new Set<string>();
+  facetIds.add("10983471");
   const statVarFacetMap: StatVarFacetMap = {
-    [svthing]: new Set(["1"]),
+    Count_Person: facetIds,
   };
 
+  // const svSet = new Set<string>();
+  // svSet.add(svthing);
+  console.log("statVarSet", statVarSet);
+  return fetchMetadata(
+    statVarSet,
+    facets["Count_Person"],
+    dataCommonsClient,
+    statVarFacetMap,
+    props.apiRoot
+  );
+}
+
+export function HighlightResult(
+  props: HighlightResultProps
+): React.ReactElement {
   const [metadataMap, setMetadataMap] = React.useState<
     Record<string, StatVarMetadata[]>
   >({});
   const [statVarList, setStatVarList] = React.useState<NamedNode[]>([]);
+  const [pageConfig, setPageConfig] = React.useState(
+    props.highlightPageMetadata.pageConfig
+  );
 
   React.useEffect(() => {
-    fetchMetadata(
-      new Set(svthing),
-      statMetadataRecord,
-      dataCommonsClient,
-      statVarFacetMap,
-      props.apiRoot
-    )
-      .then((response) => {
-        const { metadata, statVarList } = response;
-        setMetadataMap(metadata);
-        setStatVarList(statVarList);
-        console.log("Fetched metadata: ", metadata);
-        console.log("Fetched stat var list: ", statVarList);
-      })
-      .catch((error) => {
-        console.error("Error fetching metadata: ", error);
-      });
-  }, [props.highlightPageMetadata]);
+    const fetchData = async (): Promise<void> => {
+      const { metadata, statVarList } = await doMetadataFetch(props);
+      setMetadataMap(metadata);
+      setStatVarList(statVarList);
+      console.log("metadataMap", metadata);
+    };
+    fetchData();
+  }, [props]);
 
-  // Extract Stat Var information, place information, source information.
-  // const svSource = props.highlightPageMetadata.svSource;
-  // console.log("SV SOURCE IS " + JSON.stringify(svSource));
+  const optionDan = false;
+  const optionAdriana = true;
 
-  // const places = props.highlightPageMetadata.places;
-  // console.log("PLACES ARE " + JSON.stringify(places));
+  React.useEffect(() => {
+    setPageConfig(props.highlightPageMetadata.pageConfig);
+  }, []);
 
-  // const facet = props.highlightFacet;
-  // console.log("Requested facet is " + JSON.stringify(facet));
+  React.useEffect(() => {
+    if (pageConfig && optionDan) {
+      const met =
+        metadataMap && metadataMap["Count_Person"]
+          ? metadataMap["Count_Person"][0]
+          : null;
+      const desc = met?.sourceName + ", with minor processing by Data Commons";
+      pageConfig.categories[0].blocks[0].description = desc;
+      setPageConfig(JSON.parse(JSON.stringify(pageConfig)));
+    }
+  }, [metadataMap]);
+
   return (
     <div>
-      <br></br>
-      <div id="place-callout">
-        <span>Highlighted Chart</span>
-      </div>
-      <TileMetadataModalContent
-        statVars={statVarList}
-        metadataMap={metadataMap}
-        apiRoot={props.apiRoot}
-      />
-      <p>
-        This is the data that is being highlighted as requested. It comes frmo
-        the source X - [Add Provenance name and description] with minor
-        processing from datacommons.
-      </p>
+      {optionAdriana && (
+        <div>
+          <br></br>
+          <TileMetadataModalContent
+            statVars={statVarList}
+            metadataMap={metadataMap}
+            apiRoot={props.apiRoot}
+          />
+        </div>
+      )}
       <SubjectPageMainPane
         id={PAGE_ID}
         place={props.highlightPageMetadata.place}
-        pageConfig={trimCategory(
-          props.highlightPageMetadata.pageConfig,
-          props.maxBlock
-        )}
+        pageConfig={trimCategory(pageConfig, props.maxBlock)}
         showExploreMore={false}
         highlightFacet={props.highlightFacet}
       />

--- a/static/js/apps/explore/highlight_result.tsx
+++ b/static/js/apps/explore/highlight_result.tsx
@@ -1,8 +1,13 @@
-import React from "react";
+import React, { Fragment, ReactNode } from "react";
 
 import { SubjectPageMainPane } from "../../components/subject_page/main_pane";
 import { StatMetadata } from "../../shared/stat_types";
 import { NamedNode, StatVarFacetMap } from "../../shared/types";
+import { stripProtocol } from "../../shared/util";
+import {
+  buildCitationParts,
+  CitationPart,
+} from "../../tools/shared/metadata/citations";
 import { StatVarMetadata } from "../../tools/shared/metadata/metadata";
 import { fetchMetadata } from "../../tools/shared/metadata/metadata_fetcher";
 import { TileMetadataModalContent } from "../../tools/shared/metadata/tile_metadata_modal_content";
@@ -95,12 +100,25 @@ export function HighlightResult(
       setMetadataMap(metadata);
       setStatVarList(statVarList);
       console.log("metadataMap", metadata);
+      console.log("statVarList", statVarList);
     };
     fetchData();
   }, [props]);
 
-  const optionDan = false;
-  const optionAdriana = true;
+  const optionDan = true;
+  const optionAdriana = false;
+
+  const joinElements = (
+    items: ReactNode[],
+    separator: ReactNode = ", "
+  ): ReactNode[] =>
+    items.flatMap((item, idx) => (idx === 0 ? [item] : [separator, item]));
+
+  const generateCitationSources = (citationParts: CitationPart[]): string[] => {
+    return citationParts.map(({ label }) => label);
+  };
+
+  // const citationSources = generateCitationSources();
 
   React.useEffect(() => {
     setPageConfig(props.highlightPageMetadata.pageConfig);
@@ -108,12 +126,25 @@ export function HighlightResult(
 
   React.useEffect(() => {
     if (pageConfig && optionDan) {
-      const met =
-        metadataMap && metadataMap["Count_Person"]
-          ? metadataMap["Count_Person"][0]
-          : null;
-      const desc = met?.sourceName + ", with minor processing by Data Commons";
-      pageConfig.categories[0].blocks[0].description = desc;
+      // const met =
+      //   metadataMap && metadataMap["Count_Person"]
+      //     ? metadataMap["Count_Person"][0]
+      //     : null;
+      // const citationParts = buildCitationParts(statVarList, metadataMap);
+
+      console.log(
+        "citationParts",
+        joinElements(
+          generateCitationSources(
+            buildCitationParts(statVarList, metadataMap, true)
+          )
+        )
+      );
+      // const desc = met?.sourceName + ", with minor processing by Data Commons";
+      pageConfig.categories[0].blocks[0].description = generateCitationSources(
+        buildCitationParts(statVarList, metadataMap, true)
+      ).join(", ");
+      // "United States Census Bureau, American Community Survey (ACS) (data.census.gov/cedsci/table?q=S2601A&tid=ACSST5Y2019.S2601A), with minor processing by Data Commons.";
       setPageConfig(JSON.parse(JSON.stringify(pageConfig)));
     }
   }, [metadataMap]);
@@ -130,6 +161,14 @@ export function HighlightResult(
           />
         </div>
       )}
+      <br></br>
+      <br></br>
+      {/* {optionDan &&
+        joinElements(
+          generateCitationSources(
+            buildCitationParts(statVarList, metadataMap, true)
+          )
+        )} */}
       <SubjectPageMainPane
         id={PAGE_ID}
         place={props.highlightPageMetadata.place}

--- a/static/js/apps/explore/highlight_result.tsx
+++ b/static/js/apps/explore/highlight_result.tsx
@@ -136,7 +136,7 @@ export function HighlightResult(
   }, [statVarList, metadataMap, props.highlightPageMetadata.pageConfig]);
 
   return (
-    <div>
+    <div className="highlight-result-title">
       <SubjectPageMainPane
         id={PAGE_ID}
         place={props.highlightPageMetadata.place}

--- a/static/js/apps/explore/highlight_result.tsx
+++ b/static/js/apps/explore/highlight_result.tsx
@@ -2,10 +2,7 @@ import React, { ReactElement, useEffect, useMemo, useState } from "react";
 
 import { SubjectPageMainPane } from "../../components/subject_page/main_pane";
 import { NamedNode, StatVarFacetMap } from "../../shared/types";
-import {
-  buildCitationParts,
-  CitationPart,
-} from "../../tools/shared/metadata/citations";
+import { buildCitationParts } from "../../tools/shared/metadata/citations";
 import { StatVarMetadata } from "../../tools/shared/metadata/metadata";
 import { fetchMetadata } from "../../tools/shared/metadata/metadata_fetcher";
 import { FacetMetadata } from "../../types/facet_metadata";

--- a/static/js/apps/explore/highlight_result.tsx
+++ b/static/js/apps/explore/highlight_result.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 
 import { SubjectPageMainPane } from "../../components/subject_page/main_pane";
 import { NamedNode, StatVarFacetMap } from "../../shared/types";
@@ -77,18 +77,33 @@ async function doMetadataFetch(props: HighlightResultProps): Promise<{
   );
 }
 
-export function HighlightResult(
-  props: HighlightResultProps
-): React.ReactElement {
-  const [metadataMap, setMetadataMap] = React.useState<
+/**
+ * Component to render the highlight result section of the page.
+ *
+ * This component fetches metadata and statistical variable information,
+ * processes the page configuration, and renders the main pane with the
+ * processed data.
+ *
+ * @param props - The properties for the HighlightResult component.
+ * @param props.highlightPageMetadata - Metadata for the highlight page, including
+ * the page configuration and place information.
+ * @param props.maxBlock - The maximum number of blocks to display in the trimmed
+ * category configuration.
+ * @param props.highlightFacet - The facet to highlight in the rendered page.
+ *
+ * @returns A React element rendering the highlight result section.
+ */
+export function HighlightResult(props: HighlightResultProps): ReactElement {
+  const [metadataMap, setMetadataMap] = useState<
     Record<string, StatVarMetadata[]>
   >({});
-  const [statVarList, setStatVarList] = React.useState<NamedNode[]>([]);
-  const [pageConfig, setPageConfig] = React.useState(
+  const [statVarList, setStatVarList] = useState<NamedNode[]>([]);
+  const [pageConfig, setPageConfig] = useState(
     props.highlightPageMetadata.pageConfig
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
+    // Fetch metadata and stat var list when component mounts or props change
     const fetchData = async (): Promise<void> => {
       doMetadataFetch(props).then(({ metadata, statVarList }) => {
         setMetadataMap(metadata);
@@ -104,7 +119,8 @@ export function HighlightResult(
     return citationParts.map(({ label }) => label);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
+    // Process the page config and update the description for each block if we have metadata for it.
     if (
       !pageConfig ||
       pageConfig.categories.length === 0 ||

--- a/static/js/apps/explore/highlight_result.tsx
+++ b/static/js/apps/explore/highlight_result.tsx
@@ -1,20 +1,17 @@
-import React, { Fragment, ReactNode } from "react";
+import React from "react";
 
 import { SubjectPageMainPane } from "../../components/subject_page/main_pane";
-import { StatMetadata } from "../../shared/stat_types";
 import { NamedNode, StatVarFacetMap } from "../../shared/types";
-import { stripProtocol } from "../../shared/util";
 import {
   buildCitationParts,
   CitationPart,
 } from "../../tools/shared/metadata/citations";
 import { StatVarMetadata } from "../../tools/shared/metadata/metadata";
 import { fetchMetadata } from "../../tools/shared/metadata/metadata_fetcher";
-import { TileMetadataModalContent } from "../../tools/shared/metadata/tile_metadata_modal_content";
 import { FacetMetadata } from "../../types/facet_metadata";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import { getDataCommonsClient } from "../../utils/data_commons_client";
-import { getFacets } from "../../utils/data_fetch_utils";
+import { FacetResponse, getFacets } from "../../utils/data_fetch_utils";
 import { trimCategory } from "../../utils/subject_page_utils";
 
 /**
@@ -47,33 +44,31 @@ async function doMetadataFetch(props: HighlightResultProps): Promise<{
   }
 
   const dataCommonsClient = getDataCommonsClient(props.apiRoot);
-  const statMetadataRecord: { [key: string]: StatMetadata } = {
-    "1": {
-      provenanceUrl: props.highlightFacet?.importName || "",
-      measurementMethod: props.highlightFacet?.measurementMethod || "",
-      observationPeriod: props.highlightFacet?.observationPeriod || "",
-      scalingFactor: "",
-      unit: props.highlightFacet?.unit || "",
-    },
-  };
 
   const statVarArray = Array.from(statVarSet);
-  const facets = await getFacets(
+  const facets: FacetResponse = await getFacets(
     props.apiRoot,
     [props.highlightPageMetadata.place.dcid],
     statVarArray
   );
-  console.log("facets", facets);
 
-  const facetIds = new Set<string>();
-  facetIds.add("10983471");
-  const statVarFacetMap: StatVarFacetMap = {
-    Count_Person: facetIds,
-  };
+  console.log("facets", JSON.stringify(facets));
+  // console.log("HighlightFacet", JSON.stringify(props.highlightFacet));
+  const statVarFacetMap: StatVarFacetMap = {};
+  for (const statVar in facets) {
+    // if props.highlightFacet is not null, match the right facet then add it to statVarFacetMap
+    // for (const facet of facets[statVar]) {
+    const facet = facets[statVar];
+    console.log("Facet is ", facet);
+    for (const facetId in facet) {
+      if (facet[facetId].importName === props.highlightFacet?.importName) {
+        console.log(`Found matching facet for ${statVar}: ${facet.importName}`);
+        statVarFacetMap[statVar] = new Set([facetId]);
+        break;
+      }
+    }
+  }
 
-  // const svSet = new Set<string>();
-  // svSet.add(svthing);
-  console.log("statVarSet", statVarSet);
   return fetchMetadata(
     statVarSet,
     facets["Count_Person"],
@@ -96,79 +91,44 @@ export function HighlightResult(
 
   React.useEffect(() => {
     const fetchData = async (): Promise<void> => {
-      const { metadata, statVarList } = await doMetadataFetch(props);
-      setMetadataMap(metadata);
-      setStatVarList(statVarList);
-      console.log("metadataMap", metadata);
-      console.log("statVarList", statVarList);
+      doMetadataFetch(props).then(({ metadata, statVarList }) => {
+        setMetadataMap(metadata);
+        setStatVarList(statVarList);
+      });
     };
     fetchData();
+
+    setPageConfig(props.highlightPageMetadata.pageConfig);
   }, [props]);
-
-  const optionDan = true;
-  const optionAdriana = false;
-
-  const joinElements = (
-    items: ReactNode[],
-    separator: ReactNode = ", "
-  ): ReactNode[] =>
-    items.flatMap((item, idx) => (idx === 0 ? [item] : [separator, item]));
 
   const generateCitationSources = (citationParts: CitationPart[]): string[] => {
     return citationParts.map(({ label }) => label);
   };
 
-  // const citationSources = generateCitationSources();
-
   React.useEffect(() => {
-    setPageConfig(props.highlightPageMetadata.pageConfig);
-  }, []);
-
-  React.useEffect(() => {
-    if (pageConfig && optionDan) {
-      // const met =
-      //   metadataMap && metadataMap["Count_Person"]
-      //     ? metadataMap["Count_Person"][0]
-      //     : null;
-      // const citationParts = buildCitationParts(statVarList, metadataMap);
-
-      console.log(
-        "citationParts",
-        joinElements(
-          generateCitationSources(
-            buildCitationParts(statVarList, metadataMap, true)
-          )
-        )
-      );
-      // const desc = met?.sourceName + ", with minor processing by Data Commons";
-      pageConfig.categories[0].blocks[0].description = generateCitationSources(
-        buildCitationParts(statVarList, metadataMap, true)
-      ).join(", ");
-      // "United States Census Bureau, American Community Survey (ACS) (data.census.gov/cedsci/table?q=S2601A&tid=ACSST5Y2019.S2601A), with minor processing by Data Commons.";
-      setPageConfig(JSON.parse(JSON.stringify(pageConfig)));
+    if (
+      !pageConfig ||
+      pageConfig.categories.length === 0 ||
+      pageConfig.categories[0].blocks.length === 0
+    ) {
+      return;
     }
-  }, [metadataMap]);
+
+    const pageConfigCopy = structuredClone(
+      props.highlightPageMetadata.pageConfig
+    );
+
+    const highlightChartDescription = generateCitationSources(
+      buildCitationParts(statVarList, metadataMap, true)
+    ).join(", ");
+
+    pageConfigCopy.categories[0].blocks[0].description =
+      highlightChartDescription;
+    setPageConfig(pageConfigCopy);
+  }, [statVarList, metadataMap]);
 
   return (
     <div>
-      {optionAdriana && (
-        <div>
-          <br></br>
-          <TileMetadataModalContent
-            statVars={statVarList}
-            metadataMap={metadataMap}
-            apiRoot={props.apiRoot}
-          />
-        </div>
-      )}
-      <br></br>
-      <br></br>
-      {/* {optionDan &&
-        joinElements(
-          generateCitationSources(
-            buildCitationParts(statVarList, metadataMap, true)
-          )
-        )} */}
       <SubjectPageMainPane
         id={PAGE_ID}
         place={props.highlightPageMetadata.place}

--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -192,6 +192,27 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
                     maxBlock={maxBlock}
                   />
                 )}
+                {props.highlightPageMetadata && (
+                  <div
+                    className="related-data-explore"
+                    style={{
+                      margin: "20px 0",
+                      padding: "10px",
+                      backgroundColor: "#f9f9f9",
+                      borderRadius: "5px",
+                    }}
+                  >
+                    <p
+                      style={{
+                        fontSize: "16px",
+                        fontWeight: "bold",
+                        color: "#333",
+                      }}
+                    >
+                      Here is more related data to explore:
+                    </p>
+                  </div>
+                )}
                 <SubjectPageMainPane
                   id={PAGE_ID}
                   place={props.pageMetadata.place}

--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -190,28 +190,8 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
                     highlightPageMetadata={props.highlightPageMetadata}
                     highlightFacet={props.highlightFacet}
                     maxBlock={maxBlock}
+                    apiRoot={props.exploreContext.apiRoot}
                   />
-                )}
-                {props.highlightPageMetadata && (
-                  <div
-                    className="related-data-explore"
-                    style={{
-                      margin: "20px 0",
-                      padding: "10px",
-                      backgroundColor: "#f9f9f9",
-                      borderRadius: "5px",
-                    }}
-                  >
-                    <p
-                      style={{
-                        fontSize: "16px",
-                        fontWeight: "bold",
-                        color: "#333",
-                      }}
-                    >
-                      Here is more related data to explore:
-                    </p>
-                  </div>
                 )}
                 <SubjectPageMainPane
                   id={PAGE_ID}

--- a/static/js/tools/shared/metadata/citations.ts
+++ b/static/js/tools/shared/metadata/citations.ts
@@ -37,7 +37,8 @@ export interface CitationPart {
  */
 export function buildCitationParts(
   statVars: NamedNode[],
-  metadataMap: Record<string, StatVarMetadata[]>
+  metadataMap: Record<string, StatVarMetadata[]>,
+  skipUrls = false
 ): CitationPart[] {
   const seen = new Set<string>();
   const parts: CitationPart[] = [];
@@ -60,7 +61,7 @@ export function buildCitationParts(
         : metadata.provenanceName;
 
       const part: CitationPart = { label };
-      if (metadata.provenanceUrl) {
+      if (!skipUrls && metadata.provenanceUrl) {
         part.url = metadata.provenanceUrl.replace(/\/$/, "");
       }
       parts.push(part);

--- a/static/js/tools/shared/metadata/citations.ts
+++ b/static/js/tools/shared/metadata/citations.ts
@@ -68,7 +68,7 @@ export function buildCitationParts(
     });
   });
 
-  if (parts.length != 0) {
+  if (parts.length !== 0) {
     parts.push({
       label: intl.formatMessage(metadataComponentMessages.MinorProcessing),
     });

--- a/static/js/tools/shared/metadata/citations.ts
+++ b/static/js/tools/shared/metadata/citations.ts
@@ -38,7 +38,7 @@ export interface CitationPart {
 export function buildCitationParts(
   statVars: NamedNode[],
   metadataMap: Record<string, StatVarMetadata[]>,
-  skipUrls = false
+  skipUrls?: boolean
 ): CitationPart[] {
   const seen = new Set<string>();
   const parts: CitationPart[] = [];

--- a/static/js/tools/shared/metadata/citations.ts
+++ b/static/js/tools/shared/metadata/citations.ts
@@ -68,9 +68,11 @@ export function buildCitationParts(
     });
   });
 
-  parts.push({
-    label: intl.formatMessage(metadataComponentMessages.MinorProcessing),
-  });
+  if (parts.length != 0) {
+    parts.push({
+      label: intl.formatMessage(metadataComponentMessages.MinorProcessing),
+    });
+  }
 
   return parts;
 }

--- a/static/js/tools/shared/metadata/metadata_fetcher.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.ts
@@ -1,0 +1,271 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * File to contain helper functions related to fetching metadata.
+ */
+
+import { DataCommonsClient } from "@datacommonsorg/client";
+
+import { StatMetadata } from "../../../shared/stat_types";
+import { NamedNode, StatVarFacetMap } from "../../../shared/types";
+import {
+  Provenance,
+  StatVarMetadata,
+  StatVarProvenanceSummaries,
+} from "./metadata";
+
+/**
+ * This module contains helper functions for fetching and processing metadata.
+ */
+
+// TODO(gmechali): Splitting up this function into smaller ones might be helpful for maintainability.
+
+/**
+ * Fetch metadata from a given URL.
+ * @param url - The URL to fetch metadata from.
+ * @returns A promise that resolves to the fetched metadata.
+ */
+export async function fetchMetadata(
+  statVarSet: Set<string>,
+  facets: Record<string, StatMetadata>,
+  dataCommonsClient: DataCommonsClient,
+  statVarToFacets?: StatVarFacetMap,
+  apiRoot?: string
+): Promise<{
+  metadata: Record<string, StatVarMetadata[]>;
+  statVarList: NamedNode[];
+}> {
+  const statVarList: NamedNode[] = [];
+  try {
+    const statVars = [...statVarSet];
+    console.log("SO NOW STAT VARS", statVars);
+    if (statVars.length === 0) {
+      return;
+    }
+
+    /*
+       1. We retrieve the full stat var names from the DCIDs
+       */
+    const responseObj = await dataCommonsClient.getFirstNodeValues({
+      dcids: statVars,
+      prop: "name",
+    });
+    for (const dcid in responseObj) {
+      statVarList.push({ dcid, name: responseObj[dcid] });
+    }
+    statVarList.sort((a, b) => (a.name > b.name ? 1 : -1));
+
+    /*
+      2.  We get the stat var categories (e.g., "Demographics").
+          This is a two-step process: first we look up the path to the variable
+          group. We then look up the group itself to get the "absoluteName", which
+          is the readable name of the category.
+       */
+
+    // 1 a. get the category paths
+    const categoryPathPromises = statVars.map((statVarId) =>
+      fetch(`${apiRoot || ""}/api/variable/path?dcid=${statVarId}`).then(
+        (response) => response.json()
+      )
+    );
+    const categoryPathResults = await Promise.all(categoryPathPromises);
+
+    const categoryPaths = new Set<string>();
+    statVars.forEach((_, index) => {
+      const categories: string[] = categoryPathResults[index]?.slice(1) ?? [];
+      const lastDcid = categories[categories.length - 1];
+      if (lastDcid) categoryPaths.add(lastDcid);
+    });
+
+    // 1 b. from those paths, get the absolute names
+    const categoryInfoMap: Record<string, string> = {};
+    const categoryPromises = Array.from(categoryPaths).map(
+      async (categoryPath) => {
+        const response = await fetch(
+          `${apiRoot || ""}/api/variable-group/info`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              dcid: categoryPath,
+              entities: [],
+              numEntitiesExistence: 0,
+            }),
+          }
+        );
+        const data = await response.json();
+        categoryInfoMap[categoryPath] =
+          data.absoluteName || categoryPath.split("/").pop();
+      }
+    );
+    await Promise.all(categoryPromises);
+
+    const statVarCategoryMap: Record<string, string[]> = {};
+    statVars.forEach((statVarId, index) => {
+      const categories: string[] = categoryPathResults[index]?.slice(1) ?? [];
+      const lastDcid = categories[categories.length - 1];
+      const topic = lastDcid && categoryInfoMap[lastDcid];
+      statVarCategoryMap[statVarId] = topic ? [topic] : [];
+    });
+
+    /*
+        3.  We now pull the full stat var information for each stat var. The
+            results contain a lookup for each stat var of the sources, and under
+            that, information we need about the stat var-source combo
+       */
+    const dcidsParam = statVars.map((id) => `dcids=${id}`).join("&");
+    const variableResponse = await fetch(
+      `${apiRoot || ""}/api/variable/info?${dcidsParam}`
+    );
+    const variableData: Record<string, StatVarProvenanceSummaries> =
+      await variableResponse.json();
+
+    const provenances = new Set<string>();
+    const measurementMethods = new Set<string>();
+
+    statVars.forEach((statVarId) => {
+      const facetIdSet = statVarToFacets?.[statVarId] || new Set<string>();
+
+      facetIdSet.forEach((facetId) => {
+        const facetInfo = facets[facetId];
+
+        if (facetInfo?.importName) {
+          const provenanceFullPath = `dc/base/${facetInfo.importName}`;
+          provenances.add(provenanceFullPath);
+
+          const summary =
+            variableData[statVarId]?.provenanceSummary?.[provenanceFullPath]
+              ?.seriesSummary;
+          const measurementMethod = summary?.[0]?.seriesKey?.measurementMethod;
+          if (measurementMethod) measurementMethods.add(measurementMethod);
+        }
+      });
+    });
+
+    /*
+        4.  We now look up the base information about each source (provenance).
+            This gives us some of the core information we need about the source itself.
+       */
+    const provenanceMap: Record<string, Provenance> = {};
+    const provenancePromises = Array.from(provenances).map((provenanceId) =>
+      fetch(`${apiRoot || ""}/api/node/triples/out/${provenanceId}`)
+        .then((response) => response.json())
+        .then((data) => {
+          provenanceMap[provenanceId] = data;
+        })
+    );
+    await Promise.all(provenancePromises);
+
+    /*
+        5.  We now look up some attributes of required fields for which we have only the dcid.
+            Currently, this is the description of the measurement method.
+       */
+    let measurementMethodMap: Record<string, string> = {};
+    if (measurementMethods.size) {
+      measurementMethodMap = await dataCommonsClient.getFirstNodeValues({
+        dcids: Array.from(measurementMethods),
+        prop: "description",
+      });
+    }
+
+    const metadata: Record<string, StatVarMetadata[]> = {};
+
+    /*
+        With all the data collected together above, we collate it into a final
+        data structure that we send into the metadata content for actual display.
+       */
+    for (const statVarId of statVars) {
+      const facetIdSet = statVarToFacets?.[statVarId] || new Set<string>();
+      metadata[statVarId] = [];
+
+      for (const facetId of facetIdSet) {
+        const facetInfo = facets[facetId];
+
+        if (!facetInfo?.importName) continue;
+
+        const importName = facetInfo.importName;
+        const provenanceId = `dc/base/${importName}`;
+        const provenanceData = provenanceMap[provenanceId];
+
+        if (!provenanceData) continue;
+
+        let unit: string | undefined;
+        let releaseFrequency: string | undefined;
+        let observationPeriod: string | undefined;
+        let dateRangeStart: string | undefined;
+        let dateRangeEnd: string | undefined;
+        let measurementMethod: string | undefined;
+        let measurementMethodDescription: string | undefined;
+
+        if (variableData[statVarId]?.provenanceSummary) {
+          const source =
+            variableData[statVarId].provenanceSummary?.[provenanceId];
+          if (source) {
+            releaseFrequency = source.releaseFrequency;
+
+            if (source.seriesSummary && source.seriesSummary.length > 0) {
+              const seriesSummary = source.seriesSummary[0];
+              dateRangeStart = seriesSummary.earliestDate;
+              dateRangeEnd = seriesSummary.latestDate;
+
+              const seriesKey = seriesSummary.seriesKey;
+              if (seriesKey) {
+                unit = seriesKey.unit;
+                observationPeriod = seriesKey.observationPeriod;
+                measurementMethod = seriesKey.measurementMethod;
+                if (measurementMethod) {
+                  measurementMethodDescription = measurementMethodMap[
+                    measurementMethod
+                  ]
+                    ? measurementMethodMap[measurementMethod]
+                    : measurementMethod;
+                }
+              }
+            }
+          }
+        }
+
+        metadata[statVarId].push({
+          statVarId,
+          statVarName: responseObj[statVarId] || statVarId,
+          categories: statVarCategoryMap[statVarId],
+          sourceName: provenanceData?.source[0]?.name,
+          provenanceUrl: provenanceData?.url?.[0]?.value,
+          provenanceName:
+            provenanceData?.isPartOf?.[0]?.name ||
+            provenanceData?.name?.[0]?.value ||
+            importName,
+          dateRangeStart,
+          dateRangeEnd,
+          unit,
+          observationPeriod,
+          periodicity: releaseFrequency,
+          license: provenanceData?.licenseType?.[0]?.name,
+          licenseDcid: provenanceData?.licenseType?.[0]?.dcid,
+          measurementMethod,
+          measurementMethodDescription,
+        });
+      }
+    }
+
+    return { metadata, statVarList };
+  } catch (error) {
+    console.error("Error fetching metadata:", error);
+  }
+}

--- a/static/js/tools/shared/metadata/metadata_fetcher.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.ts
@@ -62,7 +62,7 @@ export async function fetchMetadata(
   try {
     const statVars = [...statVarSet];
     if (statVars.length === 0) {
-      return;
+      return { metadata: {}, statVarList: [] };
     }
 
     /*

--- a/static/js/tools/shared/metadata/metadata_fetcher.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.ts
@@ -47,6 +47,7 @@ function getFacetInfo(
  * @param url - The URL to fetch metadata from.
  * @returns A promise that resolves to the fetched metadata.
  */
+/* eslint-disable complexity */
 export async function fetchMetadata(
   statVarSet: Set<string>,
   facets: FacetResponse | Record<string, StatMetadata>,

--- a/static/js/tools/shared/metadata/metadata_fetcher.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.ts
@@ -52,7 +52,6 @@ export async function fetchMetadata(
   const statVarList: NamedNode[] = [];
   try {
     const statVars = [...statVarSet];
-    console.log("SO NOW STAT VARS", statVars);
     if (statVars.length === 0) {
       return;
     }

--- a/static/js/tools/shared/metadata/metadata_fetcher.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.ts
@@ -22,6 +22,7 @@ import { DataCommonsClient } from "@datacommonsorg/client";
 
 import { StatMetadata } from "../../../shared/stat_types";
 import { NamedNode, StatVarFacetMap } from "../../../shared/types";
+import { FacetResponse } from "../../../utils/data_fetch_utils";
 import {
   Provenance,
   StatVarMetadata,
@@ -34,6 +35,13 @@ import {
 
 // TODO(gmechali): Splitting up this function into smaller ones might be helpful for maintainability.
 
+function getFacetInfo(
+  statVarDcid: string,
+  facetId: string,
+  facets: FacetResponse | Record<string, StatMetadata>
+): StatMetadata | undefined {
+  return facets[statVarDcid]?.[facetId] || facets[facetId];
+}
 /**
  * Fetch metadata from a given URL.
  * @param url - The URL to fetch metadata from.
@@ -41,7 +49,7 @@ import {
  */
 export async function fetchMetadata(
   statVarSet: Set<string>,
-  facets: Record<string, StatMetadata>,
+  facets: FacetResponse | Record<string, StatMetadata>,
   dataCommonsClient: DataCommonsClient,
   statVarToFacets?: StatVarFacetMap,
   apiRoot?: string
@@ -142,7 +150,7 @@ export async function fetchMetadata(
       const facetIdSet = statVarToFacets?.[statVarId] || new Set<string>();
 
       facetIdSet.forEach((facetId) => {
-        const facetInfo = facets[facetId];
+        const facetInfo = getFacetInfo(statVarId, facetId, facets);
 
         if (facetInfo?.importName) {
           const provenanceFullPath = `dc/base/${facetInfo.importName}`;
@@ -194,7 +202,7 @@ export async function fetchMetadata(
       metadata[statVarId] = [];
 
       for (const facetId of facetIdSet) {
-        const facetInfo = facets[facetId];
+        const facetInfo = getFacetInfo(statVarId, facetId, facets);
 
         if (!facetInfo?.importName) continue;
 

--- a/static/js/tools/shared/metadata/tile_metadata_modal.tsx
+++ b/static/js/tools/shared/metadata/tile_metadata_modal.tsx
@@ -41,11 +41,8 @@ import { NamedNode, StatVarFacetMap, StatVarSpec } from "../../../shared/types";
 import { getDataCommonsClient } from "../../../utils/data_commons_client";
 import { buildCitationParts, citationToPlainText } from "./citations";
 import { CopyCitationButton } from "./copy_citation_button";
-import {
-  Provenance,
-  StatVarMetadata,
-  StatVarProvenanceSummaries,
-} from "./metadata";
+import { StatVarMetadata } from "./metadata";
+import { fetchMetadata } from "./metadata_fetcher";
 import { TileMetadataModalContent } from "./tile_metadata_modal_content";
 
 interface TileMetadataModalPropType {
@@ -89,235 +86,20 @@ export function TileMetadataModal(
     if (statVarSet.size === statVars.length) return;
 
     setLoading(true);
-
-    const fetchMetadata = async (): Promise<void> => {
-      try {
-        const statVars = [...statVarSet];
-        if (statVars.length === 0) {
-          return;
-        }
-
-        /*
-         1. We retrieve the full stat var names from the DCIDs
-         */
-        const responseObj = await dataCommonsClient.getFirstNodeValues({
-          dcids: statVars,
-          prop: "name",
-        });
-        const statVarList: NamedNode[] = [];
-        for (const dcid in responseObj) {
-          statVarList.push({ dcid, name: responseObj[dcid] });
-        }
-        statVarList.sort((a, b) => (a.name > b.name ? 1 : -1));
-        setStatVars(statVarList);
-
-        /*
-        2.  We get the stat var categories (e.g., "Demographics").
-            This is a two-step process: first we look up the path to the variable
-            group. We then look up the group itself to get the "absoluteName", which
-            is the readable name of the category.
-         */
-
-        // 1 a. get the category paths
-        const categoryPathPromises = statVars.map((statVarId) =>
-          fetch(
-            `${props.apiRoot || ""}/api/variable/path?dcid=${statVarId}`
-          ).then((response) => response.json())
-        );
-        const categoryPathResults = await Promise.all(categoryPathPromises);
-
-        const categoryPaths = new Set<string>();
-        statVars.forEach((_, index) => {
-          const categories: string[] =
-            categoryPathResults[index]?.slice(1) ?? [];
-          const lastDcid = categories[categories.length - 1];
-          if (lastDcid) categoryPaths.add(lastDcid);
-        });
-
-        // 1 b. from those paths, get the absolute names
-        const categoryInfoMap: Record<string, string> = {};
-        const categoryPromises = Array.from(categoryPaths).map(
-          async (categoryPath) => {
-            const response = await fetch(
-              `${props.apiRoot || ""}/api/variable-group/info`,
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                  dcid: categoryPath,
-                  entities: [],
-                  numEntitiesExistence: 0,
-                }),
-              }
-            );
-            const data = await response.json();
-            categoryInfoMap[categoryPath] =
-              data.absoluteName || categoryPath.split("/").pop();
-          }
-        );
-        await Promise.all(categoryPromises);
-
-        const statVarCategoryMap: Record<string, string[]> = {};
-        statVars.forEach((statVarId, index) => {
-          const categories: string[] =
-            categoryPathResults[index]?.slice(1) ?? [];
-          const lastDcid = categories[categories.length - 1];
-          const topic = lastDcid && categoryInfoMap[lastDcid];
-          statVarCategoryMap[statVarId] = topic ? [topic] : [];
-        });
-
-        /*
-          3.  We now pull the full stat var information for each stat var. The
-              results contain a lookup for each stat var of the sources, and under
-              that, information we need about the stat var-source combo
-         */
-        const dcidsParam = statVars.map((id) => `dcids=${id}`).join("&");
-        const variableResponse = await fetch(
-          `${props.apiRoot || ""}/api/variable/info?${dcidsParam}`
-        );
-        const variableData: Record<string, StatVarProvenanceSummaries> =
-          await variableResponse.json();
-
-        const provenances = new Set<string>();
-        const measurementMethods = new Set<string>();
-
-        statVars.forEach((statVarId) => {
-          const facetIdSet =
-            props.statVarToFacets?.[statVarId] || new Set<string>();
-
-          facetIdSet.forEach((facetId) => {
-            const facetInfo = props.facets[facetId];
-
-            if (facetInfo?.importName) {
-              const provenanceFullPath = `dc/base/${facetInfo.importName}`;
-              provenances.add(provenanceFullPath);
-
-              const summary =
-                variableData[statVarId]?.provenanceSummary?.[provenanceFullPath]
-                  ?.seriesSummary;
-              const measurementMethod =
-                summary?.[0]?.seriesKey?.measurementMethod;
-              if (measurementMethod) measurementMethods.add(measurementMethod);
-            }
-          });
-        });
-
-        /*
-          4.  We now look up the base information about each source (provenance).
-              This gives us some of the core information we need about the source itself.
-         */
-        const provenanceMap: Record<string, Provenance> = {};
-        const provenancePromises = Array.from(provenances).map((provenanceId) =>
-          fetch(`${props.apiRoot || ""}/api/node/triples/out/${provenanceId}`)
-            .then((response) => response.json())
-            .then((data) => {
-              provenanceMap[provenanceId] = data;
-            })
-        );
-        await Promise.all(provenancePromises);
-
-        /*
-          5.  We now look up some attributes of required fields for which we have only the dcid.
-              Currently, this is the description of the measurement method.
-         */
-        let measurementMethodMap: Record<string, string> = {};
-        if (measurementMethods.size) {
-          measurementMethodMap = await dataCommonsClient.getFirstNodeValues({
-            dcids: Array.from(measurementMethods),
-            prop: "description",
-          });
-        }
-
-        const metadata: Record<string, StatVarMetadata[]> = {};
-
-        /*
-          With all the data collected together above, we collate it into a final
-          data structure that we send into the metadata content for actual display.
-         */
-        for (const statVarId of statVars) {
-          const facetIdSet =
-            props.statVarToFacets?.[statVarId] || new Set<string>();
-          metadata[statVarId] = [];
-
-          for (const facetId of facetIdSet) {
-            const facetInfo = props.facets[facetId];
-
-            if (!facetInfo?.importName) continue;
-
-            const importName = facetInfo.importName;
-            const provenanceId = `dc/base/${importName}`;
-            const provenanceData = provenanceMap[provenanceId];
-
-            if (!provenanceData) continue;
-
-            let unit: string | undefined;
-            let releaseFrequency: string | undefined;
-            let observationPeriod: string | undefined;
-            let dateRangeStart: string | undefined;
-            let dateRangeEnd: string | undefined;
-            let measurementMethod: string | undefined;
-            let measurementMethodDescription: string | undefined;
-
-            if (variableData[statVarId]?.provenanceSummary) {
-              const source =
-                variableData[statVarId].provenanceSummary?.[provenanceId];
-              if (source) {
-                releaseFrequency = source.releaseFrequency;
-
-                if (source.seriesSummary && source.seriesSummary.length > 0) {
-                  const seriesSummary = source.seriesSummary[0];
-                  dateRangeStart = seriesSummary.earliestDate;
-                  dateRangeEnd = seriesSummary.latestDate;
-
-                  const seriesKey = seriesSummary.seriesKey;
-                  if (seriesKey) {
-                    unit = seriesKey.unit;
-                    observationPeriod = seriesKey.observationPeriod;
-                    measurementMethod = seriesKey.measurementMethod;
-                    if (measurementMethod) {
-                      measurementMethodDescription = measurementMethodMap[
-                        measurementMethod
-                      ]
-                        ? measurementMethodMap[measurementMethod]
-                        : measurementMethod;
-                    }
-                  }
-                }
-              }
-            }
-
-            metadata[statVarId].push({
-              statVarId,
-              statVarName: responseObj[statVarId] || statVarId,
-              categories: statVarCategoryMap[statVarId],
-              sourceName: provenanceData?.source[0]?.name,
-              provenanceUrl: provenanceData?.url?.[0]?.value,
-              provenanceName:
-                provenanceData?.isPartOf?.[0]?.name ||
-                provenanceData?.name?.[0]?.value ||
-                importName,
-              dateRangeStart,
-              dateRangeEnd,
-              unit,
-              observationPeriod,
-              periodicity: releaseFrequency,
-              license: provenanceData?.licenseType?.[0]?.name,
-              licenseDcid: provenanceData?.licenseType?.[0]?.dcid,
-              measurementMethod,
-              measurementMethodDescription,
-            });
-          }
-        }
-
-        setMetadataMap(metadata);
-      } catch (error) {
-        console.error("Error fetching metadata:", error);
-      }
-    };
-
-    fetchMetadata().finally(() => setLoading(false));
+    fetchMetadata(
+      statVarSet,
+      props.facets,
+      dataCommonsClient,
+      props.statVarToFacets,
+      props.apiRoot
+    )
+      .then((resp) => {
+        setMetadataMap(resp.metadata);
+        setStatVars(resp.statVarList);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, [
     modalOpen,
     statVarSet,

--- a/static/js/tools/shared/metadata/tile_metadata_modal_content.tsx
+++ b/static/js/tools/shared/metadata/tile_metadata_modal_content.tsx
@@ -122,7 +122,7 @@ export const TileMetadataModalContent = ({
         />
       ))}
 
-      {citationSources.length > 0 && (
+      {citationSources.length >= 0 && (
         <div
           css={css`
             padding: ${theme.spacing.xl}px 0 0 0;

--- a/static/js/tools/shared/metadata/tile_metadata_modal_content.tsx
+++ b/static/js/tools/shared/metadata/tile_metadata_modal_content.tsx
@@ -122,7 +122,7 @@ export const TileMetadataModalContent = ({
         />
       ))}
 
-      {citationSources.length >= 0 && (
+      {citationSources.length > 0 && (
         <div
           css={css`
             padding: ${theme.spacing.xl}px 0 0 0;


### PR DESCRIPTION
Adds the provenance name, source name and some text about DC processing on the Block description for the highlight chart.

This refactors some of the code to fetch the metadata from the show Metadata modal to make it shareable.

http://localhost:8080/explore#sv=LifeExpectancy_Person&p=country%2FITA___country/FRA&client=ui_related_topic&chartType=TIMELINE_WITH_HIGHLIGHT&unit=Euro&imp=WorldDevelopmentIndicators ([screenshot](https://screenshot.googleplex.com/7DbYaBYFLvzoRvM))