### PR TITLE
[Vis Tools] Add blue instruction box to landing pages

### DIFF
--- a/server/templates/tools/map.html
+++ b/server/templates/tools/map.html
@@ -26,6 +26,7 @@
   <link rel="stylesheet" href={{url_for('static', filename='css/map.min.css')}} >
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0" />
   {% if allow_leaflet %}
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.2/dist/leaflet.css" integrity="sha256-sA+zWATbFveLLNqWO2gtiw3HL/lh1giY/Inf1BJ0z14=" crossorigin="" />
   {% endif %}

--- a/server/templates/tools/scatter.html
+++ b/server/templates/tools/scatter.html
@@ -25,6 +25,7 @@
 <link rel="stylesheet" href={{url_for('static', filename='css/scatter.min.css', t=config['VERSION'])}}>
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0" />
 {% endblock %}
 
 {% block content %}

--- a/server/templates/tools/timeline.html
+++ b/server/templates/tools/timeline.html
@@ -25,6 +25,7 @@
 <link rel="stylesheet" href={{url_for('static', filename='css/timeline.min.css', t=config['VERSION'])}}>
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0" />
 {% endblock %}
 
 {% block content %}

--- a/static/js/i18n/i18n_vis_tool_messages.ts
+++ b/static/js/i18n/i18n_vis_tool_messages.ts
@@ -58,4 +58,49 @@ export const visualizationToolMessages = defineMessages({
     description:
       "a description of what our timelines explorer tool is used for",
   },
+  infoBoxInstructionHeader: {
+    id: "info_box_instruction_header",
+    defaultMessage: "Follow these steps:",
+    description: "heading for a set of instructions on how to use our tools",
+  },
+  infoBoxInstructionsPlacesIn: {
+    id: "info_box_instruction_places_in",
+    defaultMessage:
+      "Enter your desired location (e.g. city, state, country) into the search box above, and then select the type of sub-region you want to plot.",
+    description:
+      "instructions for how to enter the group of places to plot using our chart visualization tools, (e.g. plot cities in France).",
+  },
+  infoBoxInstructionsPlaces: {
+    id: "info_box_instruction_places",
+    defaultMessage:
+      "Type your desired location(s) (e.g. city, state, country) into the search box above, then select the place from the displayed results.",
+    description:
+      "instructions for how to enter a list of places to plot using our chart visualization tools",
+  },
+  infoBoxInstructionsVariableDesktop: {
+    id: "info_box_instruction_variable_desktop",
+    defaultMessage: "Pick a statistical variable in the left panel.",
+    description:
+      "An instruction for users to interact with a UI element on the left side of the page",
+  },
+  infoBoxInstructionsVariableMobile: {
+    id: "info_box_instruction_variable_desktop",
+    defaultMessage:
+      'Pick a statistical variable using the "select variable" button above.',
+    description:
+      "An instruction for users to use a button labeled 'select variable' to select a statistical variable to plot",
+  },
+  infoBoxInstructionsMultiVariableDesktop: {
+    id: "info_box_instruction_variable_desktop",
+    defaultMessage: "Pick statistical variables in the left panel.",
+    description:
+      "An instruction for users to interact with a UI element on the left side of the page to select multiple statistical variables",
+  },
+  infoBoxInstructionsMultiVariableMobile: {
+    id: "info_box_instruction_variable_desktop",
+    defaultMessage:
+      'Pick statistical variables using the "select variables" button above.',
+    description:
+      "An instruction for users to use a button labeled 'select variables' to select multiple statistical variable to plot",
+  },
 });

--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -34,7 +34,7 @@ import { InfoBox } from "../shared/info_box";
 import { ToolHeader } from "../shared/tool_header";
 import { ChartLoader } from "./chart_loader";
 import { Context, ContextType, useInitialContext } from "./context";
-import { Info } from "./info";
+import { Info, StandardizedInfo } from "./info";
 import { PlaceOptions } from "./place_options";
 import { StatVarChooser } from "./stat_var_chooser";
 import { Title } from "./title";
@@ -83,30 +83,7 @@ function App(): ReactElement {
           <Row>
             <PlaceOptions toggleSvHierarchyModal={toggleSvModalCallback} />
           </Row>
-          <Row>
-            {useStandardizedUi ? (
-              <InfoBox>
-                <h2>Follow these steps:</h2>
-                <ol>
-                  <li>
-                    Enter your desired location (county or state) into the
-                    search box above, and then select the type of place you want
-                    to plot.
-                  </li>
-                  <li>
-                    Pick a statistical variable{" "}
-                    <span className="d-none d-lg-inline">in the left pane</span>
-                    <span className="d-lg-none">
-                      using the &quot;Select variable&quot; button above
-                    </span>
-                    .
-                  </li>
-                </ol>
-              </InfoBox>
-            ) : (
-              <Info />
-            )}
-          </Row>
+          <Row>{useStandardizedUi ? <StandardizedInfo /> : <Info />}</Row>
           <Row id="chart-row">
             <ChartLoader />
           </Row>

--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -30,6 +30,7 @@ import {
   STANDARDIZED_VIS_TOOL_FEATURE_FLAG,
 } from "../../shared/feature_flags/util";
 import theme from "../../theme/theme";
+import { InfoBox } from "../shared/info_box";
 import { ToolHeader } from "../shared/tool_header";
 import { ChartLoader } from "./chart_loader";
 import { Context, ContextType, useInitialContext } from "./context";
@@ -83,7 +84,28 @@ function App(): ReactElement {
             <PlaceOptions toggleSvHierarchyModal={toggleSvModalCallback} />
           </Row>
           <Row>
-            <Info />
+            {useStandardizedUi ? (
+              <InfoBox>
+                <h2>Follow these steps:</h2>
+                <ol>
+                  <li>
+                    Enter your desired location (county or state) into the
+                    search box above, and then select the type of place you want
+                    to plot.
+                  </li>
+                  <li>
+                    Pick a statistical variable{" "}
+                    <span className="d-none d-lg-inline">in the left pane</span>
+                    <span className="d-lg-none">
+                      using the &quot;Select variable&quot; button above
+                    </span>
+                    .
+                  </li>
+                </ol>
+              </InfoBox>
+            ) : (
+              <Info />
+            )}
           </Row>
           <Row id="chart-row">
             <ChartLoader />

--- a/static/js/tools/map/info.tsx
+++ b/static/js/tools/map/info.tsx
@@ -21,6 +21,8 @@
 import _ from "lodash";
 import React, { useContext } from "react";
 
+import { intl } from "../../i18n/i18n";
+import { visualizationToolMessages } from "../../i18n/i18n_vis_tool_messages";
 import { InfoBox } from "../shared/info_box";
 import { MemoizedInfoExamples } from "../shared/info_examples";
 import { Context } from "./context";
@@ -73,19 +75,26 @@ export function Info(): JSX.Element {
 export function StandardizedInfo(): JSX.Element {
   return (
     <InfoBox>
-      <h2>Follow these steps:</h2>
+      <h2>
+        {intl.formatMessage(visualizationToolMessages.infoBoxInstructionHeader)}
+      </h2>
       <ol>
         <li>
-          Enter your desired location (county or state) into the search box
-          above, and then select the type of sub-regions you want to plot.
+          {intl.formatMessage(
+            visualizationToolMessages.infoBoxInstructionsPlacesIn
+          )}
         </li>
         <li>
-          Pick a statistical variable{" "}
-          <span className="d-none d-lg-inline">in the left pane</span>
-          <span className="d-lg-none">
-            using the &quot;Select variable&quot; button above
+          <span className="d-none d-lg-inline">
+            {intl.formatMessage(
+              visualizationToolMessages.infoBoxInstructionsVariableDesktop
+            )}
           </span>
-          .
+          <span className="d-lg-none">
+            {intl.formatMessage(
+              visualizationToolMessages.infoBoxInstructionsVariableMobile
+            )}
+          </span>
         </li>
       </ol>
     </InfoBox>

--- a/static/js/tools/map/info.tsx
+++ b/static/js/tools/map/info.tsx
@@ -21,6 +21,7 @@
 import _ from "lodash";
 import React, { useContext } from "react";
 
+import { InfoBox } from "../shared/info_box";
 import { MemoizedInfoExamples } from "../shared/info_examples";
 import { Context } from "./context";
 import { ifShowChart } from "./util";
@@ -66,5 +67,27 @@ export function Info(): JSX.Element {
         </div>
       )}
     </>
+  );
+}
+
+export function StandardizedInfo(): JSX.Element {
+  return (
+    <InfoBox>
+      <h2>Follow these steps:</h2>
+      <ol>
+        <li>
+          Enter your desired location (county or state) into the search box
+          above, and then select the type of sub-regions you want to plot.
+        </li>
+        <li>
+          Pick a statistical variable{" "}
+          <span className="d-none d-lg-inline">in the left pane</span>
+          <span className="d-lg-none">
+            using the &quot;Select variable&quot; button above
+          </span>
+          .
+        </li>
+      </ol>
+    </InfoBox>
   );
 }

--- a/static/js/tools/map/place_options.tsx
+++ b/static/js/tools/map/place_options.tsx
@@ -78,7 +78,7 @@ export function PlaceOptions(props: PlaceOptionsProps): JSX.Element {
       getEnclosedPlaceTypes={getAllChildPlaceTypes}
       customSearchPlaceholder={"Enter a country or state to get started"}
     >
-      <Row className="d-lg-none">
+      <Row className="d-inline d-lg-none">
         <Col>
           <Button color="primary" onClick={props.toggleSvHierarchyModal}>
             Select variable

--- a/static/js/tools/scatter/app.tsx
+++ b/static/js/tools/scatter/app.tsx
@@ -39,7 +39,7 @@ import {
   PlaceInfo,
   useContextStore,
 } from "./context";
-import { MemoizedInfo } from "./info";
+import { MemoizedInfo, StandardizedInfo } from "./info";
 import { PlaceOptions } from "./place_and_type_options";
 import { StatVarChooser } from "./statvar";
 import {
@@ -103,7 +103,7 @@ function App(): ReactElement {
           )}
           {showInfo && (
             <Row>
-              <MemoizedInfo />
+              {useStandardizedUi ? <StandardizedInfo /> : <MemoizedInfo />}
             </Row>
           )}
           {showChart && (

--- a/static/js/tools/scatter/info.tsx
+++ b/static/js/tools/scatter/info.tsx
@@ -21,6 +21,8 @@
 import _ from "lodash";
 import React from "react";
 
+import { intl } from "../../i18n/i18n";
+import { visualizationToolMessages } from "../../i18n/i18n_vis_tool_messages";
 import { InfoBox } from "../shared/info_box";
 import { MemoizedInfoExamples } from "../shared/info_examples";
 
@@ -64,20 +66,26 @@ export const MemoizedInfo = React.memo(Info);
 export function StandardizedInfo(): JSX.Element {
   return (
     <InfoBox>
-      <h2>Follow these steps:</h2>
+      <h2>
+        {intl.formatMessage(visualizationToolMessages.infoBoxInstructionHeader)}
+      </h2>
       <ol>
         <li>
-          Enter your desired location (e.g. city, state, county, or country)
-          into the search box above, and then select the type of sub-regions you
-          want to plot.
+          {intl.formatMessage(
+            visualizationToolMessages.infoBoxInstructionsPlacesIn
+          )}
         </li>
         <li>
-          Pick a statistical variable{" "}
-          <span className="d-none d-lg-inline">in the left pane</span>
-          <span className="d-lg-none">
-            using the &quot;Select variable&quot; button above
+          <span className="d-none d-lg-inline">
+            {intl.formatMessage(
+              visualizationToolMessages.infoBoxInstructionsMultiVariableDesktop
+            )}
           </span>
-          .
+          <span className="d-lg-none">
+            {intl.formatMessage(
+              visualizationToolMessages.infoBoxInstructionsMultiVariableMobile
+            )}
+          </span>
         </li>
       </ol>
     </InfoBox>

--- a/static/js/tools/scatter/info.tsx
+++ b/static/js/tools/scatter/info.tsx
@@ -21,6 +21,7 @@
 import _ from "lodash";
 import React from "react";
 
+import { InfoBox } from "../shared/info_box";
 import { MemoizedInfoExamples } from "../shared/info_examples";
 
 function Info(): JSX.Element {
@@ -59,3 +60,26 @@ function Info(): JSX.Element {
 }
 
 export const MemoizedInfo = React.memo(Info);
+
+export function StandardizedInfo(): JSX.Element {
+  return (
+    <InfoBox>
+      <h2>Follow these steps:</h2>
+      <ol>
+        <li>
+          Enter your desired location (e.g. city, state, county, or country)
+          into the search box above, and then select the type of sub-regions you
+          want to plot.
+        </li>
+        <li>
+          Pick a statistical variable{" "}
+          <span className="d-none d-lg-inline">in the left pane</span>
+          <span className="d-lg-none">
+            using the &quot;Select variable&quot; button above
+          </span>
+          .
+        </li>
+      </ol>
+    </InfoBox>
+  );
+}

--- a/static/js/tools/scatter/place_and_type_options.tsx
+++ b/static/js/tools/scatter/place_and_type_options.tsx
@@ -95,7 +95,7 @@ function PlaceAndTypeOptions(props: PlaceAndTypeOptionsProps): JSX.Element {
       onPlaceSelected={place.setEnclosingPlace}
       onEnclosedPlaceTypeSelected={place.setEnclosedPlaceType}
     >
-      <div className="d-lg-none" id="btn-sv-widget-modal">
+      <div className="d-inline d-lg-none" id="btn-sv-widget-modal">
         <div className="btn btn-primary" onClick={props.toggleSvHierarchyModal}>
           Select variables
         </div>

--- a/static/js/tools/shared/info_box.tsx
+++ b/static/js/tools/shared/info_box.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @jsxImportSource @emotion/react */
+
+/**
+ * Box with info or instructions to display on tool landing pages
+ */
+
+import { css } from "@emotion/react";
+import React from "react";
+
+interface InfoBoxProps {
+  children?: React.ReactNode;
+  // material symbol icon name of the icon to show on top left of the box
+  // if not provided, defaults to the "reminder" icon
+  icon?: string;
+}
+
+export function InfoBox(props: InfoBoxProps): JSX.Element {
+  return (
+    <div>
+      <div
+        css={css`
+          background-color: #c2e7ff33;
+          border-radius: 16px;
+          display: flex;
+          flex-direction: row;
+          gap: 16px;
+          margin-bottom: 24px;
+          padding: 20px 24px;
+
+          .icon {
+            font-size: 32px;
+          }
+        `}
+      >
+        <i
+          className="material-symbols-outlined"
+          css={css`
+            font-size: 28px;
+          `}
+        >
+          {props.icon || "reminder"}
+        </i>
+        <div
+          css={css`
+            color: var(--GM3-ref-neutral-neutral20, #303030);
+            font-size: 22px;
+            line-height: 28px;
+            font-weight: 400;
+
+            h2 {
+              font-size: 24px;
+              font-weight: 500;
+              line-height: 28px;
+            }
+            ol,
+            ul {
+              margin: 16px 0;
+            }
+            li {
+              margin: 24px 0;
+            }
+          `}
+        >
+          {props.children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/static/js/tools/shared/info_box.tsx
+++ b/static/js/tools/shared/info_box.tsx
@@ -59,8 +59,8 @@ export function InfoBox(props: InfoBoxProps): JSX.Element {
           css={css`
             color: var(--GM3-ref-neutral-neutral20, #303030);
             font-size: 22px;
-            line-height: 28px;
             font-weight: 400;
+            line-height: 28px;
 
             h2 {
               font-size: 24px;
@@ -69,7 +69,7 @@ export function InfoBox(props: InfoBoxProps): JSX.Element {
             }
             ol,
             ul {
-              margin: 16px 0;
+              margin: 24px 0;
             }
             li {
               margin: 24px 0;

--- a/static/js/tools/stat_var/info.tsx
+++ b/static/js/tools/stat_var/info.tsx
@@ -20,24 +20,23 @@
 
 import React, { Component } from "react";
 
+import { InfoBox } from "../shared/info_box";
+
 class Info extends Component {
   render(): JSX.Element {
     return (
-      <div id="placeholder-container">
-        <div className="start-instruction-tile">
-          <i className="material-symbols-outlined icon">reminder</i>
-          <p className="start-instruction-text">
-            To start,{" "}
-            <span className="d-none d-lg-inline">
-              select a variable from the left panel
-            </span>
-            <span className="d-lg-none">
-              click the &quot;Select variable&quot; button below
-            </span>
-            . Need more specific data? Filter by choosing a data source above.
-          </p>
-        </div>
-      </div>
+      <InfoBox>
+        <p>
+          To start,{" "}
+          <span className="d-none d-lg-inline">
+            select a variable from the left panel
+          </span>
+          <span className="d-lg-none">
+            click the &quot;Select variable&quot; button below
+          </span>
+          . Need more specific data? Filter by choosing a data source above.
+        </p>
+      </InfoBox>
     );
   }
 }

--- a/static/js/tools/stat_var/page.tsx
+++ b/static/js/tools/stat_var/page.tsx
@@ -140,7 +140,7 @@ class Page extends Component<unknown, PageStateType> {
               <>
                 <Info />
                 <Button
-                  className="d-lg-none"
+                  className="d-inline d-lg-none"
                   color="primary"
                   onClick={this.toggleSvHierarchyModal}
                 >

--- a/static/js/tools/stat_var/page.tsx
+++ b/static/js/tools/stat_var/page.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../shared/types";
 import { stringifyFn } from "../../utils/axios";
 import { getUrlToken, updateHash } from "../../utils/url_utils";
+import { InfoBox } from "../shared/info_box";
 import { StatVarWidget } from "../shared/stat_var_widget";
 import { DatasetSelector } from "./dataset_selector";
 import { Explorer } from "./explorer";

--- a/static/js/tools/timeline/info.tsx
+++ b/static/js/tools/timeline/info.tsx
@@ -17,6 +17,7 @@
 import _ from "lodash";
 import React, { Component } from "react";
 
+import { InfoBox } from "../shared/info_box";
 import { MemoizedInfoExamples } from "../shared/info_examples";
 
 class Info extends Component {
@@ -49,3 +50,24 @@ class Info extends Component {
 }
 
 export const MemoizedInfo = React.memo(Info);
+
+export function StandardizedInfo(): JSX.Element {
+  return (
+    <InfoBox>
+      <h2>Follow these steps:</h2>
+      <ol>
+        <li>
+          Type your desired location(s) (city, state, country, county) into the
+          search box above, then select the place from the displayed results.
+        </li>
+        <li>
+          Pick a statistical variable{" "}
+          <span className="d-none d-lg-inline">in the left pane</span>
+          <span className="d-lg-none">
+            using the &quot;Select variable&quot; button above
+          </span>
+        </li>
+      </ol>
+    </InfoBox>
+  );
+}

--- a/static/js/tools/timeline/info.tsx
+++ b/static/js/tools/timeline/info.tsx
@@ -17,6 +17,8 @@
 import _ from "lodash";
 import React, { Component } from "react";
 
+import { intl } from "../../i18n/i18n";
+import { visualizationToolMessages } from "../../i18n/i18n_vis_tool_messages";
 import { InfoBox } from "../shared/info_box";
 import { MemoizedInfoExamples } from "../shared/info_examples";
 
@@ -54,17 +56,25 @@ export const MemoizedInfo = React.memo(Info);
 export function StandardizedInfo(): JSX.Element {
   return (
     <InfoBox>
-      <h2>Follow these steps:</h2>
+      <h2>
+        {intl.formatMessage(visualizationToolMessages.infoBoxInstructionHeader)}
+      </h2>
       <ol>
         <li>
-          Type your desired location(s) (city, state, country, county) into the
-          search box above, then select the place from the displayed results.
+          {intl.formatMessage(
+            visualizationToolMessages.infoBoxInstructionsPlaces
+          )}
         </li>
         <li>
-          Pick a statistical variable{" "}
-          <span className="d-none d-lg-inline">in the left pane</span>
-          <span className="d-lg-none">
-            using the &quot;Select variable&quot; button above
+          <span className="d-none d-lg-inline">
+            {intl.formatMessage(
+              visualizationToolMessages.infoBoxInstructionsMultiVariableDesktop
+            )}
+          </span>
+          <span className="d-inline d-lg-none">
+            {intl.formatMessage(
+              visualizationToolMessages.infoBoxInstructionsMultiVariableMobile
+            )}
           </span>
         </li>
       </ol>

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -174,7 +174,7 @@ class Page extends Component<unknown, PageStateType> {
                   />
                 </Col>
               </Row>
-              <Row className="d-lg-none">
+              <Row className="d-inline d-lg-none">
                 <Col>
                   <Button color="primary" onClick={this.toggleSvHierarchyModal}>
                     Select variables

--- a/static/js/tools/timeline/page.tsx
+++ b/static/js/tools/timeline/page.tsx
@@ -37,7 +37,7 @@ import { getPlaceNames } from "../../utils/place_utils";
 import { StatVarWidget } from "../shared/stat_var_widget";
 import { ToolHeader } from "../shared/tool_header";
 import { ChartRegion } from "./chart_region";
-import { MemoizedInfo } from "./info";
+import { MemoizedInfo, StandardizedInfo } from "./info";
 import {
   addToken,
   getTokensFromUrl,
@@ -182,7 +182,8 @@ class Page extends Component<unknown, PageStateType> {
                 </Col>
               </Row>
             </Card>
-            {numPlaces === 0 && <MemoizedInfo />}
+            {numPlaces === 0 &&
+              (useStandardizedUi ? <StandardizedInfo /> : <MemoizedInfo />)}
             {numPlaces !== 0 && numStatVarInfo !== 0 && (
               <div id="chart-region">
                 <ChartRegion


### PR DESCRIPTION
Adds a blue box with instructions on how to use our tools, following [the mocks](https://docs.google.com/presentation/d/1ztyZwu8b3YzU1MMAFPI3iC-Hm00CE63rPb7eP6vGZlw/edit?slide=id.g3052c79bc05_0_12#slide=id.g3052c79bc05_0_12).

In particular:
* Converted the blue box currently used by the stat var tool into a reusable component
* Applied the new component to each of the visualization tools and the current stat var tool
* [Bug fix] Some slight CSS adjustments to the "select variable" button on smaller screens so that the button always appears when the stat var selector panel disappears.
* Added two versions of the instructions, depending on if the user is looking at a larger (desktop) version of the site or the smaller (mobile) version of the site.

Screenshots:

<img width="1309" height="668" alt="Screenshot 2025-07-14 at 12 58 36 PM" src="https://github.com/user-attachments/assets/e9beb136-dadc-451f-bbd4-7993c54a8f03" />
<img width="870" height="720" alt="Screenshot 2025-07-14 at 12 56 46 PM" src="https://github.com/user-attachments/assets/742447fe-87a5-437c-8868-e893520524ff" />


<img width="1306" height="655" alt="Screenshot 2025-07-14 at 12 58 01 PM" src="https://github.com/user-attachments/assets/22919730-b3c9-4635-8f36-f8d351265585" />

<img width="867" height="731" alt="Screenshot 2025-07-14 at 12 57 50 PM" src="https://github.com/user-attachments/assets/8d00be5d-ed93-4877-b069-4a8bcd2dd208" />

<img width="1314" height="649" alt="Screenshot 2025-07-14 at 12 58 17 PM" src="https://github.com/user-attachments/assets/b2fa3701-9353-45d4-b1f8-b7b8f4a844b1" />
<img width="867" height="838" alt="Screenshot 2025-07-14 at 12 57 40 PM" src="https://github.com/user-attachments/assets/e7b904bb-acb3-40c7-9592-ac3b4bced776" />
