### PR TITLE
[v0/v1 migration] [New ranking pages] Set Earth as the default place if missing.

### DIFF
--- a/server/routes/ranking/html.py
+++ b/server/routes/ranking/html.py
@@ -34,6 +34,7 @@ def ranking(stat_var, place_type, place_dcid=''):
     if place_name == '':
       place_name = place_dcid
   else:
+    place_dcid = 'Earth'
     place_name = 'the World'
   per_capita = flask.request.args.get('pc', False) != False
 

--- a/server/routes/ranking/html.py
+++ b/server/routes/ranking/html.py
@@ -35,6 +35,13 @@ def ranking(stat_var, place_type, place_dcid=''):
       place_name = place_dcid
   else:
     place_dcid = 'Earth'
+    # TODO(juliawu): Add localization for page titles that use "the World".
+    # Currently, when defaulting to "Earth" as the parent place, we don't localize the place name.
+    # This is because at the time of revamping the ranking pages, we were restricted to
+    # using already available translations, and we don't have translations in place for
+    # titles that use "the world" (with leading particle "the") for all locales. Localizing by using
+    # place_api.get_i18n_name("Earth") would not work because the resulting titles would be missing the
+    # leading "the" (e.g. "Top 100 in World" instead of "Top 100 in the World").
     place_name = 'the World'
   per_capita = flask.request.args.get('pc', False) != False
 

--- a/static/js/ranking/ranking.ts
+++ b/static/js/ranking/ranking.ts
@@ -22,14 +22,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { loadLocaleData } from "../i18n/i18n";
-import { EARTH_NAMED_TYPED_PLACE } from "../shared/constants";
 import { RankingPage } from "./ranking_page";
 
 window.addEventListener("load", (): void => {
   // Get page metadata
   const parentPlaceDcid =
-    document.getElementById("within-place-dcid").dataset.pwp ||
-    EARTH_NAMED_TYPED_PLACE.dcid;
+    document.getElementById("within-place-dcid").dataset.pwp;
   const childPlaceType = document.getElementById("place-type").dataset.pt;
   const parentPlaceNameLocalized =
     document.getElementById("place-name").dataset.pn; // Already localized by flask

--- a/static/js/ranking/ranking.ts
+++ b/static/js/ranking/ranking.ts
@@ -22,12 +22,14 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { loadLocaleData } from "../i18n/i18n";
+import { EARTH_NAMED_TYPED_PLACE } from "../shared/constants";
 import { RankingPage } from "./ranking_page";
 
 window.addEventListener("load", (): void => {
   // Get page metadata
   const parentPlaceDcid =
-    document.getElementById("within-place-dcid").dataset.pwp;
+    document.getElementById("within-place-dcid").dataset.pwp ||
+    EARTH_NAMED_TYPED_PLACE.dcid;
   const childPlaceType = document.getElementById("place-type").dataset.pt;
   const parentPlaceNameLocalized =
     document.getElementById("place-name").dataset.pn; // Already localized by flask


### PR DESCRIPTION
Fixes ranking pages that don't explicitly provide a parent place by defaulting to Earth.

## Context
Some ranking page URLs are broken when the new ranking pages are used, like https://autopush.datacommons.org/ranking/Count_Person/Country/. These are URLs where an explicit parent place for the ranking is not provided.

Trying to load the page results in an infinite spinner, and the console returns this error:
```
https://dev.datacommons.org/api/facets?entities=&variables=Count_Person: error: must provide a `entities` field
```

The problem was that the old `v1/place/ranking/` call would handle a missing parent place gracefully by defaulting to "Earth" in mixer. When we moved to v2/, we lost this functionality.

## Fix

This PR explicitly sets the parent place DCID to "Earth" in the flask route if it is not provided in the URL. This is done in flask as opposed to client-side to match the current approach to setting "in the world" as the default title.

## Testing strategy

Manual verification:
* Checkout this PR and spin up a local server at localhost:8080
* Go to http://localhost:8080/ranking/Count_Person/Country/ and verify that the page loads without issue.

## Screenshot:
<img width="2544" height="1372" alt="Screenshot 2026-04-23 at 10 46 13 AM" src="https://github.com/user-attachments/assets/f831d721-dbfd-44f0-8042-57cf79a355f1" />
