### PR TITLE
Modify the nl search go include the logic to go through v2 resolve

### DIFF
--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -36,6 +36,7 @@ ENABLE_NL_AGENT_DETECTOR = 'enable_nl_agent_detector'
 NEW_RANKING_PAGE = 'new_ranking_page'
 ENABLE_GEMINI_3_FLASH = 'enable_gemini_3_flash'
 USE_V2_API = 'use_v2_api'
+USE_V2_RESOLVE_FOR_NL_SEARCH_VARS = 'use_v2_resolve_for_nl_search_vars'
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:
@@ -104,7 +105,7 @@ def is_feature_enabled(feature_name: str, app=None, request=None) -> bool:
     return False
 
   # Check for feature flags in the app config
-  feature_flags = app.config['FEATURE_FLAGS']
+  feature_flags = app.config.get('FEATURE_FLAGS', {})
   is_feature_enabled = feature_flags.get(feature_name, {}).get('enabled', False)
 
   # Apply rollout percentage if specified

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -36,6 +36,7 @@ ENABLE_NL_AGENT_DETECTOR = 'enable_nl_agent_detector'
 NEW_RANKING_PAGE = 'new_ranking_page'
 ENABLE_GEMINI_3_FLASH = 'enable_gemini_3_flash'
 USE_V2_API = 'use_v2_api'
+# This flag controls the switching of detect-and-fulfill API to use v2/resolve from current nl search vars
 USE_V2_RESOLVE_FOR_NL_SEARCH_VARS = 'use_v2_resolve_for_nl_search_vars'
 
 

--- a/server/lib/nl/detection/variable.py
+++ b/server/lib/nl/detection/variable.py
@@ -45,7 +45,8 @@ _MAX_MULTIVAR_PARTS = 2
 def _detect_vars_with_resolve(
     all_queries: List[str],
     debug_logs: Dict) -> tuple[Dict[str, vars.VarCandidates], float]:
-  """Detects variables using the v2/resolve API.
+  """
+  Detects variables using the v2/resolve API.
 
   Args
   ----
@@ -73,7 +74,8 @@ def _detect_vars_with_resolve(
 def _detect_vars_with_nl_search(
     all_queries: List[str], dargs: DetectionArgs,
     debug_logs: Dict) -> tuple[Dict[str, vars.VarCandidates], float]:
-  """Detects variables using the traditional nl_search_vars API.
+  """
+  Detects variables using the traditional nl_search_vars API.
 
   Args
   ----

--- a/server/lib/nl/detection/variable.py
+++ b/server/lib/nl/detection/variable.py
@@ -45,15 +45,17 @@ _MAX_MULTIVAR_PARTS = 2
 def _detect_vars_with_resolve(
     all_queries: List[str],
     debug_logs: Dict) -> tuple[Dict[str, vars.VarCandidates], float]:
-  """
-  Detects variables using the v2/resolve API.
+  """Detects variables using the v2/resolve API.
 
-  Args:
+  Args
+  ----
     all_queries: A list of query strings.
     debug_logs: A dictionary for logging debug information.
 
-  Returns:
+  Returns
+  -------
     A tuple containing the mapping of queries to candidates and the threshold.
+
   """
   resp = dc.resolve(nodes=all_queries, prop="", resolver="indicator")
   query2results = {}
@@ -71,16 +73,18 @@ def _detect_vars_with_resolve(
 def _detect_vars_with_nl_search(
     all_queries: List[str], dargs: DetectionArgs,
     debug_logs: Dict) -> tuple[Dict[str, vars.VarCandidates], float]:
-  """
-  Detects variables using the traditional nl_search_vars API.
+  """Detects variables using the traditional nl_search_vars API.
 
-  Args:
+  Args
+  ----
     all_queries: A list of query strings.
     dargs: Detection arguments including embedding indices and reranker.
     debug_logs: A dictionary for logging debug information.
 
-  Returns:
+  Returns
+  -------
     A tuple containing the mapping of queries to candidates and the threshold.
+
   """
   resp = dc.nl_search_vars(all_queries, dargs.embeddings_index_types,
                            dargs.reranker)

--- a/server/lib/nl/detection/variable.py
+++ b/server/lib/nl/detection/variable.py
@@ -17,6 +17,8 @@
 
 from typing import Dict, List
 
+from server.lib.feature_flags import is_feature_enabled
+from server.lib.feature_flags import USE_V2_RESOLVE_FOR_NL_SEARCH_VARS
 from server.lib.nl.detection import query_util
 from server.lib.nl.detection.types import DetectionArgs
 import server.lib.nl.detection.utils as dutils
@@ -25,8 +27,6 @@ from server.services import datacommons as dc
 from shared.lib import constants
 import shared.lib.detected_variables as vars
 import shared.lib.utils as shared_utils
-from server.lib.feature_flags import is_feature_enabled
-from server.lib.feature_flags import USE_V2_RESOLVE_FOR_NL_SEARCH_VARS
 
 # A value higher than the highest score.
 _HIGHEST_SCORE = 1.0
@@ -82,7 +82,9 @@ def detect_vars(orig_query: str, debug_logs: Dict,
   #
   # Make API call to the NL models/embeddings server.
   if is_feature_enabled(USE_V2_RESOLVE_FOR_NL_SEARCH_VARS):
-    resp = dc.resolve(nodes=all_queries, prop="<-description->dcid", resolver="indicator")
+    resp = dc.resolve(nodes=all_queries,
+                      prop="<-description->dcid",
+                      resolver="indicator")
     query2results = {}
     # Assuming the order/nodes match the input queries or we can find by node string.
     # v2/resolve returns a list of entities matching the input nodes.
@@ -93,14 +95,17 @@ def detect_vars(orig_query: str, debug_logs: Dict,
     # Ensure every query has a result entry.
     for q in all_queries:
       if q not in query2results:
-        query2results[q] = vars.VarCandidates(svs=[], scores=[], sv2sentences={})
+        query2results[q] = vars.VarCandidates(svs=[],
+                                              scores=[],
+                                              sv2sentences={})
     # Set a default threshold for resolve API candidates
     model_threshold = 0.7
   else:
     resp = dc.nl_search_vars(all_queries, dargs.embeddings_index_types,
                              dargs.reranker)
     query2results = {
-        q: vars.dict_to_var_candidates(r) for q, r in resp['queryResults'].items()
+        q: vars.dict_to_var_candidates(r)
+        for q, r in resp['queryResults'].items()
     }
     model_threshold = resp['scoreThreshold']
 

--- a/server/lib/nl/detection/variable.py
+++ b/server/lib/nl/detection/variable.py
@@ -45,6 +45,16 @@ _MAX_MULTIVAR_PARTS = 2
 def _detect_vars_with_resolve(
     all_queries: List[str],
     debug_logs: Dict) -> tuple[Dict[str, vars.VarCandidates], float]:
+  """
+  Detects variables using the v2/resolve API.
+
+  Args:
+    all_queries: A list of query strings.
+    debug_logs: A dictionary for logging debug information.
+
+  Returns:
+    A tuple containing the mapping of queries to candidates and the threshold.
+  """
   resp = dc.resolve(nodes=all_queries, prop="", resolver="indicator")
   query2results = {}
   for entity in resp.get('entities', []):
@@ -61,6 +71,17 @@ def _detect_vars_with_resolve(
 def _detect_vars_with_nl_search(
     all_queries: List[str], dargs: DetectionArgs,
     debug_logs: Dict) -> tuple[Dict[str, vars.VarCandidates], float]:
+  """
+  Detects variables using the traditional nl_search_vars API.
+
+  Args:
+    all_queries: A list of query strings.
+    dargs: Detection arguments including embedding indices and reranker.
+    debug_logs: A dictionary for logging debug information.
+
+  Returns:
+    A tuple containing the mapping of queries to candidates and the threshold.
+  """
   resp = dc.nl_search_vars(all_queries, dargs.embeddings_index_types,
                            dargs.reranker)
   query2results = {

--- a/server/lib/nl/detection/variable.py
+++ b/server/lib/nl/detection/variable.py
@@ -25,6 +25,8 @@ from server.services import datacommons as dc
 from shared.lib import constants
 import shared.lib.detected_variables as vars
 import shared.lib.utils as shared_utils
+from server.lib.feature_flags import is_feature_enabled
+from server.lib.feature_flags import USE_V2_RESOLVE_FOR_NL_SEARCH_VARS
 
 # A value higher than the highest score.
 _HIGHEST_SCORE = 1.0
@@ -79,13 +81,30 @@ def detect_vars(orig_query: str, debug_logs: Dict,
   # 2. Lookup embeddings with both single-var and multi-var queries.
   #
   # Make API call to the NL models/embeddings server.
-  resp = dc.nl_search_vars(all_queries, dargs.embeddings_index_types,
-                           dargs.reranker)
-  query2results = {
-      q: vars.dict_to_var_candidates(r) for q, r in resp['queryResults'].items()
-  }
+  if is_feature_enabled(USE_V2_RESOLVE_FOR_NL_SEARCH_VARS):
+    resp = dc.resolve(nodes=all_queries, prop="<-description->dcid", resolver="indicator")
+    query2results = {}
+    # Assuming the order/nodes match the input queries or we can find by node string.
+    # v2/resolve returns a list of entities matching the input nodes.
+    for entity in resp.get('entities', []):
+      node = entity.get('node')
+      if node in all_queries:
+        query2results[node] = vars.resolve_entity_to_var_candidates(entity)
+    # Ensure every query has a result entry.
+    for q in all_queries:
+      if q not in query2results:
+        query2results[q] = vars.VarCandidates(svs=[], scores=[], sv2sentences={})
+    # Set a default threshold for resolve API candidates
+    model_threshold = 0.7
+  else:
+    resp = dc.nl_search_vars(all_queries, dargs.embeddings_index_types,
+                             dargs.reranker)
+    query2results = {
+        q: vars.dict_to_var_candidates(r) for q, r in resp['queryResults'].items()
+    }
+    model_threshold = resp['scoreThreshold']
+
   debug_logs.update(resp.get('debugLogs', {}))
-  model_threshold = resp['scoreThreshold']
 
   #
   # 3. Prepare result candidates.

--- a/server/lib/nl/detection/variable.py
+++ b/server/lib/nl/detection/variable.py
@@ -42,6 +42,34 @@ _MAX_MULTIVAR_PARTS = 2
 # calls the NL Server and returns a dict with both single-SV and multi-SV
 # (if relevant) detections.  For more details see create_sv_detection().
 #
+def _detect_vars_with_resolve(
+    all_queries: List[str],
+    debug_logs: Dict) -> tuple[Dict[str, vars.VarCandidates], float]:
+  resp = dc.resolve(nodes=all_queries, prop="", resolver="indicator")
+  query2results = {}
+  for entity in resp.get('entities', []):
+    node = entity.get('node')
+    if node in all_queries:
+      query2results[node] = vars.resolve_entity_to_var_candidates(entity)
+  for q in all_queries:
+    if q not in query2results:
+      query2results[q] = vars.VarCandidates(svs=[], scores=[], sv2sentences={})
+  debug_logs.update(resp.get('debugLogs', {}))
+  return query2results, 0.7
+
+
+def _detect_vars_with_nl_search(
+    all_queries: List[str], dargs: DetectionArgs,
+    debug_logs: Dict) -> tuple[Dict[str, vars.VarCandidates], float]:
+  resp = dc.nl_search_vars(all_queries, dargs.embeddings_index_types,
+                           dargs.reranker)
+  query2results = {
+      q: vars.dict_to_var_candidates(r) for q, r in resp['queryResults'].items()
+  }
+  debug_logs.update(resp.get('debugLogs', {}))
+  return query2results, resp['scoreThreshold']
+
+
 def detect_vars(orig_query: str, debug_logs: Dict,
                 dargs: DetectionArgs) -> vars.VarDetectionResult:
 
@@ -82,34 +110,11 @@ def detect_vars(orig_query: str, debug_logs: Dict,
   #
   # Make API call to the NL models/embeddings server.
   if is_feature_enabled(USE_V2_RESOLVE_FOR_NL_SEARCH_VARS):
-    resp = dc.resolve(nodes=all_queries,
-                      prop="<-description->dcid",
-                      resolver="indicator")
-    query2results = {}
-    # Assuming the order/nodes match the input queries or we can find by node string.
-    # v2/resolve returns a list of entities matching the input nodes.
-    for entity in resp.get('entities', []):
-      node = entity.get('node')
-      if node in all_queries:
-        query2results[node] = vars.resolve_entity_to_var_candidates(entity)
-    # Ensure every query has a result entry.
-    for q in all_queries:
-      if q not in query2results:
-        query2results[q] = vars.VarCandidates(svs=[],
-                                              scores=[],
-                                              sv2sentences={})
-    # Set a default threshold for resolve API candidates
-    model_threshold = 0.7
+    query2results, model_threshold = _detect_vars_with_resolve(
+        all_queries, debug_logs)
   else:
-    resp = dc.nl_search_vars(all_queries, dargs.embeddings_index_types,
-                             dargs.reranker)
-    query2results = {
-        q: vars.dict_to_var_candidates(r)
-        for q, r in resp['queryResults'].items()
-    }
-    model_threshold = resp['scoreThreshold']
-
-  debug_logs.update(resp.get('debugLogs', {}))
+    query2results, model_threshold = _detect_vars_with_nl_search(
+        all_queries, dargs, debug_logs)
 
   #
   # 3. Prepare result candidates.

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -684,12 +684,7 @@ def resolve(nodes, prop, resolver="place"):
   return post(url, {"nodes": nodes, "property": prop, "resolver": resolver})
 
 
-def _use_resolve() -> bool:
-  """Returns True if we should use resolve API instead of NL search vars."""
-  return False
- 
- 
-def _nl_search_vars_v1(
+def nl_search_vars(
     queries,
     index_types: List[str],
     reranker="",
@@ -704,18 +699,6 @@ def _nl_search_vars_v1(
   if skip_topics:
     url = f"{url}&skip_topics={skip_topics}"
   return post(url, {"queries": queries})
- 
- 
-def nl_search_vars(
-    queries,
-    index_types: List[str],
-    reranker="",
-    skip_topics="",
-):
-  """Search sv using either resolve or NL search vars based on control function."""
-  if _use_resolve():
-    return resolve(nodes=queries, prop="<-description->dcid", resolver="indicator")
-  return _nl_search_vars_v1(queries, index_types, reranker, skip_topics)
 
 
 async def nl_search_vars_in_parallel(

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -672,18 +672,24 @@ def get_series_dates(parent_entity, child_type, variables):
   return {"datesByVariable": resp_dates, "facets": all_facets}
 
 
-def resolve(nodes, prop):
+def resolve(nodes, prop, resolver="place"):
   """Resolves nodes based on the given property.
 
     Args:
         nodes: A list of node dcids.
         prop: Property expression indicating the property to resolve.
+        resolver: The resolver to use (default: "place").
     """
   url = get_service_url("/v2/resolve")
-  return post(url, {"nodes": nodes, "property": prop})
+  return post(url, {"nodes": nodes, "property": prop, "resolver": resolver})
 
 
-def nl_search_vars(
+def _use_resolve() -> bool:
+  """Returns True if we should use resolve API instead of NL search vars."""
+  return False
+ 
+ 
+def _nl_search_vars_v1(
     queries,
     index_types: List[str],
     reranker="",
@@ -698,6 +704,18 @@ def nl_search_vars(
   if skip_topics:
     url = f"{url}&skip_topics={skip_topics}"
   return post(url, {"queries": queries})
+ 
+ 
+def nl_search_vars(
+    queries,
+    index_types: List[str],
+    reranker="",
+    skip_topics="",
+):
+  """Search sv using either resolve or NL search vars based on control function."""
+  if _use_resolve():
+    return resolve(nodes=queries, prop="<-description->dcid", resolver="indicator")
+  return _nl_search_vars_v1(queries, index_types, reranker, skip_topics)
 
 
 async def nl_search_vars_in_parallel(

--- a/server/tests/services/datacommons_test.py
+++ b/server/tests/services/datacommons_test.py
@@ -207,7 +207,6 @@ class TestServiceDataCommonsNLSearchVars(unittest.TestCase):
 
     mock_post.side_effect = side_effect
 
-    from server.services.datacommons import nl_search_vars
     nl_search_vars(
         queries=["foo", "bar"],
         index_types=[idx_param],
@@ -226,7 +225,6 @@ class TestServiceDataCommonsNLSearchVars(unittest.TestCase):
 
     mock_post.side_effect = side_effect
 
-    from server.services.datacommons import nl_search_vars
     nl_search_vars(
         queries=["foo", "bar"],
         index_types=[idx_param],
@@ -354,24 +352,14 @@ class TestServiceDataCommonsNLSearchVarsInParallel(
         "scoreThreshold": 0.7,
     }
 
-    call_count = 0
-
     def side_effect(url, *args, **kwargs):
-      nonlocal call_count
-      call_count += 1
       resp = Response()
       resp.status_code = 200
 
-      assert "/api/search_vars" in url
-      
-      # Check that the payload is correct
-      json_data = kwargs.get('json')
-      assert json_data == {
-          "queries": ["foo"]
-      }
-
-      if call_count == 1:
+      if "idx1" in url:
+        # Setting the ._content attribute automatically makes both resp.json() and resp.text available.
         resp._content = json.dumps(idx1_result).encode('utf-8')
+
       else:
         resp._content = json.dumps(idx2_result).encode('utf-8')
 

--- a/server/tests/services/datacommons_test.py
+++ b/server/tests/services/datacommons_test.py
@@ -250,11 +250,12 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
 
     def side_effect(url, data, headers=None):
       assert url.endswith("/v2/resolve")
-      self.assertEqual(data, {
-          "nodes": ["foo", "bar"],
-          "property": "<-description->dcid",
-          "resolver": "indicator"
-      })
+      self.assertEqual(
+          data, {
+              "nodes": ["foo", "bar"],
+              "property": "<-description->dcid",
+              "resolver": "indicator"
+          })
       return {}
 
     mock_post.side_effect = side_effect

--- a/server/tests/services/datacommons_test.py
+++ b/server/tests/services/datacommons_test.py
@@ -207,6 +207,7 @@ class TestServiceDataCommonsNLSearchVars(unittest.TestCase):
 
     mock_post.side_effect = side_effect
 
+    from server.services.datacommons import nl_search_vars
     nl_search_vars(
         queries=["foo", "bar"],
         index_types=[idx_param],
@@ -225,10 +226,46 @@ class TestServiceDataCommonsNLSearchVars(unittest.TestCase):
 
     mock_post.side_effect = side_effect
 
+    from server.services.datacommons import nl_search_vars
     nl_search_vars(
         queries=["foo", "bar"],
         index_types=[idx_param],
         skip_topics="true",
+    )
+
+    assert mock_post.call_count == 1
+
+
+class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
+
+  def setUp(self):
+    self.app = Flask(__name__)
+    self.app.config["NL_ROOT"] = "fake_root"
+    self.app_context = self.app.app_context()
+    self.app_context.push()
+
+  def tearDown(self):
+    self.app_context.pop()
+
+  @mock.patch("server.services.datacommons.post")
+  def test_resolve_indicator(self, mock_post):
+
+    def side_effect(url, data, headers=None):
+      assert url.endswith("/v2/resolve")
+      self.assertEqual(data, {
+          "nodes": ["foo", "bar"],
+          "property": "<-description->dcid",
+          "resolver": "indicator"
+      })
+      return {}
+
+    mock_post.side_effect = side_effect
+
+    from server.services.datacommons import resolve
+    resolve(
+        nodes=["foo", "bar"],
+        prop="<-description->dcid",
+        resolver="indicator",
     )
 
     assert mock_post.call_count == 1
@@ -317,14 +354,24 @@ class TestServiceDataCommonsNLSearchVarsInParallel(
         "scoreThreshold": 0.7,
     }
 
+    call_count = 0
+
     def side_effect(url, *args, **kwargs):
+      nonlocal call_count
+      call_count += 1
       resp = Response()
       resp.status_code = 200
 
-      if "idx1" in url:
-        # Setting the ._content attribute automatically makes both resp.json() and resp.text available.
-        resp._content = json.dumps(idx1_result).encode('utf-8')
+      assert "/api/search_vars" in url
+      
+      # Check that the payload is correct
+      json_data = kwargs.get('json')
+      assert json_data == {
+          "queries": ["foo"]
+      }
 
+      if call_count == 1:
+        resp._content = json.dumps(idx1_result).encode('utf-8')
       else:
         resp._content = json.dumps(idx2_result).encode('utf-8')
 

--- a/shared/lib/detected_variables.py
+++ b/shared/lib/detected_variables.py
@@ -100,6 +100,14 @@ def dict_to_var_candidates(nlresp: Dict) -> VarCandidates:
 
 
 def resolve_entity_to_var_candidates(entity: Dict) -> VarCandidates:
+  """Converts an entity dictionary from v2/resolve response into VarCandidates.
+
+  Args:
+    entity: A dictionary containing a list of candidate variables.
+
+  Returns:
+    A VarCandidates object containing the parsed candidates and scores.
+  """
   svs = []
   scores = []
   sv2sentences: SV2Sentences = {}

--- a/shared/lib/detected_variables.py
+++ b/shared/lib/detected_variables.py
@@ -100,7 +100,8 @@ def dict_to_var_candidates(nlresp: Dict) -> VarCandidates:
 
 
 def resolve_entity_to_var_candidates(entity: Dict) -> VarCandidates:
-  """Converts an entity dictionary from v2/resolve response into VarCandidates.
+  """
+  Converts an entity dictionary from v2/resolve response into VarCandidates.
 
   Args
   ----

--- a/shared/lib/detected_variables.py
+++ b/shared/lib/detected_variables.py
@@ -100,13 +100,14 @@ def dict_to_var_candidates(nlresp: Dict) -> VarCandidates:
 
 
 def resolve_entity_to_var_candidates(entity: Dict) -> VarCandidates:
-  """Converts an entity dictionary from v2/resolve response into VarCandidates.
+  """
+  Converts an entity dictionary from v2/resolve response into VarCandidates.
 
   Args:
-    entity: A dictionary containing a list of candidate variables.
+    entity: A dictionary containing a list of candidate variables
 
   Returns:
-    A VarCandidates object containing the parsed candidates and scores.
+    A VarCandidates object containing the parsed candidates and scores
   """
   svs = []
   scores = []

--- a/shared/lib/detected_variables.py
+++ b/shared/lib/detected_variables.py
@@ -99,6 +99,32 @@ def dict_to_var_candidates(nlresp: Dict) -> VarCandidates:
                        sv2sentences=sv2sentences)
 
 
+def resolve_entity_to_var_candidates(entity: Dict) -> VarCandidates:
+  svs = []
+  scores = []
+  sv2sentences: SV2Sentences = {}
+
+  for candidate in entity.get('candidates', []):
+    sv = candidate.get('dcid')
+    if not sv:
+      continue
+    meta = candidate.get('metadata', {})
+    score_str = meta.get('score')
+    try:
+      score = float(score_str) if score_str is not None else 0.0
+    except ValueError:
+      score = 0.0
+    sentence = meta.get('sentence', '')
+
+    svs.append(sv)
+    scores.append(score)
+    if sv not in sv2sentences:
+      sv2sentences[sv] = []
+    sv2sentences[sv].append(SentenceScore(sentence=sentence, score=score))
+
+  return VarCandidates(svs=svs, scores=scores, sv2sentences=sv2sentences)
+
+
 def var_candidates_to_dict(res: VarCandidates) -> Dict:
   result = {'SV': res.svs, 'CosineScore': res.scores}
   if res.sv2sentences:

--- a/shared/lib/detected_variables.py
+++ b/shared/lib/detected_variables.py
@@ -100,14 +100,16 @@ def dict_to_var_candidates(nlresp: Dict) -> VarCandidates:
 
 
 def resolve_entity_to_var_candidates(entity: Dict) -> VarCandidates:
-  """
-  Converts an entity dictionary from v2/resolve response into VarCandidates.
+  """Converts an entity dictionary from v2/resolve response into VarCandidates.
 
-  Args:
+  Args
+  ----
     entity: A dictionary containing a list of candidate variables
 
-  Returns:
+  Returns
+  -------
     A VarCandidates object containing the parsed candidates and scores
+
   """
   svs = []
   scores = []

--- a/shared/tests/lib/detected_variables_test.py
+++ b/shared/tests/lib/detected_variables_test.py
@@ -95,27 +95,24 @@ _MULTI_SV = {
     }]
 }
 
-
 _RESOLVE_ENTITY = {
-    "node": "Alcohol Establishments",
-    "candidates": [
-        {
-            "dcid": "dc/topic/AlcoholIndustry",
-            "metadata": {
-                "score": "0.7859",
-                "sentence": "Alcohol Industry"
-            },
-            "typeOf": ["Topic"]
+    "node":
+        "Alcohol Establishments",
+    "candidates": [{
+        "dcid": "dc/topic/AlcoholIndustry",
+        "metadata": {
+            "score": "0.7859",
+            "sentence": "Alcohol Industry"
         },
-        {
-            "dcid": "Count_Establishment",
-            "metadata": {
-                "score": "xyz",
-                "sentence": "Count of Establishment"
-            },
-            "typeOf": ["StatisticalVariable"]
-        }
-    ]
+        "typeOf": ["Topic"]
+    }, {
+        "dcid": "Count_Establishment",
+        "metadata": {
+            "score": "xyz",
+            "sentence": "Count of Establishment"
+        },
+        "typeOf": ["StatisticalVariable"]
+    }]
 }
 
 
@@ -129,7 +126,9 @@ class TestDetectedVariables(unittest.TestCase):
 
   def test_resolve_entity_to_var_candidates(self):
     res = vars.resolve_entity_to_var_candidates(_RESOLVE_ENTITY)
-    self.assertEqual(res.svs, ["dc/topic/AlcoholIndustry", "Count_Establishment"])
+    self.assertEqual(res.svs,
+                     ["dc/topic/AlcoholIndustry", "Count_Establishment"])
     self.assertEqual(res.scores, [0.7859, 0.0])
-    self.assertEqual(res.sv2sentences["dc/topic/AlcoholIndustry"][0].sentence, "Alcohol Industry")
+    self.assertEqual(res.sv2sentences["dc/topic/AlcoholIndustry"][0].sentence,
+                     "Alcohol Industry")
     self.assertEqual(res.sv2sentences["Count_Establishment"][0].score, 0.0)

--- a/shared/tests/lib/detected_variables_test.py
+++ b/shared/tests/lib/detected_variables_test.py
@@ -96,6 +96,29 @@ _MULTI_SV = {
 }
 
 
+_RESOLVE_ENTITY = {
+    "node": "Alcohol Establishments",
+    "candidates": [
+        {
+            "dcid": "dc/topic/AlcoholIndustry",
+            "metadata": {
+                "score": "0.7859",
+                "sentence": "Alcohol Industry"
+            },
+            "typeOf": ["Topic"]
+        },
+        {
+            "dcid": "Count_Establishment",
+            "metadata": {
+                "score": "xyz",
+                "sentence": "Count of Establishment"
+            },
+            "typeOf": ["StatisticalVariable"]
+        }
+    ]
+}
+
+
 class TestDetectedVariables(unittest.TestCase):
 
   def test_main(self):
@@ -103,3 +126,10 @@ class TestDetectedVariables(unittest.TestCase):
         _MULTI_SV,
         vars.multivar_candidates_to_dict(
             vars.dict_to_multivar_candidates(_MULTI_SV)))
+
+  def test_resolve_entity_to_var_candidates(self):
+    res = vars.resolve_entity_to_var_candidates(_RESOLVE_ENTITY)
+    self.assertEqual(res.svs, ["dc/topic/AlcoholIndustry", "Count_Establishment"])
+    self.assertEqual(res.scores, [0.7859, 0.0])
+    self.assertEqual(res.sv2sentences["dc/topic/AlcoholIndustry"][0].sentence, "Alcohol Industry")
+    self.assertEqual(res.sv2sentences["Count_Establishment"][0].score, 0.0)


### PR DESCRIPTION
This PR added the logic to switch between v2/resolve and the current directly call from nl server to search