### PR TITLE
[Vis Tools] Map vis tool selective display

### DIFF
--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -86,7 +86,11 @@ function App(): ReactElement {
           </Row>
           {showInstructions && (
             <Row>
-              {useStandardizedUi ? <VisToolInstructionsBox /> : <Info />}
+              {useStandardizedUi ? (
+                <VisToolInstructionsBox toolType="map" />
+              ) : (
+                <Info />
+              )}
             </Row>
           )}
           {showChart && (


### PR DESCRIPTION
## Description

This PR updates the old map vis tool so that auxiliary information (instructions, etc) appear conditionally based on whether the chart is ready to start loading and display.

## Notes

We are now conditionally rendering the `<ChartLoader />` component, preventing it from mounting until the required inputs (place and stat var) are selected. 

While `<ChartLoader />` is robust enough to render nothing when idle, this prevents it from mounting entirely, avoiding the need to activate its complex rendering lifecycle (for performance) until ready.

## Screenshots

### Before

<img width="1449" height="978" alt="Screenshot 2025-07-28 at 4 46 36 PM" src="https://github.com/user-attachments/assets/ae6a6f0c-5aca-46e9-aef8-8c3ddc6994dd" />

### After

<img width="1466" height="758" alt="Screenshot 2025-07-28 at 4 52 42 PM" src="https://github.com/user-attachments/assets/84120158-cb83-4879-b7b6-1cf08f2fec95" />
