### PR TITLE
[Feature flags] Add ability to disable flags

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -1,8 +1,9 @@
 # Feature Flags in Data Commons
 
-Feature flags allow us to rapidly deploy flag-gated changes per environment, outside of the typical build schedule. 
+Feature flags allow us to rapidly deploy flag-gated changes per environment, outside of the typical build schedule.
 
 ## Deployment
+
 This script automates the deployment of feature flags from `master` to a Google Cloud Storage (GCS) bucket and optionally restarts a Kubernetes deployment.
 
 ### Usage
@@ -10,7 +11,6 @@ This script automates the deployment of feature flags from `master` to a Google 
 ```bash
 ./scripts/update_gcs_feature_flags.sh <environment>
 ```
-
 
 Where `<environment>` is one of:
 
@@ -61,7 +61,7 @@ This script uploads the feature flag configuration files from the Github master 
 
 1. **Add flag in flag configurations**: Check the flags in the Github master branch [`server/config/feature_flag_configs`](https://github.com/datacommonsorg/website/tree/master/server/config/feature_flag_configs). The flag must be added to all environments.
     * TIP: Use [this script](https://github.com/datacommonsorg/website/tree/master/scripts/create_feature_flag.sh) to add a new flag to each config file.
-    > ```
+    > ```bash
     > ./scripts/create_feature_flag.sh
     > ```
 2. **Define flag in server layer**: Add your flag constant to [feature_flags.py](https://github.com/datacommonsorg/website/blob/master/server/lib/feature_flags.py#L19) helper file for use in the API layer.
@@ -70,16 +70,24 @@ This script uploads the feature flag configuration files from the Github master 
 5. **Deploy & update GCS Flag files**: Once your code reaches production, you can enable your flags and run the script to update the GCS flag files.
 6. **Restart Kubernetes**: The script to update the GCS flag files will prompt you to restart Kubernetes, on restart the new flags will be applied and your feature will be enabled.
 
-## Manually enable feature flags
+## Manually enable or disable feature flags
 
 Feature flags can be enabled manually on any datacommons.org page using the `enable_feature` URL parameter.
 
 For example, to enable the "autocomplete" feature:
- - Enable: https://datacommons.org/explore?enable_feature=autocomplete
+
+* Enable: https://datacommons.org/explore?enable_feature=autocomplete
 
 To enable both the autocomplete and metadata_modal features:
- - Disable: https://datacommons.org/explore?enable_feature=autocomplete&enable_feature=metadata_modal
- 
+
+* Enable: https://datacommons.org/explore?enable_feature=autocomplete&enable_feature=metadata_modal
+
+To manually disable a feature flag, use the `disable_feature` URL parameter.
+
+For example, to disable the "autocomplete" feature:
+
+* Disable: https://datacommons.org/explore?disable_feature=autocomplete
+
 These URL overrides take precedence over the environment-specific feature flag settings defined in server/config/feature_flag_configs/<environment>.json
 
 ### Propagating Feature Flags

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -71,6 +71,9 @@ This script uploads the feature flag configuration files from the Github master 
 6. **Restart Kubernetes**: The script to update the GCS flag files will prompt you to restart Kubernetes, on restart the new flags will be applied and your feature will be enabled.
 
 ## Manually enable or disable feature flags
+> [!NOTE:]
+> Manually enabling or disabling currently only works for client side code. On the server side, you'll need to
+> propagate the feature flag in request arguments.
 
 Feature flags can be enabled manually on any datacommons.org page using the `enable_feature` URL parameter.
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -71,7 +71,8 @@ This script uploads the feature flag configuration files from the Github master 
 6. **Restart Kubernetes**: The script to update the GCS flag files will prompt you to restart Kubernetes, on restart the new flags will be applied and your feature will be enabled.
 
 ## Manually enable or disable feature flags
-> [!NOTE:]
+
+> [!NOTE]
 > Manually enabling or disabling currently only works for client side code. On the server side, you'll need to
 > propagate the feature flag in request arguments.
 

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -15,11 +15,14 @@
 
 from flask import current_app
 
+# URL Query Parameters
+FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM = 'enable_feature'
+FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM = 'disable_feature'
+
+# Feature Flags
 AUTOCOMPLETE_FEATURE_FLAG = 'autocomplete'
 BIOMED_NL_FEATURE_FLAG = 'biomed_nl'
 DATA_OVERVIEW_FEATURE_FLAG = 'data_overview'
-FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM = 'enable_feature'
-FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM = 'disable_feature'
 STANDARDIZED_VIS_TOOL_FEATURE_FLAG = 'standardized_vis_tool'
 VAI_FOR_STATVAR_SEARCH_FEATURE_FLAG = 'vai_for_statvar_search'
 

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -35,7 +35,9 @@ def is_feature_override_enabled(feature_name: str, request=None) -> bool:
   """
   if request is None:
     return False
-  return request.args.get(FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM) == feature_name
+  return request.args.get(
+      FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM) == feature_name
+
 
 def is_feature_override_disabled(feature_name: str, request=None) -> bool:
   """Check if a URL param to manually disable a feature is present.
@@ -49,7 +51,9 @@ def is_feature_override_disabled(feature_name: str, request=None) -> bool:
   """
   if request is None:
     return False
-  return request.args.get(FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM) == feature_name
+  return request.args.get(
+      FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM) == feature_name
+
 
 def is_feature_enabled(feature_name: str, app=None, request=None) -> bool:
   """Returns whether the feature with `feature_name` is enabled.
@@ -62,7 +66,7 @@ def is_feature_enabled(feature_name: str, app=None, request=None) -> bool:
 
   if is_feature_override_enabled(feature_name, request):
     return True
-  
+
   if is_feature_override_disabled(feature_name, request):
     return False
 

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -18,31 +18,52 @@ from flask import current_app
 AUTOCOMPLETE_FEATURE_FLAG = 'autocomplete'
 BIOMED_NL_FEATURE_FLAG = 'biomed_nl'
 DATA_OVERVIEW_FEATURE_FLAG = 'data_overview'
-FEATURE_FLAG_URL_OVERRIDE_PARAM = 'enable_feature'
+FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM = 'enable_feature'
+FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM = 'disable_feature'
 STANDARDIZED_VIS_TOOL_FEATURE_FLAG = 'standardized_vis_tool'
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:
-  """Check if a URL param override for a feature is present.
+  """Check if a URL param to manually enable a feature is present.
 
   Args:
     feature_name: feature flag string to look for in the URL
     request: HTTP request as a flask.Request object
   
   Returns:
-      True if URL param override is present, False otherwise
+      True if URL param override to enable is present, False otherwise
   """
   if request is None:
     return False
-  return request.args.get(FEATURE_FLAG_URL_OVERRIDE_PARAM) == feature_name
+  return request.args.get(FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM) == feature_name
 
+def is_feature_override_disabled(feature_name: str, request=None) -> bool:
+  """Check if a URL param to manually disable a feature is present.
+
+  Args:
+      feature_name: feature flag string to look for in the URL
+      request: HTTP request as a flask.Request object
+
+  Returns:
+      True if URL param override to disable is present, False otherwise
+  """
+  if request is None:
+    return False
+  return request.args.get(FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM) == feature_name
 
 def is_feature_enabled(feature_name: str, app=None, request=None) -> bool:
-  """Returns whether the feature with `feature_name` is enabled."""
+  """Returns whether the feature with `feature_name` is enabled.
+  
+  If both the enable and disable feature flags are present, will default to
+  enabling the feature.
+  """
   if not app:
     app = current_app
 
   if is_feature_override_enabled(feature_name, request):
     return True
+  
+  if is_feature_override_disabled(feature_name, request):
+    return False
 
   return app.config['FEATURE_FLAGS'].get(feature_name, False)

--- a/server/tests/lib/feature_flag_test.py
+++ b/server/tests/lib/feature_flag_test.py
@@ -15,7 +15,6 @@
 # Tests for feature flag utility functions
 
 import unittest
-from unittest.mock import patch
 
 from server.__init__ import create_app
 from server.lib.feature_flags import FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM
@@ -35,6 +34,11 @@ class TestFeatureFlags(unittest.TestCase):
   def setUpClass(cls):
     cls.app = create_app()
     cls.client = cls.app.test_client()
+
+  @classmethod
+  def tearDownClass(cls):
+    cls.app = None
+    cls.client = None
 
   def test_is_feature_override_enabled_helper(self):
     """Tests the is_feature_override_enabled helper function."""

--- a/server/tests/lib/feature_flag_test.py
+++ b/server/tests/lib/feature_flag_test.py
@@ -110,7 +110,3 @@ class TestFeatureFlags(unittest.TestCase):
         is_feature_enabled(TEST_FEATURE_FLAG,
                            app=self.app,
                            request=response.request))
-
-
-if __name__ == '__main__':
-  unittest.main()

--- a/server/tests/lib/feature_flag_test.py
+++ b/server/tests/lib/feature_flag_test.py
@@ -67,15 +67,14 @@ class TestFeatureFlags(unittest.TestCase):
     self.assertTrue(
         is_feature_override_disabled(TEST_FEATURE_FLAG,
                                      request=response.request))
-    # Return False if request does not include enable override
+    # Return False if request does not include disable override
     response = self.client.get(
         f"/?{FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM}=INVALID_{TEST_FEATURE_FLAG}"
     )
-    # return False if request is not provided
     self.assertFalse(
         is_feature_override_disabled(TEST_FEATURE_FLAG,
                                      request=response.request))
-    # Return false if request is not provided
+    # Return False if request is not provided
     self.assertFalse(
         is_feature_override_disabled(TEST_FEATURE_FLAG, request=None))
 

--- a/server/tests/lib/feature_flag_test.py
+++ b/server/tests/lib/feature_flag_test.py
@@ -1,0 +1,114 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests for feature flag utility functions
+
+import unittest
+from unittest.mock import patch
+
+from server.lib.feature_flags import FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM
+from server.lib.feature_flags import FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM
+from server.lib.feature_flags import is_feature_enabled
+from server.lib.feature_flags import is_feature_override_disabled
+from server.lib.feature_flags import is_feature_override_enabled
+from web_app import app
+
+TEST_FEATURE_FLAG = "test_feature_flag"
+
+
+class TestFeatureFlags(unittest.TestCase):
+  """Test suite for feature_flags.py"""
+
+  @classmethod
+  def setUpClass(cls):
+    cls.client = app.test_client()
+
+  def test_is_feature_override_enabled_helper(self):
+    """Tests the is_feature_override_enabled helper function."""
+    # Return True if request includes enable override
+    response = self.client.get(
+        f"/?{FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM}={TEST_FEATURE_FLAG}")
+    self.assertTrue(
+        is_feature_override_enabled(TEST_FEATURE_FLAG,
+                                    request=response.request))
+    # Return False if request does not include enable override
+    response = self.client.get(
+        f"/?{FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM}=INVALID_{TEST_FEATURE_FLAG}"
+    )
+    self.assertFalse(
+        is_feature_override_enabled(TEST_FEATURE_FLAG,
+                                    request=response.request))
+    # Return False if request is not provided
+    self.assertFalse(
+        is_feature_override_enabled(TEST_FEATURE_FLAG, request=None))
+
+  def test_is_feature_override_disabled_helper(self):
+    """Tests the is_feature_override_disabled helper function."""
+    # Return True if request includes disable override
+    response = self.client.get(
+        f"/?{FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM}={TEST_FEATURE_FLAG}")
+    self.assertTrue(
+        is_feature_override_disabled(TEST_FEATURE_FLAG,
+                                     request=response.request))
+    # Return False if request does not include enable override
+    response = self.client.get(
+        f"/?{FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM}=INVALID_{TEST_FEATURE_FLAG}"
+    )
+    # return False if request is not provided
+    self.assertFalse(
+        is_feature_override_disabled(TEST_FEATURE_FLAG,
+                                     request=response.request))
+    # Return false if request is not provided
+    self.assertFalse(
+        is_feature_override_disabled(TEST_FEATURE_FLAG, request=None))
+
+  def test_feature_flag_enabled_by_app_config(self):
+    """Should return true if feature flag is enabled in config"""
+    with patch.dict(app.config, {'FEATURE_FLAGS': {TEST_FEATURE_FLAG: True}}):
+      self.assertTrue(is_feature_enabled(TEST_FEATURE_FLAG, app=app))
+
+  def test_feature_flag_disabled_when_not_in_config(self):
+    """Should default to False if feature is not in config."""
+    app.config = {'FEATURE_FLAGS': {"Invalid_flag": True}}
+    self.assertFalse(is_feature_enabled(TEST_FEATURE_FLAG, app=app))
+
+  def test_url_enable_override_wins_over_config(self):
+    """Should return True if URL enable override is provided"""
+    # Config says False
+    with patch.dict(app.config, {'FEATURE_FLAGS': {TEST_FEATURE_FLAG: False}}):
+      # But request says True
+      response = self.client.get(
+          f"/?{FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM}={TEST_FEATURE_FLAG}")
+      # The override should win
+      self.assertTrue(
+          is_feature_enabled(TEST_FEATURE_FLAG,
+                             app=app,
+                             request=response.request))
+
+  def test_url_disable_override_wins_over_config(self):
+    """Should return False if URL disable override is provided"""
+    # Config says False
+    with patch.dict(app.config, {'FEATURE_FLAGS': {TEST_FEATURE_FLAG: True}}):
+      # But request says True
+      response = self.client.get(
+          f"/?{FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM}={TEST_FEATURE_FLAG}")
+      # The override should win
+      self.assertFalse(
+          is_feature_enabled(TEST_FEATURE_FLAG,
+                             app=app,
+                             request=response.request))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/server/tests/lib/feature_flag_test.py
+++ b/server/tests/lib/feature_flag_test.py
@@ -101,9 +101,9 @@ class TestFeatureFlags(unittest.TestCase):
 
   def test_url_disable_override_wins_over_config(self):
     """Should return False if URL disable override is provided"""
-    # Config says False
+    # Config says True
     mock_feature_flags(self.app, [TEST_FEATURE_FLAG], True)
-    # But request says True
+    # But request says False
     response = self.client.get(
         f"/?{FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM}={TEST_FEATURE_FLAG}")
     # The override should win

--- a/static/js/shared/feature_flags/util.test.ts
+++ b/static/js/shared/feature_flags/util.test.ts
@@ -31,7 +31,11 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 
-import { ENABLE_FEATURE_URL_PARAM, isFeatureEnabled } from "./util";
+import {
+  DISABLE_FEATURE_URL_PARAM,
+  ENABLE_FEATURE_URL_PARAM,
+  isFeatureEnabled,
+} from "./util";
 
 describe("isFeatureEnabled", () => {
   const featureName = "testFeature";
@@ -78,12 +82,15 @@ describe("isFeatureEnabled", () => {
     window.location.search = "";
     expect(isFeatureEnabled(featureName)).toBe(false);
   });
-
   test("returns true when multiple features are enabled", () => {
     window.location.search = `?${ENABLE_FEATURE_URL_PARAM}=${featureName}&${ENABLE_FEATURE_URL_PARAM}=${otherFeatureName}`;
     expect(isFeatureEnabled(featureName)).toBe(true);
     expect(isFeatureEnabled(otherFeatureName)).toBe(true);
     expect(isFeatureEnabled("invalidFeature")).toBe(false);
+  });
+  test("returns false when disable param is present", () => {
+    window.location.search = `/${DISABLE_FEATURE_URL_PARAM}=${featureName}`;
+    expect(isFeatureEnabled(featureName)).toBe(false);
   });
 
   // Test environment-specific feature flag settings

--- a/static/js/shared/feature_flags/util.test.ts
+++ b/static/js/shared/feature_flags/util.test.ts
@@ -88,10 +88,6 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(otherFeatureName)).toBe(true);
     expect(isFeatureEnabled("invalidFeature")).toBe(false);
   });
-  test("returns false when disable param is present", () => {
-    window.location.search = `/${DISABLE_FEATURE_URL_PARAM}=${featureName}`;
-    expect(isFeatureEnabled(featureName)).toBe(false);
-  });
 
   // Test environment-specific feature flag settings
   test("returns true when feature flag is enabled in FEATURE_FLAGS", () => {
@@ -104,5 +100,18 @@ describe("isFeatureEnabled", () => {
     window.location.search = "";
     globalThis.FEATURE_FLAGS = { [featureName]: false };
     expect(isFeatureEnabled(featureName)).toBe(false);
+  });
+
+  // Test disabling feature flags
+  test("returns false when disable param is present", () => {
+    window.location.search = `/?${DISABLE_FEATURE_URL_PARAM}=${featureName}`;
+    globalThis.FEATURE_FLAGS = { [featureName]: true };
+    expect(isFeatureEnabled(featureName)).toBe(false);
+  });
+  test("keyword in url but not as a query parameter does not override", () => {
+    // test case: url is missing the '?' in front
+    window.location.search = `/${DISABLE_FEATURE_URL_PARAM}=${featureName}`;
+    globalThis.FEATURE_FLAGS = { [featureName]: true };
+    expect(isFeatureEnabled(featureName)).toBe(true);
   });
 });

--- a/static/js/shared/feature_flags/util.test.ts
+++ b/static/js/shared/feature_flags/util.test.ts
@@ -82,6 +82,7 @@ describe("isFeatureEnabled", () => {
     window.location.search = "";
     expect(isFeatureEnabled(featureName)).toBe(false);
   });
+
   test("returns true when multiple features are enabled", () => {
     window.location.search = `?${ENABLE_FEATURE_URL_PARAM}=${featureName}&${ENABLE_FEATURE_URL_PARAM}=${otherFeatureName}`;
     expect(isFeatureEnabled(featureName)).toBe(true);
@@ -104,13 +105,14 @@ describe("isFeatureEnabled", () => {
 
   // Test disabling feature flags
   test("returns false when disable param is present", () => {
-    window.location.search = `/?${DISABLE_FEATURE_URL_PARAM}=${featureName}`;
+    window.location.search = `?${DISABLE_FEATURE_URL_PARAM}=${featureName}`;
     globalThis.FEATURE_FLAGS = { [featureName]: true };
     expect(isFeatureEnabled(featureName)).toBe(false);
   });
+
   test("keyword in url but not as a query parameter does not override", () => {
     // test case: url is missing the '?' in front
-    window.location.search = `/${DISABLE_FEATURE_URL_PARAM}=${featureName}`;
+    window.location.href = `/${DISABLE_FEATURE_URL_PARAM}=${featureName}`;
     globalThis.FEATURE_FLAGS = { [featureName]: true };
     expect(isFeatureEnabled(featureName)).toBe(true);
   });

--- a/static/js/shared/feature_flags/util.ts
+++ b/static/js/shared/feature_flags/util.ts
@@ -45,8 +45,8 @@ export function isFeatureOverrideEnabled(featureName: string): boolean {
  */
 export function isFeatureOverrideDisabled(featureName: string): boolean {
   const urlParams = new URLSearchParams(window.location.search);
-  const enabledFeatures = urlParams.getAll(DISABLE_FEATURE_URL_PARAM);
-  return enabledFeatures.includes(featureName);
+  const disabledFeatures = urlParams.getAll(DISABLE_FEATURE_URL_PARAM);
+  return disabledFeatures.includes(featureName);
 }
 
 /**
@@ -77,11 +77,11 @@ export function getFeatureFlags(): Record<string, boolean> {
  * @returns Bool describing if the feature is enabled
  */
 export function isFeatureEnabled(featureName: string): boolean {
-  // Check URL params for feature flag overrides
+  // Check URL params for feature flag enable overrides
   if (isFeatureOverrideEnabled(featureName)) {
     return true;
   }
-  // Check URL params for feature flag overrides
+  // Check URL params for feature flag disable overrides
   if (isFeatureOverrideDisabled(featureName)) {
     return false;
   }

--- a/static/js/shared/feature_flags/util.ts
+++ b/static/js/shared/feature_flags/util.ts
@@ -25,15 +25,27 @@ export const STANDARDIZED_VIS_TOOL_FEATURE_FLAG = "standardized_vis_tool";
 
 // Feature flag URL parameters
 export const ENABLE_FEATURE_URL_PARAM = "enable_feature";
+export const DISABLE_FEATURE_URL_PARAM = "disable_feature";
 
 /**
  * Returns true if the feature is enabled by the URL parameter.
  * @param featureName name of feature for which we want status.
  * @returns true if the feature is enabled by the URL parameter, false otherwise.
  */
-export function getFeatureOverride(featureName: string): boolean {
+export function isFeatureOverrideEnabled(featureName: string): boolean {
   const urlParams = new URLSearchParams(window.location.search);
   const enabledFeatures = urlParams.getAll(ENABLE_FEATURE_URL_PARAM);
+  return enabledFeatures.includes(featureName);
+}
+
+/**
+ * Returns true if the feature is disabled by the URL parameter.
+ * @param featureName name of feature for which we want status.
+ * @returns true if the feature is disabled by the URL parameter, false otherwise.
+ */
+export function isFeatureOverrideDisabled(featureName: string): boolean {
+  const urlParams = new URLSearchParams(window.location.search);
+  const enabledFeatures = urlParams.getAll(DISABLE_FEATURE_URL_PARAM);
   return enabledFeatures.includes(featureName);
 }
 
@@ -52,19 +64,26 @@ export function getFeatureFlags(): Record<string, boolean> {
  * server/config/feature_flag_configs/<environment>.json
  *
  * Feature flags can be overridden and enabled manually
- * by adding ?enable_feature=<feature_name> to the URL.
+ * by adding ?enable_feature=<feature_name> to the URL
+ * or disabled manually by adding ?disable_feature=<feature_name>
+ * to the URL. If both overrides are provided, the feature will be enabled.
  *
  * Example:
  * https://datacommons.org/explore?enable_feature=autocomplete will enable the autocomplete feature.
  * https://datacommons.org/explore?enable_feature=autocomplete&enable_feature=metadata_modal will enable both the autocomplete and metadata_modal features.
+ * https://datacommons.org/explore?disable_feature=autocomplete will disable the autocomplete feature.
  *
  * @param featureName name of feature for which we want status.
  * @returns Bool describing if the feature is enabled
  */
 export function isFeatureEnabled(featureName: string): boolean {
   // Check URL params for feature flag overrides
-  if (getFeatureOverride(featureName)) {
+  if (isFeatureOverrideEnabled(featureName)) {
     return true;
+  }
+  // Check URL params for feature flag overrides
+  if (isFeatureOverrideDisabled(featureName)) {
+    return false;
   }
   // Check if the feature flag is enabled in server config
   const featureFlags = getFeatureFlags();


### PR DESCRIPTION
Adds a URL override param to manually disable a feature flag.

This is currently necessary to keep tests for production code that have features disabled, while keeping new features enabled by default in autopush.

This PR also:
* Updates the feature flag page in our development guide with changes, a typo fix, and some linting
* Updates the names of some helper functions and constants for clarity.

Testing strategy:
* Added tests for server side feature flag functions
* Added to the current client side tests
* Manually tested locally using `http://localhost:8080/tools/map?disable_feature=standardized_vis_tool`