### PR TITLE
[Explore] Add Google Analytic Triggers for Follow Up Questions with Tests

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -81,3 +81,11 @@ To enable both the autocomplete and metadata_modal features:
  - Disable: https://datacommons.org/explore?enable_feature=autocomplete&enable_feature=metadata_modal
  
 These URL overrides take precedence over the environment-specific feature flag settings defined in server/config/feature_flag_configs/<environment>.json
+
+### Propagating Feature Flags
+
+This override can be utilized to propagate the feature flags into future pages.
+
+For example, the following anchor element would maintain the "autocomplete" feature enabled:
+
+`<a href="https://datacommons.org/explore?enable_feature=autocomplete">Autocomplete Still Enabled<a/>`

--- a/server/webdriver/shared_tests/explore_test.py
+++ b/server/webdriver/shared_tests/explore_test.py
@@ -143,14 +143,15 @@ class ExplorePageTestMixin():
     """Test that the Follow Up Questions are generated and displayed when queries have related topics."""
     follow_up_flag = "?enable_feature=follow_up_questions_ga"
     query = "#q=What is the population of Mountain View?"
-    
-    self.driver.get(self.url_ + EXPLORE_URL + follow_up_flag + query)
-    shared.wait_elem(driver=self.driver,value="follow-up-questions-container")
 
-    follow_up_questions = find_elems(self.driver, By.CLASS_NAME, 'follow-up-questions-list-text')
+    self.driver.get(self.url_ + EXPLORE_URL + follow_up_flag + query)
+    shared.wait_elem(driver=self.driver, value="follow-up-questions-container")
+
+    follow_up_questions = find_elems(self.driver, By.CLASS_NAME,
+                                     'follow-up-questions-list-text')
     self.assertGreater(len(follow_up_questions), 0,
                        "No follow up questions found in the list.")
-  
+
   def test_follow_up_questions_no_related_topics(self):
     """Test that the Follow Up Questions component does not exist for queries that have no related topics."""
     follow_up_flag = "?enable_feature=follow_up_questions_ga"
@@ -158,7 +159,11 @@ class ExplorePageTestMixin():
     query = "#q=Which countries have the highest college-educated population in the world?"
 
     self.driver.get(self.url_ + EXPLORE_URL + follow_up_flag + query)
-    shared.wait_elem(driver=self.driver,value="follow-up-questions-container")
+    shared.wait_elem(driver=self.driver, value="follow-up-questions-container")
 
-    empty_follow_up = find_elem(parent=self.driver,value="follow-up-questions-container")
-    self.assertIsNone(empty_follow_up,"Follow Up Questions component is not empty despite having no related topics.")
+    empty_follow_up = find_elem(parent=self.driver,
+                                value="follow-up-questions-container")
+    self.assertIsNone(
+        empty_follow_up,
+        "Follow Up Questions component is not empty despite having no related topics."
+    )

--- a/server/webdriver/shared_tests/explore_test.py
+++ b/server/webdriver/shared_tests/explore_test.py
@@ -138,3 +138,27 @@ class ExplorePageTestMixin():
     highlight_divs = find_elems(self.driver, By.CLASS_NAME,
                                 'highlight-result-title')
     self.assertEqual(len(highlight_divs), 0)
+
+  def test_follow_up_questions_typical(self):
+    """Test that the Follow Up Questions are generated and displayed when queries have related topics."""
+    follow_up_flag = "?enable_feature=follow_up_questions_ga"
+    query = "#q=What is the population of Mountain View?"
+    
+    self.driver.get(self.url_ + EXPLORE_URL + follow_up_flag + query)
+    shared.wait_elem(driver=self.driver,value="follow-up-questions-container")
+
+    follow_up_questions = find_elems(self.driver, By.CLASS_NAME, 'follow-up-questions-list-text')
+    self.assertGreater(len(follow_up_questions), 0,
+                       "No follow up questions found in the list.")
+  
+  def test_follow_up_questions_no_related_topics(self):
+    """Test that the Follow Up Questions component does not exist for queries that have no related topics."""
+    follow_up_flag = "?enable_feature=follow_up_questions_ga"
+    # The query below has no related topics identified.
+    query = "#q=Which countries have the highest college-educated population in the world?"
+
+    self.driver.get(self.url_ + EXPLORE_URL + follow_up_flag + query)
+    shared.wait_elem(driver=self.driver,value="follow-up-questions-container")
+
+    empty_follow_up = find_elem(parent=self.driver,value="follow-up-questions-container")
+    self.assertIsNone(empty_follow_up,"Follow Up Questions component is not empty despite having no related topics.")

--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -19,17 +19,19 @@
  */
 import axios from "axios";
 import _ from "lodash";
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 
 import { Loading } from "../../components/elements/loading";
 import { URL_HASH_PARAMS } from "../../constants/app/explore_constants";
 import { FOLLOW_UP_QUESTIONS_GA } from "../../shared/feature_flags/util";
 import {
+  GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW,
   GA_EVENT_RELATED_TOPICS_CLICK,
   GA_PARAM_RELATED_TOPICS_MODE,
   GA_VALUE_RELATED_TOPICS_EXPERIMENT,
   triggerGAEvent,
 } from "../../shared/ga_events";
+import { useOnScreen } from "../../shared/hooks";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import { getTopics } from "../../utils/app/explore_utils";
 import { getUpdatedHash } from "../../utils/url_utils";
@@ -50,6 +52,9 @@ interface FollowUpQuestionsPropType {
 export function FollowUpQuestions(
   props: FollowUpQuestionsPropType
 ): ReactElement {
+  const ref = useRef(null);
+  const isOnScreen = useOnScreen(ref);
+  const [hasReportedView, setReportedView] = useState(false);
   const [followUpQuestions, setFollowUpQuestions] = useState(null);
   const [loading, setLoading] = useState(true);
   useEffect(() => {
@@ -60,18 +65,24 @@ export function FollowUpQuestions(
       .slice(0, FOLLOW_UP_QUESTIONS_LIMIT);
     getFollowUpQuestions(props.query, relatedTopics)
       .then((value) => {
+        console.error(value)
         setFollowUpQuestions(value);
       })
       .catch(() => {
-        setFollowUpQuestions([]);
+        setFollowUpQuestions([{text:"What is the health equity in Mountain View?",url:""}]);
       })
       .finally(() => {
         setLoading(false);
       });
   }, [props.query, props.pageMetadata]);
 
+  if (isOnScreen && !hasReportedView) {
+    onComponentView();
+    setReportedView(true);
+  }
+
   return (
-    <>
+    <div ref={ref}>
       {loading && (
         <div className="loading-container">
           <Loading />
@@ -100,7 +111,7 @@ export function FollowUpQuestions(
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 }
 
@@ -136,4 +147,8 @@ export const onQuestionClicked = (mode: string): void => {
   triggerGAEvent(GA_EVENT_RELATED_TOPICS_CLICK, {
     [GA_PARAM_RELATED_TOPICS_MODE]: mode,
   });
+};
+
+export const onComponentView = (): void => {
+  triggerGAEvent(GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW, {});
 };

--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -26,6 +26,7 @@ import { URL_HASH_PARAMS } from "../../constants/app/explore_constants";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import { getTopics } from "../../utils/app/explore_utils";
 import { getUpdatedHash } from "../../utils/url_utils";
+import { GA_EVENT_RELATED_TOPICS_CLICK, GA_PARAM_RELATED_TOPICS_MODE, GA_VALUE_RELATED_TOPICS_EXPERIMENT, triggerGAEvent } from "../../shared/ga_events";
 
 // Number of follow up questions displayed
 const FOLLOW_UP_QUESTIONS_LIMIT = 10;
@@ -80,6 +81,7 @@ export function FollowUpQuestions(
                   <a
                     className="follow-up-questions-list-text"
                     href={question.url}
+                    onClick={() => onQuestionClicked(GA_VALUE_RELATED_TOPICS_EXPERIMENT)}
                   >
                     {question.text}
                     <br></br>
@@ -118,4 +120,10 @@ const getFollowUpQuestions = async (
       };
     });
   });
+};
+
+export const onQuestionClicked = (mode: string) => {
+  triggerGAEvent(GA_EVENT_RELATED_TOPICS_CLICK,{
+    [GA_PARAM_RELATED_TOPICS_MODE]: mode,
+  })
 };

--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -23,10 +23,16 @@ import React, { ReactElement, useEffect, useState } from "react";
 
 import { Loading } from "../../components/elements/loading";
 import { URL_HASH_PARAMS } from "../../constants/app/explore_constants";
+import { FOLLOW_UP_QUESTIONS_GA } from "../../shared/feature_flags/util";
+import {
+  GA_EVENT_RELATED_TOPICS_CLICK,
+  GA_PARAM_RELATED_TOPICS_MODE,
+  GA_VALUE_RELATED_TOPICS_EXPERIMENT,
+  triggerGAEvent,
+} from "../../shared/ga_events";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
 import { getTopics } from "../../utils/app/explore_utils";
 import { getUpdatedHash } from "../../utils/url_utils";
-import { GA_EVENT_RELATED_TOPICS_CLICK, GA_PARAM_RELATED_TOPICS_MODE, GA_VALUE_RELATED_TOPICS_EXPERIMENT, triggerGAEvent } from "../../shared/ga_events";
 
 // Number of follow up questions displayed
 const FOLLOW_UP_QUESTIONS_LIMIT = 10;
@@ -81,7 +87,9 @@ export function FollowUpQuestions(
                   <a
                     className="follow-up-questions-list-text"
                     href={question.url}
-                    onClick={() => onQuestionClicked(GA_VALUE_RELATED_TOPICS_EXPERIMENT)}
+                    onClick={(): void =>
+                      onQuestionClicked(GA_VALUE_RELATED_TOPICS_EXPERIMENT)
+                    }
                   >
                     {question.text}
                     <br></br>
@@ -114,16 +122,18 @@ const getFollowUpQuestions = async (
     return data.follow_up_questions.map((question) => {
       return {
         text: question,
-        url: `/explore/#${getUpdatedHash({
-          [URL_HASH_PARAMS.QUERY]: question,
-        })}`,
+        url: `/explore/?enable_feature=${FOLLOW_UP_QUESTIONS_GA}#${getUpdatedHash(
+          {
+            [URL_HASH_PARAMS.QUERY]: question,
+          }
+        )}`,
       };
     });
   });
 };
 
-export const onQuestionClicked = (mode: string) => {
-  triggerGAEvent(GA_EVENT_RELATED_TOPICS_CLICK,{
+export const onQuestionClicked = (mode: string): void => {
+  triggerGAEvent(GA_EVENT_RELATED_TOPICS_CLICK, {
     [GA_PARAM_RELATED_TOPICS_MODE]: mode,
-  })
+  });
 };

--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -65,11 +65,10 @@ export function FollowUpQuestions(
       .slice(0, FOLLOW_UP_QUESTIONS_LIMIT);
     getFollowUpQuestions(props.query, relatedTopics)
       .then((value) => {
-        console.error(value)
         setFollowUpQuestions(value);
       })
       .catch(() => {
-        setFollowUpQuestions([{text:"What is the health equity in Mountain View?",url:""}]);
+        setFollowUpQuestions([]);
       })
       .finally(() => {
         setLoading(false);

--- a/static/js/apps/explore/item_list.tsx
+++ b/static/js/apps/explore/item_list.tsx
@@ -19,6 +19,7 @@
  */
 
 import React, { ReactElement } from "react";
+import { GA_EVENT_RELATED_TOPICS_CLICK,GA_PARAM_RELATED_TOPICS_MODE,GA_VALUE_RELATED_TOPICS_CURRENT,triggerGAEvent } from "../../shared/ga_events";
 
 export interface Item {
   text: string;
@@ -28,6 +29,7 @@ export interface Item {
 interface ItemListPropType {
   items: Item[];
   showRelevantTopicLabel?: boolean;
+  trackRelatedTopicExperiment?: boolean;
 }
 
 export function ItemList(props: ItemListPropType): ReactElement {
@@ -40,7 +42,7 @@ export function ItemList(props: ItemListPropType): ReactElement {
         {props.items.map((item, idx) => {
           return (
             <div key={idx} className="item-list-item">
-              <a className="item-list-text" href={item.url}>
+              <a className="item-list-text" href={item.url} onClick={() => props.trackRelatedTopicExperiment ? onTopicClicked(GA_VALUE_RELATED_TOPICS_CURRENT) : undefined}>
                 {item.text}
               </a>
             </div>
@@ -50,3 +52,9 @@ export function ItemList(props: ItemListPropType): ReactElement {
     </div>
   );
 }
+
+export const onTopicClicked = (mode: string): void => {
+  triggerGAEvent(GA_EVENT_RELATED_TOPICS_CLICK, {
+    [GA_PARAM_RELATED_TOPICS_MODE]: mode,
+  });
+};

--- a/static/js/apps/explore/result_header_section.tsx
+++ b/static/js/apps/explore/result_header_section.tsx
@@ -59,7 +59,7 @@ export function ResultHeaderSection(
       </div>
       {!_.isEmpty(props.pageMetadata.mainTopics) && !_.isEmpty(topicList) && (
         <div className="explore-topics-box">
-          <ItemList items={topicList} showRelevantTopicLabel={true}></ItemList>
+          <ItemList items={topicList} showRelevantTopicLabel={true} trackRelatedTopicExperiment={true}></ItemList>
         </div>
       )}
     </>

--- a/static/js/shared/ga_events.test.tsx
+++ b/static/js/shared/ga_events.test.tsx
@@ -55,12 +55,22 @@ jest.mock("../chart/draw_utils", () => {
     wrap: jest.fn(),
   };
 });
+jest.mock("../utils/app/explore_utils", () => {
+  const originalModule = jest.requireActual("../utils/app/explore_utils");
+  return {
+    __esModule: true,
+    ...originalModule,
+    getTopics: jest.fn().mockImplementation(() => [{ text: TOPIC, url: "" }]),
+  };
+});
 
 import { ThemeProvider } from "@emotion/react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, waitForElementToBeRemoved } from "@testing-library/react";
 import axios from "axios";
 import React from "react";
 
+import { FollowUpQuestions } from "../apps/explore/follow_up_questions";
+import { ResultHeaderSection } from "../apps/explore/result_header_section";
 import { chartTypeEnum, GeoJsonData, MapPoint } from "../chart/types";
 import { StatVarHierarchy } from "../stat_var_hierarchy/stat_var_hierarchy";
 import { StatVarHierarchySearch } from "../stat_var_hierarchy/stat_var_search";
@@ -87,6 +97,8 @@ import * as dataFetcher from "../tools/timeline/data_fetcher";
 import { axiosMock } from "../tools/timeline/mock_functions";
 import { FacetSelectorFacetInfo } from "./facet_selector";
 import {
+  GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW,
+  GA_EVENT_RELATED_TOPICS_CLICK,
   GA_EVENT_STATVAR_HIERARCHY_CLICK,
   GA_EVENT_STATVAR_SEARCH_TRIGGERED,
   GA_EVENT_TOOL_CHART_OPTION_CLICK,
@@ -95,10 +107,13 @@ import {
   GA_EVENT_TOOL_STAT_VAR_CLICK,
   GA_EVENT_TOOL_STAT_VAR_SEARCH_NO_RESULT,
   GA_PARAM_PLACE_DCID,
+  GA_PARAM_RELATED_TOPICS_MODE,
   GA_PARAM_SEARCH_TERM,
   GA_PARAM_SOURCE,
   GA_PARAM_STAT_VAR,
   GA_PARAM_TOOL_CHART_OPTION,
+  GA_VALUE_RELATED_TOPICS_CURRENT,
+  GA_VALUE_RELATED_TOPICS_EXPERIMENT,
   GA_VALUE_TOOL_CHART_OPTION_DELTA,
   GA_VALUE_TOOL_CHART_OPTION_EDIT_SOURCES,
   GA_VALUE_TOOL_CHART_OPTION_FILTER_BY_POPULATION,
@@ -125,6 +140,8 @@ const SOURCES = "sources";
 const ID = "a";
 const NUMBER = 123;
 const PLACE_ADDED = "africa";
+const QUERY = "What is the health equity in Mountain View?";
+const TOPIC = "Health Equity";
 
 // Props for place explorer chart.
 const PLACE_CHART_PROPS = {
@@ -252,6 +269,36 @@ const SCATTER_PROPS = {
   facetListLoading: false,
   facetListError: false,
   onSvFacetIdUpdated: (): null => null,
+};
+
+const PAGE_METADATA_PROPS = {
+  place: {
+    name: PLACE_NAME,
+    dcid: PLACE_DCID,
+    types: [],
+  },
+  places: [],
+  pageConfig: {
+    metadata: {
+      topicId: "",
+      topicName: "",
+      containedPlaceTypes: {},
+      eventTypeSpec: {},
+    },
+    categories: [],
+  },
+  mainTopics: [{name: PLACE_NAME,dcid: PLACE_DCID,types:[]}]
+};
+
+const FOLLOW_UP_QUESTIONS_PROPS = {
+  query: QUERY,
+  pageMetadata: PAGE_METADATA_PROPS,
+};
+
+const RESULT_HEADER_SECTION_PROPS = {
+  placeUrlVal: "",
+  pageMetadata: PAGE_METADATA_PROPS,
+  hideRelatedTopics: false,
 };
 
 const MAP_CONTEXT = {
@@ -1049,6 +1096,76 @@ describe("test ga event for the FacetSelector component", () => {
         {
           [GA_PARAM_TOOL_CHART_OPTION]: GA_VALUE_TOOL_CHART_OPTION_EDIT_SOURCES,
         }
+      );
+    });
+  });
+});
+
+describe("test ga event for Related Topics experiment", () => {
+  test("triggers GA event when FollowUpQuestion URL is clicked", async () => {
+    // Mock gtag
+    const mockgtag = jest.fn();
+    window.gtag = mockgtag;
+
+    axios.post = jest.fn().mockImplementation(() => Promise.resolve({data:{follow_up_questions:[QUERY]}}));
+    
+    // Render follow up component
+    const followUp = render(
+      <FollowUpQuestions {...FOLLOW_UP_QUESTIONS_PROPS} />
+    );
+    
+    // Wait for questions to render
+    await waitForElementToBeRemoved(followUp.getByText("Loading..."));
+    
+    // Click question url
+    fireEvent.click(followUp.getByText(QUERY));
+
+    await waitFor(() => {
+      expect(mockgtag).toHaveBeenCalledWith(
+        "event",
+        GA_EVENT_RELATED_TOPICS_CLICK,
+        {
+          [GA_PARAM_RELATED_TOPICS_MODE]: GA_VALUE_RELATED_TOPICS_EXPERIMENT,
+        }
+      );
+    });
+  });
+  test("triggers GA event when Related Topics URL is clicked", async () => {
+    // Mock gtag
+    const mockgtag = jest.fn();
+    window.gtag = mockgtag;
+
+    // Render result header component
+    const resultHeader = render(
+      <ResultHeaderSection {...RESULT_HEADER_SECTION_PROPS} />
+    );
+
+    // Click related topic url
+    fireEvent.click(resultHeader.getByText(TOPIC));
+
+    await waitFor(() => {
+      expect(mockgtag).toHaveBeenCalledWith(
+        "event",
+        GA_EVENT_RELATED_TOPICS_CLICK,
+        {
+          [GA_PARAM_RELATED_TOPICS_MODE]: GA_VALUE_RELATED_TOPICS_CURRENT,
+        }
+      );
+    });
+  });
+  test("triggers GA event when FollowUpQuestion component is viewed", async () => {
+    // Mock gtag
+    const mockgtag = jest.fn();
+    window.gtag = mockgtag;
+
+    // Render follow up component
+    render(<FollowUpQuestions {...FOLLOW_UP_QUESTIONS_PROPS} />);
+
+    await waitFor(() => {
+      expect(mockgtag).toHaveBeenCalledWith(
+        "event",
+        GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW,
+        {}
       );
     });
   });

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -130,6 +130,14 @@ export const GA_EVENT_NL_DETECT_FULFILL = "explore_detect_fulfill";
 export const GA_EVENT_NL_FULFILL = "explore_fulfill";
 
 /**
+ * Triggered when users click on a related topics url to keep exploring.
+ * It could either be the current Related Topics chip or the experimental Follow Up Questions.
+ * Parameters:
+ *   "related_topics_mode" : "related_topics_experiment" || "related_topics_current"
+ */
+export const GA_EVENT_RELATED_TOPICS_CLICK = "related_topics_click";
+
+/**
  * Triggered when "download" button is clicked on a tile.
  * Parameters:
  *    "type": "Timeline Tool" | "Scatter Tool" | "Map Tool" | ""
@@ -249,6 +257,7 @@ export const GA_PARAM_TIMING_MS = "time_ms";
 export const GA_PARAM_AUTOCOMPLETE_SELECTION_INDEX = "selection_index";
 export const GA_PARAM_DYNAMIC_PLACEHOLDER = "dynamic_placeholders_enabled";
 export const GA_PARAM_SEARCH_SELECTION = "search_selection";
+export const GA_PARAM_RELATED_TOPICS_MODE = "related_topics_mode";
 
 //GA event parameter values
 export const GA_VALUE_PLACE_CHART_CLICK_STAT_VAR_CHIP = "stat var chip";
@@ -281,3 +290,5 @@ export const GA_VALUE_SEARCH_SOURCE_HOMEPAGE = "homepage";
 export const GA_VALUE_SEARCH_SOURCE_PLACE_PAGE = "place";
 export const GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY = "sv_hierarchy";
 export const GA_VALUE_TOOL_STAT_VAR_OPTION_SEARCH = "sv_search";
+export const GA_VALUE_RELATED_TOPICS_EXPERIMENT = "related_topics_experiment";
+export const GA_VALUE_RELATED_TOPICS_CURRENT = "related_topics_current";

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -138,6 +138,12 @@ export const GA_EVENT_NL_FULFILL = "explore_fulfill";
 export const GA_EVENT_RELATED_TOPICS_CLICK = "related_topics_click";
 
 /**
+ * Triggered once when the Follow Up Questions component is in view.
+ * Parameters: None
+ */
+export const GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW = "follow_up_questions_view";
+
+/**
  * Triggered when "download" button is clicked on a tile.
  * Parameters:
  *    "type": "Timeline Tool" | "Scatter Tool" | "Map Tool" | ""

--- a/static/js/shared/hooks.ts
+++ b/static/js/shared/hooks.ts
@@ -20,6 +20,7 @@ import { MutableRefObject, useEffect, useMemo, useRef, useState } from "react";
 
 // By default will lazy load components that overlap the viewport
 const DEFAULT_LAZY_LOAD_ROOT_MARGIN = "0px";
+const DEFAULT_ON_SCREEN_ROOT_MARGIN = "0px";
 
 /**
  * Custom React hook that tracks whether a referenced element is in close
@@ -81,4 +82,50 @@ export const useLazyLoad = (
     };
   }, [observer]);
   return { shouldLoad, containerRef };
+};
+
+/**
+ * Custom React hook that tracks whether a referenced element is in close
+ * proximity to the viewport.
+ * When the element comes close to the view (within specified margin) view, it
+ * sets a flag `isOnScreen` to true.
+ *
+ * Usage:
+ * const ref = useRef(null);
+ * const isOnScreen = useOnScreen(ref)
+ *
+ * <div ref={ref}>
+ *   {isOnScreen ? "On Screen": "Not On Screen"}
+ * </div>
+ *
+ * @param {MutableRefObject<HTMLDivElement | null>} ref - A reference to the element whose visibility is in question.
+ * @param {string} rootMargin - Optional root margin configuration for the IntersectionObserver. Will set the onScreen flag
+ * to true when the component is within this margin of the viewport (Default: "0px")
+ *
+ * @returns {boolen} A boolean flag indicating wheter the element is on screen.
+ *
+ */
+export const useOnScreen = (
+  ref: MutableRefObject<HTMLDivElement | null>,
+  rootMargin?: string
+): boolean => {
+  const [isOnScreen, setOnScreen] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setOnScreen(entry.isIntersecting);
+      },
+      {
+        rootMargin: rootMargin || DEFAULT_ON_SCREEN_ROOT_MARGIN,
+      }
+    );
+
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref, rootMargin]);
+
+  return isOnScreen;
 };


### PR DESCRIPTION
- Added Events to track the number of clicks for Follow up Questions and Related Topic links, and for views of the Follow Up Questions component. 
- Added tests for each GA event and webdriver tests for the component.
- Propagated the Follow up Questions feature flag when clicked through one of the question links.