### PR TITLE
Include current day's results in screenshot endpoint by default

### DIFF
--- a/server/lib/gcs.py
+++ b/server/lib/gcs.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import collections
+from datetime import datetime
+from datetime import timedelta
 
 from google.cloud import storage
 
@@ -59,10 +61,17 @@ def list_folder(bucket_name, prefix, start_offset='', end_offset=''):
   storage_client = storage.Client()
   bucket = storage_client.get_bucket(bucket_name)
   start_offset = prefix + '/' + start_offset
-  end_offset = prefix + '/' + end_offset
+  final_end_offset = None
+  if end_offset:
+    # The end_offset parameter is exclusive. To make it inclusive, we add one
+    # day to the end_offset date.
+    end_date = datetime.strptime(end_offset, '%Y_%m_%d')
+    next_day = end_date + timedelta(days=1)
+    final_end_offset = prefix + '/' + next_day.strftime('%Y_%m_%d')
+
   blobs = bucket.list_blobs(prefix=prefix,
                             start_offset=start_offset,
-                            end_offset=end_offset)
+                            end_offset=final_end_offset)
   folders = set()
   for blob in blobs:
     parts = blob.name.split('/')

--- a/server/lib/gcs.py
+++ b/server/lib/gcs.py
@@ -63,11 +63,16 @@ def list_folder(bucket_name, prefix, start_offset='', end_offset=''):
   start_offset = prefix + '/' + start_offset
   final_end_offset = None
   if end_offset:
-    # The end_offset parameter is exclusive. To make it inclusive, we add one
-    # day to the end_offset date.
-    end_date = datetime.strptime(end_offset, '%Y_%m_%d')
-    next_day = end_date + timedelta(days=1)
-    final_end_offset = prefix + '/' + next_day.strftime('%Y_%m_%d')
+    try:
+      # The end_offset parameter is exclusive. To make it inclusive, we add one
+      # day to the end_offset date.
+      end_date = datetime.strptime(end_offset, '%Y_%m_%d')
+      next_day = end_date + timedelta(days=1)
+      final_end_offset = prefix + '/' + next_day.strftime('%Y_%m_%d')
+    except ValueError:
+      # Consider logging a warning that end_offset has an invalid format.
+      # `final_end_offset` will remain `None` as initialized before.
+      pass
 
   blobs = bucket.list_blobs(prefix=prefix,
                             start_offset=start_offset,

--- a/server/lib/gcs.py
+++ b/server/lib/gcs.py
@@ -61,22 +61,12 @@ def list_folder(bucket_name, prefix, start_offset='', end_offset=''):
   storage_client = storage.Client()
   bucket = storage_client.get_bucket(bucket_name)
   start_offset = prefix + '/' + start_offset
-  final_end_offset = None
   if end_offset:
-    try:
-      # The end_offset parameter is exclusive. To make it inclusive, we add one
-      # day to the end_offset date.
-      end_date = datetime.strptime(end_offset, '%Y_%m_%d')
-      next_day = end_date + timedelta(days=1)
-      final_end_offset = prefix + '/' + next_day.strftime('%Y_%m_%d')
-    except ValueError:
-      # Consider logging a warning that end_offset has an invalid format.
-      # `final_end_offset` will remain `None` as initialized before.
-      pass
+    end_offset = prefix + '/' + end_offset
 
   blobs = bucket.list_blobs(prefix=prefix,
                             start_offset=start_offset,
-                            end_offset=final_end_offset)
+                            end_offset=end_offset)
   folders = set()
   for blob in blobs:
     parts = blob.name.split('/')

--- a/server/lib/gcs.py
+++ b/server/lib/gcs.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import collections
-from datetime import datetime
-from datetime import timedelta
 
 from google.cloud import storage
 

--- a/server/routes/screenshot/html.py
+++ b/server/routes/screenshot/html.py
@@ -17,7 +17,6 @@ from datetime import datetime
 from datetime import timedelta
 import io
 import json
-import logging
 import os
 import urllib.parse
 

--- a/server/routes/screenshot/html.py
+++ b/server/routes/screenshot/html.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from datetime import timedelta
 import io
 import json
+import logging
 import os
 import urllib.parse
 
@@ -117,11 +118,21 @@ def home():
   base_date = request.args.get('base_date')
   start_date = request.args.get('start_date')
   end_date = request.args.get('end_date')
-  if not start_date:
+  if start_date:
+    try:
+      datetime.strptime(start_date, "%Y_%m_%d")
+    except ValueError:
+      flask.abort(400,
+                  description="Invalid start_date format. Expected YYYY_MM_DD.")
+  else:
     one_month_ago = datetime.now() - timedelta(days=30)
     start_date = one_month_ago.strftime("%Y_%m_%d")
-  if not end_date:
-    end_date = datetime.now().strftime("%Y_%m_%d")
+  if end_date:
+    try:
+      datetime.strptime(end_date, "%Y_%m_%d")
+    except ValueError:
+      flask.abort(400,
+                  description="Invalid end_date format. Expected YYYY_MM_DD.")
   folders = list_folder(SCREENSHOT_BUCKET, domain, start_date, end_date)
   data = []
   prev_date = ''

--- a/server/templates/screenshot/home.html
+++ b/server/templates/screenshot/home.html
@@ -33,12 +33,18 @@
           "2024_06_06_21_00_05"
         </li>
         <li>
-          start_date (YYYY_MM_DD): the start date to fetch screenshots from. By
-          default is 30 days ago from now.
+          start_date (YYYY_MM_DD): the start date to fetch screenshots from.
+          <ul>
+            <li>Default: 30 days ago</li>
+            <li>Inclusive (screenshots on the start date are included)</li>
+          </ul>
         </li>
         <li>
-          end_date (YYYY_MM_DD): the end date to fetch screenshots from. By
-          default is today.
+          end_date (YYYY_MM_DD): the end date to fetch screenshots until.
+          <ul>
+            <li>Default: none</li>
+            <li>Exclusive (screenshots on the end date are excluded)</li>
+          </ul>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
The `server/lib/gcs.list_folder` function uses `end_offset` which is exclusive in the GCS API. This caused an issue in the screenshot viewer where items from the specified end date (which defaults to today) were not being included in the results.

This change addresses the issue by modifying the screenshot endpoint and `list_folder` to make `end_offset` optional and omit it from the call to GCS when it's not provided explicity.