### PR TITLE
Debug info modal button adjustments

### DIFF
--- a/static/js/apps/base/header_app.tsx
+++ b/static/js/apps/base/header_app.tsx
@@ -18,9 +18,11 @@
  * The app that renders the header component on all pages via the base template
  */
 
+import { ThemeProvider } from "@emotion/react";
 import React, { ReactElement } from "react";
 
 import { HeaderMenu, Labels, Routes } from "../../shared/types/base";
+import theme from "../../theme/theme";
 import HeaderBar from "./components/header_bar/header_bar";
 
 interface HeaderAppProps {
@@ -60,7 +62,7 @@ export function HeaderApp({
   routes,
 }: HeaderAppProps): ReactElement {
   return (
-    <>
+    <ThemeProvider theme={theme}>
       <HeaderBar
         name={name}
         logoPath={logoPath}
@@ -72,6 +74,6 @@ export function HeaderApp({
         labels={labels}
         routes={routes}
       />
-    </>
+    </ThemeProvider>
   );
 }

--- a/static/js/apps/explore/debug_info.tsx
+++ b/static/js/apps/explore/debug_info.tsx
@@ -23,7 +23,6 @@ import queryString from "query-string";
 import React, { ReactElement, useState } from "react";
 
 import { Button } from "../../components/elements/button/button";
-import theme from "../../theme/theme";
 import {
   MultiSVCandidate,
   QueryResult,

--- a/static/js/apps/explore/debug_info.tsx
+++ b/static/js/apps/explore/debug_info.tsx
@@ -18,7 +18,6 @@
  * Debug info for a single query for the NL interface
  */
 
-import { css, ThemeProvider } from "@emotion/react";
 import _ from "lodash";
 import queryString from "query-string";
 import React, { ReactElement, useState } from "react";
@@ -462,18 +461,14 @@ export function DebugInfo(props: DebugInfoProps): ReactElement {
                   {JSON.stringify(debugInfo.queryDetectionDebugLogs, null, 2)}
                 </pre>
               </div>
-              <ThemeProvider theme={theme}>
+              <div className="show-more">
                 <Button
-                  css={css`
-                    margin-bottom: ${theme.spacing.md}px;
-                  `}
                   variant="flat"
                   onClick={(): void => setIsCollapsed(!isCollapsed)}
                 >
                   {isCollapsed ? "Show More" : "Show Less"}
                 </Button>
-              </ThemeProvider>
-
+              </div>
               {!isCollapsed && (
                 <>
                   <div className="block">


### PR DESCRIPTION
As a follow up to #5551, moves the theme provider to the application level, and uses the old class name for spacing instead of custom css.

Screenshots:
<img width="1378" height="1269" alt="Screenshot 2025-09-29 at 2 56 48 PM" src="https://github.com/user-attachments/assets/7d5e862b-0cd4-46d2-8b4c-454ae463e545" />
<img width="1965" height="1245" alt="Screenshot 2025-09-29 at 1 47 47 PM" src="https://github.com/user-attachments/assets/fb322310-d144-4aec-81dd-581fae37eca0" />
