### PR TITLE
Update Saint Martin name in custom DC test goldens

### DIFF
--- a/server/integration_tests/test_data/cdc_nl/chart_config.json
+++ b/server/integration_tests/test_data/cdc_nl/chart_config.json
@@ -371,7 +371,7 @@
         },
         {
           "dcid": "country/MAF",
-          "name": "Saint Martin (French part)",
+          "name": "Saint Martin",
           "types": [
             "Country"
           ]


### PR DESCRIPTION
We've been getting alerts about failing custom DC tests, that are a result of the V2 APIs returning "Saint Martin" for the name of dcid country/MFA instead of "Saint Martin (French part)". This PR updates the goldens to match V2 api behavior, which will be needed after the next data release.