### PR TITLE
Skip mixer cache based on header

### DIFF
--- a/server/lib/cache.py
+++ b/server/lib/cache.py
@@ -15,6 +15,7 @@
 import os
 from pathlib import Path
 
+from flask import request
 from flask_caching import Cache
 
 import server.lib.config as lib_config
@@ -65,3 +66,16 @@ if cfg.USE_MEMCACHE or REDIS_HOST:
 else:
   # For some instance with fast updated data, we may not want to use memcache.
   cache = Cache(config={'CACHE_TYPE': 'NullCache'})
+
+
+def should_bypass_cache():
+  """Check if cache should be bypassed based on request header.
+  
+  Returns:
+    True if X-Bypass-Cache header is set to '1', False otherwise.
+  """
+  try:
+    return request.headers.get('X-Bypass-Cache') == '1'
+  except RuntimeError:
+    # Request context not available
+    return False

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -23,6 +23,7 @@ import requests
 
 from server.lib import log
 from server.lib.cache import cache
+from server.lib.cache import should_bypass_cache
 import server.lib.config as libconfig
 from server.routes import TIMEOUT
 from server.services.discovery import get_health_check_urls
@@ -31,7 +32,7 @@ from server.services.discovery import get_service_url
 cfg = libconfig.get_config()
 
 
-@cache.memoize(timeout=TIMEOUT)
+@cache.memoize(timeout=TIMEOUT, unless=should_bypass_cache)
 def get(url: str):
   headers = {'Content-Type': 'application/json'}
   dc_api_key = current_app.config.get('DC_API_KEY', '')
@@ -57,7 +58,7 @@ def post(url: str, req: Dict):
   return post_wrapper(url, req_str)
 
 
-@cache.memoize(timeout=TIMEOUT)
+@cache.memoize(timeout=TIMEOUT, unless=should_bypass_cache)
 def post_wrapper(url, req_str: str):
   req = json.loads(req_str)
   headers = {'Content-Type': 'application/json'}


### PR DESCRIPTION
Modified cache behavior to aid in debugging mixer interactions. 

The same would be used to create uptime tests for website mixer

- We can't have direct uptime checks for website mixer, as endpoints are  not exposed publicly.
- Website uptime routing to website mixers would be needed. Disabling cache per request would help achieve that.