### PR TITLE
[Vertex AI Search] Change the StatVar Explorer to use the new Vertex AI App with Periodic Updates

### DIFF
--- a/server/routes/shared_api/stats.py
+++ b/server/routes/shared_api/stats.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 # TODO: Move the VAI app to a different GCP project and figure out a better way to authenticate (ex. use API keys)
 VAI_PROJECT_ID = "datcom-nl"
 VAI_LOCATION = "global"
-VAI_ENGINE_ID = "full-statvar-search-prod_1753469819363"
+VAI_ENGINE_ID = "full-statvar-search-prod-p_1757437817854"
 VAI_SERVING_CONFIG_ID = "default_config"
 
 


### PR DESCRIPTION
Productionized a new [Vertex AI Search App](https://pantheon.corp.google.com/gen-app-builder/locations/global/engines/full-statvar-search-prod-p_1757437817854/overview/system?e=13803378&mods=-monitoring_api_staging&project=datcom-nl) which is connected to periodic updates from added BigQuery statVars.

This new Vertex AI Search app is connected to a datastore with periodic ingestion on my Cloud Storage bucket. There is a weekly GCP Workflow which triggers a series of Cloud Run Job to run the BigQuery Diff mode of the NL Metadata Generator and output it in the GCS bucket that has periodic ingestion from the data store.

Evals ran against this new VAI App show similar results to the old VAI app. 