### PR TITLE
[v0/v1 migration]Add pagination to map charts

### DIFF
--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -384,7 +384,7 @@ def properties(nodes, out=True):
   return result
 
 
-def property_values(nodes, prop, out=True, constraints=''):
+def property_values(nodes, prop, out=True, constraints='', max_pages=1):
   """Returns a compact property values data out of REST API response.
 
   The response is the following format:
@@ -392,8 +392,16 @@ def property_values(nodes, prop, out=True, constraints=''):
     <node_dcid>: [value list]
   }
   """
-  resp = dc.v2node(nodes, '{}{}{}'.format('->' if out else '<-', prop,
-                                          constraints))
+  from server.lib.feature_flags import is_feature_enabled
+  from server.lib.feature_flags import USE_V2_API
+
+  if is_feature_enabled(USE_V2_API):
+    resp = dc.v2node_paginated(
+        nodes, '{}{}{}'.format('->' if out else '<-', prop, constraints),
+        max_pages)
+  else:
+    resp = dc.v2node(nodes, '{}{}{}'.format('->' if out else '<-', prop,
+                                            constraints))
   result = {}
   for node, node_arcs in resp.get('data', {}).items():
     result[node] = []
@@ -505,16 +513,16 @@ def triples(nodes, out=True, max_pages=1):
   return result
 
 
-def descendent_places(nodes, descendent_type):
+def descendent_places(nodes, descendent_type, max_pages=1):
   # When the only node being requested is also the descendent_type, fetch all nodes of that type.
   if nodes and len(nodes) == 1 and nodes[0] == descendent_type:
-    return property_values(nodes, "typeOf", out=False)
-  return property_values(
-      nodes,
-      "containedInPlace+",
-      out=False,
-      constraints="{{typeOf:{}}}".format(descendent_type),
-  )
+    return property_values(nodes, "typeOf", out=False, max_pages=max_pages)
+
+  return property_values(nodes,
+                         "containedInPlace+",
+                         out=False,
+                         constraints="{{typeOf:{}}}".format(descendent_type),
+                         max_pages=max_pages)
 
 
 def raw_descendent_places(nodes, descendent_type):

--- a/server/routes/shared_api/choropleth.py
+++ b/server/routes/shared_api/choropleth.py
@@ -512,7 +512,7 @@ def get_map_points():
   # eg. epaGhgrpFacilityId/1003010 has latitude and longitude but no location
   # epa/120814013 which is an AirQualitySite has a location, but no latitude
   # or longitude
-  location_by_geo = fetch.property_values(geos, "location")
+  location_by_geo = fetch.property_values(geos, "location", max_pages=None)
   # dict of <dcid used to get latlon>: <dcid of the place>
   geo_by_latlon_subject = {}
   for geo_dcid in geos:
@@ -522,9 +522,11 @@ def get_map_points():
     else:
       geo_by_latlon_subject[geo_dcid] = geo_dcid
   lat_by_subject = fetch.property_values(list(geo_by_latlon_subject.keys()),
-                                         "latitude")
+                                         "latitude",
+                                         max_pages=None)
   lon_by_subject = fetch.property_values(list(geo_by_latlon_subject.keys()),
-                                         "longitude")
+                                         "longitude",
+                                         max_pages=None)
 
   map_points_list = []
   for subject_dcid, latitude in lat_by_subject.items():

--- a/server/routes/shared_api/choropleth.py
+++ b/server/routes/shared_api/choropleth.py
@@ -260,7 +260,8 @@ def geojson():
     return lib_util.gzip_compress_response(result, is_json=True)
   geos = []
   if place_dcid and place_type:
-    geos = fetch.descendent_places([place_dcid], place_type).get(place_dcid, [])
+    geos = fetch.descendent_places([place_dcid], place_type,
+                                   max_pages=None).get(place_dcid, [])
   if not geos:
     return Response(json.dumps({}), 200, mimetype='application/json')
   # When fetching geojson data from kg, use the geojson prop at the correct
@@ -278,7 +279,7 @@ def geojson():
     names_by_geo = place_api.get_display_name(geos)
   features = []
   if geojson_prop:
-    geojson_by_geo = fetch.property_values(geos, geojson_prop)
+    geojson_by_geo = fetch.property_values(geos, geojson_prop, max_pages=None)
     # geoId/46102 is known to only have unsimplified geojson so need to use
     # geoJsonCoordinates as the prop for this one place
     if 'geoId/46102' in geojson_by_geo:
@@ -499,7 +500,8 @@ def get_map_points():
                     400,
                     mimetype='application/json')
   geos = []
-  geos = fetch.descendent_places([place_dcid], place_type).get(place_dcid, [])
+  geos = fetch.descendent_places([place_dcid], place_type,
+                                 max_pages=None).get(place_dcid, [])
   if not geos:
     return Response(json.dumps([]), 200, mimetype='application/json')
   names_by_geo = place_api.get_i18n_name(geos)

--- a/server/tests/routes/api/choropleth_test.py
+++ b/server/tests/routes/api/choropleth_test.py
@@ -127,7 +127,7 @@ class TestGetGeoJson(unittest.TestCase):
     parentDcid = "parentDcid"
     mock_display_level.return_value = (parentDcid, "State")
 
-    def descendent_places_(*args):
+    def descendent_places_(*args, **kwargs):
       if args[0] == [parentDcid] and args[1] == "State":
         return {parentDcid: [dcid1, dcid2]}
       else:
@@ -192,7 +192,7 @@ class TestGetGeoJson(unittest.TestCase):
     dcid2 = "dcid2"
     parentDcid = "parentDcid"
 
-    def descendent_places_(*args):
+    def descendent_places_(*args, **kwargs):
       if args[0] == [parentDcid] and args[1] == "State":
         return {parentDcid: [dcid1, dcid2]}
       else:

--- a/server/tests/routes/place/utils_test.py
+++ b/server/tests/routes/place/utils_test.py
@@ -149,6 +149,7 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
     self.mock_place_url.side_effect = mock_url_for_side_effect
 
     self.mock_translate = self.patch(place_api, "gettext")
+    self.mock_v2node_paginated = self.patch(dc, "v2node_paginated")
     self.mock_v2node = self.patch(dc, "v2node")
 
     def fetch_translate(args, **kwargs):
@@ -173,7 +174,7 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
 
   def mock_v2node_api_data(self, response_list: list[dict]):
 
-    def mock_v2node_side_effect(nodes, props):
+    def mock_v2node_side_effect(nodes, props, *args, **kwargs):
       value = {
           "data":
               response_list[self.v2node_api_response_index % len(response_list)]
@@ -181,6 +182,7 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
       self.v2node_api_response_index += 1
       return value
 
+    self.mock_v2node_paginated.side_effect = mock_v2node_side_effect
     self.mock_v2node.side_effect = mock_v2node_side_effect
 
   def test_get_parent_places(self):


### PR DESCRIPTION
## Issue

[b/483800718](https://b.corp.google.com/issues/483800718)

## Description

The issue is that for maps that contain a large number of elements, Spanner's pagination was causing the choropleth to only partially display. This can be screen in the screenshots provided in this PR.

## Replication

This can be seen immediately in dev, where Spanner is in use: [Issue on dev](https://dev.datacommons.org/tools/map#%26sv%3DCount_Farm%26pc%3D0%26denom%3DCount_Person%26pd%3Dcountry%2FUSA%26ept%3DCounty).

You can replicate this locally be enabling Spanner on your local mixer and then instructing your Flask instance to use local mixer:

*  Ensure that in your local.yaml, you have `EnableV3` set to `true`, `UseSpannerGraph` set to `true`, and `V2DivertFraction` set to `1.0`.
* Run mixer, telling it to use local flags:

```
export MIXER_API_KEY={key}
./run_server.sh \
    --feature_flags_path=$PWD/deploy/featureflags/local.yaml \
    --spanner_graph_info="$(cat deploy/storage/spanner_graph_info.yaml)"
```
* Run `envoy` as per normal: `envoy -l warning --config-path esp/envoy-config.yaml`
* Run your Flask server, indicating that you want it to use local mixer: `./run_server.sh -m -l`

Now when you visit the above page locally when on master you will see the issue replicated as well.

[Issue on local master](http://localhost:8080/tools/map#%26sv%3DCount_Farm%26pc%3D0%26denom%3DCount_Person%26pd%3Dcountry%2FUSA%26ept%3DCounty)

When switched to this branch, the full chart should display, as it does on production, or when not using Spanner.

## Considerations

We wanted to solve this problem elegantly but with as small a blast radius as possible. One possibility would be to try to globally solve this by converting all calls to `v2/node` into calls to `v2/node_paginated`, but this would have far-reaching effects on the site, for a problem whose scope may be limited. If a global solution like that is ultimately needed, we may want to look at a solution on the Spanner side.

The more local solution is to ensure that maps, with their geojson, choropleths and at times very large numbers of items, display correctly with Spanner's current pagination limitation.

There is a core update, wrapping the property_values with a feature_flag (note that this parallels the `triples` call. This is wrapped in the migration feature flag. 

## Screenshots

### Without pagination
<img width="1029" height="668" alt="Screenshot 2026-04-08 at 5 12 43 PM" src="https://github.com/user-attachments/assets/36c77bbd-54a9-45f6-b50f-0c5e027b981d" />

### With pagination

<img width="1181" height="729" alt="Screenshot 2026-04-08 at 5 49 14 PM" src="https://github.com/user-attachments/assets/c24aca98-f42d-46e4-8cce-bb455b0661ef" />