### PR TITLE
Updated map tooltip to show full variable name instead of dcid

### DIFF
--- a/server/webdriver/shared_tests/vis_map_test.py
+++ b/server/webdriver/shared_tests/vis_map_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -230,3 +231,25 @@ class VisMapTestMixin():
     chart_map = self.driver.find_element(By.ID, 'map-items')
     map_regions = chart_map.find_elements(By.TAG_NAME, 'path')
     self.assertGreater(len(map_regions), 1)
+
+  def test_hover_tooltip(self):
+    """Test hover tooltip shows up correctly."""
+    self.driver.get(self.url_ + MAP_URL + URL_HASH_1)
+
+    # Wait until the chart has loaded.
+    WebDriverWait(self.driver, self.TIMEOUT_SEC).until(shared.charts_rendered)
+
+    # Find the map region for Kern County (geoId/06029)
+    kern_county = self.driver.find_element(
+        By.XPATH,
+        '//*[@id="map-items"]//*[local-name()="path"][contains(@part, "place-path-geoId/06029")]',
+    )
+
+    # Hover over the region using ActionChains
+    actions = ActionChains(self.driver)
+    actions.move_to_element(kern_county).perform()
+
+    # Wait for tooltip to appear and verify contents
+    tooltip = WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
+        EC.presence_of_element_located((By.ID, "tooltip")))
+    self.assertIn("Female population", tooltip.text)

--- a/static/js/chart/draw_map_utils.ts
+++ b/static/js/chart/draw_map_utils.ts
@@ -534,7 +534,6 @@ export function getTooltipHtmlFn(
       allMetadataValues[place][layer.variable.statVar] = layer.metadata[place];
     }
   }
-
   const getTooltipHtml = (place: NamedPlace): string => {
     const tooltipLines: string[] = [place.name];
     if (place.dcid in allDataValues) {
@@ -558,7 +557,10 @@ export function getTooltipHtmlFn(
         const date = ` (${
           allMetadataValues[place.dcid][variable].placeStatDate
         })`;
-        tooltipLines.push(`${variable}: ${value}${date}`);
+        const variableName = chartData.statVarToVariableName[variable];
+        // Display the full variable name if it exists, otherwise display the
+        // variable dcid.
+        tooltipLines.push(`${variableName || variable}${date}: ${value}`);
       }
     }
     return tooltipLines.join("<br />");


### PR DESCRIPTION
Updated the map tile to show the variable name when hovering over a place instead of the variable dcid.

Before:
<img width="1862" height="962" alt="maptooltip-before" src="https://github.com/user-attachments/assets/81191b63-777c-4978-99f1-2a840a473e10" />

After:
<img width="1634" height="948" alt="maptooltip-after" src="https://github.com/user-attachments/assets/87af9119-60d3-4734-aa01-9905deb5e1a6" />



Issue: b/432035816
