### PR TITLE
Auto-iterate all /v2/node response pages

### DIFF
--- a/build/ci/cloudbuild.push_image.yaml
+++ b/build/ci/cloudbuild.push_image.yaml
@@ -38,11 +38,8 @@ steps:
         DOCKER_BUILDKIT=1
         # Bundle container with website, esp and mixer.
         docker build -f build/cdc_services/Dockerfile \
-          --tag gcr.io/$_PROJECT_ID/datacommons-services:${_TAG} \
-          --tag gcr.io/$_PROJECT_ID/datacommons-services:latest \
-          .
+          --tag gcr.io/$_PROJECT_ID/datacommons-services:${_TAG} .
         docker push gcr.io/$_PROJECT_ID/datacommons-services:${_TAG}
-        docker push gcr.io/$_PROJECT_ID/datacommons-services:latest
     waitFor: ["-"]
 
   - id: push-nl-server
@@ -76,11 +73,8 @@ steps:
         set -e
         DOCKER_BUILDKIT=1
         docker build -f build/website_cron_testing/Dockerfile \
-          --tag gcr.io/$_PROJECT_ID/website-cron-testing:${_TAG} \
-          --tag gcr.io/$_PROJECT_ID/website-cron-testing:latest \
-          .
+          --tag gcr.io/$_PROJECT_ID/website-cron-testing:${_TAG} .
         docker push gcr.io/$_PROJECT_ID/website-cron-testing:${_TAG}
-        docker push gcr.io/$_PROJECT_ID/website-cron-testing:latest
     waitFor: ["-"]
 
 timeout: 3600s

--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": true,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": true,
     "owner": "clincoln8",
@@ -42,6 +48,12 @@
     "description": "Enable stat var autocompletion in the NL Search bar"
   },
   {
+    "name": "enable_v2node_auto_iteration",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Auto-iterate all pages for v2node when no limit is specified"
+  },
+  {
     "name": "explore_result_header",
     "enabled": true,
     "owner": "nick-next",
@@ -58,12 +70,6 @@
     "enabled": false,
     "owner": "javiervazquez",
     "description": "Enables the follow up questions generated from related topics to general audience."
-  },
-  {
-    "name": "enable_gemini_3_flash",
-    "enabled": true,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
   },
   {
     "name": "metadata_modal",

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": false,
     "owner": "clincoln8",
@@ -42,6 +48,12 @@
     "description": "Enable stat var autocompletion in the NL Search bar"
   },
   {
+    "name": "enable_v2node_auto_iteration",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Auto-iterate all pages for v2node when no limit is specified"
+  },
+  {
     "name": "explore_result_header",
     "enabled": false,
     "owner": "nick-next",
@@ -58,12 +70,6 @@
     "enabled": false,
     "owner": "javiervazquez",
     "description": "Enables the follow up questions generated from related topics to general audience."
-  },
-  {
-    "name": "enable_gemini_3_flash",
-    "enabled": false,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
   },
   {
     "name": "metadata_modal",

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": false,
     "owner": "clincoln8",
@@ -42,6 +48,12 @@
     "description": "Enable stat var autocompletion in the NL Search bar"
   },
   {
+    "name": "enable_v2node_auto_iteration",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Auto-iterate all pages for v2node when no limit is specified"
+  },
+  {
     "name": "explore_result_header",
     "enabled": true,
     "owner": "nick-next",
@@ -58,12 +70,6 @@
     "enabled": true,
     "owner": "javiervazquez",
     "description": "Enables the follow up questions generated from related topics to general audience."
-  },
-  {
-    "name": "enable_gemini_3_flash",
-    "enabled": false,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
   },
   {
     "name": "metadata_modal",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": true,
     "owner": "clincoln8",
@@ -42,6 +48,12 @@
     "description": "Enable stat var autocompletion in the NL Search bar"
   },
   {
+    "name": "enable_v2node_auto_iteration",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Auto-iterate all pages for v2node when no limit is specified"
+  },
+  {
     "name": "explore_result_header",
     "enabled": true,
     "owner": "nick-next",
@@ -58,12 +70,6 @@
     "enabled": true,
     "owner": "javiervazquez",
     "description": "Enables the follow up questions generated from related topics to general audience."
-  },
-  {
-    "name": "enable_gemini_3_flash",
-    "enabled": false,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
   },
   {
     "name": "metadata_modal",

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": true,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": false,
     "owner": "clincoln8",
@@ -42,6 +48,12 @@
     "description": "Enable stat var autocompletion in the NL Search bar"
   },
   {
+    "name": "enable_v2node_auto_iteration",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Auto-iterate all pages for v2node when no limit is specified"
+  },
+  {
     "name": "explore_result_header",
     "enabled": true,
     "owner": "nick-next",
@@ -58,12 +70,6 @@
     "enabled": true,
     "owner": "javiervazquez",
     "description": "Enables the follow up questions generated from related topics to general audience."
-  },
-  {
-    "name": "enable_gemini_3_flash",
-    "enabled": true,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
   },
   {
     "name": "metadata_modal",

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -37,6 +37,7 @@ ENABLE_GEMINI_3_FLASH = 'enable_gemini_3_flash'
 USE_V2_API = 'use_v2_api'
 # This flag controls the switching of detect-and-fulfill API to use v2/resolve from current nl search vars
 USE_V2_RESOLVE_FOR_NL_SEARCH_VARS = 'use_v2_resolve_for_nl_search_vars'
+ENABLE_V2NODE_AUTO_ITERATION = 'enable_v2node_auto_iteration'
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:

--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -384,7 +384,7 @@ def properties(nodes, out=True):
   return result
 
 
-def property_values(nodes, prop, out=True, constraints='', max_pages=1):
+def property_values(nodes, prop, out=True, constraints='', max_pages=None):
   """Returns a compact property values data out of REST API response.
 
   The response is the following format:

--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -384,7 +384,11 @@ def properties(nodes, out=True):
   return result
 
 
-def property_values(nodes, prop, out=True, constraints='', max_pages=None):
+def property_values(nodes,
+                    prop,
+                    out=True,
+                    constraints='',
+                    max_pages=dc.DEFAULT_MAX_PAGES):
   """Returns a compact property values data out of REST API response.
 
   The response is the following format:

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -341,10 +341,10 @@ def _merge_v2node_response(result, paged_response):
 
 
 # Sentinel object to distinguish between default value and explicit None.
-_DEFAULT_MAX_PAGES = object()
+DEFAULT_MAX_PAGES = object()
 
 
-def v2node_paginated(nodes, prop, max_pages=_DEFAULT_MAX_PAGES):
+def v2node_paginated(nodes, prop, max_pages=DEFAULT_MAX_PAGES):
   """Wrapper to call V2 Node REST API.
 
     Args:
@@ -353,15 +353,15 @@ def v2node_paginated(nodes, prop, max_pages=_DEFAULT_MAX_PAGES):
         max_pages: The maximum number of pages to fetch. If None, v2node is
           queried until nextToken is not in the response.
     """
-  # We use a sentinel object (_DEFAULT_MAX_PAGES) as the default value to
+  # We use a sentinel object (DEFAULT_MAX_PAGES) as the default value to
   # distinguish between the caller not passing max_pages vs. explicitly
   # passing None.
   #
-  # - If caller does not pass max_pages, it gets _DEFAULT_MAX_PAGES. We then
+  # - If caller does not pass max_pages, it gets DEFAULT_MAX_PAGES. We then
   #   use the feature flag to decide the default behavior.
   # - If caller explicitly passes None, max_pages is None, and we preserve
   #   the behavior of auto-iterating all pages.
-  if max_pages is _DEFAULT_MAX_PAGES:
+  if max_pages is DEFAULT_MAX_PAGES:
     if is_feature_enabled(ENABLE_V2NODE_AUTO_ITERATION):
       max_pages = None  # New default: Auto-iterate all pages
     else:

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -30,6 +30,7 @@ from server.lib.cache import cache
 from server.lib.cache import memoize_and_log_mixer_usage
 from server.lib.cache import should_skip_cache
 import server.lib.config as libconfig
+from server.lib.feature_flags import ENABLE_V2NODE_AUTO_ITERATION
 from server.lib.feature_flags import is_feature_enabled
 from server.lib.feature_flags import USE_V2_API
 from server.routes import TIMEOUT
@@ -339,7 +340,11 @@ def _merge_v2node_response(result, paged_response):
     del result["nextToken"]
 
 
-def v2node_paginated(nodes, prop, max_pages=None):
+# Sentinel object to distinguish between default value and explicit None.
+_DEFAULT_MAX_PAGES = object()
+
+
+def v2node_paginated(nodes, prop, max_pages=_DEFAULT_MAX_PAGES):
   """Wrapper to call V2 Node REST API.
 
     Args:
@@ -348,6 +353,20 @@ def v2node_paginated(nodes, prop, max_pages=None):
         max_pages: The maximum number of pages to fetch. If None, v2node is
           queried until nextToken is not in the response.
     """
+  # We use a sentinel object (_DEFAULT_MAX_PAGES) as the default value to
+  # distinguish between the caller not passing max_pages vs. explicitly
+  # passing None.
+  #
+  # - If caller does not pass max_pages, it gets _DEFAULT_MAX_PAGES. We then
+  #   use the feature flag to decide the default behavior.
+  # - If caller explicitly passes None, max_pages is None, and we preserve
+  #   the behavior of auto-iterating all pages.
+  if max_pages is _DEFAULT_MAX_PAGES:
+    if is_feature_enabled(ENABLE_V2NODE_AUTO_ITERATION):
+      max_pages = None  # New default: Auto-iterate all pages
+    else:
+      max_pages = 1  # Old default: Fetch only 1 page
+
   fetched_pages = 0
   result = {}
   next_token = ""

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -339,7 +339,7 @@ def _merge_v2node_response(result, paged_response):
     del result["nextToken"]
 
 
-def v2node_paginated(nodes, prop, max_pages=1):
+def v2node_paginated(nodes, prop, max_pages=None):
   """Wrapper to call V2 Node REST API.
 
     Args:
@@ -361,8 +361,20 @@ def v2node_paginated(nodes, prop, max_pages=1):
     _merge_v2node_response(result, response)
     fetched_pages += 1
     next_token = response.get("nextToken", "")
-    if not next_token or (max_pages and fetched_pages >= max_pages):
+    
+    # Check if we should stop
+    if not next_token:
       break
+      
+    # Log if we are using the default (None) AND there is another page to fetch
+    if max_pages is None and fetched_pages == 1:
+      logging.warning(
+          "v2node_paginated: Hit default page limit for property '%s'. Auto-iterating all pages as requested.",
+          prop)
+          
+    if max_pages and fetched_pages >= max_pages:
+      break
+      
   return result
 
 

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -368,8 +368,8 @@ def v2node_paginated(nodes, prop, max_pages=None):
       
     # Log if we are using the default (None) AND there is another page to fetch
     if max_pages is None and fetched_pages == 1:
-      logging.warning(
-          "v2node_paginated: Hit default page limit for property '%s'. Auto-iterating all pages as requested.",
+      logger.warning(
+          "v2node_paginated: Property '%s' has multiple pages. Auto-iterating all pages as no limit was specified.",
           prop)
           
     if max_pages and fetched_pages >= max_pages:

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -380,20 +380,20 @@ def v2node_paginated(nodes, prop, max_pages=_DEFAULT_MAX_PAGES):
     _merge_v2node_response(result, response)
     fetched_pages += 1
     next_token = response.get("nextToken", "")
-    
+
     # Check if we should stop
     if not next_token:
       break
-      
+
     # Log if we are using the default (None) AND there is another page to fetch
     if max_pages is None and fetched_pages == 1:
       logger.warning(
           "v2node_paginated: Property '%s' has multiple pages. Auto-iterating all pages as no limit was specified.",
           prop)
-          
+
     if max_pages and fetched_pages >= max_pages:
       break
-      
+
   return result
 
 


### PR DESCRIPTION
* also ensures we don't publish to `:latest` tag for `cdc-services` when pushing dev images