### PR TITLE
[Vis Tools] Propogate query parameters in map tool URLs

### DIFF
--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -148,17 +148,20 @@ function updateHash(context: ContextType): void {
   let hash = updateHashStatVar("", context.statVar.value);
   hash = updateHashPlaceInfo(hash, context.placeInfo.value);
   hash = updateHashDisplay(hash, context.display.value);
-  // leaflet flag is part of the search arguments instead of hash, so need to
-  // update that separately
-  // TODO: forward along all args and then append hash in the url.
-  let args = "";
+  const args = new URLSearchParams(location.search);
   if (context.display.value.allowLeaflet) {
-    args += `?${ALLOW_LEAFLET_URL_ARG}=1`;
+    // leaflet flag is part of the search arguments instead of hash, so need to
+    // update that separately
+    args.set(`${ALLOW_LEAFLET_URL_ARG}`, "1");
   }
-  const newHash = encodeURIComponent(hash);
+  const newHash = hash ? `#${encodeURIComponent(hash)}` : "";
+  const newArgs = args.toString() ? `?${args.toString()}` : "";
   const currentHash = location.hash.replace("#", "");
   const currentArgs = location.search;
-  if (newHash && (newHash !== currentHash || args !== currentArgs)) {
-    history.pushState({}, "", `${MAP_URL_PATH}${args}#${newHash}`);
+  if (
+    (newHash || newArgs) &&
+    (newHash !== currentHash || newArgs !== currentArgs)
+  ) {
+    history.pushState({}, "", `${MAP_URL_PATH}${newArgs}${newHash}`);
   }
 }

--- a/static/js/tools/map/app.tsx
+++ b/static/js/tools/map/app.tsx
@@ -149,10 +149,13 @@ function updateHash(context: ContextType): void {
   hash = updateHashPlaceInfo(hash, context.placeInfo.value);
   hash = updateHashDisplay(hash, context.display.value);
   const args = new URLSearchParams(location.search);
+  // leaflet flag is part of the search arguments instead of hash, so need to
+  // update that separately
   if (context.display.value.allowLeaflet) {
-    // leaflet flag is part of the search arguments instead of hash, so need to
-    // update that separately
-    args.set(`${ALLOW_LEAFLET_URL_ARG}`, "1");
+    args.set(ALLOW_LEAFLET_URL_ARG, "1");
+  } else {
+    // Do not propagate this argument. Let context settings control this instead.
+    args.delete(ALLOW_LEAFLET_URL_ARG);
   }
   const newHash = hash ? `#${encodeURIComponent(hash)}` : "";
   const newArgs = args.toString() ? `?${args.toString()}` : "";


### PR DESCRIPTION
The map tool currently clears out query parameters from the URL whenever a place/place type/stat var is selected. This results in feature flag url overrides disappearing whenever the user interacts with the tool. 

This PR updates the hash parameter update logic to keep any existing query parameters.

Testing strategy:

1. Spin up a server with `./run_server.sh` and go to `localhost:8080/tools/map?disable_feature=standardized_vis_tool` in your browser.
2. Enter a place, place type, and a stat var into the tool.
3. See that the `disable_feature=standardized_vis_tool` is propagated in the URL.