### PR TITLE
Added controlling relevance threshold for Vertex AI using feature flag

### DIFF
--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -21,6 +21,7 @@ DATA_OVERVIEW_FEATURE_FLAG = 'data_overview'
 FEATURE_FLAG_URL_OVERRIDE_PARAM = 'enable_feature'
 STANDARDIZED_VIS_TOOL_FEATURE_FLAG = 'standardized_vis_tool'
 VAI_FOR_STATVAR_SEARCH_FEATURE_FLAG = 'vai_for_statvar_search'
+VAI_MEDIUM_RELEVANCE_FEATURE_FLAG = 'vai_medium_relevance_threshold'
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:

--- a/server/routes/shared_api/stats.py
+++ b/server/routes/shared_api/stats.py
@@ -25,7 +25,8 @@ from server.lib import fetch
 from server.lib import shared
 from server.lib.cache import cache
 from server.lib.feature_flags import is_feature_enabled
-from server.lib.feature_flags import VAI_FOR_STATVAR_SEARCH_FEATURE_FLAG, VAI_MEDIUM_RELEVANCE_FEATURE_FLAG
+from server.lib.feature_flags import VAI_FOR_STATVAR_SEARCH_FEATURE_FLAG
+from server.lib.feature_flags import VAI_MEDIUM_RELEVANCE_FEATURE_FLAG
 import server.lib.util as lib_util
 from server.routes import TIMEOUT
 import server.services.datacommons as dc
@@ -59,8 +60,9 @@ def search_vertexai(
       page_size=100,
       spell_correction_spec=discoveryengine.SearchRequest.SpellCorrectionSpec(
           mode=discoveryengine.SearchRequest.SpellCorrectionSpec.Mode.AUTO),
-      relevance_threshold=discoveryengine.SearchRequest.RelevanceThreshold.MEDIUM if is_medium_relevance_enabled 
-      else discoveryengine.SearchRequest.RelevanceThreshold.LOW)
+      relevance_threshold=discoveryengine.SearchRequest.RelevanceThreshold.
+      MEDIUM if is_medium_relevance_enabled else
+      discoveryengine.SearchRequest.RelevanceThreshold.LOW)
 
   page_result = vai_client.search(search_request)
 
@@ -159,7 +161,8 @@ def search_statvar():
     statVars = []
     page_token = None
     while len(statVars) < limit:
-      search_results = search_vertexai(query, page_token, is_vai_medium_relevance_enabled)
+      search_results = search_vertexai(query, page_token,
+                                       is_vai_medium_relevance_enabled)
       for response in search_results.results:
         dcid = response.document.struct_data.get("dcid")
         name = response.document.struct_data.get("name")

--- a/server/routes/shared_api/stats.py
+++ b/server/routes/shared_api/stats.py
@@ -25,7 +25,7 @@ from server.lib import fetch
 from server.lib import shared
 from server.lib.cache import cache
 from server.lib.feature_flags import is_feature_enabled
-from server.lib.feature_flags import VAI_FOR_STATVAR_SEARCH_FEATURE_FLAG
+from server.lib.feature_flags import VAI_FOR_STATVAR_SEARCH_FEATURE_FLAG, VAI_MEDIUM_RELEVANCE_FEATURE_FLAG
 import server.lib.util as lib_util
 from server.routes import TIMEOUT
 import server.services.datacommons as dc
@@ -48,7 +48,8 @@ vai_serving_config = f"projects/{VAI_PROJECT_ID}/locations/{VAI_LOCATION}/collec
 
 def search_vertexai(
     query: str,
-    page_token: str | None = None
+    page_token: str | None = None,
+    is_medium_relevance_enabled: bool = False
 ) -> discoveryengine.services.search_service.pagers.SearchPager:
   """Search statvars using Vertex AI search application."""
   search_request = discoveryengine.SearchRequest(
@@ -58,7 +59,8 @@ def search_vertexai(
       page_size=100,
       spell_correction_spec=discoveryengine.SearchRequest.SpellCorrectionSpec(
           mode=discoveryengine.SearchRequest.SpellCorrectionSpec.Mode.AUTO),
-      relevance_threshold=discoveryengine.SearchRequest.RelevanceThreshold.LOW)
+      relevance_threshold=discoveryengine.SearchRequest.RelevanceThreshold.MEDIUM if is_medium_relevance_enabled 
+      else discoveryengine.SearchRequest.RelevanceThreshold.LOW)
 
   page_result = vai_client.search(search_request)
 
@@ -140,6 +142,8 @@ def search_statvar():
   """Gets the statvars and statvar groups that match the tokens in the query."""
   is_vai_enabled = is_feature_enabled(VAI_FOR_STATVAR_SEARCH_FEATURE_FLAG,
                                       request=request)
+  is_vai_medium_relevance_enabled = is_feature_enabled(
+      VAI_MEDIUM_RELEVANCE_FEATURE_FLAG, request=request)
   if request.method == 'GET':
     query = request.args.get("query")
     places = request.args.getlist("places")
@@ -155,7 +159,7 @@ def search_statvar():
     statVars = []
     page_token = None
     while len(statVars) < limit:
-      search_results = search_vertexai(query, page_token)
+      search_results = search_vertexai(query, page_token, is_vai_medium_relevance_enabled)
       for response in search_results.results:
         dcid = response.document.struct_data.get("dcid")
         name = response.document.struct_data.get("name")

--- a/server/tests/routes/api/stats_test.py
+++ b/server/tests/routes/api/stats_test.py
@@ -245,7 +245,7 @@ class TestSearchStatVar(unittest.TestCase):
     expected_result_page_one = mock_data.VERTEX_AI_STAT_VAR_SEARCH_RESULT_PAGE_ONE
     expected_result_all = mock_data.VERTEX_AI_STAT_VAR_SEARCH_RESULT_ALL
 
-    def search_vai_side_effect(query, token):
+    def search_vai_side_effect(query, token, _=None):
       if query == expected_query and not token:
         return vai_response_page_one
       elif query == expected_query and token == 'page_two':
@@ -289,7 +289,7 @@ class TestSearchStatVar(unittest.TestCase):
     vai_response = mock_data.VERTEX_AI_STAT_VAR_SEARCH_API_RESPONSE_MISSING_DATA
     expected_result = mock_data.STAT_VAR_SEARCH_RESPONSE_SV_ONLY
 
-    def search_vai_side_effect(query, token):
+    def search_vai_side_effect(query, token, _=None):
       if query == expected_query and not token:
         return vai_response
       else:


### PR DESCRIPTION
Adds the logic for using a feature flag to decide whether to set the Vertex AI search relevance threshold to LOW or MEDIUM. I tested locally and it works, and decided to hold off on adding a unit test for this change since we can't test that the results are filtered without calling the actual VAI endpoint, and being able to fetch/pass in the feature flag seems trivial to test in the stats module. 