### PR TITLE
Update topic dcid check so it works for custom DCs

### DIFF
--- a/nl_server/search.py
+++ b/nl_server/search.py
@@ -23,7 +23,8 @@ from nl_server.embeddings import EmbeddingsResult
 from nl_server.merge import merge_search_results
 import shared.lib.detected_variables as dvars
 
-_TOPIC_PREFIX = 'dc/topic/'
+# Topic DCIDs contain this string.
+_TOPIC_DCID_SUBSTRING = '/topic/'
 
 # Number of matches to find within the SV index.
 _NUM_SV_INDEX_MATCHES = 40
@@ -76,7 +77,7 @@ def _rank_vars(candidates: EmbeddingsResult,
   sv2sentences = {}
   for c in candidates:
     for dcid in c.vars:
-      if skip_topics and dcid.startswith(_TOPIC_PREFIX):
+      if skip_topics and _TOPIC_DCID_SUBSTRING in dcid:
         continue
       # Prefer the top score (`candidates` is ordered!)
       if dcid not in sv2score:

--- a/nl_server/tests/embeddings_test.py
+++ b/nl_server/tests/embeddings_test.py
@@ -57,6 +57,12 @@ class TestEmbeddings(unittest.TestCase):
           "agricultural output", False,
           ["dc/g/FarmInventory", 'dc/topic/AgriculturalProduction']
       ],
+      # Check that the topic is skipped when skip_topics is True.
+      [
+          "agricultural output",
+          True,
+          ["Count_Person_Agriculture_Employed"],
+      ],
       [
           "agriculture workers", False,
           ["dc/topic/Agriculture", "dc/15lrzqkb6n0y7"]


### PR DESCRIPTION
* The current topic checks were based on a `dc/topic/` prefix.
* However, for custom DCs, topic DCIDs won't be prefixed with that but will *contain* `/topic/`.
   + e.g. one.org's topics are prefixed with `ONE/topic/`
* This PR updates the logic from a prefix match to a contains check.