### PR TITLE
[Vis Tools] Redirect from /tools/visualization to /tools/scatter

### DIFF
--- a/server/webdriver/shared_tests/vis_scatter_test.py
+++ b/server/webdriver/shared_tests/vis_scatter_test.py
@@ -20,7 +20,7 @@ from server.webdriver.base_utils import find_elems
 from server.webdriver.base_utils import LONG_TIMEOUT
 import server.webdriver.shared as shared
 
-SCATTER_URL = '/tools/visualization#visType=scatter'
+SCATTER_URL = '/tools/visualization?disable_feature=standardized_vis_tool#visType=scatter'
 URL_HASH_1 = '&place=geoId/06&placeType=County&sv=%7B"dcid"%3A"Count_Person_NoHealthInsurance"%7D___%7B"dcid"%3A"Count_Person_Female"%7D'
 
 

--- a/static/js/apps/visualization/main.ts
+++ b/static/js/apps/visualization/main.ts
@@ -39,7 +39,7 @@ window.addEventListener("load", (): void => {
       const visType = getVisTypeFromHash();
       if (
         isFeatureEnabled(STANDARDIZED_VIS_TOOL_FEATURE_FLAG) &&
-        visType == "timeline"
+        ["timeline", "scatter"].includes(visType)
       ) {
         window.location.href = getStandardizedToolUrl();
       } else {

--- a/static/js/apps/visualization/redirect_constants.ts
+++ b/static/js/apps/visualization/redirect_constants.ts
@@ -18,6 +18,7 @@
  * Constants and types for implementing the redirects from the Visualization Tool to the "old" tools.
  */
 
+import { FieldToAbbreviation } from "../../tools/scatter/context";
 import { TIMELINE_URL_PARAM_KEYS } from "../../tools/timeline/util";
 
 // Explicit type for a list of DCIDs to improve readability
@@ -50,12 +51,12 @@ export interface ParamNameMapping {
   dcid?: string;
   denom?: string;
   display?: string;
-  l?: string;
+  l?: string; // scatter labels
   log?: string;
   pc?: string;
   place?: string;
   placeType?: string;
-  q?: string;
+  q?: string; // scatter quadrants
   sv?: string;
 }
 
@@ -65,8 +66,8 @@ export type VisType = "map" | "scatter" | "timeline";
 // Allowed values for visType hash parameter
 export const ALLOWED_VIS_TOOL_TYPES = ["map", "scatter", "timeline"];
 
-// Separator between multiple hash parameter values used by /tools/timeline
-export const TIMELINE_DEFAULT_SEPARATOR = ",";
+// Separator between multiple hash parameter values used by /tools/*
+export const DEFAULT_PARAM_SEPARATOR = ",";
 
 // Separator between multiple variables used by /tools/timeline
 export const TIMELINE_STAT_VAR_SEPARATOR = "__"; // 2 underscores
@@ -77,4 +78,18 @@ export const TIMELINE_URL_PARAM_MAPPING: ParamNameMapping = {
   place: TIMELINE_URL_PARAM_KEYS.PLACE,
   sv: TIMELINE_URL_PARAM_KEYS.STAT_VAR,
   pc: "pc",
+};
+
+// Mapping of visualization tool param names
+// to param names used by the scatter tool
+export const SCATTER_URL_PARAM_MAPPING: ParamNameMapping = {
+  date: FieldToAbbreviation.date,
+  denom: FieldToAbbreviation.denom,
+  l: FieldToAbbreviation.showLabels,
+  log: FieldToAbbreviation.log,
+  pc: FieldToAbbreviation.perCapita,
+  place: FieldToAbbreviation.enclosingPlaceDcid,
+  placeType: FieldToAbbreviation.enclosedPlaceType,
+  q: FieldToAbbreviation.showQuadrant,
+  sv: FieldToAbbreviation.statVarDcid,
 };

--- a/static/js/apps/visualization/redirect_constants.ts
+++ b/static/js/apps/visualization/redirect_constants.ts
@@ -85,6 +85,7 @@ export const TIMELINE_URL_PARAM_MAPPING: ParamNameMapping = {
 export const SCATTER_URL_PARAM_MAPPING: ParamNameMapping = {
   date: FieldToAbbreviation.date,
   denom: FieldToAbbreviation.denom,
+  display: "display",
   l: FieldToAbbreviation.showLabels,
   log: FieldToAbbreviation.log,
   pc: FieldToAbbreviation.perCapita,

--- a/static/js/apps/visualization/vis_type_selector.tsx
+++ b/static/js/apps/visualization/vis_type_selector.tsx
@@ -50,7 +50,7 @@ export function VisTypeSelector(): JSX.Element {
   function onTypeSelected(type: VisType): void {
     if (
       isFeatureEnabled(STANDARDIZED_VIS_TOOL_FEATURE_FLAG) &&
-      [VisType.TIMELINE].includes(type)
+      [VisType.TIMELINE, VisType.SCATTER].includes(type)
     ) {
       // redirect to old tool
       window.location.href = getStandardizedToolUrl(type);

--- a/static/js/tools/scatter/app.tsx
+++ b/static/js/tools/scatter/app.tsx
@@ -82,7 +82,6 @@ function App(): ReactElement {
                   subtitle={intl.formatMessage(
                     toolMessages.scatterToolSubtitle
                   )}
-                  switchToolsUrl="/tools/visualization#visType%3Dscatter"
                 />
               ) : (
                 <div className="app-header">


### PR DESCRIPTION
This PR implements a redirect from `/tools/visualization#visType=scatter to the equivalent /tools/scatter#` page when the `standardized_vis_tool` flag is enabled.

## Testing Strategy

1. Checkout these changes and spin up a local instance of the website repo

1. Go to `http://localhost:8080/tools/visualization` and click on the 'Scatter Plot` tab. See that you are redirected to the old scatter tool at /tools/scatter.

1. Go to `http://localhost:8080/tools/visualization#visType=scatter` and see that you are redirected to the old scatter tool at /tools/scatter.

1. Go to the original visualization tool landing page by going to `http://localhost:8080/tools/visualization?disable_feature=standardized_vis_tool`

1. Click on the 'Scatter Plot' tab

1. Click through each of the links on the page. If you remove `disable_feature=standardized_vis_tool` from the URL, see that they link to a corresponding /tool/timeline page, and that each of the charts renders correctly.