### PR TITLE
Update debug info button

### DIFF
--- a/static/js/apps/explore/debug_info.tsx
+++ b/static/js/apps/explore/debug_info.tsx
@@ -18,10 +18,13 @@
  * Debug info for a single query for the NL interface
  */
 
+import { css, ThemeProvider } from "@emotion/react";
 import _ from "lodash";
 import queryString from "query-string";
 import React, { ReactElement, useState } from "react";
 
+import { Button } from "../../components/elements/button/button";
+import theme from "../../theme/theme";
 import {
   MultiSVCandidate,
   QueryResult,
@@ -459,12 +462,17 @@ export function DebugInfo(props: DebugInfoProps): ReactElement {
                   {JSON.stringify(debugInfo.queryDetectionDebugLogs, null, 2)}
                 </pre>
               </div>
-
-              <div className="show-more">
-                <a onClick={(): void => setIsCollapsed(!isCollapsed)}>
+              <ThemeProvider theme={theme}>
+                <Button
+                  css={css`
+                    margin-bottom: ${theme.spacing.md}px;
+                  `}
+                  variant="flat"
+                  onClick={(): void => setIsCollapsed(!isCollapsed)}
+                >
                   {isCollapsed ? "Show More" : "Show Less"}
-                </a>
-              </div>
+                </Button>
+              </ThemeProvider>
 
               {!isCollapsed && (
                 <>


### PR DESCRIPTION
Updates the styling of the "show more" button in our explore debug info to use the standard Data Commons Button component for better readability. The current button is very long and low contrast, so it's unclear it is clickable.

Before:
<img width="2031" height="1264" alt="Screenshot 2025-09-29 at 12 55 45 PM" src="https://github.com/user-attachments/assets/3e2451fb-d699-4023-ab46-29a814bb145b" />


After:
<img width="1988" height="1250" alt="Screenshot 2025-09-29 at 1 47 36 PM" src="https://github.com/user-attachments/assets/6b7c1958-aa9f-4705-b21f-5e4117b46331" />
<img width="1965" height="1245" alt="Screenshot 2025-09-29 at 1 47 47 PM" src="https://github.com/user-attachments/assets/724f1fa6-c82e-4839-9217-539b671c0aa8" />
