### PR TITLE
Metadata Modal - Observation period

### DIFF
--- a/static/js/tools/shared/metadata/tile_metadata_stat_var_section.tsx
+++ b/static/js/tools/shared/metadata/tile_metadata_stat_var_section.tsx
@@ -140,20 +140,28 @@ export const TileMetadataStatVarSection = ({
           const unitDisplay = metadata.unit
             ? startCase(metadata.unit)
             : undefined;
-          const periodicity = metadata.periodicity
-            ? humanizeIsoDuration(metadata.periodicity)
-            : undefined;
+
+          let observationPeriodDisplay: string;
+          if (metadata.observationPeriod) {
+            const humanizedPeriod = humanizeIsoDuration(
+              metadata.observationPeriod
+            );
+            observationPeriodDisplay =
+              humanizedPeriod !== metadata.observationPeriod
+                ? `${humanizedPeriod} (${metadata.observationPeriod})`
+                : humanizedPeriod;
+          }
 
           const hasDateRange = !!(
             metadata.dateRangeStart || metadata.dateRangeEnd
           );
           const hasUnit = !!unitDisplay;
-          const hasPeriodicity = !!periodicity;
+          const hasObservationPeriod = !!observationPeriodDisplay;
 
           const optionalFieldsCount = [
             hasDateRange,
             hasUnit,
-            hasPeriodicity,
+            hasObservationPeriod,
           ].filter(Boolean).length;
           const measurementMethodSpan = optionalFieldsCount % 2 === 0;
 
@@ -260,16 +268,14 @@ export const TileMetadataStatVarSection = ({
                   </ContentWrapper>
                 )}
 
-                {hasPeriodicity && (
+                {hasObservationPeriod && (
                   <ContentWrapper>
                     <h4>
                       {intl.formatMessage(
-                        metadataComponentMessages.PublicationCadence
+                        metadataComponentMessages.ObservationPeriod
                       )}
                     </h4>
-                    <p>
-                      {periodicity} ({metadata.periodicity})
-                    </p>
+                    <p>{observationPeriodDisplay}</p>
                   </ContentWrapper>
                 )}
 


### PR DESCRIPTION
## Description

Previously, the metadata modal was displaying `Publication cadence` (periodicity), whereas the dataset selector, by necessity, shows `Observation period` (one of the facet keys). 

To alleviate potential confusion (as these two values look very similar), these two are now consistent, with both the dataset selector and the metadata modal are now both showing `Observation period`.

Although in practice these two values are often the same (i.e., the publication cadence happens to follow the observation period), they are sometimes very different, as is indicated in the screenshots.

## Screenshots

### Select datasets modal

This is unchanged (it still shows the `Observation period`).

<img width="633" alt="Screenshot 2025-06-29 at 2 48 12 PM" src="https://github.com/user-attachments/assets/09d92a2b-74b4-4745-9deb-b7afca94c754" />

### Metadata modal - Before

The before shows the `Publication cadence`

<img width="769" alt="Screenshot 2025-06-29 at 2 48 22 PM" src="https://github.com/user-attachments/assets/e10cbb93-9dcb-468d-94d1-84d2bee7ddc9" />

### Metadata modal - After

The after shows the `Observation period`, following the Select datasets modal.

<img width="763" alt="Screenshot 2025-06-29 at 2 49 06 PM" src="https://github.com/user-attachments/assets/49426b6e-4b05-4775-9526-c7819711b1e0" />
