### PR TITLE
Page Overview - Spacing updates

### DIFF
--- a/static/js/apps/explore/page_overview.tsx
+++ b/static/js/apps/explore/page_overview.tsx
@@ -207,7 +207,7 @@ export function PageOverview(props: PageOverviewPropType): ReactElement {
           css={[
             theme.typography.text.lg,
             css`
-              padding-top: 1.5rem;
+              margin-bottom: ${theme.spacing.xl}px;
             `,
           ]}
         >


### PR DESCRIPTION
## Description

This PR updates the spacing around the page overview text in the results page to account for recent changes to the overall page header.

This is row number 13. in the [Bugbash](https://docs.google.com/spreadsheets/d/1VtmR1H3VOBbEL_D0OxP9z0ZSFmD3H6k_ZldraM11CjA/edit?gid=690212228#gid=690212228), 'Page overview - layout on page'.

## Screenshots

### Before

<img width="1361" height="403" alt="page-overview-spacing-before" src="https://github.com/user-attachments/assets/fec42506-020a-4291-bb34-246e300f2af7" />

### After

<img width="1345" height="406" alt="page-overview-spacing-after" src="https://github.com/user-attachments/assets/d10d33d1-21bf-4ccb-8be0-14cef01bd50d" />
