### PR TITLE
[ProductionExcellence] Mark deprecated flags as such

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -9,24 +9,28 @@
     "name": "dev_place_experiment",
     "enabled": true,
     "owner": "gmechali",
+    "deprecated": true,
     "description": "Feature flag to enable the V2 place page only for the experiment places."
   },
   {
     "name": "dev_place_ga",
     "enabled": true,
     "owner": "dwnoble",
+    "deprecated": true,
     "description": "Feature flag to enable the V2 Place page to GA."
   },
   {
     "name": "dynamic_placeholder_experiment",
     "enabled": true,
     "owner": "gmechali",
+    "deprecated": true,
     "description": "Feature flag to enable the dynamic placeholder experiment in the NL search bar."
   },
   {
     "name": "dynamic_placeholder_ga",
     "enabled": true,
     "owner": "gmechali",
+    "deprecated": true,
     "description": "Feature flag to enable the dynamic placeholder GA rollout in the NL search bar."
   },
   {


### PR DESCRIPTION
These flags all correspond to features that have been released in GA and for which we got rid of the code. 

We can remove these flags, however, they must first be removed in staging. 
https://github.com/datacommonsorg/website/pull/5184 Needs to be submitted first.
Then this current PR.
Then https://github.com/datacommonsorg/website/pull/5183