### PR TITLE
Reduce website staging V3 mirror fraction

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -25,7 +25,6 @@ kind: Config
 metadata:
   name: website
 
-
 build:
   artifacts:
     # Artifacts for local development
@@ -134,8 +133,8 @@ profiles:
               mixer.githash: ${MIXER_GITHASH}
   - name: mixer-dev
     customActions:
-        - name: deploy-cloud-esp-mixer-dev
-          containers:
+      - name: deploy-cloud-esp-mixer-dev
+        containers:
           - name: gcloud-website0
             image: gcr.io/datcom-ci/datacommons-script-runner:latest
             command: ["/bin/bash"]
@@ -287,7 +286,7 @@ profiles:
             args:
               - "-c"
               - |
-                gcloud builds submit --config tools/release_automation/percy_snapshot_script/cloudbuild.per_environment_percy_snapshots.yaml --substitutions=_ENVIRONMENT=staging --project=datcom-ci 
+                gcloud builds submit --config tools/release_automation/percy_snapshot_script/cloudbuild.per_environment_percy_snapshots.yaml --substitutions=_ENVIRONMENT=staging --project=datcom-ci
     manifests:
       helm:
         releases:
@@ -318,7 +317,7 @@ profiles:
               mixer.useSpannerGraph: true
               mixer.enableV3: true
               mixer.enableOtlp: true
-              mixer.v3MirrorFraction: 0.5
+              mixer.v3MirrorFraction: 0.01
               serviceAccount.name: website-ksa
               ingress.enabled: "true"
               mixer.useRedis: "true"
@@ -345,7 +344,7 @@ profiles:
             args:
               - "-c"
               - |
-                gcloud builds submit --config build/ci/cloudbuild.update_nl_goldens.yaml --project=datcom-ci 
+                gcloud builds submit --config build/ci/cloudbuild.update_nl_goldens.yaml --project=datcom-ci
     manifests:
       helm:
         releases:


### PR DESCRIPTION
This value got bumped when we switched to using Cloud Deploy, since we went from using Helm charts in website repo to using the ones in mixer repo with overrides defined in skaffold.yaml.

- Before Cloud Deploy: https://github.com/datacommonsorg/website/blob/afea0ba1dc70d1680146a4cbafd04bfc6f26a062/deploy/helm_charts/envs/staging.yaml#L48
- After Cloud Deploy: https://github.com/datacommonsorg/website/blob/afea0ba1dc70d1680146a4cbafd04bfc6f26a062/skaffold.yaml#L321