### PR TITLE
Fix dataset selector bug

### DIFF
--- a/static/js/tools/stat_var/dataset_selector.tsx
+++ b/static/js/tools/stat_var/dataset_selector.tsx
@@ -77,7 +77,7 @@ export function DatasetSelector(props: DatasetSelectorProps): JSX.Element {
             value={props.dataset}
             onChange={(e): void => {
               const dcid = e.currentTarget.value ? e.currentTarget.value : "";
-              updateHash({ [SV_URL_PARAMS.DATASET]: dcid });
+              updateHash({ [SV_URL_PARAMS.SOURCE]: props.source, [SV_URL_PARAMS.DATASET]: dcid });
             }}
           >
             <option value="">Dataset</option>


### PR DESCRIPTION
Fixes a [bug](https://buganizer.corp.google.com/issues/433923263) in the stat var dataset selector where if a dataset was selected, both the source and the dataset would be cleared.

[Demo of fix](http://screencast/cast/NjUyNTgwNzAzOTA4NjU5Mnw4NzBmNzA1My0yYQ)