### PR TITLE
[Revert Per Capita Change] 

### DIFF
--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -248,23 +248,23 @@ export function Block(props: BlockPropType): JSX.Element {
     })();
   }, [props]);
 
-  useEffect(() => {
-    function shouldUseDenom(
-      denom: string | undefined,
-      highlightFacet: FacetMetadata | undefined
-    ): string {
-      if (highlightFacet || !denom) {
-        return "";
-      }
-      return denom;
-    }
-    setDenomToUse(shouldUseDenom(props.denom, props.highlightFacet));
-  }, [props.denom, props.highlightFacet]);
+  // useEffect(() => {
+  //   function shouldUseDenom(
+  //     denom: string | undefined,
+  //     highlightFacet: FacetMetadata | undefined
+  //   ): string {
+  //     if (highlightFacet || !denom) {
+  //       return "";
+  //     }
+  //     return denom;
+  //   }
+  //   setDenomToUse(shouldUseDenom(props.denom, props.highlightFacet));
+  // }, [props.denom, props.highlightFacet]);
 
   return (
     <>
       <div className="block-controls">
-        {!_.isEmpty(denomToUse) && (
+        {props.denom && (
           <span className="block-toggle">
             <label>
               <Input
@@ -344,7 +344,7 @@ export function Block(props: BlockPropType): JSX.Element {
                         minIdxToHide,
                         overridePlaceTypes,
                         columnTileClassName,
-                        denomToUse,
+                        useDenom ? props.denom : "",
                         snapToHighestCoverage
                           ? DATE_HIGHEST_COVERAGE
                           : undefined
@@ -356,7 +356,7 @@ export function Block(props: BlockPropType): JSX.Element {
                         minIdxToHide,
                         overridePlaceTypes,
                         columnTileClassName,
-                        denomToUse,
+                        useDenom ? props.denom : "",
                         snapToHighestCoverage
                           ? DATE_HIGHEST_COVERAGE
                           : undefined

--- a/static/js/components/subject_page/block.tsx
+++ b/static/js/components/subject_page/block.tsx
@@ -198,7 +198,6 @@ export function Block(props: BlockPropType): JSX.Element {
     setShowSnapToHighestCoverageCheckbox,
   ] = useState(false);
   const [enableSnapToLatestData, setEnableSnapToLatestData] = useState(true);
-  const [denomToUse, setDenomToUse] = useState<string>("");
   const columnSectionRef = useRef(null);
   const expandoRef = useRef(null);
   const snapToLatestDataInfoRef = useRef<HTMLDivElement>(null);
@@ -247,19 +246,6 @@ export function Block(props: BlockPropType): JSX.Element {
       setShowSnapToHighestCoverageCheckbox(!props.highlightFacet);
     })();
   }, [props]);
-
-  // useEffect(() => {
-  //   function shouldUseDenom(
-  //     denom: string | undefined,
-  //     highlightFacet: FacetMetadata | undefined
-  //   ): string {
-  //     if (highlightFacet || !denom) {
-  //       return "";
-  //     }
-  //     return denom;
-  //   }
-  //   setDenomToUse(shouldUseDenom(props.denom, props.highlightFacet));
-  // }, [props.denom, props.highlightFacet]);
 
   return (
     <>


### PR DESCRIPTION
I noticed this updated logic caused a regression where some queries default to using the per capita value when they should not have. Reverting for now, will find proper way forward later.

Verified fix locally.