### PR TITLE
Enabled follow_up_questions_ga feature in autopush and local

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -37,7 +37,7 @@
   },
   {
     "name": "follow_up_questions_ga",
-    "enabled": false,
+    "enabled": true,
     "owner": "javiervazquez",
     "description": "Enables the follow up questions generated from related topics to general audience."
   },

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -37,7 +37,7 @@
   },
   {
     "name": "follow_up_questions_ga",
-    "enabled": false,
+    "enabled": true,
     "owner": "javiervazquez",
     "description": "Enables the follow up questions generated from related topics to general audience."
   },


### PR DESCRIPTION
This change ensures users will see the follow-up questions 100% of the time both locally and in autopush.

cc @miss-o-soup 