### PR TITLE
Hide the explore search bar from the stat var explorer and data download tools.

### DIFF
--- a/server/templates/tools/download.html
+++ b/server/templates/tools/download.html
@@ -18,6 +18,7 @@
 
 {% set is_hide_full_footer = true %}
 {% set title = "Download Tool" %}
+{% set is_hide_header_search_bar = true %}
 {% set main_id = 'main-download' %}
 {% set page_id = 'page-download' %}
 

--- a/server/templates/tools/stat_var.html
+++ b/server/templates/tools/stat_var.html
@@ -18,6 +18,7 @@
 
 {% set is_hide_full_footer = true %}
 {% set title = "Statistical Variable Explorer" %}
+{% set is_hide_header_search_bar = true %}
 
 {% block head %}
   <link rel="stylesheet" href={{url_for('static', filename='css/stat_var.min.css')}} >


### PR DESCRIPTION
## Issue

[b/508324881](b/508324881) [internal]

## Description

The three primary visualization tools  hide the search bar in the header. These are now extended to the stat var explorer and the data download tools.