### PR TITLE
Updated website cron testing image

### DIFF
--- a/build/ci/cloudbuild.cdc_autopush.yaml
+++ b/build/ci/cloudbuild.cdc_autopush.yaml
@@ -14,7 +14,7 @@
 
 steps:
   - id: run_tests
-    name: gcr.io/datcom-ci/webdriver-chrome:2025-12-23
+    name: gcr.io/datcom-ci/webdriver-chrome:2026-05-09
     entrypoint: /bin/sh
     waitFor: ["-"]
     args:

--- a/build/webdriver-chrome/Dockerfile
+++ b/build/webdriver-chrome/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.11.6
+FROM python:3.11
 COPY --from=ghcr.io/astral-sh/uv:0.9.18 /uv /uvx /bin/
 
 WORKDIR /resources

--- a/build/webdriver-chrome/Dockerfile
+++ b/build/webdriver-chrome/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.11
+FROM python:3.11.6
 COPY --from=ghcr.io/astral-sh/uv:0.9.18 /uv /uvx /bin/
 
 WORKDIR /resources

--- a/build/webdriver-chrome/cloudbuild.yaml
+++ b/build/webdriver-chrome/cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 substitutions:
-  _VERS: "2025-12-23"
+  _VERS: "2026-05-09"
 
 steps:
   - name: "gcr.io/cloud-builders/docker"

--- a/build/website_cron_testing/Dockerfile
+++ b/build/website_cron_testing/Dockerfile
@@ -14,8 +14,6 @@
 
 FROM gcr.io/datcom-ci/webdriver-chrome:2026-05-09
 
-RUN apt-get update && apt-get -y upgrade
-
 WORKDIR /resources
 
 # Install python requirements

--- a/build/website_cron_testing/Dockerfile
+++ b/build/website_cron_testing/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/datcom-ci/webdriver-chrome:2025-01-15
+FROM gcr.io/datcom-ci/webdriver-chrome:2026-05-09
+
+RUN apt-get update && apt-get -y upgrade
 
 WORKDIR /resources
 


### PR DESCRIPTION
This pull request updates the `webdriver-chrome` Docker image and its usage throughout the CI/CD pipeline to use a newer version, along with a minor base image change and a security update in the `website_cron_testing` image.

**Docker image version updates:**

* Updated the `webdriver-chrome` image version to `2026-05-09` in both the `cloudbuild.yaml` and `cloudbuild.cdc_autopush.yaml` files to ensure consistency across builds. **NOTE: This build is not yet published. I'll publish it once this PR is approved**


**Base image and security improvements:**

* Changed the Python base image in `webdriver-chrome/Dockerfile` from `python:3.11.6` to the more general `python:3.11` tag, which may pull the latest patch version.
* Added a step in `website_cron_testing/Dockerfile` to run `apt-get update && apt-get -y upgrade` for improved security and up-to-date system packages.