### PR TITLE
[Explore] Fixes the uneven spacing between modules at the bottom of the page.

### DIFF
--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -79,6 +79,12 @@
   }
 }
 
+/* Eliminates the extra padding at the bottom of Explore charts
+to provide spacing consistency with other components. */
+[id^="explore_cat_"].category.col-12 {
+  padding-bottom: 0 !important;
+}
+
 #explore-more-section {
   padding: 24px;
   border-radius: var(--border-radius-primary);
@@ -256,7 +262,7 @@
   border-radius: var(--border-radius-primary);
   border: var(--border-primary);
   background: var(--loading-background);
-  margin-bottom: 24px;
+  margin-bottom: 31px;
   width: 100%;
   color: var(--gm-3-ref-neutral-neutral-50) !important
 }
@@ -268,7 +274,7 @@
   border-radius: var(--border-radius-primary);
   border: var(--border-primary);
   background: var(--gm-3-white);
-  margin-bottom: 24px;
+  margin-bottom: 31px;
   width: 100%;
 }
 


### PR DESCRIPTION
The spacing between the charts module and the related places module was fixed to be even.

Before in Desktop (Uneven spacing): https://screenshot.googleplex.com/3wHFfxMffbCKJXu
<img width="2142" height="603" alt="image" src="https://github.com/user-attachments/assets/b2be3840-745b-4e44-90b4-daaddc9155c7" />

After in Desktop (Even spacing): https://screenshot.googleplex.com/6YXRwryqEH7Gtq7
<img width="1345" height="398" alt="image" src="https://github.com/user-attachments/assets/8f118be5-fdda-4e38-b96f-e6b05bd0c43d" />

===

Before in Mobile (Uneven spacing): https://screenshot.googleplex.com/8b2RrFFtXb5Fgr6
<img width="540" height="1074" alt="image" src="https://github.com/user-attachments/assets/a9a87d3e-5ce1-4b51-9f1b-9e19d0d9b6e5" />

After in Mobile (Even spacing): https://screenshot.googleplex.com/4EVCpqpPofR2xV2
<img width="361" height="774" alt="image" src="https://github.com/user-attachments/assets/2b5abe99-a1df-4706-a88c-f736e2a5d525" />
