### PR TITLE
Enable standardized visualization tool UI on autopush and local

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -55,7 +55,7 @@
   },
   {
     "name": "standardized_vis_tool",
-    "enabled": false,
+    "enabled": true,
     "owner": "juliawu",
     "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
   },

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -55,7 +55,7 @@
   },
   {
     "name": "standardized_vis_tool",
-    "enabled": false,
+    "enabled": true,
     "owner": "juliawu",
     "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
   },


### PR DESCRIPTION
Updates the `standardized_vis_tool` feature flag to be turned on by default for autopush and local.

Changes made following discussion in PR #5294. 