### PR TITLE
[search-indicators] Read typeOf from dcid instead of name

### DIFF
--- a/server/routes/nl/api.py
+++ b/server/routes/nl/api.py
@@ -16,8 +16,12 @@
 import json
 
 import flask
-from flask import Blueprint, Response, request
-from pydantic import BaseModel, ConfigDict, Field
+from flask import Blueprint
+from flask import request
+from flask import Response
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
 
 from server.services import datacommons as dc
 

--- a/server/routes/nl/api.py
+++ b/server/routes/nl/api.py
@@ -16,12 +16,8 @@
 import json
 
 import flask
-from flask import Blueprint
-from flask import request
-from flask import Response
-from pydantic import BaseModel
-from pydantic import ConfigDict
-from pydantic import Field
+from flask import Blueprint, Response, request
+from pydantic import BaseModel, ConfigDict, Field
 
 from server.services import datacommons as dc
 
@@ -129,12 +125,12 @@ def search_vector():
 def _get_property_value(sv_data: dict,
                         prop: str,
                         *,
-                        by_name: bool = False) -> str | None:
+                        by_dcid: bool = False) -> str | None:
   """Safely extracts a property value from a v2/node response item."""
   prop_arcs = sv_data.get("arcs", {})
   prop_nodes = prop_arcs.get(prop, {}).get("nodes", [])
 
-  selector = "name" if by_name else "value"
+  selector = "dcid" if by_dcid else "value"
   return prop_nodes[0].get(selector) if prop_nodes else None
 
 
@@ -208,7 +204,7 @@ def _get_indicator_metadata(dcids: set[str]) -> dict[str, dict]:
     indicator_info_map[dcid] = {
         "name": _get_property_value(sv_data, "name"),
         "description": _get_property_value(sv_data, "description"),
-        "type_of": _get_property_value(sv_data, "typeOf", by_name=True)
+        "type_of": _get_property_value(sv_data, "typeOf", by_dcid=True)
     }
   return indicator_info_map
 

--- a/server/tests/routes/nl/search_indicators_test.py
+++ b/server/tests/routes/nl/search_indicators_test.py
@@ -66,7 +66,7 @@ MOCK_V2NODE_RESPONSE = {
                 },
                 "typeOf": {
                     "nodes": [{
-                        "name": "StatisticalVariable"
+                        "dcid": "StatisticalVariable"
                     }]
                 },
             }
@@ -85,7 +85,7 @@ MOCK_V2NODE_RESPONSE = {
                 },
                 "typeOf": {
                     "nodes": [{
-                        "name": "StatisticalVariable"
+                        "dcid": "StatisticalVariable"
                     }]
                 },
             }
@@ -183,7 +183,7 @@ class TestSearchVariables(unittest.TestCase):
                       },
                       "typeOf": {
                           "nodes": [{
-                              "name": "StatisticalVariable"
+                              "dcid": "StatisticalVariable"
                           }]
                       },
                   }
@@ -202,7 +202,7 @@ class TestSearchVariables(unittest.TestCase):
                       },
                       "typeOf": {
                           "nodes": [{
-                              "name": "StatisticalVariable"
+                              "dcid": "StatisticalVariable"
                           }]
                       },
                   }
@@ -221,7 +221,7 @@ class TestSearchVariables(unittest.TestCase):
                       },
                       "typeOf": {
                           "nodes": [{
-                              "name": "Topic"
+                              "dcid": "Topic"
                           }]
                       },
                   }
@@ -306,7 +306,7 @@ class TestSearchVariables(unittest.TestCase):
                       },
                       "typeOf": {
                           "nodes": [{
-                              "name": "StatisticalVariable"
+                              "dcid": "StatisticalVariable"
                           }]
                       }
                   }
@@ -320,7 +320,7 @@ class TestSearchVariables(unittest.TestCase):
                       },
                       "typeOf": {
                           "nodes": [{
-                              "name": "StatisticalVariable"
+                              "dcid": "StatisticalVariable"
                           }]
                       }
                   }
@@ -483,7 +483,7 @@ class TestSearchVariables(unittest.TestCase):
                     },
                     "typeOf": {
                         "nodes": [{
-                            "name": "StatisticalVariable"
+                            "dcid": "StatisticalVariable"
                         }]
                     },
                 }
@@ -533,7 +533,7 @@ class TestSearchVariables(unittest.TestCase):
                     },
                     "typeOf": {
                         "nodes": [{
-                            "name": "StatisticalVariable"
+                            "dcid": "StatisticalVariable"
                         }]
                     },
                 }
@@ -602,7 +602,7 @@ class TestSearchVariables(unittest.TestCase):
                     },
                     "typeOf": {
                         "nodes": [{
-                            "name": "StatisticalVariable"
+                            "dcid": "StatisticalVariable"
                         }]
                     }
                 }
@@ -616,7 +616,7 @@ class TestSearchVariables(unittest.TestCase):
                     },
                     "typeOf": {
                         "nodes": [{
-                            "name": "Topic"
+                            "dcid": "Topic"
                         }]
                     }
                 }


### PR DESCRIPTION
Context: https://github.com/datacommonsorg/agent-toolkit/pull/55/files/cd3e5786aa04f47baef47c265ba079c1df0f6f8e#r2349599413

* Custom Nodes might not have `name` set: 
<img width="3024" height="1646" alt="image" src="https://github.com/user-attachments/assets/f986da27-557a-4473-8525-6a10d4ab158f" />

* Base Nodes have both `name` and `dcid`: 
<img width="3024" height="1646" alt="image" src="https://github.com/user-attachments/assets/d43725b0-d18c-42f8-9d9b-bb39c95b9b28" />

So we should read typeOf from dcid and not name.

Tested locally and typeOf is still set: 
<img width="2160" height="1287" alt="image" src="https://github.com/user-attachments/assets/547c2efb-7066-448c-99b2-5eb9812a35e6" />

