### PR TITLE
Fix Custom DC Webdriver Test Errors

### DIFF
--- a/nl_requirements.txt
+++ b/nl_requirements.txt
@@ -7,7 +7,7 @@ pandas==2.1.1
 scikit-learn==1.5.0
 sentence-transformers==2.2.2
 spacy==3.7.4
-torchvision==0.17.2
+torchvision==0.23.0
 # TODO: this is pinned because latest huggingface_hub is not compatible with
 # sentence-transformers v2.2.2. Look into upgrading sentence-transformers to
 # v2.3.0 or newer

--- a/run_test.sh
+++ b/run_test.sh
@@ -21,7 +21,7 @@ function setup_python {
   source .env/bin/activate
   echo "installing server/requirements.txt"
   pip3 install -r server/requirements.txt -q
-  pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
+  pip3 install torch==2.8.0 --extra-index-url https://download.pytorch.org/whl/cpu
   echo "installing nl_server/requirements.txt"
   pip3 install -r nl_server/requirements.txt -q
   deactivate
@@ -32,7 +32,7 @@ function setup_website_python {
   source .env_website/bin/activate
   echo "installing server/requirements.txt"
   pip3 install -r server/requirements.txt -q
-  pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
+  pip3 install torch==2.8.0 --extra-index-url https://download.pytorch.org/whl/cpu
   deactivate
 }
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -21,7 +21,7 @@ function setup_python {
   source .env/bin/activate
   echo "installing server/requirements.txt"
   pip3 install -r server/requirements.txt -q
-  pip3 install torch==2.8.0 --extra-index-url https://download.pytorch.org/whl/cpu
+  pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
   echo "installing nl_server/requirements.txt"
   pip3 install -r nl_server/requirements.txt -q
   deactivate
@@ -32,7 +32,7 @@ function setup_website_python {
   source .env_website/bin/activate
   echo "installing server/requirements.txt"
   pip3 install -r server/requirements.txt -q
-  pip3 install torch==2.8.0 --extra-index-url https://download.pytorch.org/whl/cpu
+  pip3 install torch==2.2.2 --extra-index-url https://download.pytorch.org/whl/cpu
   deactivate
 }
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -26,7 +26,7 @@ jinja2==3.1.6
 json5==0.9.14
 langdetect==1.0.9
 markupsafe==2.1.2
-numpy==2.2.4
+numpy==1.26.4
 parameterized==0.8.1
 pillow==10.4.0
 protobuf==4.25.3


### PR DESCRIPTION
`flask_cdc_webdriver_test` tests have been failing with
```
RuntimeError: Failed to import transformers.models.auto.modeling_auto because of the following error:
Failed to import transformers.generation.utils because of the following error:
module 'torch' has no attribute 'uint64'
```

The fix:
1. Pin `numpy==1.26.4` to fix the version conflict error @javi-vaz mentions in the comments. This is the latest numpy version before they moved to v2.0.0.
2. Upgrade torch to `torch==2.8.0`, the latest version, which includes `uint64`.
3. Upgrade torchvision to `torchvision==0.23`, the latest version, because the previously used v0.17.2 required torch to be pinned at v2.2.2 (the version giving us issues).