### PR TITLE
Ranking Tile - Chart embed citations

### DIFF
--- a/static/js/components/tiles/ranking_tile.tsx
+++ b/static/js/components/tiles/ranking_tile.tsx
@@ -137,7 +137,7 @@ export function RankingTile(props: RankingTilePropType): ReactElement {
   ]);
 
   /**
-    This hook mergers all the facets across ranking units, providing a single
+    This hook merges all the facets across ranking units, providing a single
     list that is sent into the ChartEmbed (data/svg download) component. This
     allows the dialog to build a citation string that matches the data it provides.
    */

--- a/static/js/place/chart_embed.tsx
+++ b/static/js/place/chart_embed.tsx
@@ -16,6 +16,8 @@
 
 /** @jsxImportSource @emotion/react */
 
+//TODO (nick-next): Add the chart embed dialog to the screenshot test suite.
+
 import { css, ThemeContext } from "@emotion/react";
 import * as d3 from "d3";
 import React, { ReactElement, RefObject } from "react";


### PR DESCRIPTION
## Description

This PR wires the combined facets and stat var to facet map into the ChartEmbed (download data/SVG) dialog.

This is row number 12. in the [Bugbash](https://docs.google.com/spreadsheets/d/1VtmR1H3VOBbEL_D0OxP9z0ZSFmD3H6k_ZldraM11CjA/edit?gid=690212228#gid=690212228), 'Ranking chart download does not include sources'.

## Notes

The metadata modal itself (which appears at the top of each ranking unit section) did not need this combined list, because each ranking unit has its own metadata button. However, the download dialog does, because it appears once at the bottom of the ranking chart. This combined list matches the data that the dialog is providing.

## Screenshots

### Before

<img width="995" height="406" alt="ranking-download-dialog-no-citations" src="https://github.com/user-attachments/assets/13004f85-f93d-494d-8006-60ef72c6b101" />

### After

<img width="980" height="580" alt="ranking-download-dialog-citations" src="https://github.com/user-attachments/assets/a8a0d3cf-7578-4266-ae5f-4a578a1b13e1" />
