### PR TITLE
[Follow Up Questions] Cleaning Up GA'd Feature Flag

### DIFF
--- a/static/js/apps/explore/follow_up_questions.tsx
+++ b/static/js/apps/explore/follow_up_questions.tsx
@@ -32,7 +32,6 @@ import {
 } from "../../constants/app/explore_constants";
 import { intl } from "../../i18n/i18n";
 import { messages } from "../../i18n/i18n_messages";
-import { FOLLOW_UP_QUESTIONS_GA } from "../../shared/feature_flags/util";
 import {
   GA_EVENT_RELATED_TOPICS_CLICK,
   GA_EVENT_RELATED_TOPICS_VIEW,
@@ -168,7 +167,7 @@ const getFollowUpQuestions = async (
     return data.follow_up_questions.map((question) => {
       return {
         text: question,
-        url: `/explore?enable_feature=${FOLLOW_UP_QUESTIONS_GA}#${getUpdatedHash(
+        url: `/explore#${getUpdatedHash(
           {
             [URL_HASH_PARAMS.QUERY]: question,
             [URL_HASH_PARAMS.CLIENT]: CLIENT_TYPES.RELATED_QUESTION,

--- a/static/js/apps/explore/success_result.tsx
+++ b/static/js/apps/explore/success_result.tsx
@@ -36,8 +36,6 @@ import {
 } from "../../shared/context";
 import {
   EXPLORE_RESULT_HEADER,
-  FOLLOW_UP_QUESTIONS_EXPERIMENT,
-  FOLLOW_UP_QUESTIONS_GA,
   isFeatureEnabled,
   PAGE_OVERVIEW_EXPERIMENT,
   PAGE_OVERVIEW_GA,
@@ -65,13 +63,7 @@ import { UserMessage } from "./user_message";
 
 const PAGE_ID = "explore";
 
-const EXPERIMENT_FOLLOW_UP_ROLLOUT_RATIO = 0.2;
 const EXPERIMENT_PAGE_OVERVIEW_ROLLOUT_RATIO = 0.2;
-
-const showFollowUpQuestions =
-  isFeatureEnabled(FOLLOW_UP_QUESTIONS_GA) ||
-  (isFeatureEnabled(FOLLOW_UP_QUESTIONS_EXPERIMENT) &&
-    Math.random() < EXPERIMENT_FOLLOW_UP_ROLLOUT_RATIO);
 
 const showPageOverview =
   isFeatureEnabled(PAGE_OVERVIEW_GA) ||
@@ -190,14 +182,14 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
                 <ResultHeaderSection
                   pageMetadata={props.pageMetadata}
                   placeUrlVal={placeUrlVal}
-                  hideRelatedTopics={showFollowUpQuestions}
+                  hideRelatedTopics={true}
                   query={props.query}
                 />
               ) : (
                 <ResultHeaderSectionLegacy
                   pageMetadata={props.pageMetadata}
                   placeUrlVal={placeUrlVal}
-                  hideRelatedTopics={showFollowUpQuestions}
+                  hideRelatedTopics={true}
                 />
               ))}
             {showPageOverview && (
@@ -251,7 +243,7 @@ export function SuccessResult(props: SuccessResultPropType): ReactElement {
                 <ScrollToTopButton />
               </ExploreContext.Provider>
             </RankingUnitUrlFuncContext.Provider>
-            {showFollowUpQuestions && !_.isEmpty(relatedTopics) && (
+            {!_.isEmpty(relatedTopics) && (
               <FollowUpQuestions
                 query={props.query}
                 pageMetadata={props.pageMetadata}

--- a/static/js/shared/feature_flags/util.ts
+++ b/static/js/shared/feature_flags/util.ts
@@ -17,8 +17,6 @@
 // Feature flag names
 export const AUTOCOMPLETE_FEATURE_FLAG = "autocomplete";
 export const METADATA_FEATURE_FLAG = "metadata_modal";
-export const FOLLOW_UP_QUESTIONS_EXPERIMENT = "follow_up_questions_experiment";
-export const FOLLOW_UP_QUESTIONS_GA = "follow_up_questions_ga";
 export const PAGE_OVERVIEW_EXPERIMENT = "page_overview_experiment";
 export const PAGE_OVERVIEW_GA = "page_overview_ga";
 export const PAGE_OVERVIEW_LINKS = "page_overview_links";


### PR DESCRIPTION
The Follow up questions feature is in GA, we should make sure to clean up feature flags! This PR removes references to follow_up_questions_ga and follow_up_questions_experiment. Once they're in production, I will delete the feature flag from the config files.