### PR TITLE
[v0/v1 migration] Production flag reversion

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -55,7 +55,7 @@
   },
   {
     "name": "new_ranking_page",
-    "enabled": true,
+    "enabled": false,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
   },
@@ -67,7 +67,7 @@
   },
   {
     "name": "use_v2_api",
-    "enabled": true,
+    "enabled": false,
     "owner": "juliawu",
     "description": "Enables features that rely on the V2 REST APIs"
   },


### PR DESCRIPTION
## Description

Temporary reversion of [6270](https://github.com/datacommonsorg/website/pull/6270) to debug mixer alerts.