### PR TITLE
[v0/v1 migration] Production flag flip

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -54,6 +54,12 @@
     "description": "Feature flag to show the complete metadata modal. If not set, the older modal will be used as a fallback."
   },
   {
+    "name": "new_ranking_page",
+    "enabled": true,
+    "owner": "juliawu",
+    "description": "Enables the new ranking page UI"
+  },
+  {
     "name": "standardized_vis_tool",
     "enabled": true,
     "owner": "juliawu",
@@ -61,7 +67,7 @@
   },
   {
     "name": "use_v2_api",
-    "enabled": false,
+    "enabled": true,
     "owner": "juliawu",
     "description": "Enables features that rely on the V2 REST APIs"
   },


### PR DESCRIPTION
## Description

This PR sets the `use_v2_api` flag in production to true, and adds in the `new_ranking_page` flag, also set to true.

With these flags flipped, the v2 migration functionality that was previously gated will now be active.

## Affected Functionality

### Flask

* `/v2/bulk/info/variable-group`: The server switches to this endpoint instead of /`v1/bulk/info/variable-group` to fetch statistical variable group information. It also enables the passing of the `includeDefinitions` parameter to retrieve definitions for variable groups.
* `/v2/bulk/info/variable`: The server switches to this endpoint instead of `/v1/bulk/info/variable` to fetch statistical variable information.
* `v1/variable/ancestors`: This endpoint is bypassed. Instead of calling that `v1` endpoint, we use `/v2/node`.
* `/api/stats/stat-var-search`: If VAI is enabled, this is used (as before). Otherwise, if we are a custom DC with embeddings, we use a new `v2` search implementation using `v2/resolve`. Otherwise the search is disabled.
* `property_values`: This is now paginated in the `v2` path (facilitating the loading of more data-heavy charts).

### Frontend

* Stat Var Explorer: The "Places Summary" is removed, in the sources list, "Release Frequency" is hidden and the tooltips are simplified (all intended turndowns based on changes in what we receive back from the APIs
* Stat Var Hierarchy: In the path described in the final Flask bullet point where search is disabled, the search box is hidden (in practice, this path is unlikely).
* The ranking pages are now replaced with the a new Ranking page that uses the ranking tile (and contains no `v0/v1` usage.