### PR TITLE
[Explore] Add component view to the Header Related Topics

### DIFF
--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -26,10 +26,10 @@ import { Loading } from "../../components/elements/loading";
 import { URL_HASH_PARAMS } from "../../constants/app/explore_constants";
 import { FOLLOW_UP_QUESTIONS_GA } from "../../shared/feature_flags/util";
 import {
-  GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW,
   GA_EVENT_RELATED_TOPICS_CLICK,
+  GA_EVENT_RELATED_TOPICS_VIEW,
   GA_PARAM_RELATED_TOPICS_MODE,
-  GA_VALUE_RELATED_TOPICS_DISPLAY_QUESTIONS,
+  GA_VALUE_RELATED_TOPICS_GENERATED_QUESTIONS,
   triggerGAEvent,
 } from "../../shared/ga_events";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
@@ -143,10 +143,12 @@ const getFollowUpQuestions = async (
 
 const onQuestionClicked = (): void => {
   triggerGAEvent(GA_EVENT_RELATED_TOPICS_CLICK, {
-    [GA_PARAM_RELATED_TOPICS_MODE]: GA_VALUE_RELATED_TOPICS_DISPLAY_QUESTIONS,
+    [GA_PARAM_RELATED_TOPICS_MODE]: GA_VALUE_RELATED_TOPICS_GENERATED_QUESTIONS,
   });
 };
 
 const onComponentInitialView = (): void => {
-  triggerGAEvent(GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW, {});
+  triggerGAEvent(GA_EVENT_RELATED_TOPICS_VIEW, {
+    [GA_PARAM_RELATED_TOPICS_MODE]: GA_VALUE_RELATED_TOPICS_GENERATED_QUESTIONS,
+  });
 };

--- a/static/js/apps/explore/result_header_section.tsx
+++ b/static/js/apps/explore/result_header_section.tsx
@@ -20,12 +20,14 @@
 
 import _ from "lodash";
 import React from "react";
+import { useInView } from "react-intersection-observer";
 
 import { DEFAULT_TOPIC } from "../../constants/app/explore_constants";
 import {
   GA_EVENT_RELATED_TOPICS_CLICK,
+  GA_EVENT_RELATED_TOPICS_VIEW,
   GA_PARAM_RELATED_TOPICS_MODE,
-  GA_VALUE_RELATED_TOPICS_DISPLAY_TOPICS,
+  GA_VALUE_RELATED_TOPICS_HEADER_TOPICS,
   triggerGAEvent,
 } from "../../shared/ga_events";
 import { SubjectPageMetadata } from "../../types/subject_page_types";
@@ -41,6 +43,15 @@ interface ResultHeaderSectionPropType {
 export function ResultHeaderSection(
   props: ResultHeaderSectionPropType
 ): JSX.Element {
+  const { ref: inViewRef } = useInView({
+    triggerOnce: true,
+    rootMargin: "0px",
+    onChange: (inView) => {
+      if (inView) {
+        onComponentInitialView();
+      }
+    },
+  });
   const topicList = props.hideRelatedTopics
     ? []
     : getTopics(props.pageMetadata, props.placeUrlVal);
@@ -64,14 +75,14 @@ export function ResultHeaderSection(
         {topicNameStr && <span> • {topicNameStr}</span>}
       </div>
       {!_.isEmpty(props.pageMetadata.mainTopics) && !_.isEmpty(topicList) && (
-        <div className="explore-topics-box">
+        <div className="explore-topics-box" ref={inViewRef}>
           <ItemList
             items={topicList}
             showRelevantTopicLabel={true}
             onItemClicked={(): void => {
               triggerGAEvent(GA_EVENT_RELATED_TOPICS_CLICK, {
                 [GA_PARAM_RELATED_TOPICS_MODE]:
-                  GA_VALUE_RELATED_TOPICS_DISPLAY_TOPICS,
+                  GA_VALUE_RELATED_TOPICS_HEADER_TOPICS,
               });
             }}
           ></ItemList>
@@ -109,3 +120,9 @@ export function ResultHeaderSection(
     );
   }
 }
+
+const onComponentInitialView = (): void => {
+  triggerGAEvent(GA_EVENT_RELATED_TOPICS_VIEW, {
+    [GA_PARAM_RELATED_TOPICS_MODE]: GA_VALUE_RELATED_TOPICS_HEADER_TOPICS,
+  });
+};

--- a/static/js/shared/ga_events.test.tsx
+++ b/static/js/shared/ga_events.test.tsx
@@ -104,8 +104,8 @@ import * as dataFetcher from "../tools/timeline/data_fetcher";
 import { axiosMock } from "../tools/timeline/mock_functions";
 import { FacetSelectorFacetInfo } from "./facet_selector";
 import {
-  GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW,
   GA_EVENT_RELATED_TOPICS_CLICK,
+  GA_EVENT_RELATED_TOPICS_VIEW,
   GA_EVENT_STATVAR_HIERARCHY_CLICK,
   GA_EVENT_STATVAR_SEARCH_TRIGGERED,
   GA_EVENT_TOOL_CHART_OPTION_CLICK,
@@ -119,8 +119,8 @@ import {
   GA_PARAM_SOURCE,
   GA_PARAM_STAT_VAR,
   GA_PARAM_TOOL_CHART_OPTION,
-  GA_VALUE_RELATED_TOPICS_DISPLAY_QUESTIONS,
-  GA_VALUE_RELATED_TOPICS_DISPLAY_TOPICS,
+  GA_VALUE_RELATED_TOPICS_GENERATED_QUESTIONS,
+  GA_VALUE_RELATED_TOPICS_HEADER_TOPICS,
   GA_VALUE_TOOL_CHART_OPTION_DELTA,
   GA_VALUE_TOOL_CHART_OPTION_EDIT_SOURCES,
   GA_VALUE_TOOL_CHART_OPTION_FILTER_BY_POPULATION,
@@ -1143,12 +1143,12 @@ describe("test ga event for Related Topics experiment", () => {
         GA_EVENT_RELATED_TOPICS_CLICK,
         {
           [GA_PARAM_RELATED_TOPICS_MODE]:
-            GA_VALUE_RELATED_TOPICS_DISPLAY_QUESTIONS,
+            GA_VALUE_RELATED_TOPICS_GENERATED_QUESTIONS,
         }
       );
     });
   });
-  test("triggers GA event when Related Topics URL is clicked", async () => {
+  test("triggers GA event when Header Related Topics URL is clicked", async () => {
     // Mock gtag
     const mockgtag = jest.fn();
     window.gtag = mockgtag;
@@ -1166,8 +1166,7 @@ describe("test ga event for Related Topics experiment", () => {
         "event",
         GA_EVENT_RELATED_TOPICS_CLICK,
         {
-          [GA_PARAM_RELATED_TOPICS_MODE]:
-            GA_VALUE_RELATED_TOPICS_DISPLAY_TOPICS,
+          [GA_PARAM_RELATED_TOPICS_MODE]: GA_VALUE_RELATED_TOPICS_HEADER_TOPICS,
         }
       );
     });
@@ -1183,8 +1182,29 @@ describe("test ga event for Related Topics experiment", () => {
     await waitFor(() => {
       expect(mockgtag).toHaveBeenCalledWith(
         "event",
-        GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW,
-        {}
+        GA_EVENT_RELATED_TOPICS_VIEW,
+        {
+          [GA_PARAM_RELATED_TOPICS_MODE]:
+            GA_VALUE_RELATED_TOPICS_GENERATED_QUESTIONS,
+        }
+      );
+    });
+  });
+  test("triggers GA event when Header RelatedTopics component is viewed", async () => {
+    // Mock gtag
+    const mockgtag = jest.fn();
+    window.gtag = mockgtag;
+
+    // Render result header component
+    render(<ResultHeaderSection {...RESULT_HEADER_SECTION_PROPS} />);
+    mockAllIsIntersecting(true);
+    await waitFor(() => {
+      expect(mockgtag).toHaveBeenCalledWith(
+        "event",
+        GA_EVENT_RELATED_TOPICS_VIEW,
+        {
+          [GA_PARAM_RELATED_TOPICS_MODE]: GA_VALUE_RELATED_TOPICS_HEADER_TOPICS,
+        }
       );
     });
   });

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -133,15 +133,16 @@ export const GA_EVENT_NL_FULFILL = "explore_fulfill";
  * Triggered when users click on a related topics url to keep exploring.
  * It could either be the current Related Topics chip or the experimental Follow Up Questions.
  * Parameters:
- *   "related_topics_mode" : "related_topics_experiment" || "related_topics_current"
+ *   "related_topics_mode" : "related_topics_generated_questions" || "related_topics_header_topics"
  */
 export const GA_EVENT_RELATED_TOPICS_CLICK = "related_topics_click";
 
 /**
  * Triggered once when the Follow Up Questions component is in view.
- * Parameters: None
+ * Parameters:
+ *  "related_topics_mode" : "related_topics_generated_questions" || "related_topics_header_topics"
  */
-export const GA_EVENT_FOLLOW_UP_QUESTIONS_VIEW = "follow_up_questions_view";
+export const GA_EVENT_RELATED_TOPICS_VIEW = "related_topics_view";
 
 /**
  * Triggered when "download" button is clicked on a tile.
@@ -297,8 +298,8 @@ export const GA_VALUE_SEARCH_SOURCE_PLACE_PAGE = "place";
 export const GA_VALUE_TOOL_STAT_VAR_OPTION_HIERARCHY = "sv_hierarchy";
 export const GA_VALUE_TOOL_STAT_VAR_OPTION_SEARCH = "sv_search";
 // Parameter value for GA_PARAM_RELATED_TOPICS_MODE to represent the Follow Up Questions mode.
-export const GA_VALUE_RELATED_TOPICS_DISPLAY_QUESTIONS =
-  "related_topics_display_questions";
+export const GA_VALUE_RELATED_TOPICS_GENERATED_QUESTIONS =
+  "related_topics_generated_questions";
 // Parameter value for GA_PARAM_RELATED_TOPICS_MODE to represent the Related Topics mode in the Result Header.
-export const GA_VALUE_RELATED_TOPICS_DISPLAY_TOPICS =
-  "related_topics_display_topics";
+export const GA_VALUE_RELATED_TOPICS_HEADER_TOPICS =
+  "related_topics_header_topics";


### PR DESCRIPTION
- Added a GA event trigger to the initial view of the Related Topics in the Result Header
- Modified the FOLLOW_UP_QUESTIONS_VIEW event to RELATED_TOPICS_VIEW with a support for different modes (Follow Up Questions and Header Related Topics).