### PR TITLE
[Vis Tools] Code Cleanup: refactor switch tool button

### DIFF
--- a/static/js/components/elements/button/button.tsx
+++ b/static/js/components/elements/button/button.tsx
@@ -185,6 +185,7 @@ export const Button = forwardRef<
     cursor: pointer;
     opacity: ${disabled ? 0.6 : 1};
     text-decoration: none;
+    text-align: center;
     &:hover {
       text-decoration: none;
     }

--- a/static/js/tools/shared/tool_header.tsx
+++ b/static/js/tools/shared/tool_header.tsx
@@ -19,10 +19,11 @@
  * Title component for the tools
  */
 
-import { css } from "@emotion/react";
+import { css, useTheme } from "@emotion/react";
 import React from "react";
 
-import { intl, LocalizedLink } from "../../i18n/i18n";
+import { Button } from "../../components/elements/button/button";
+import { intl, localizeLink } from "../../i18n/i18n";
 import { toolMessages } from "../../i18n/i18n_tool_messages";
 
 interface ToolHeaderProps {
@@ -32,6 +33,7 @@ interface ToolHeaderProps {
 }
 
 export function ToolHeader(props: ToolHeaderProps): JSX.Element {
+  const theme = useTheme();
   return (
     <div
       css={css`
@@ -59,27 +61,14 @@ export function ToolHeader(props: ToolHeaderProps): JSX.Element {
           {props.title}
         </h1>
         {props.switchToolsUrl && (
-          <LocalizedLink
+          <Button
+            href={localizeLink(props.switchToolsUrl)}
             css={css`
-              display: flex;
-              align-items: center;
-              font-size: 14px;
-              height: fit-content;
-              line-height: 21px;
-              font-weight: 400;
-              border: 1px solid #747775;
-              border-radius: 100px;
-              padding: 8px 16px;
-              text-decoration: none;
-
-              :hover {
-                outline: 1px solid var(--dc-primary);
-                border-color: var(--dc-primary);
-              }
+              ${theme.typography.text.sm}
             `}
-            href={props.switchToolsUrl}
-            text={intl.formatMessage(toolMessages.switchToolVersion)}
-          ></LocalizedLink>
+          >
+            {intl.formatMessage(toolMessages.switchToolVersion)}
+          </Button>
         )}
       </div>
       {props.subtitle && (


### PR DESCRIPTION
Update the "switch tool version" button to use the shared button component instead of custom anchor styling. This allows for the button to follow set theming and standardizes the look with the rest of the buttons on the site.

Screenshot:
<img width="1461" height="650" alt="image" src="https://github.com/user-attachments/assets/33100f6c-25e8-4463-a0ea-aed466dd420b" />
