### PR TITLE
Add /v2/bulk/info/variable-group to svg serviceGroup on website

### DIFF
--- a/deploy/helm_charts/dc_website/values.yaml
+++ b/deploy/helm_charts/dc_website/values.yaml
@@ -85,6 +85,7 @@ serviceGroups:
       - "/stat-var/*"
       - "/v1/variable/*"
       - "/v1/bulk/info/variable-group"
+      - "/v2/bulk/info/variable-group"
       - "/v1/bulk/info/variable"
     replicas: 1
     resources:


### PR DESCRIPTION
right now v2 is just a wrapper of v1 which needs the svg cache which is only part of svg service group