### PR TITLE
Add feature flag to set MEDIUM relevance threshold for Vertex AI search

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -64,5 +64,11 @@
     "enabled": false,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "vai_medium_relevance_threshold",
+    "enabled": false,
+    "owner": "alyssaguo",
+    "description": "Enables setting the relevance threshold to \"MEDIUM\" for Vertex AI stat var search application."
   }
 ]

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -64,5 +64,11 @@
     "enabled": false,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "vai_medium_relevance_threshold",
+    "enabled": false,
+    "owner": "alyssaguo",
+    "description": "Enables setting the relevance threshold to \"MEDIUM\" for Vertex AI stat var search application."
   }
 ]

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -64,5 +64,11 @@
     "enabled": false,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "vai_medium_relevance_threshold",
+    "enabled": false,
+    "owner": "alyssaguo",
+    "description": "Enables setting the relevance threshold to \"MEDIUM\" for Vertex AI stat var search application."
   }
 ]

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -64,5 +64,11 @@
     "enabled": false,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "vai_medium_relevance_threshold",
+    "enabled": false,
+    "owner": "alyssaguo",
+    "description": "Enables setting the relevance threshold to \"MEDIUM\" for Vertex AI stat var search application."
   }
 ]

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -64,5 +64,11 @@
     "enabled": false,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "vai_medium_relevance_threshold",
+    "enabled": false,
+    "owner": "alyssaguo",
+    "description": "Enables setting the relevance threshold to \"MEDIUM\" for Vertex AI stat var search application."
   }
 ]


### PR DESCRIPTION
adds a feature flag. If enabled, relevance threshold for Vertex AI search will be set to MEDIUM.