### PR TITLE
[StatVar Autocomplete] Adds Google Analytics events for StatVar autocompletion

### DIFF
--- a/static/js/components/nl_search_bar/auto_complete_input.tsx
+++ b/static/js/components/nl_search_bar/auto_complete_input.tsx
@@ -34,8 +34,12 @@ import { intl } from "../../i18n/i18n";
 import {
   GA_EVENT_AUTOCOMPLETE_SELECTION,
   GA_EVENT_AUTOCOMPLETE_SELECTION_REDIRECTS_TO_PLACE,
+  GA_EVENT_AUTOCOMPLETE_SELECTION_REDIRECTS_TO_SV,
   GA_PARAM_AUTOCOMPLETE_SELECTION_INDEX,
   GA_PARAM_DYNAMIC_PLACEHOLDER,
+  GA_PARAM_QUERY_AT_SELECTION,
+  GA_PARAM_SELECTION_TEXT,
+  GA_PARAM_SELECTION_TYPE,
   triggerGAEvent,
 } from "../../shared/ga_events";
 import { useQueryStore } from "../../shared/stores/query_store_hook";
@@ -309,6 +313,9 @@ export function AutoCompleteInput(
   ): void {
     triggerGAEvent(GA_EVENT_AUTOCOMPLETE_SELECTION, {
       [GA_PARAM_AUTOCOMPLETE_SELECTION_INDEX]: String(idx),
+      [GA_PARAM_SELECTION_TYPE]: result.matchType,
+      [GA_PARAM_SELECTION_TEXT]: result.name,
+      [GA_PARAM_QUERY_AT_SELECTION]: baseInput,
     });
 
     const queryText = replaceQueryWithSelection(
@@ -324,6 +331,9 @@ export function AutoCompleteInput(
       if (result.dcid) {
         setHasLocation(hasLocation || result.hasPlace);
         if (!skipRedirection) {
+          triggerGAEvent(GA_EVENT_AUTOCOMPLETE_SELECTION_REDIRECTS_TO_SV, {
+            [GA_PARAM_AUTOCOMPLETE_SELECTION_INDEX]: String(idx),
+          });
           window.location.href =
             EXPLORE_SV_FOR_EARTH +
             encodeURIComponent(result.dcid) +

--- a/static/js/components/nl_search_bar/auto_complete_suggestions.tsx
+++ b/static/js/components/nl_search_bar/auto_complete_suggestions.tsx
@@ -21,6 +21,7 @@
 import React, { ReactElement, useEffect, useState } from "react";
 
 import {
+  GA_EVENT_AUTOCOMPLETE_LOAD_MORE,
   GA_EVENT_AUTOCOMPLETE_TRIGGERED,
   GA_PARAM_QUERY,
   triggerGAEvent,
@@ -139,7 +140,12 @@ export function AutoCompleteSuggestions(
       {showLoadMore && (
         <div
           className="search-input-result-section load-more-section"
-          onClick={() => setVisibleCount(visibleCount + RESULTS_TO_LOAD)}
+          onClick={() => {
+            triggerGAEvent(GA_EVENT_AUTOCOMPLETE_LOAD_MORE, {
+              [GA_PARAM_QUERY]: props.baseInput,
+            });
+            setVisibleCount(visibleCount + RESULTS_TO_LOAD);
+          }}
         >
           <div className="search-input-result">
             <span className="search-result-icon">

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -279,7 +279,7 @@ export const GA_EVENT_AUTOCOMPLETE_SELECTION_REDIRECTS_TO_PLACE =
 /**
  * Triggered on autocomplete selections that redirect directly to the explore page for an SV.
  * Parameters:
- *  "selection_index": <index of the selected autocomplete result.>
+ *  "selection_index": <index of the selected autocomplete result according to order shown to users>
  */
 export const GA_EVENT_AUTOCOMPLETE_SELECTION_REDIRECTS_TO_SV =
   "autocomplete_select_redirects_to_sv";

--- a/static/js/shared/ga_events.ts
+++ b/static/js/shared/ga_events.ts
@@ -277,6 +277,21 @@ export const GA_EVENT_AUTOCOMPLETE_SELECTION_REDIRECTS_TO_PLACE =
   "autocomplete_select_redirects_to_place";
 
 /**
+ * Triggered on autocomplete selections that redirect directly to the explore page for an SV.
+ * Parameters:
+ *  "selection_index": <index of the selected autocomplete result.>
+ */
+export const GA_EVENT_AUTOCOMPLETE_SELECTION_REDIRECTS_TO_SV =
+  "autocomplete_select_redirects_to_sv";
+
+/**
+ * Triggered when the "load more" button is clicked in autocomplete suggestions.
+ * Parameters:
+ *    "query": <the query text when load more was clicked>
+ */
+export const GA_EVENT_AUTOCOMPLETE_LOAD_MORE = "autocomplete_load_more";
+
+/**
  * Triggered on autocomplete trigger.
  * Parameters:
  *    "query": <sample query>
@@ -337,6 +352,9 @@ export const GA_PARAM_TOPIC = "topic";
 export const GA_PARAM_PLACE = "place";
 export const GA_PARAM_TIMING_MS = "time_ms";
 export const GA_PARAM_AUTOCOMPLETE_SELECTION_INDEX = "selection_index";
+export const GA_PARAM_SELECTION_TYPE = "selection_type";
+export const GA_PARAM_SELECTION_TEXT = "selection_text";
+export const GA_PARAM_QUERY_AT_SELECTION = "query_at_selection";
 export const GA_PARAM_DYNAMIC_PLACEHOLDER = "dynamic_placeholders_enabled";
 export const GA_PARAM_SEARCH_SELECTION = "search_selection";
 export const GA_PARAM_RELATED_TOPICS_MODE = "related_topics_mode";


### PR DESCRIPTION
This adds metrics for things such as SV autocompletion selection and trigger. And gives the breakdown with the correct parameters to better understand usage including query at selection, selected stat var and more.