### PR TITLE
Remove vis tool feature flag from configs

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -84,12 +84,6 @@
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
   },
   {
-    "name": "standardized_vis_tool",
-    "enabled": true,
-    "owner": "juliawu",
-    "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
-  },
-  {
     "name": "use_v2_api",
     "enabled": true,
     "owner": "juliawu",

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -84,12 +84,6 @@
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
   },
   {
-    "name": "standardized_vis_tool",
-    "enabled": true,
-    "owner": "juliawu",
-    "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
-  },
-  {
     "name": "use_v2_api",
     "enabled": false,
     "owner": "juliawu",

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -84,12 +84,6 @@
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
   },
   {
-    "name": "standardized_vis_tool",
-    "enabled": true,
-    "owner": "juliawu",
-    "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
-  },
-  {
     "name": "use_v2_api",
     "enabled": true,
     "owner": "juliawu",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -84,12 +84,6 @@
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
   },
   {
-    "name": "standardized_vis_tool",
-    "enabled": true,
-    "owner": "juliawu",
-    "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
-  },
-  {
     "name": "use_v2_api",
     "enabled": true,
     "owner": "juliawu",

--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -60,12 +60,6 @@
     "description": "Enables the new ranking page UI"
   },
   {
-    "name": "standardized_vis_tool",
-    "enabled": true,
-    "owner": "juliawu",
-    "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
-  },
-  {
     "name": "use_v2_api",
     "enabled": false,
     "owner": "juliawu",

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -84,12 +84,6 @@
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
   },
   {
-    "name": "standardized_vis_tool",
-    "enabled": true,
-    "owner": "juliawu",
-    "description": "Enables standardized visualization tool UI for the /tool/map, /tool/scatter, and /tool/timeline pages"
-  },
-  {
     "name": "use_v2_api",
     "enabled": true,
     "owner": "juliawu",


### PR DESCRIPTION
Removes the `standardized_vis_tool` feature flag from feature flag config .json files.

# Context

All remaining code references to the `standardized_vis_tool` flag have been removed in https://github.com/datacommonsorg/website/pull/6240. That change has hit production in [release v23.4.10](https://github.com/datacommonsorg/website/releases/tag/v3.4.10) and [custom DC stable release](https://github.com/datacommonsorg/website/pull/6283).

This change completes the deprecation by removing the now-unused feature flag from our feature flag configs.