### PR TITLE
[Productionization Excellence] Use a shared docker image in the webdriver tests.

### DIFF
--- a/build/ci/cloudbuild.webdriver.yaml
+++ b/build/ci/cloudbuild.webdriver.yaml
@@ -13,10 +13,28 @@
 # limitations under the License.
 
 steps:
-  - id: flask_webdriver_test
-    name: gcr.io/datcom-ci/full-env:latest
-    entrypoint: /bin/sh
+  - id: package_js
+    name: gcr.io/datcom-ci/node:2024-11-19
+    entrypoint: /bin/bash
     waitFor: ["-"]
+    args:
+      - -c
+      - |
+        # The node docker image comes with a pre-installed node_modules directory.
+        # Copy node_modules onto the static folder and update the node_module packages instead of downloading from scratch.
+        # This step is done for speed, downloading the delta files is faster than downloading the entire dependencies.
+        rm -rf static/node_modules
+        cp -r /resources/node_modules -d static/
+
+        # ./run_test.sh -b will build client packages.
+        # These js files generated will be necessery for the flask_webdriver_test task.
+        ./run_test.sh -b
+
+
+  - id: flask_webdriver_test
+    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
+    entrypoint: /bin/sh
+    waitFor: ["package_js"]
     args:
       - -c
       - |

--- a/build/ci/cloudbuild.webdriver.yaml
+++ b/build/ci/cloudbuild.webdriver.yaml
@@ -13,70 +13,22 @@
 # limitations under the License.
 
 steps:
-  # Build the static files
-  - id: package_js
-    name: gcr.io/datcom-ci/node:2024-11-19
-    entrypoint: /bin/bash
-    waitFor: ["-"]
-    args:
-      - -c
-      - |
-        # The node docker image comes with a pre-installed node_modules directory.
-        # Copy node_modules onto the static folder and update the node_module packages instead of downloading from scratch.
-        # This step is done for speed, downloading the delta files is faster than downloading the entire dependencies.
-        rm -rf static/node_modules
-        cp -r /resources/node_modules -d static/
-
-        # ./run_test.sh -b will build client packages.
-        # These js files generated will be necessery for the flask_webdriver_test task.
-        ./run_test.sh -b
-
-  - id: setup_python
-    name: python:3.11.4
-    entrypoint: /bin/bash
-    waitFor: ["-"]
-    args:
-      - -c
-      - |
-        ./run_test.sh --setup_python
-
-  - id: setup_website
-    name: python:3.11.4
-    entrypoint: /bin/bash
-    waitFor: ["-"]
-    args:
-      - -c
-      - |
-        ./run_test.sh --setup_website
-
-  - id: setup_nl
-    name: python:3.11.4
-    entrypoint: /bin/bash
-    waitFor: ["-"]
-    args:
-      - -c
-      - |
-        ./run_test.sh --setup_nl
-
-  # Run the webdriver tests
   - id: flask_webdriver_test
-    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
+    name: gcr.io/datcom-ci/full-env:latest
     entrypoint: /bin/sh
-    waitFor: ["package_js", "setup_python"]
+    waitFor: ["-"]
     args:
       - -c
       - |
         ./run_test.sh -w
 
-  # Run the Custom DC webdriver tests
   - id: flask_cdc_webdriver_test
-    name: gcr.io/datcom-ci/full-env:2025-05-20
+    name: gcr.io/datcom-ci/full-env:latest
     entrypoint: /bin/sh
-    waitFor: ["package_js", "setup_python", "setup_website", "setup_nl"]
+    waitFor: ["-"]
     args:
       - -c
       - |
-        git submodule update --init --recursive
         export STARTUP_WAIT_SEC=60
         ./run_test.sh --cdc
 

--- a/build/ci/cloudbuild.webdriver.yaml
+++ b/build/ci/cloudbuild.webdriver.yaml
@@ -13,10 +13,27 @@
 # limitations under the License.
 
 steps:
-  - id: flask_webdriver_test
-    name: gcr.io/datcom-ci/full-env:latest
-    entrypoint: /bin/sh
+  - id: package_js
+    name: gcr.io/datcom-ci/node:2024-11-19
+    entrypoint: /bin/bash
     waitFor: ["-"]
+    args:
+      - -c
+      - |
+        # The node docker image comes with a pre-installed node_modules directory.
+        # Copy node_modules onto the static folder and update the node_module packages instead of downloading from scratch.
+        # This step is done for speed, downloading the delta files is faster than downloading the entire dependencies.
+        rm -rf static/node_modules
+        cp -r /resources/node_modules -d static/
+
+        # ./run_test.sh -b will build client packages.
+        # These js files generated will be necessery for the flask_webdriver_test task.
+        ./run_test.sh -b
+
+  - id: flask_webdriver_test
+    name: gcr.io/datcom-ci/webdriver-chrome:2025-01-15
+    entrypoint: /bin/sh
+    waitFor: ["package_js"]
     args:
       - -c
       - |
@@ -25,7 +42,7 @@ steps:
   - id: flask_cdc_webdriver_test
     name: gcr.io/datcom-ci/full-env:latest
     entrypoint: /bin/sh
-    waitFor: ["-"]
+    waitFor: ["package_js"]
     args:
       - -c
       - |

--- a/build/full_env/Dockerfile
+++ b/build/full_env/Dockerfile
@@ -126,10 +126,10 @@ RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin && \
 WORKDIR /app
 COPY . /app
 
-RUN python3 -m venv .venv
+RUN python3 -m venv .env
 
 # You might want to set the PATH to include the virtual environment's bin directory
-ENV PATH="/app/.venv/bin:$PATH"
+ENV PATH="/app/.env/bin:$PATH"
 
 
 # --- Now, execute your setup scripts ---

--- a/build/full_env/Dockerfile
+++ b/build/full_env/Dockerfile
@@ -124,11 +124,13 @@ RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin && \
 
 
 WORKDIR /app
+COPY . /app
 
-COPY run_test.sh ./
-COPY requirements.txt ./
-COPY package.json ./
-COPY static/ static/
+RUN python3 -m venv .venv
+
+# You might want to set the PATH to include the virtual environment's bin directory
+ENV PATH="/app/.venv/bin:$PATH"
+
 
 # --- Now, execute your setup scripts ---
 # Ensure run_test.sh is executable

--- a/build/full_env/Dockerfile
+++ b/build/full_env/Dockerfile
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 # Stage 1: Python Builder
 # Uses a specific Python patch version on a slim Debian Bookworm base
 FROM python:3.11.4-slim-bookworm as python-builder
@@ -52,6 +51,8 @@ FROM google/cloud-sdk:469.0.0-slim as gcloud-builder
 # Final Stage: Combine all components + Chrome/ChromeDriver
 # Using debian:bookworm-slim as a minimal base for the final image.
 FROM debian:bookworm-slim
+
+RUN echo "DEBUG: Listing build context..." && ls -la && ls -la /app /
 
 # Install common utilities needed for the combined environment,
 # including build-essential for some tools, and tools for Chrome/ChromeDriver.
@@ -121,3 +122,21 @@ ENV PATH="/usr/local/go/bin:${GOPATH}/bin:/usr/local/bin:/usr/lib/google-cloud-s
 RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin && \
     go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0 && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
+
+
+WORKDIR /app
+
+COPY run_test.sh ./
+COPY requirements.txt ./
+COPY package.json ./
+COPY static/ static/
+
+# --- Now, execute your setup scripts ---
+# Ensure run_test.sh is executable
+RUN chmod +x run_test.sh
+
+# Run the setup scripts. These will now execute *during the Docker image build*.
+RUN ./run_test.sh --setup_python
+RUN ./run_test.sh -b
+RUN ./run_test.sh --setup_website
+RUN ./run_test.sh --setup_nl

--- a/build/full_env/Dockerfile
+++ b/build/full_env/Dockerfile
@@ -52,7 +52,6 @@ FROM google/cloud-sdk:469.0.0-slim as gcloud-builder
 # Using debian:bookworm-slim as a minimal base for the final image.
 FROM debian:bookworm-slim
 
-RUN echo "DEBUG: Listing build context..." && ls -la && ls -la /app /
 
 # Install common utilities needed for the combined environment,
 # including build-essential for some tools, and tools for Chrome/ChromeDriver.

--- a/build/full_env/README.md
+++ b/build/full_env/README.md
@@ -20,9 +20,9 @@ This container includes:
 To generate the Docker image and push it to GCS:
 
 1. Change the version date in cloudbuild.yaml
-2. Run (from this directory):
+2. Run (from the website directory):
 
 ```bash
 gcloud config set project datcom-ci
-gcloud builds submit . --config=cloudbuild.yaml
+gcloud builds submit . --config=/build/full_env/cloudbuild.yaml
 ```

--- a/build/full_env/cloudbuild.yaml
+++ b/build/full_env/cloudbuild.yaml
@@ -12,18 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-substitutions:
-  _VERS: "2025-05-20"
-
 steps:
   - name: "gcr.io/cloud-builders/docker"
     args:
       - build
-      - "--build-arg=VERS=${_VERS}"
-      - --tag=gcr.io/datcom-ci/full-env:${_VERS}
-      - --tag=gcr.io/datcom-ci/full-env:latest
+      - "--tag=gcr.io/datcom-ci/full-env:latest"
+      - "-f"
+      - "build/full_env/Dockerfile"
       - "."
 
 images:
-  - "gcr.io/datcom-ci/full-env:${_VERS}"
   - "gcr.io/datcom-ci/full-env:latest"


### PR DESCRIPTION
This allows us to reduce build time. 