### PR TITLE
[v0/v1 migration] Upate stat var hierarchy to match behavior between Spanner and BT

### DIFF
--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -182,6 +182,8 @@ export class StatVarGroupNode extends React.Component<
         svgOnSvPath.add(path[level]);
       }
     }
+    // No filtering is active if no places, data sources, or entity count thresholds are indicated.
+    // In this case, we are in full hierarchy exploration mode.
     const noFilteringActive =
       this.props.entities.length === 0 &&
       !this.props.dataSource &&

--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -182,16 +182,22 @@ export class StatVarGroupNode extends React.Component<
         svgOnSvPath.add(path[level]);
       }
     }
-    const childSV = this.props.showAllSV
-      ? this.state.childSV
-      : this.state.childSV.filter(
-          (sv) => sv.hasData || sv.id in this.context.svPath
-        );
-    const childSVG = this.props.showAllSV
-      ? this.state.childSVG
-      : this.state.childSVG.filter((svg) => {
-          return svg.descendentStatVarCount > 0 || svgOnSvPath.has(svg.id);
-        });
+    const noFilteringActive =
+      this.props.entities.length === 0 &&
+      !this.props.dataSource &&
+      !this.props.numEntitiesExistence;
+    const childSV =
+      this.props.showAllSV || noFilteringActive
+        ? this.state.childSV.map((sv) => ({ ...sv, hasData: true }))
+        : this.state.childSV.filter(
+            (sv) => sv.hasData || sv.id in this.context.svPath
+          );
+    const childSVG =
+      this.props.showAllSV || noFilteringActive
+        ? this.state.childSVG
+        : this.state.childSVG.filter((svg) => {
+            return svg.descendentStatVarCount > 0 || svgOnSvPath.has(svg.id);
+          });
     const getTrigger = (
       opened: boolean
     ): React.CElement<

--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -186,19 +186,21 @@ export class StatVarGroupNode extends React.Component<
       this.props.entities.length === 0 &&
       !this.props.dataSource &&
       !this.props.numEntitiesExistence;
-    const childSV = noFilteringActive
-      ? this.state.childSV.map((sv) => ({ ...sv, hasData: true }))
-      : this.props.showAllSV
-      ? this.state.childSV
-      : this.state.childSV.filter(
-          (sv) => sv.hasData || sv.id in this.context.svPath
-        );
-    const childSVG =
-      this.props.showAllSV || noFilteringActive
-        ? this.state.childSVG
-        : this.state.childSVG.filter((svg) => {
-            return svg.descendentStatVarCount > 0 || svgOnSvPath.has(svg.id);
-          });
+    let childSV = this.state.childSV;
+    if (noFilteringActive) {
+      childSV = childSV.map((sv) => ({ ...sv, hasData: true }));
+    } else if (!this.props.showAllSV) {
+      childSV = childSV.filter(
+        (sv) => sv.hasData || sv.id in this.context.svPath
+      );
+    }
+
+    let childSVG = this.state.childSVG;
+    if (!this.props.showAllSV && !noFilteringActive) {
+      childSVG = childSVG.filter((svg) => {
+        return svg.descendentStatVarCount > 0 || svgOnSvPath.has(svg.id);
+      });
+    }
     const getTrigger = (
       opened: boolean
     ): React.CElement<

--- a/static/js/stat_var_hierarchy/stat_var_group_node.tsx
+++ b/static/js/stat_var_hierarchy/stat_var_group_node.tsx
@@ -186,12 +186,13 @@ export class StatVarGroupNode extends React.Component<
       this.props.entities.length === 0 &&
       !this.props.dataSource &&
       !this.props.numEntitiesExistence;
-    const childSV =
-      this.props.showAllSV || noFilteringActive
-        ? this.state.childSV.map((sv) => ({ ...sv, hasData: true }))
-        : this.state.childSV.filter(
-            (sv) => sv.hasData || sv.id in this.context.svPath
-          );
+    const childSV = noFilteringActive
+      ? this.state.childSV.map((sv) => ({ ...sv, hasData: true }))
+      : this.props.showAllSV
+      ? this.state.childSV
+      : this.state.childSV.filter(
+          (sv) => sv.hasData || sv.id in this.context.svPath
+        );
     const childSVG =
       this.props.showAllSV || noFilteringActive
         ? this.state.childSVG


### PR DESCRIPTION
## Issue

[b/505058380](https://b.corp.google.com/issues/505058380)

## Description

When mixer is using BigTable and using the bulk variable group info endpoint to construct the hierarchy, if no filtering is applied, then mixer hardcodes all items as having data. The reason for this may have been for efficiency purposes, but it does produce inaccurate results.  The Spanner flow is producing accurate results.

However, the stat var hierarchy relies on that behavior to show all stat vars, even those that have no data, as long as no filtering is applied.

When using Spanner, certain stat var groups were showing, but without their children, because of the differences in the results that the different databases were returning.

Because Spanner is returning more accurate results in this this case, in order to restore parity between the two, we have updated the frontend to explicitly mimic the BT behavior regardless of the database being used (rather than updating mixer to have Spanner mimic BT).

## Screenshot

### Spanner, before change

<img width="780" height="422" alt="7vJwAmrKmzRH5Fi" src="https://github.com/user-attachments/assets/4706ece5-fb4e-4158-be19-4bad24c9b4ff" />

### Spanner, after change

<img width="716" height="294" alt="image" src="https://github.com/user-attachments/assets/723c5a31-1f89-4572-8be7-ce8fabb5fc49" />

## Testing

When running locally, with spanner, the 12 UN Data Thematic Areas -> 1: Poverty and food security -> Inequality and social protection item exists, indicates that there is one child, but does not display that child.

In this branch, the child will appear (as it does when using V1).

[Stat Var Explorer](http://localhost:8080/tools/statvar)