### PR TITLE
Metadata Fetch Refactor

### DIFF
--- a/static/js/tools/shared/metadata/metadata_fetcher.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.ts
@@ -34,6 +34,12 @@ import {
  * This module contains helper functions for fetching and processing metadata.
  */
 
+/*
+  TODO (nick-next): provide options on degree of metadata returned, in order
+      to accommodate requests such as those for just enough information
+      to build citations.
+ */
+
 /**
  * Retrieves facet information for a given stat variable and facet ID.
  *
@@ -53,6 +59,12 @@ function getFacetInfo(
 /**
  * Determines if a series summary matches the criteria defined in a facet.
  * Compares measurement method, observation period, unit, and scaling factor.
+ *
+ * This function is run on series entries from a list of series summaries
+ * that have already been limited to a particular import id. Because of
+ * that, it determines whether there is a match based only the series key
+ * which only can contain the attributes above (that vary within a
+ * provenance).
  *
  * @param series - The series summary whose key will be checked for a match
  * @param facet - The facet whose attributes will be checked against the key
@@ -108,7 +120,6 @@ async function fetchStatVarNames(
   for (const dcid in responseObj) {
     statVarList.push({ dcid, name: responseObj[dcid] });
   }
-  statVarList.sort((a, b) => (a.name > b.name ? 1 : -1));
 
   return statVarList;
 }


### PR DESCRIPTION
## Description

This PR does the following:

- factors the fetchMetadata function into multiple smaller functions.
- the purpose of this is to make the fetchMetadata suite more efficient and more maintainable and easier to follow, and to change how errors are handled.
- as part of that factoring, we converted calls that were happening sequentially into parallel calls
- a remaining issue where the first series measurement method (rather than the matching measurement) is fixed
- errors are now no longer caught and silently suppressed, but allowed to bubble up to the calling function. This will allow us to handle errors in a subsequent PR.
- all functions (including functions used only internally within the file) are now commented with JSDoc comments

## Testing

The results of fetchMetadata should not have changed because of this PR (with the exception of if the picked out series had a differing measuring method.

The function `fetchMetadata` is used in two places:
- in the `HighlightResult`, where it is used to generate a blurb of the metadata
- in the full metadata modal.

In both of these scenarios, the results should be the same before and after the metadata fetch refactor.

Pages where this can be tested:

Highlight result
- http://localhost:8080/explore#sv=LifeExpectancy_Person&p=country%2FITA___country/FRA&client=ui_related_topic&chartType=TIMELINE_WITH_HIGHLIGHT&unit=Euro&imp=WorldDevelopmentIndicators

Metadata modal
- http://localhost:8080/tools/visualization#visType%3Dtimeline%26place%3Dcountry%2FSWE%26placeType%3DAdministrativeArea1%26sv%3D%7B%22dcid%22%3A%22Amount_EconomicActivity_GrossDomesticProduction_Nominal%22%7D
- http://localhost:8080/explore#q=life+expectancy+versus+population+in+african+countries&client=ui_query
- http://localhost:8080/tools/visualization#visType%3Dscatter%26place%3Dcountry%2FSWE%26placeType%3DAdministrativeArea1%26sv%3D%7B%22dcid%22%3A%22Amount_EconomicActivity_GrossDomesticProduction_Nominal%22%7D___%7B%22dcid%22%3A%22Amount_EconomicActivity_GrossDomesticProduction_Nominal_AsAFractionOf_Count_Person%22%7D

## Codacy
Codacy is triggering a single complaint: 
- expected parameter: 'apiRoot' to have a typedef

However, this can't be trivially fixed because of a conflicting direct ESLint rule:
- ESLint: Type string trivially inferred from a string literal, remove type annotation. (@typescript-eslint/no-inferrable-types)

I opted not try to suppress this with comments (to avoid the potential of masking other real errors in the future). Also this lint rule conflict has happened in other PRs, and so we can consider a more permanent solution than masking with comments by reconciling the settings in the repo.