### PR TITLE
Fix fulfill when no svgs

### DIFF
--- a/server/lib/nl/common/variable_group.py
+++ b/server/lib/nl/common/variable_group.py
@@ -31,6 +31,9 @@ def open_svgs(svgs: List[str]) -> Dict[str, variable.SV]:
 
 
 def _get_svg_info(svgs, processed, result, level=0):
+  # Don't do anything if the list of svgs is empty
+  if not svgs:
+    return
   resp = dc.get_variable_group_info(svgs[:MAX_SVGS_IN_CALL], [])
   recurse_nodes = set()
   for data in resp.get('data', []):


### PR DESCRIPTION
This fixes a bug in /fulfill when the returned variables are not attached to any svgs:
- when there are no groups attached to the SVs in the result, we will call /v1/bulk/info/variable-group with an empty list of nodes (https://github.com/datacommonsorg/website/blob/master/server/lib/nl/common/variable_group.py#L34)

- and looking at the handler for /v1/bulk/info/variable-group, if it gets called with an empty list of variables, it will return all the variable groups in the DC graph which ends up exceeding the response size limit (https://github.com/datacommonsorg/mixer/blob/master/internal/server/v1/info/variable_group.go#L68-L82)

This PR avoids calling /v1/bulk/info/variable-group when there are no svgs

Tested manually