### PR TITLE
[StatVar Autocomplete] Enable SV Autocomplete at 20% in production

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -18,6 +18,13 @@
     "description": "Enabling Gemini 2.5 Flash for NL detection."
   },
   {
+    "name": "enable_stat_var_autocomplete",
+    "enabled": true,
+    "owner": "gmechali",
+    "rollout_percentage": 20,
+    "description": "Enable stat var autocompletion in the NL Search bar"
+  },
+  {
     "name": "explore_result_header",
     "enabled": true,
     "owner": "nick-next",


### PR DESCRIPTION
This has been enabled in staging in https://github.com/datacommonsorg/website/pull/5586

This 20% experiment will allow us to get metrics on usefulness.