### PR TITLE
Enabled explore results header, follow-up questions GA, and metadata modal features in production

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -12,6 +12,12 @@
     "description": "Enables the biomed_nl experimental features by registering the experiments/biomed_nl api and html routes."
   },
   {
+    "name": "explore_result_header",
+    "enabled": true,
+    "owner": "nick-next",
+    "description": "Enables the display of an updated explore page results header."
+  },
+  {
     "name": "follow_up_questions_experiment",
     "enabled": true,
     "owner": "javiervazquez",
@@ -19,7 +25,7 @@
   },
   {
     "name": "follow_up_questions_ga",
-    "enabled": false,
+    "enabled": true,
     "owner": "javiervazquez",
     "description": "Enables the follow up questions generated from related topics to general audience."
   },
@@ -56,7 +62,7 @@
   },
   {
     "name": "metadata_modal",
-    "enabled": false,
+    "enabled": true,
     "owner": "nick-next",
     "description": "Feature flag to show the complete metadata modal. If not set, the older modal will be used as a fallback."
   },


### PR DESCRIPTION
These features are currently enabled in staging

* explore results header: https://screenshot.googleplex.com/5y2eA9cEt4Uzt4F
* Follow-up questions GA: https://screenshot.googleplex.com/xX5fizSDhycqjBA
* Metadata modal. Includes explore other datasets + API code: https://screenshot.googleplex.com/8pnnDD7ay7QqkVf) and the enriched metadata modal: https://screenshot.googleplex.com/5Q2GHrCigLv35W5