### PR TITLE
Propagate feature flags in stat var hierarchy

### DIFF
--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -37,6 +37,7 @@ import {
   StatVarHierarchyType,
   StatVarInfo,
 } from "../shared/types";
+import { getUrlWithSearchParamsToPropagate } from "../utils/url_utils";
 import {
   StatVarHierarchyNodeHeader,
   StatVarHierarchyNodeHeaderPropType,
@@ -272,7 +273,7 @@ export class StatVarGroupNode extends React.Component<
       numEntitiesExistence = entityDcids.length;
     }
     axios
-      .post("/api/variable-group/info", {
+      .post(getUrlWithSearchParamsToPropagate("/api/variable-group/info"), {
         dcid: this.props.data.id,
         entities: entityDcids,
         numEntitiesExistence,

--- a/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_hierarchy.tsx
@@ -268,7 +268,7 @@ export class StatVarHierarchy extends React.Component<
           ? [statVarHierarchyConfigNode.dataSourceDcid]
           : [];
         return axios
-          .post("/api/variable-group/info", {
+          .post(getUrlWithSearchParamsToPropagate("/api/variable-group/info"), {
             dcid: statVarHierarchyConfigNode.dcid,
             entities: [...entityList, ...dataSourceEntities],
             numEntitiesExistence: this.props.numEntitiesExistence,


### PR DESCRIPTION
## Description

The API calls made by the frontend in the stat var hierarchy were not propagating the feature flags from the page's URL.

This meant that even if the v2 feature flag had been enabled/disabled via the command line, the API calls would not include that flag override, and the API call would use the primary configuration's feature flag setting.

## Testing

On master, this URL will result in v2 API calls (locally) via the Flask endpoint. On this branch, it will result in V1 calls.

[Stat var explorer](http://localhost:8080/tools/statvar?disable_feature=use_v2_api)

If autopush is still producing no values via the v2 call at the time this PR is reviewed, the difference between the master and this branch will be very apparent, as in master, this branch will not load the hierarchy.