### PR TITLE
Fix Equity Page Chart Links

### DIFF
--- a/static/js/apps/explore_landing/components/stat_var_queries.tsx
+++ b/static/js/apps/explore_landing/components/stat_var_queries.tsx
@@ -43,7 +43,7 @@ export function StatVarQueries({ queries }: StatVarQueriesProps): ReactElement {
   return (
     <LinkChips
       header={
-        "Explore statistical variables around the world in the Timeline explorer tool"
+        "Explore statistical variables around the world in the Visualization tool"
       }
       headerComponent="h3"
       section="statvar"

--- a/static/js/apps/explore_landing/topics.json
+++ b/static/js/apps/explore_landing/topics.json
@@ -66,24 +66,20 @@
         ],
         "statvar": [
           {
-            "title": "Population with household spending on health greater than 10% of total household in the world",
-            "url": "/tools/visualization#visType%3Dtimeline%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22who%2FFINPROTECTION_CATA_TOT_10_LEVEL_SH%22%7D"
+            "title": "Gini Index around the world",
+            "url": "/tools/visualization#visType%3Dmap%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22GiniIndex_EconomicActivity%22%7D"
           },
           {
-            "title": "Total population pushed below a relative poverty line by household health expenditures in the world",
-            "url": "/tools/visualization#visType%3Dtimeline%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22who%2FFINPROTECTION_IMP_NP_REL_LEVEL_MILLION%22%7D"
+            "title": "Proportion of population with access to electricity in the world",
+            "url": "/tools/visualization#visType%3Dmap%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22sdg%2FEG_ACS_ELEC%22%7D"
           },
           {
-            "title": "Mortality rate attributed to unsafe water, unsafe sanitation in the world",
-            "url": "/tools/visualization#visType%3Dtimeline%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22who%2FWSH_1%22%7D"
+            "title": "Proportion of individuals using the internet in the world",
+            "url": "/tools/visualization#visType%3Dmap%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22sdg%2FIT_USE_ii99%22%7D"
           },
           {
-            "title": "Legal frameworks that promote, enforce and monitor gender equality -- Area 3: employment and economic benefits in the world",
-            "url": "/tools/visualization#visType%3Dtimeline%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22sdg%2FSG_LGL_GENEQEMP%22%7D"
-          },
-          {
-            "title": "Legal frameworks that promote, enforce and monitor gender equality -- Area 2: violence against women in the world",
-            "url": "/tools/visualization#visType%3Dtimeline%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22sdg%2FSG_LGL_GENEQVAW%22%7D"
+            "title": "Proportion of population using basic drinking water services in the world",
+            "url": "/tools/visualization#visType%3Dmap%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22sdg%2FSH_H2O_SAFE%22%7D"
           }
         ]
       },


### PR DESCRIPTION
Fixes the broken timeline tool links on /explore/equity by:

(1) Switching to new links to the map tool, with more interesting/clear stat vars.
(2) Updating the heading of the section to say "Visualization tool" instead of the Timeline tool.

With this change, the links now go to:
* Gini Index: https://datacommons.org/tools/visualization#visType%3Dmap%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22GiniIndex_EconomicActivity%22%7D
* Electricity Access: https://datacommons.org/tools/visualization#visType%3Dmap%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22sdg%2FEG_ACS_ELEC%22%7D
* Internet Access: https://datacommons.org/tools/visualization#visType%3Dmap%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22sdg%2FIT_USE_ii99%22%7D
* Access to basic water services: https://datacommons.org/tools/visualization#visType%3Dmap%26place%3DEarth%26placeType%3DCountry%26sv%3D%7B%22dcid%22%3A%22sdg%2FSH_H2O_SAFE%22%7D


### Screenshot
<img width="1988" height="1314" alt="image" src="https://github.com/user-attachments/assets/c818313a-896f-4014-8553-b68978a2196d" />
