### PR TITLE
Add the flags to switch nl search vars from NL Server directly to go through v2 resolve

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -96,6 +96,12 @@
     "description": "Enables features that rely on the V2 REST APIs"
   },
   {
+    "name": "use_v2_resolve_for_nl_search_vars",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables using the V2 resolve API for NL search vars."
+  },
+  {
     "name": "vai_for_statvar_search",
     "enabled": true,
     "owner": "alyssaguo",

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -96,6 +96,12 @@
     "description": "Enables features that rely on the V2 REST APIs"
   },
   {
+    "name": "use_v2_resolve_for_nl_search_vars",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables using the V2 resolve API for NL search vars."
+  },
+  {
     "name": "vai_for_statvar_search",
     "enabled": false,
     "owner": "alyssaguo",

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -96,6 +96,12 @@
     "description": "Enables features that rely on the V2 REST APIs"
   },
   {
+    "name": "use_v2_resolve_for_nl_search_vars",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables using the V2 resolve API for NL search vars."
+  },
+  {
     "name": "vai_for_statvar_search",
     "enabled": true,
     "owner": "alyssaguo",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -96,6 +96,12 @@
     "description": "Enables features that rely on the V2 REST APIs"
   },
   {
+    "name": "use_v2_resolve_for_nl_search_vars",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables using the V2 resolve API for NL search vars."
+  },
+  {
     "name": "vai_for_statvar_search",
     "enabled": true,
     "owner": "alyssaguo",

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -96,6 +96,12 @@
     "description": "Enables features that rely on the V2 REST APIs"
   },
   {
+    "name": "use_v2_resolve_for_nl_search_vars",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables using the V2 resolve API for NL search vars."
+  },
+  {
     "name": "vai_for_statvar_search",
     "enabled": true,
     "owner": "alyssaguo",


### PR DESCRIPTION
This change add a flag to use v2 resolve for the nl_search_var and then detect-and-fulfill endpoint