### PR TITLE
[DCP - Enable V2 API] Enable the V2 API on the website when USE_SPANNER is enabled.

### DIFF
--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -154,6 +154,7 @@ COPY --from=mixer /workspace/bin/ bin
 COPY --from=mixer /workspace/esp/ esp
 COPY --from=mixer /workspace/internal/ internal
 COPY --from=mixer /workspace/mixer-grpc.pb .
+COPY mixer/deploy/featureflags mixer/deploy/featureflags
 # nginx.
 COPY build/cdc_services/nginx.conf .
 # Website and NL servers.

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -154,7 +154,6 @@ COPY --from=mixer /workspace/bin/ bin
 COPY --from=mixer /workspace/esp/ esp
 COPY --from=mixer /workspace/internal/ internal
 COPY --from=mixer /workspace/mixer-grpc.pb .
-COPY mixer/deploy/featureflags mixer/deploy/featureflags
 # nginx.
 COPY build/cdc_services/nginx.conf .
 # Website and NL servers.

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -15,10 +15,6 @@
 
 set -e
 
-# Workaround for Go runtime.Caller path issue when mounting local binary
-# mkdir -p /workspace/mixer
-# ln -sf /workspace/internal /workspace/mixer/internal
-
 export MIXER_API_KEY=$DC_API_KEY
 # https://stackoverflow.com/a/62703850
 export TOKENIZERS_PARALLELISM=false

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -15,10 +15,6 @@
 
 set -e
 
-# Workaround for Go runtime.Caller path issue when mounting local binary
-mkdir -p /workspace/mixer
-ln -sf /workspace/internal /workspace/mixer/internal
-
 export MIXER_API_KEY=$DC_API_KEY
 # https://stackoverflow.com/a/62703850
 export TOKENIZERS_PARALLELISM=false

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -105,7 +105,7 @@ except Exception as e:
     SPANNER_CONFIG_YAML="{project: \"$GCP_PROJECT_ID\", instance: \"$GCP_SPANNER_INSTANCE_ID\", database: \"$GCP_SPANNER_DATABASE_NAME\"}"
     
     # 2. Enable V2 API for Mixer
-    MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true" "--feature_flags_path=/workspace/mixer/deploy/featureflags/custom.yaml")
+    MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true")
 fi
 
 # Start mixer.

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -15,6 +15,10 @@
 
 set -e
 
+# Workaround for Go runtime.Caller path issue when mounting local binary
+mkdir -p /workspace/mixer
+ln -sf /workspace/internal /workspace/mixer/internal
+
 export MIXER_API_KEY=$DC_API_KEY
 # https://stackoverflow.com/a/62703850
 export TOKENIZERS_PARALLELISM=false
@@ -72,8 +76,26 @@ if [[ $ENABLE_MODEL == "true" ]]; then
 fi
 
 if [[ $USE_SPANNER_GRAPH == "true" ]]; then
-    echo "Spanner Graph detected."
+    echo "Spanner Graph detected. Enabling V2 API for Website and Mixer."
     
+    # 1. Dynamically enable use_v2_api feature flag in custom.json for Website
+    # TODO: Delete this once every customer is on DCP, and we can just update custom.json.
+    python3 -c "
+import json
+path = 'server/config/feature_flag_configs/custom.json'
+try:
+    with open(path) as f:
+        data = json.load(f)
+    for flag in data:
+        if flag.get('name') == 'use_v2_api':
+            flag['enabled'] = True
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=2)
+    print('Successfully enabled use_v2_api in custom.json')
+except Exception as e:
+    print(f'Warning: Failed to auto-enable use_v2_api in custom.json: {e}')
+"
+
     # TODO: Rename this to existing GOOGLE_CLOUD_PROJECT.
     
     # Use existing GCP project ID, or fetch it from Metadata Server if empty
@@ -86,8 +108,8 @@ if [[ $USE_SPANNER_GRAPH == "true" ]]; then
     
     SPANNER_CONFIG_YAML="{project: \"$GCP_PROJECT_ID\", instance: \"$GCP_SPANNER_INSTANCE_ID\", database: \"$GCP_SPANNER_DATABASE_NAME\"}"
     
-    MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true")
-    # Until V2 APIs are enabled 100%, use the flag --use_v2_api=true on your docker run command
+    # 2. Enable V2 API for Mixer
+    MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true" "--use_v2_api=true")
 fi
 
 # Start mixer.

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -15,6 +15,10 @@
 
 set -e
 
+# Workaround for Go runtime.Caller path issue when mounting local binary
+# mkdir -p /workspace/mixer
+# ln -sf /workspace/internal /workspace/mixer/internal
+
 export MIXER_API_KEY=$DC_API_KEY
 # https://stackoverflow.com/a/62703850
 export TOKENIZERS_PARALLELISM=false
@@ -60,7 +64,7 @@ fi
 
 nginx -c /workspace/nginx.conf
 
-MIXER_ARGS=("--feature_flags_path=/workspace/mixer/deploy/featureflags/custom.yaml")
+MIXER_ARGS=()
 if [[ $ENABLE_MODEL == "true" ]]; then
     # Custom embeddings index built at 
     # https://github.com/datacommonsorg/website/blob/40111935bd6e564f8825c7abc1ccd920ea942aef/build/cdc_data/run.sh#L90-L94
@@ -105,7 +109,7 @@ except Exception as e:
     SPANNER_CONFIG_YAML="{project: \"$GCP_PROJECT_ID\", instance: \"$GCP_SPANNER_INSTANCE_ID\", database: \"$GCP_SPANNER_DATABASE_NAME\"}"
     
     # 2. Enable V2 API for Mixer
-    MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true")
+    MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true" "--feature_flags_path=/workspace/mixer/deploy/featureflags/custom.yaml")
 fi
 
 # Start mixer.

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -15,6 +15,10 @@
 
 set -e
 
+# Workaround for Go runtime.Caller path issue when mounting local binary
+# mkdir -p /workspace/mixer
+# ln -sf /workspace/internal /workspace/mixer/internal
+
 export MIXER_API_KEY=$DC_API_KEY
 # https://stackoverflow.com/a/62703850
 export TOKENIZERS_PARALLELISM=false
@@ -60,7 +64,7 @@ fi
 
 nginx -c /workspace/nginx.conf
 
-MIXER_ARGS=()
+MIXER_ARGS=("--feature_flags_path=/workspace/mixer/deploy/featureflags/custom.yaml")
 if [[ $ENABLE_MODEL == "true" ]]; then
     # Custom embeddings index built at 
     # https://github.com/datacommonsorg/website/blob/40111935bd6e564f8825c7abc1ccd920ea942aef/build/cdc_data/run.sh#L90-L94
@@ -105,7 +109,7 @@ except Exception as e:
     SPANNER_CONFIG_YAML="{project: \"$GCP_PROJECT_ID\", instance: \"$GCP_SPANNER_INSTANCE_ID\", database: \"$GCP_SPANNER_DATABASE_NAME\"}"
     
     # 2. Enable V2 API for Mixer
-    MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true" "--use_v2_api=true")
+    MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true")
 fi
 
 # Start mixer.


### PR DESCRIPTION
This PR copies over the default custom.yaml for custom DC mixer flags. note that this will only ever be used for DCP customers. 
CDC customers never had to use a custom.yaml file.

We also update the v2 api flag based on the use_spanner_graph variable. 

https://github.com/datacommonsorg/mixer/pull/1902 See 