### PR TITLE
[Explore] Add new client type for generated questions

### DIFF
--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -23,7 +23,7 @@ import React, { ReactElement, useEffect, useState } from "react";
 import { useInView } from "react-intersection-observer";
 
 import { Loading } from "../../components/elements/loading";
-import { URL_HASH_PARAMS } from "../../constants/app/explore_constants";
+import { CLIENT_TYPES, URL_HASH_PARAMS } from "../../constants/app/explore_constants";
 import { FOLLOW_UP_QUESTIONS_GA } from "../../shared/feature_flags/util";
 import {
   GA_EVENT_RELATED_TOPICS_CLICK,
@@ -135,6 +135,7 @@ const getFollowUpQuestions = async (
         url: `/explore/?enable_feature=${FOLLOW_UP_QUESTIONS_GA}#${getUpdatedHash(
           {
             [URL_HASH_PARAMS.QUERY]: question,
+            [URL_HASH_PARAMS.CLIENT]: CLIENT_TYPES.RELATED_QUESTION,
           }
         )}`,
       };

--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -23,7 +23,10 @@ import React, { ReactElement, useEffect, useState } from "react";
 import { useInView } from "react-intersection-observer";
 
 import { Loading } from "../../components/elements/loading";
-import { CLIENT_TYPES, URL_HASH_PARAMS } from "../../constants/app/explore_constants";
+import {
+  CLIENT_TYPES,
+  URL_HASH_PARAMS,
+} from "../../constants/app/explore_constants";
 import { FOLLOW_UP_QUESTIONS_GA } from "../../shared/feature_flags/util";
 import {
   GA_EVENT_RELATED_TOPICS_CLICK,

--- a/static/js/constants/app/explore_constants.ts
+++ b/static/js/constants/app/explore_constants.ts
@@ -70,6 +70,8 @@ export const CLIENT_TYPES = {
   RELATED_PLACE: "ui_related_place",
   // User clicked on a related topic
   RELATED_TOPIC: "ui_related_topic",
+  // User clicked on a generated question from a related topic
+  RELATED_QUESTION: "ui_related_question",
 };
 // Dcid of the default topic to use
 export const DEFAULT_TOPIC = "dc/topic/Root";


### PR DESCRIPTION
Adds a new client type to help track which queries succeed or fail from the Follow Up Questions component. This helps compile the types of failing queries Gemini would generate which can then be used to fine tune the prompt. 