### PR TITLE
[ProductionExcellence] Remove the flags to deprecate from production.

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -6,30 +6,6 @@
     "description": "Feature flag to enable place autocomplete."
   },
   {
-    "name": "dev_place_experiment",
-    "enabled": true,
-    "owner": "gmechali",
-    "description": "Feature flag to enable the V2 place page only for the experiment places."
-  },
-  {
-    "name": "dev_place_ga",
-    "enabled": true,
-    "owner": "dwnoble",
-    "description": "Feature flag to enable the V2 Place page to GA."
-  },
-  {
-    "name": "dynamic_placeholder_experiment",
-    "enabled": true,
-    "owner": "gmechali",
-    "description": "Feature flag to enable the dynamic placeholder experiment in the NL search bar."
-  },
-  {
-    "name": "dynamic_placeholder_ga",
-    "enabled": true,
-    "owner": "gmechali",
-    "description": "Feature flag to enable the dynamic placeholder GA rollout in the NL search bar."
-  },
-  {
     "name": "biomed_nl",
     "enabled": false,
     "owner": "calinc",


### PR DESCRIPTION
In order of submission:
- https://github.com/datacommonsorg/website/pull/5184 - Filters out deprecated flags
- https://github.com/datacommonsorg/website/pull/5185 - Marks deprecated flags in production.
- https://github.com/datacommonsorg/website/pull/5183 - Removes deprecate flags on non-prod env
- Then this PR - Removes deprecated flags on prod env.