### PR TITLE
Highlight Result Tile Padding Fix

### DIFF
--- a/static/css/shared/_subject_page.scss
+++ b/static/css/shared/_subject_page.scss
@@ -115,6 +115,7 @@ article.category {
 
 .highlight-result-title .subtopic:last-of-type {
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  padding-bottom: 1.5em;
 }
 
 .subtopic.notitle:not(:first-of-type) {


### PR DESCRIPTION
## Description

This PR fixes the bottom padding in the highlight result section.

Previously, the subtopic section inside the highlight was rendering a bottom border (correctly) but without padding.

## Screenshots

### Before

<img width="3008" height="1964" alt="Screenshot 2025-09-17 at 3 49 56 PM" src="https://github.com/user-attachments/assets/ea67c189-404f-4e83-a611-3b6d8b17062c" />

### After

<img width="1464" height="988" alt="Screenshot 2025-09-17 at 12 24 13 PM" src="https://github.com/user-attachments/assets/bf5bfcfc-71c7-4d84-805a-a4890be59bf1" />

## Testing

This scenario can be replicated at the following link:

http://localhost:8080/explore?p=country/IND&sv=Amount_EconomicActivity_GrossDomesticProduction_Nominal&unit=USDollar&imp=WorldDevelopmentIndicators&obsPer=P1Y&chartType=TIMELINE_WITH_HIGHLIGHT&origin=aim