### PR TITLE
[sv-autocomplete] Rename flag to match definition

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -72,7 +72,7 @@
     "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
   },
   {
-    "name": "stat_var_autocomplete_search_bar",
+    "name": "enable_stat_var_autocomplete",
     "enabled": false,
     "owner": "gmechali",
     "description": "Enable stat var autocompletion in the NL Search bar"

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -72,7 +72,7 @@
     "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
   },
   {
-    "name": "stat_var_autocomplete_search_bar",
+    "name": "enable_stat_var_autocomplete",
     "enabled": false,
     "owner": "gmechali",
     "description": "Enable stat var autocompletion in the NL Search bar"

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -72,7 +72,7 @@
     "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
   },
   {
-    "name": "stat_var_autocomplete_search_bar",
+    "name": "enable_stat_var_autocomplete",
     "enabled": false,
     "owner": "gmechali",
     "description": "Enable stat var autocompletion in the NL Search bar"

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -72,7 +72,7 @@
     "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
   },
   {
-    "name": "stat_var_autocomplete_search_bar",
+    "name": "enable_stat_var_autocomplete",
     "enabled": false,
     "owner": "gmechali",
     "description": "Enable stat var autocompletion in the NL Search bar"

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -72,7 +72,7 @@
     "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
   },
   {
-    "name": "stat_var_autocomplete_search_bar",
+    "name": "enable_stat_var_autocomplete",
     "enabled": false,
     "owner": "gmechali",
     "description": "Enable stat var autocompletion in the NL Search bar"


### PR DESCRIPTION
Flag is defined as `enable_stat_var_autocomplete` here: https://github.com/datacommonsorg/website/blob/45c417f3b3e0d842f1e2a25fecbf7422b2f83fda/server/lib/feature_flags.py#L29