### PR TITLE
[Gsutil to Gcloud] Reverting just the two commands in the Dockerfile.

### DIFF
--- a/build/cdc_data/Dockerfile
+++ b/build/cdc_data/Dockerfile
@@ -17,10 +17,10 @@
 FROM google/cloud-sdk:slim AS model-downloader
 
 # Copy model.
-RUN mkdir -p /tmp/datcom-nl-models \
-    && gsutil cp -r gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/
-
-
+RUN gcloud config set auth/disable_credentials True \
+    && mkdir -p /tmp/datcom-nl-models \
+    && gcloud storage cp --recursive gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/
+    
 # #### Stage 2: Python runtime. ####
 FROM python:3.11.14-slim AS runner
 

--- a/build/cdc_data/Dockerfile
+++ b/build/cdc_data/Dockerfile
@@ -18,7 +18,7 @@ FROM google/cloud-sdk:slim AS model-downloader
 
 # Copy model.
 RUN mkdir -p /tmp/datcom-nl-models \
-    && gcloud storage cp --recursive gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/
+    && gsutil cp -r gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/
 
 
 # #### Stage 2: Python runtime. ####

--- a/build/cdc_data/Dockerfile
+++ b/build/cdc_data/Dockerfile
@@ -16,6 +16,7 @@
 # #### Stage 1: Download base dc model from GCS. ####
 FROM google/cloud-sdk:slim AS model-downloader
 
+# Remove auth check since these are public buckets and we don't have credentials within the container.
 # Copy model.
 RUN gcloud config set auth/disable_credentials True \
     && mkdir -p /tmp/datcom-nl-models \

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -118,11 +118,14 @@ RUN npm run-script build
 # #### Stage 4: Download base dc model and embeddings from GCS. ####
 FROM --platform=linux/amd64 google/cloud-sdk:slim as download
 
+# Remove auth check since these are public buckets and we don't have credentials within the container.
 # Copy model and embeddings.
 RUN gcloud config set auth/disable_credentials True \
     && mkdir -p /tmp/datcom-nl-models \
-    && gcloud storage cp --recursive gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/ \
-    && gcloud storage cp gs://datcom-nl-models/embeddings_medium_2024_05_09_18_01_32.ft_final_v20230717230459.all-MiniLM-L6-v2.csv /tmp/datcom-nl-models/
+    && gcloud storage cp --recursive \
+        gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ \
+        gs://datcom-nl-models/embeddings_medium_2024_05_09_18_01_32.ft_final_v20230717230459.all-MiniLM-L6-v2.csv \
+        /tmp/datcom-nl-models/
 
 
 # #### Final stage: Runtime env. ####

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -119,9 +119,9 @@ RUN npm run-script build
 FROM --platform=linux/amd64 google/cloud-sdk:slim as download
 
 # Copy model and embeddings.
-RUN mkdir -p /tmp/datcom-nl-models \
-    && gsutil cp -r gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/ \
-    && gsutil cp gs://datcom-nl-models/embeddings_medium_2024_05_09_18_01_32.ft_final_v20230717230459.all-MiniLM-L6-v2.csv /tmp/datcom-nl-models/
+RUN gcloud config set auth/disable_credentials True \
+    && gcloud storage cp --recursive gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/ \
+    && gcloud storage cp gs://datcom-nl-models/embeddings_medium_2024_05_09_18_01_32.ft_final_v20230717230459.all-MiniLM-L6-v2.csv /tmp/datcom-nl-models/
 
 
 # #### Final stage: Runtime env. ####

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -120,8 +120,8 @@ FROM --platform=linux/amd64 google/cloud-sdk:slim as download
 
 # Copy model and embeddings.
 RUN mkdir -p /tmp/datcom-nl-models \
-    && gcloud storage cp --recursive gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/ \
-    && gcloud storage cp --recursive gs://datcom-nl-models/embeddings_medium_2024_05_09_18_01_32.ft_final_v20230717230459.all-MiniLM-L6-v2.csv /tmp/datcom-nl-models/
+    && gsutil cp -r gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/ \
+    && gsutil cp gs://datcom-nl-models/embeddings_medium_2024_05_09_18_01_32.ft_final_v20230717230459.all-MiniLM-L6-v2.csv /tmp/datcom-nl-models/
 
 
 # #### Final stage: Runtime env. ####

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -120,6 +120,7 @@ FROM --platform=linux/amd64 google/cloud-sdk:slim as download
 
 # Copy model and embeddings.
 RUN gcloud config set auth/disable_credentials True \
+    && mkdir -p /tmp/datcom-nl-models \
     && gcloud storage cp --recursive gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/ \
     && gcloud storage cp gs://datcom-nl-models/embeddings_medium_2024_05_09_18_01_32.ft_final_v20230717230459.all-MiniLM-L6-v2.csv /tmp/datcom-nl-models/
 


### PR DESCRIPTION
We needed to specify to run the gcloud storage cp command wihtout auth since these are public buckets and we dont expect the authentication passed in to the image.

Tested successfully.