### PR TITLE
[Explore] Enable Follow Up Questions experiment

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -12,6 +12,18 @@
     "description": "Enables the biomed_nl experimental features by registering the experiments/biomed_nl api and html routes."
   },
   {
+    "name": "follow_up_questions_experiment",
+    "enabled": true,
+    "owner": "javiervazquez",
+    "description": "Enables the follow up questions generated from related topics as an experiment."
+  },
+  {
+    "name": "follow_up_questions_ga",
+    "enabled": false,
+    "owner": "javiervazquez",
+    "description": "Enables the follow up questions generated from related topics to general audience."
+  },
+  {
     "name": "show_api_modal",
     "enabled": false,
     "owner": "dwnoble",


### PR DESCRIPTION
Adds the Follow Up Questions feature flags to the production JSON. Specifically, it adds:
- follow_up_questions_experiment: True
This enables the feature in 20% of the pages to begin collecting data for the experiment.
- follow_up_questions_ga: False
This guards the feature for general audience, and it is included to match the feature flags in staging.