### PR TITLE
Webdriver Test Tightening

### DIFF
--- a/server/webdriver/shared_tests/vis_timeline_test.py
+++ b/server/webdriver/shared_tests/vis_timeline_test.py
@@ -20,7 +20,8 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 from server.webdriver.base_utils import find_elem
-from server.webdriver.base_utils import find_elems
+from server.webdriver.base_utils import wait_elem
+from server.webdriver.base_utils import wait_for_text
 import server.webdriver.shared as shared
 
 TIMELINE_URL = '/tools/visualization#visType=timeline'
@@ -149,15 +150,18 @@ class VisTimelineTestMixin():
     # Wait until the chart has loaded
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(shared.charts_rendered)
 
-    # Find the chart timeline container element
-    chart_timeline = find_elem(self.driver,
-                               value='.chart.timeline',
-                               by=By.CSS_SELECTOR)
+    # Wait for the chart timeline container element
+    chart_timeline = wait_elem(self.driver,
+                               by=By.CSS_SELECTOR,
+                               value=".chart.timeline")
+    self.assertIsNotNone(chart_timeline, "Chart timeline container not found.")
 
-    # Check for the existence of the message
-    header_message = chart_timeline.find_element(
-        By.XPATH, ".//header/p[text()='One dataset available for this chart']")
-    self.assertIsNotNone(header_message)
+    # Wait for the existence of the message
+    expected_text = "One dataset available for this chart"
+    wait_for_text(self.driver,
+                  text=expected_text,
+                  by=By.CSS_SELECTOR,
+                  value=".chart.timeline header")
 
   def test_manually_enter_options(self):
     """Test entering place and stat var options manually will cause chart to
@@ -250,9 +254,12 @@ class VisTimelineTestMixin():
 
     shared.wait_for_loading(self.driver)
 
-    original_source_text = find_elems(self.driver,
-                                      value='sources',
-                                      path_to_elem=['chart'])[0].text
+    sources_element = wait_elem(self.driver,
+                                by=By.CSS_SELECTOR,
+                                value=".chart .sources")
+    self.assertIsNotNone(sources_element, "Initial sources element not found.")
+
+    original_source_text = sources_element.text
     self.assertEqual(original_source_text, 'Source: census.gov • Show metadata')
 
     # Click on the button to open the source selector modal
@@ -278,9 +285,13 @@ class VisTimelineTestMixin():
     shared.wait_for_loading(self.driver)
 
     # Verify the source text has changed
-    updated_source_text = find_elem(self.driver,
-                                    value='sources',
-                                    path_to_elem=['chart']).text
+    updated_sources_element = wait_elem(self.driver,
+                                        by=By.CSS_SELECTOR,
+                                        value=".chart .sources")
+    self.assertIsNotNone(updated_sources_element,
+                         "Updated sources element not found.")
+
+    updated_source_text = updated_sources_element.text
     self.assertEqual(
         updated_source_text,
         'Sources: census.gov, data-explorer.oecd.org • Show metadata')

--- a/server/webdriver/tests/explore_test.py
+++ b/server/webdriver/tests/explore_test.py
@@ -160,7 +160,10 @@ class TestExplorePage(ExplorePageTestMixin, BaseDcWebdriverTest):
 
     # Wait for the dialog to be visible again
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
-        EC.presence_of_element_located((By.CSS_SELECTOR, '.dialog-content h4')))
+        EC.visibility_of_element_located((
+            By.XPATH,
+            "//h4[contains(text(), 'Observation period')]/following-sibling::p[contains(text(), 'Yearly (P1Y)')]"
+        )))
 
     dialog_content_after = find_elem(self.driver,
                                      value='dialog-content',

--- a/server/webdriver/tests/timeline_test.py
+++ b/server/webdriver/tests/timeline_test.py
@@ -101,7 +101,10 @@ class TestTimeline(TimelineTestMixin, StandardizedTimelineTestMixin,
 
     # Wait until the dialog is visible and populated with content
     WebDriverWait(self.driver, self.TIMEOUT_SEC).until(
-        EC.presence_of_element_located((By.CSS_SELECTOR, '.dialog-content h3')))
+        EC.visibility_of_element_located((
+            By.XPATH,
+            "//div[contains(@class, 'dialog-content')]//h3[contains(text(), 'Total population')]"
+        )))
 
     # Search for "Total population" text in dialog-content h3 elements
     dialog_content = find_elem(self.driver,


### PR DESCRIPTION
## Description

This PR contains measures to tighten four tests, all of which exhibited intermittent failures due to race conditions.

* `test_bar_select_different_facet` and `test_per_capita_metadata`: These tests occasionally failed via the same mechanism. The presence of the element was waited for, but this sometimes resolved before the content tested for afterwards was ready. We resolved this by waiting for the relevant element to be visible and with that text.
*  `test_no_facet_choices_available` and `test_select_different_facet`: These tests both assumed the existence of certain elements after the chart finished loading (which was usually true). We now explicitly wait for them.

## Notes

These were based on reports by @juliawu (thank you!). I could replicate the first two issues. However, I was unable to replicate the last two. Nevertheless, I did identify those possible routes to a race condition in those latter tests and resolved them.