### PR TITLE
Enable mixer metrics, mirroring, Redis, and V3 + Spanner Graph

### DIFF
--- a/deploy/helm_charts/envs/autopush.yaml
+++ b/deploy/helm_charts/envs/autopush.yaml
@@ -45,7 +45,17 @@ mixer:
   hostProject:
   serviceName:
   cacheSVFormula: true
+  useSpannerGraph: true
+  enableV3: true
+  redis:
+    enabled: true
+    configFile: |
+      instances:
+        - region: "us-central1"
+          host: "10.13.112.19"
+          port: "6379"
   enableOtlp: true
+  v3MirrorFraction: 0.5
 
 serviceAccount:
   name: website-ksa

--- a/deploy/helm_charts/envs/dev.yaml
+++ b/deploy/helm_charts/envs/dev.yaml
@@ -30,7 +30,17 @@ website:
     enabled: false
 
 mixer:
+  useSpannerGraph: true
+  enableV3: true
+  redis:
+    enabled: true
+    configFile: |
+      instances:
+        - region: "us-central1"
+          host: "10.60.165.235"
+          port: "6379"
   enableOtlp: true
+  v3MirrorFraction: 0.5
 
 serviceAccount:
   name: website-ksa

--- a/deploy/helm_charts/envs/prod.yaml
+++ b/deploy/helm_charts/envs/prod.yaml
@@ -40,6 +40,19 @@ website:
         }
       }
 
+mixer:
+  useSpannerGraph: true
+  enableV3: true
+  redis:
+    enabled: true
+    configFile: |
+      instances:
+        - region: "us-central1"
+          host: "10.212.232.163"
+          port: "6379"
+  enableOtlp: true
+  v3MirrorFraction: 0.0002
+
 serviceAccount:
   name: website-ksa
 

--- a/deploy/helm_charts/envs/staging.yaml
+++ b/deploy/helm_charts/envs/staging.yaml
@@ -38,7 +38,17 @@ website:
       }
 
 mixer:
+  useSpannerGraph: true
+  enableV3: true
+  redis:
+    enabled: true
+    configFile: |
+      instances:
+        - region: "us-central1"
+          host: "10.38.211.19"
+          port: "6379"
   enableOtlp: true
+  v3MirrorFraction: 0.01
 
 ingress:
   enabled: false

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -5,20 +5,38 @@
 If you would like to use [Cloud Memorystore](https://cloud.google.com/memorystore/docs/redis/quickstart-gcloud), run
 
 ```bash
-cd gke
-./create_redis.sh <ENV> <REGION>
+./gke/create_redis.sh website <ENV> <REGION>
 ```
 
 `<ENV>` is the name of an instance and `<REGION>` is a region that the app is hosted in.
 This needs to be run for all the regions that the app is hosted. Check out the
 regions from the project GKE cluster console.
 
-Record the **host** and **port** as inline config file
-([example](../deploy/helm_charts/envs/prod.yaml)) under `website.redis`.
+Record the **host** and **port** as inline config file.
+- [Website example](../deploy/helm_charts/envs/prod.yaml) under `website.redis`.
+
+## Deploying Redis for Mixer
+
+The Redis creation script can also be used for Mixer, either standalone or
+with website. Mixer Redis instances are named `mixer-cache`.
+
+Standalone:
+```bash
+./gke/create_redis.sh mixer-standalone <ENV> <REGION>
+```
+
+With website:
+```bash
+./gke/create_redis.sh mixer-website <ENV> <REGION>
+```
+
+You will need to record the host and port, though the expected config format is
+YAML instead of JSON.
+- [Mixer for website example](../deploy/helm_charts/envs/prod.yaml) under `mixer.redis`.
+- [Standalone mixer example](../mixer/deploy/helm_charts/envs/mixer_autopush.yaml) under `mixer.redis`
 
 ## Clear the cache
 
 Follow the instructions of [clear cache tool](../tools/clearcache/README.md) to clear Redis cache.
 
-Note the tool now only clears production Redis cache. You may need to update it
-to clear other Redis instance.
+When clearing the cache for website, both `webserver-cache` and `mixer-cache` (if it exists) are cleared.

--- a/scripts/deploy_gke_helm.sh
+++ b/scripts/deploy_gke_helm.sh
@@ -98,7 +98,8 @@ function deploy_mixer() {
   --set-file mixer.schemaConfigs."base\.mcf"=mixer/deploy/mapping/base.mcf \
   --set-file mixer.schemaConfigs."encode\.mcf"=mixer/deploy/mapping/encode.mcf \
   --set-file kgStoreConfig.bigqueryVersion=mixer/deploy/storage/bigquery.version \
-  --set-file kgStoreConfig.baseBigtableInfo=mixer/deploy/storage/base_bigtable_info.yaml
+  --set-file kgStoreConfig.baseBigtableInfo=mixer/deploy/storage/base_bigtable_info.yaml \
+  --set-file kgStoreConfig.spannerGraphInfo=mixer/deploy/storage/spanner_graph_info.yaml
 }
 
 # Deploy Cloud Endpoints

--- a/tools/clearcache/README.md
+++ b/tools/clearcache/README.md
@@ -11,7 +11,7 @@ The `run.sh` script allows you to clear the cache for a specific target (`websit
 ### Usage
 
 ```bash
-./run.sh <TARGET> <ENVIRONMENT>
+./tools/clearcache/run.sh <TARGET> <ENVIRONMENT>
 ```
 
 ### Examples
@@ -19,13 +19,13 @@ The `run.sh` script allows you to clear the cache for a specific target (`websit
 To clear the website cache in the `dev` environment:
 
 ```bash
-./run.sh website dev
+./tools/clearcache/run.sh website dev
 ```
 
 To clear the mixer cache in the `autopush` environment:
 
 ```bash
-./run.sh mixer autopush
+./tools/clearcache/run.sh mixer autopush
 ```
 
 ## Cloud Build Execution

--- a/tools/clearcache/run.sh
+++ b/tools/clearcache/run.sh
@@ -65,7 +65,7 @@ clear_website_cache() {
 
   # If there is a mixer-cache instance in the project, clear that too
   local MIXER_HOST
-  MIXER_HOST=$(gcloud redis instances describe mixer-cache --region="$REDIS_REGION" --format="get(host)")
+  MIXER_HOST=$(gcloud redis instances describe mixer-cache --region="$REDIS_REGION" --format="get(host)" 2>/dev/null || true)
   if [ -n "$MIXER_HOST" ]; then
     echo "--- Clearing mixer cache for Project: $PROJECT_ID, Cluster: $CLUSTER_NAME, Location: $LOCATION ---"
     local script="import redis; redis_client = redis.StrictRedis(host=\"$MIXER_HOST\", port=6379); resp = redis_client.flushall(asynchronous=True); print(\"Clearing mixer cache for $PROJECT_ID/$CLUSTER_NAME/$LOCATION, redis host $MIXER_HOST:\",resp)"


### PR DESCRIPTION
- Update Redis creation and clearing scripts for mixer
- Set traffic mirroring fractions per environment
- Use Redis hosts returned by creation script for each environment

Tested in datcom-website-dev. IAM permissions for datcom-store have been updated so that all environments can access the test Spanner instance.