### PR TITLE
[Explore] Implement the Follow Up Questions Component

### DIFF
--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -24,6 +24,7 @@
 @import "./shared/story_block";
 @import "./shared/story_chart";
 @import "./nl_interface";
+@import "./base";
 
 #main {
   height: auto;
@@ -224,7 +225,7 @@
   justify-content: center;
   align-self: stretch;
   color: #212529;
-  font-family: Google Sans;
+  font-family: Google Sans, $font-family-sans-serif;
   font-size: 22px;
   font-style: normal;
   font-weight: 400;
@@ -244,12 +245,11 @@
   align-self: stretch;
   color: var(--gm-3-sys-light-primary);
 
-  /* GM3/Static/body/large-emphasized */
-  font-family: var(--Static-Body-Large-Font, "Google Sans Text");
-  font-size: var(--Static-Body-Large-Size, 16px);
+  font-family: Google Sans Text, $font-family-sans-serif;
+  font-size: 16px;
   font-style: normal;
   font-weight: 500;
-  line-height: var(--Static-Body-Large-Line-Height, 24px); /* 150% */
+  line-height: 24px 
 }
 
 .related-places,

--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -224,7 +224,7 @@
   justify-content: center;
   align-self: stretch;
   color: #212529;
-  font-family: "Google Sans";
+  font-family: Google Sans;
   font-size: 22px;
   font-style: normal;
   font-weight: 400;
@@ -250,7 +250,6 @@
   font-style: normal;
   font-weight: 500;
   line-height: var(--Static-Body-Large-Line-Height, 24px); /* 150% */
-  letter-spacing: var(--Static-Body-Large-Tracking, 0px);
 }
 
 .related-places,

--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -209,8 +209,53 @@
   }
 }
 
+.follow-up-questions-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  align-self: stretch;
+}
+
+.follow-up-questions-title {
+  display: flex;
+  height: 28px;
+  flex-direction: column;
+  justify-content: center;
+  align-self: stretch;
+  color: #212529;
+  font-family: "Google Sans";
+  font-size: 22px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 28px; /* 127.273% */
+}
+
+.follow-up-questions-list-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  align-self: stretch;
+}
+
+.follow-up-questions-list-text {
+  height: 23px;
+  align-self: stretch;
+  color: var(--gm-3-sys-light-primary);
+
+  /* GM3/Static/body/large-emphasized */
+  font-family: var(--Static-Body-Large-Font, "Google Sans Text");
+  font-size: var(--Static-Body-Large-Size, 16px);
+  font-style: normal;
+  font-weight: 500;
+  line-height: var(--Static-Body-Large-Line-Height, 24px); /* 150% */
+  letter-spacing: var(--Static-Body-Large-Tracking, 0px);
+}
+
 .related-places,
-.user-message-container {
+.user-message-container,
+.follow-up-questions-container {
   padding: 24px;
   border-radius: var(--border-radius-primary);
   border: var(--border-primary);

--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -249,7 +249,7 @@
   font-size: 16px;
   font-style: normal;
   font-weight: 500;
-  line-height: 24px 
+  line-height: 24px; 
 }
 
 .related-places,

--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -244,7 +244,6 @@
   height: 23px;
   align-self: stretch;
   color: var(--gm-3-sys-light-primary);
-
   font-family: Google Sans Text, $font-family-sans-serif;
   font-size: 16px;
   font-style: normal;

--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -19,7 +19,7 @@
  */
 import axios from "axios";
 import _ from "lodash";
-import React, { ReactElement,useEffect, useState } from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 
 import {
   DEFAULT_TOPIC,

--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -19,8 +19,7 @@
  */
 import axios from "axios";
 import _ from "lodash";
-import React, { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import React, { ReactElement,useEffect, useState } from "react";
 
 import {
   DEFAULT_TOPIC,

--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -21,10 +21,7 @@ import axios from "axios";
 import _ from "lodash";
 import React, { ReactElement, useEffect, useState } from "react";
 
-import {
-  DEFAULT_TOPIC,
-  URL_HASH_PARAMS,
-} from "../../constants/app/explore_constants";
+import { URL_HASH_PARAMS } from "../../constants/app/explore_constants";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import { getTopics } from "../../utils/app/explore_utils";
 import { getUpdatedHash } from "../../utils/url_utils";
@@ -45,18 +42,14 @@ interface FollowUpQuestionsPropType {
 export function FollowUpQuestions(
   props: FollowUpQuestionsPropType
 ): ReactElement {
-  // Gets the name of all related topics while removing the Root topic.
-  // Empty string can be passed since only the topic name will be used, which is stored in the property `text`.
-  const relatedTopics = getTopics(props.pageMetadata, "")
-    .map((topic) => topic.text)
-    .slice(0, FOLLOW_UP_QUESTIONS_LIMIT);
-
-  if (_.isEmpty(relatedTopics) || _.isEmpty(props.query)) {
-    return <></>;
-  }
-
   const [followUpQuestions, setFollowUpQuestions] = useState(null);
   useEffect(() => {
+    // Gets the name of all related topics while removing the Root topic.
+    // Empty string can be passed since only the topic name will be used, which is stored in the property `text`.
+    const relatedTopics = getTopics(props.pageMetadata, "")
+      .map((topic) => topic.text)
+      .slice(0, FOLLOW_UP_QUESTIONS_LIMIT);
+
     getFollowUpQuestions(props.query, relatedTopics)
       .then((value) => {
         setFollowUpQuestions(value);
@@ -64,11 +57,11 @@ export function FollowUpQuestions(
       .catch(() => {
         setFollowUpQuestions([]);
       });
-  }, []);
+  }, [props.query, props.pageMetadata]);
 
   return (
-    <div>
-      {followUpQuestions && (
+    <>
+      {!_.isEmpty(followUpQuestions) && (
         <div className="follow-up-questions-container">
           <div className="follow-up-questions-inner">
             <span className="follow-up-questions-title">Keep Exploring</span>
@@ -88,16 +81,18 @@ export function FollowUpQuestions(
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }
 
-//  Parses request from /api/explore/follow-up-questions by creating a
-//  url with the generated question as the query.
+// Gets followup questions from the /api/explore/follow-up-questions endpoint and processes the response
 const getFollowUpQuestions = async (
   query: string,
   relatedTopics: string[]
 ): Promise<Question[]> => {
+  if (_.isEmpty(query) || _.isEmpty(relatedTopics)) {
+    return [];
+  }
   const url = "/api/explore/follow-up-questions";
   const body = {
     q: query,

--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Component for rendering the generated follow up questions.
+ */
+import _ from "lodash";
+import React, { ReactElement } from "react";
+import axios from "axios";
+import { useEffect,useState } from "react";
+import { SubjectPageMetadata } from "../../types/subject_page_types";
+import { getUpdatedHash } from "../../utils/url_utils";
+import { DEFAULT_TOPIC, URL_HASH_PARAMS } from "../../constants/app/explore_constants";
+
+// Number of follow up questions displayed
+const FOLLOW_UP_QUESTIONS_LIMIT = 10;
+
+export interface Question {
+  text: string;
+  url: string;
+}
+
+export interface FollowUpQuestionsPropType {
+    query: string;
+    pageMetadata: SubjectPageMetadata;
+}
+
+export function FollowUpQuestions(props: FollowUpQuestionsPropType): ReactElement {
+
+  // Gets the name of all related topics while removing the Root topic.
+  const relatedTopics = []
+    .concat(props.pageMetadata?.childTopics || [])
+    .concat(props.pageMetadata?.peerTopics || [])
+    .concat(props.pageMetadata?.parentTopics || [])
+    .filter(topic => topic.dcid != DEFAULT_TOPIC || topic.name)
+    .map(topic => topic.name)
+    .slice(0,FOLLOW_UP_QUESTIONS_LIMIT);
+
+  if ((_.isEmpty(relatedTopics)) || (_.isEmpty(props.query))){
+    return <></>
+  }
+
+  const [followUpQuestions, setFollowUpQuestions] = useState(null);
+  useEffect(() => {
+    getFollowUpQuestions(props.query,relatedTopics)
+    .then((value) => {
+        setFollowUpQuestions(value.followUpQuestions);
+    })
+    .catch(() => {
+        setFollowUpQuestions([]);
+    });
+  },[]);
+
+  return (
+    <div>
+        {followUpQuestions && <div className="follow-up-questions-container">
+            <div className="follow-up-questions-inner">
+                <span className="follow-up-questions-title">Keep Exploring</span>
+                {followUpQuestions.map((question, idx) => {
+                return (
+                    <div key={idx} className="follow-up-questions-list-item">
+                    <a className="follow-up-questions-list-text" href={question.url}>
+                        {question.text}<br></br>
+                    </a>
+                    </div>
+                );
+                })}
+            </div>
+        </div>}
+    </div>
+  );
+}
+
+// Full result from /api/explore/follow-up-questions
+interface FollowUpQuestionsResult {
+  followUpQuestions: Question[];
+
+}
+
+const getFollowUpQuestions = async (
+    query:string,
+    relatedTopics:string[]
+
+): Promise<FollowUpQuestionsResult> => {
+    const url = "/api/explore/follow-up-questions";
+    const body = {
+        q: query,
+        relatedTopics: relatedTopics
+    };
+    return await axios.post(url, body).then((resp) => {
+        const data = resp.data;
+        return {
+        followUpQuestions: data.follow_up_questions.map((question) => {return {text: question, url:`/explore/#${getUpdatedHash({
+                  [URL_HASH_PARAMS.QUERY]: question,
+                })}`}})
+        };
+    });
+}

--- a/static/js/apps/explore/result_header_section.tsx
+++ b/static/js/apps/explore/result_header_section.tsx
@@ -25,6 +25,7 @@ import { DEFAULT_TOPIC } from "../../constants/app/explore_constants";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import { getTopics } from "../../utils/app/explore_utils";
 import { ItemList } from "./item_list";
+import { showFollowUpQuestions } from "./success_result";
 
 interface ResultHeaderSectionPropType {
   placeUrlVal: string;
@@ -57,7 +58,7 @@ export function ResultHeaderSection(
         {getPlaceHeader()}
         {topicNameStr && <span> • {topicNameStr}</span>}
       </div>
-      {!_.isEmpty(props.pageMetadata.mainTopics) && !_.isEmpty(topicList) && (
+      {!_.isEmpty(props.pageMetadata.mainTopics) && !_.isEmpty(topicList) && !showFollowUpQuestions && (
         <div className="explore-topics-box">
           <ItemList items={topicList} showRelevantTopicLabel={true}></ItemList>
         </div>

--- a/static/js/apps/explore/result_header_section.tsx
+++ b/static/js/apps/explore/result_header_section.tsx
@@ -30,7 +30,6 @@ interface ResultHeaderSectionPropType {
   placeUrlVal: string;
   pageMetadata: SubjectPageMetadata;
   hideRelatedTopics: boolean;
-  showFollowUpQuestions: boolean;
 }
 
 export function ResultHeaderSection(
@@ -58,16 +57,11 @@ export function ResultHeaderSection(
         {getPlaceHeader()}
         {topicNameStr && <span> • {topicNameStr}</span>}
       </div>
-      {!_.isEmpty(props.pageMetadata.mainTopics) &&
-        !_.isEmpty(topicList) &&
-        !props.showFollowUpQuestions && (
-          <div className="explore-topics-box">
-            <ItemList
-              items={topicList}
-              showRelevantTopicLabel={true}
-            ></ItemList>
-          </div>
-        )}
+      {!_.isEmpty(props.pageMetadata.mainTopics) && !_.isEmpty(topicList) && (
+        <div className="explore-topics-box">
+          <ItemList items={topicList} showRelevantTopicLabel={true}></ItemList>
+        </div>
+      )}
     </>
   );
 

--- a/static/js/apps/explore/result_header_section.tsx
+++ b/static/js/apps/explore/result_header_section.tsx
@@ -25,12 +25,12 @@ import { DEFAULT_TOPIC } from "../../constants/app/explore_constants";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import { getTopics } from "../../utils/app/explore_utils";
 import { ItemList } from "./item_list";
-import { showFollowUpQuestions } from "./success_result";
 
 interface ResultHeaderSectionPropType {
   placeUrlVal: string;
   pageMetadata: SubjectPageMetadata;
   hideRelatedTopics: boolean;
+  showFollowUpQuestions: boolean;
 }
 
 export function ResultHeaderSection(
@@ -60,7 +60,7 @@ export function ResultHeaderSection(
       </div>
       {!_.isEmpty(props.pageMetadata.mainTopics) &&
         !_.isEmpty(topicList) &&
-        !showFollowUpQuestions && (
+        !props.showFollowUpQuestions && (
           <div className="explore-topics-box">
             <ItemList
               items={topicList}

--- a/static/js/apps/explore/result_header_section.tsx
+++ b/static/js/apps/explore/result_header_section.tsx
@@ -58,11 +58,16 @@ export function ResultHeaderSection(
         {getPlaceHeader()}
         {topicNameStr && <span> • {topicNameStr}</span>}
       </div>
-      {!_.isEmpty(props.pageMetadata.mainTopics) && !_.isEmpty(topicList) && !showFollowUpQuestions && (
-        <div className="explore-topics-box">
-          <ItemList items={topicList} showRelevantTopicLabel={true}></ItemList>
-        </div>
-      )}
+      {!_.isEmpty(props.pageMetadata.mainTopics) &&
+        !_.isEmpty(topicList) &&
+        !showFollowUpQuestions && (
+          <div className="explore-topics-box">
+            <ItemList
+              items={topicList}
+              showRelevantTopicLabel={true}
+            ></ItemList>
+          </div>
+        )}
     </>
   );
 

--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -50,8 +50,18 @@ import { RelatedPlace } from "./related_place";
 import { ResultHeaderSection } from "./result_header_section";
 import { SearchSection } from "./search_section";
 import { UserMessage } from "./user_message";
+import { isFeatureEnabled,FOLLOW_UP_QUESTIONS_GA,FOLLOW_UP_QUESTIONS_EXPERIMENT } from "../../shared/feature_flags/util";
+import { FollowUpQuestions } from "./follow_up_questions";
 
 const PAGE_ID = "explore";
+
+
+const EXPERIMENT_FOLLOW_UP_ROLLOUT_RATIO = 0.2;
+
+export const showFollowUpQuestions =
+    isFeatureEnabled(FOLLOW_UP_QUESTIONS_GA) ||
+    (isFeatureEnabled(FOLLOW_UP_QUESTIONS_EXPERIMENT) &&
+      Math.random() < EXPERIMENT_FOLLOW_UP_ROLLOUT_RATIO);
 
 interface SuccessResultPropType {
   //the query string that brought up the given results
@@ -206,6 +216,11 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
                 <ScrollToTopButton />
               </ExploreContext.Provider>
             </RankingUnitUrlFuncContext.Provider>
+            {showFollowUpQuestions && (
+              <FollowUpQuestions 
+              query={props.query}
+              pageMetadata={props.pageMetadata}/>
+            )}
             {!emptyPlaceOverview &&
               !_.isEmpty(props.pageMetadata.childPlaces) && (
                 <RelatedPlace

--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -174,8 +174,7 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
               <ResultHeaderSection
                 pageMetadata={props.pageMetadata}
                 placeUrlVal={placeUrlVal}
-                hideRelatedTopics={false}
-                showFollowUpQuestions={showFollowUpQuestions}
+                hideRelatedTopics={showFollowUpQuestions}
               />
             )}
             <RankingUnitUrlFuncContext.Provider

--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -34,6 +34,11 @@ import {
   ExploreContext,
   RankingUnitUrlFuncContext,
 } from "../../shared/context";
+import {
+  FOLLOW_UP_QUESTIONS_EXPERIMENT,
+  FOLLOW_UP_QUESTIONS_GA,
+  isFeatureEnabled,
+} from "../../shared/feature_flags/util";
 import { QueryResult, UserMessageInfo } from "../../types/app/explore_types";
 import { FacetMetadata } from "../../types/facet_metadata";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
@@ -45,23 +50,21 @@ import { getPlaceTypePlural } from "../../utils/string_utils";
 import { trimCategory } from "../../utils/subject_page_utils";
 import { getUpdatedHash } from "../../utils/url_utils";
 import { DebugInfo } from "./debug_info";
+import { FollowUpQuestions } from "./follow_up_questions";
 import { HighlightResult } from "./highlight_result";
 import { RelatedPlace } from "./related_place";
 import { ResultHeaderSection } from "./result_header_section";
 import { SearchSection } from "./search_section";
 import { UserMessage } from "./user_message";
-import { isFeatureEnabled,FOLLOW_UP_QUESTIONS_GA,FOLLOW_UP_QUESTIONS_EXPERIMENT } from "../../shared/feature_flags/util";
-import { FollowUpQuestions } from "./follow_up_questions";
 
 const PAGE_ID = "explore";
-
 
 const EXPERIMENT_FOLLOW_UP_ROLLOUT_RATIO = 0.2;
 
 export const showFollowUpQuestions =
-    isFeatureEnabled(FOLLOW_UP_QUESTIONS_GA) ||
-    (isFeatureEnabled(FOLLOW_UP_QUESTIONS_EXPERIMENT) &&
-      Math.random() < EXPERIMENT_FOLLOW_UP_ROLLOUT_RATIO);
+  isFeatureEnabled(FOLLOW_UP_QUESTIONS_GA) ||
+  (isFeatureEnabled(FOLLOW_UP_QUESTIONS_EXPERIMENT) &&
+    Math.random() < EXPERIMENT_FOLLOW_UP_ROLLOUT_RATIO);
 
 interface SuccessResultPropType {
   //the query string that brought up the given results
@@ -217,9 +220,10 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
               </ExploreContext.Provider>
             </RankingUnitUrlFuncContext.Provider>
             {showFollowUpQuestions && (
-              <FollowUpQuestions 
-              query={props.query}
-              pageMetadata={props.pageMetadata}/>
+              <FollowUpQuestions
+                query={props.query}
+                pageMetadata={props.pageMetadata}
+              />
             )}
             {!emptyPlaceOverview &&
               !_.isEmpty(props.pageMetadata.childPlaces) && (

--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -61,7 +61,7 @@ const PAGE_ID = "explore";
 
 const EXPERIMENT_FOLLOW_UP_ROLLOUT_RATIO = 0.2;
 
-export const showFollowUpQuestions =
+const showFollowUpQuestions =
   isFeatureEnabled(FOLLOW_UP_QUESTIONS_GA) ||
   (isFeatureEnabled(FOLLOW_UP_QUESTIONS_EXPERIMENT) &&
     Math.random() < EXPERIMENT_FOLLOW_UP_ROLLOUT_RATIO);
@@ -175,6 +175,7 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
                 pageMetadata={props.pageMetadata}
                 placeUrlVal={placeUrlVal}
                 hideRelatedTopics={false}
+                showFollowUpQuestions={showFollowUpQuestions}
               />
             )}
             <RankingUnitUrlFuncContext.Provider


### PR DESCRIPTION
It is the initial version of the Follow Up Questions Component, displaying up to 10 generated questions at the bottom of the explore page. 

Before: https://screenshot.googleplex.com/87kBdiichniHvtu
After: https://screenshot.googleplex.com/428GmoCvvrzL2ZZ 