### PR TITLE
[feature flags] Create nl_use_v2resolve

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": true,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": true,
     "owner": "clincoln8",
@@ -60,12 +66,6 @@
     "description": "Enables the follow up questions generated from related topics to general audience."
   },
   {
-    "name": "enable_gemini_3_flash",
-    "enabled": true,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
-  },
-  {
     "name": "metadata_modal",
     "enabled": true,
     "owner": "nick-next",
@@ -76,6 +76,12 @@
     "enabled": true,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
+  },
+  {
+    "name": "nl_use_v2resolve",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
   },
   {
     "name": "page_overview_ga",

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": false,
     "owner": "clincoln8",
@@ -60,12 +66,6 @@
     "description": "Enables the follow up questions generated from related topics to general audience."
   },
   {
-    "name": "enable_gemini_3_flash",
-    "enabled": false,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
-  },
-  {
     "name": "metadata_modal",
     "enabled": true,
     "owner": "nick-next",
@@ -76,6 +76,12 @@
     "enabled": false,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
+  },
+  {
+    "name": "nl_use_v2resolve",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
   },
   {
     "name": "page_overview_ga",

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": false,
     "owner": "clincoln8",
@@ -60,12 +66,6 @@
     "description": "Enables the follow up questions generated from related topics to general audience."
   },
   {
-    "name": "enable_gemini_3_flash",
-    "enabled": false,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
-  },
-  {
     "name": "metadata_modal",
     "enabled": true,
     "owner": "nick-next",
@@ -76,6 +76,12 @@
     "enabled": true,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
+  },
+  {
+    "name": "nl_use_v2resolve",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
   },
   {
     "name": "page_overview_ga",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": false,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": true,
     "owner": "clincoln8",
@@ -60,12 +66,6 @@
     "description": "Enables the follow up questions generated from related topics to general audience."
   },
   {
-    "name": "enable_gemini_3_flash",
-    "enabled": false,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
-  },
-  {
     "name": "metadata_modal",
     "enabled": true,
     "owner": "nick-next",
@@ -76,6 +76,12 @@
     "enabled": true,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
+  },
+  {
+    "name": "nl_use_v2resolve",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
   },
   {
     "name": "page_overview_ga",

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -24,6 +24,12 @@
     "description": "Adds the ability to deep link to bar charts, line charts, ranking and map charts"
   },
   {
+    "name": "enable_gemini_3_flash",
+    "enabled": true,
+    "owner": "shixiao",
+    "description": "Enables Gemini 3 Flash for NL detection."
+  },
+  {
     "name": "enable_nl_agent_detector",
     "enabled": false,
     "owner": "clincoln8",
@@ -60,12 +66,6 @@
     "description": "Enables the follow up questions generated from related topics to general audience."
   },
   {
-    "name": "enable_gemini_3_flash",
-    "enabled": true,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
-  },
-  {
     "name": "metadata_modal",
     "enabled": true,
     "owner": "nick-next",
@@ -76,6 +76,12 @@
     "enabled": true,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
+  },
+  {
+    "name": "nl_use_v2resolve",
+    "enabled": false,
+    "owner": "calinc",
+    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
   },
   {
     "name": "page_overview_ga",

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -37,6 +37,8 @@ ENABLE_GEMINI_3_FLASH = 'enable_gemini_3_flash'
 USE_V2_API = 'use_v2_api'
 # This flag controls the switching of detect-and-fulfill API to use v2/resolve from current nl search vars
 USE_V2_RESOLVE_FOR_NL_SEARCH_VARS = 'use_v2_resolve_for_nl_search_vars'
+NL_USE_V2RESOLVE_FEATURE_FLAG = 'nl_use_v2resolve'
+
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -40,7 +40,6 @@ USE_V2_RESOLVE_FOR_NL_SEARCH_VARS = 'use_v2_resolve_for_nl_search_vars'
 NL_USE_V2RESOLVE_FEATURE_FLAG = 'nl_use_v2resolve'
 
 
-
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:
   """Check if a URL param to manually enable a feature is present.
 


### PR DESCRIPTION
This flag will be used to divert detect-and-fufill to use v2resolve instead of direct nl server calls.