### PR TITLE
Enable all-page fetch for StatVar properties in detect-and-fulfill

### DIFF
--- a/server/lib/nl/common/variable.py
+++ b/server/lib/nl/common/variable.py
@@ -23,6 +23,7 @@ import server.lib.fetch as fetch
 import server.lib.nl.common.constants as constants
 import server.lib.nl.common.topic as topic
 import server.lib.nl.common.utils as utils
+from server.lib.feature_flags import is_feature_enabled, ENABLE_NL_V2NODE_FETCHALL
 from server.lib.nl.explore.params import DCNames
 import server.lib.shared as shared
 import server.services.datacommons as dc
@@ -31,6 +32,8 @@ import server.services.datacommons as dc
 EXTENSION_SV_PRE_EXISTENCE_CHECK_LIMIT = 50
 # This is the number that we want to fit in a bar chart.
 EXTENSION_SV_POST_EXISTENCE_CHECK_LIMIT = 15
+
+DEFAULT_MAX_PAGES = 1
 
 
 @dataclass
@@ -132,9 +135,10 @@ def _fetch_indirect_siblings(
   # Batch 1: Fetch parents for all identified SVGs
   svgs_to_expand = list({sv2svg[sv] for sv in svs_needing_indirect})
   parents_resp = {}
+  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
   if svgs_to_expand:
     parents_resp = fetch.property_values(svgs_to_expand, "specializationOf",
-                                         True)
+                                         True, max_pages=max_pages)
 
   # Collect parents
   svg_to_parent = {}
@@ -150,7 +154,7 @@ def _fetch_indirect_siblings(
   siblings_resp = {}
   if all_parents:
     siblings_resp = fetch.property_values(all_parents, "specializationOf",
-                                          False)
+                                          False, max_pages=max_pages)
 
   # Collect all sibling SVGs
   parent_to_siblings = {}
@@ -196,7 +200,8 @@ def extend_svs(svs: List[str]):
   """
   if not svs:
     return {}
-  sv2svgs = fetch.property_values(svs, "memberOf", True)
+  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  sv2svgs = fetch.property_values(svs, "memberOf", True, max_pages=max_pages)
   sv2svg = {sv: svg[0] for sv, svg in sv2svgs.items() if svg}
   svg2childsvs = {}
   if not sv2svg:
@@ -285,7 +290,8 @@ def extend_svs(svs: List[str]):
 def get_sv_name(all_svs: List[str],
                 sv_chart_titles: Dict,
                 dc: str = DCNames.MAIN_DC.value) -> Dict:
-  sv2name_raw = fetch.property_values(all_svs, 'name')
+  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  sv2name_raw = fetch.property_values(all_svs, 'name', max_pages=max_pages)
   uncurated_names = {
       sv: names[0] if names else sv for sv, names in sv2name_raw.items()
   }
@@ -330,7 +336,8 @@ def get_sv_unit(all_svs: List[str]) -> Dict:
 
 
 def get_sv_description(all_svs: List[str]) -> Dict:
-  sv2desc_dc = fetch.property_values(all_svs, 'description')
+  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  sv2desc_dc = fetch.property_values(all_svs, 'description', max_pages=max_pages)
   sv2desc_dc = {sv: desc[0] if desc else '' for sv, desc in sv2desc_dc.items()}
   sv_desc_map = {}
   for sv in all_svs:
@@ -344,7 +351,8 @@ def get_sv_description(all_svs: List[str]) -> Dict:
 
 
 def get_sv_footnote(all_svs: List[str]) -> Dict:
-  sv2footnote_raw = fetch.property_values(all_svs, 'footnote')
+  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  sv2footnote_raw = fetch.property_values(all_svs, 'footnote', max_pages=max_pages)
   uncurated_footnotes = {
       sv: footnotes[0] if footnotes else ''
       for sv, footnotes in sv2footnote_raw.items()

--- a/server/lib/nl/common/variable.py
+++ b/server/lib/nl/common/variable.py
@@ -37,6 +37,12 @@ EXTENSION_SV_POST_EXISTENCE_CHECK_LIMIT = 15
 DEFAULT_MAX_PAGES = 1
 
 
+def _get_max_pages() -> int | None:
+  """Returns the max pages to fetch based on the fetchall feature flag."""
+  return None if is_feature_enabled(
+      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+
+
 @dataclass
 class SV:
   id: str
@@ -136,8 +142,7 @@ def _fetch_indirect_siblings(
   # Batch 1: Fetch parents for all identified SVGs
   svgs_to_expand = list({sv2svg[sv] for sv in svs_needing_indirect})
   parents_resp = {}
-  max_pages = None if is_feature_enabled(
-      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  max_pages = _get_max_pages()
   if svgs_to_expand:
     parents_resp = fetch.property_values(svgs_to_expand,
                                          "specializationOf",
@@ -206,8 +211,7 @@ def extend_svs(svs: List[str]):
   """
   if not svs:
     return {}
-  max_pages = None if is_feature_enabled(
-      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  max_pages = _get_max_pages()
   sv2svgs = fetch.property_values(svs, "memberOf", True, max_pages=max_pages)
   sv2svg = {sv: svg[0] for sv, svg in sv2svgs.items() if svg}
   svg2childsvs = {}
@@ -297,8 +301,7 @@ def extend_svs(svs: List[str]):
 def get_sv_name(all_svs: List[str],
                 sv_chart_titles: Dict,
                 dc: str = DCNames.MAIN_DC.value) -> Dict:
-  max_pages = None if is_feature_enabled(
-      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  max_pages = _get_max_pages()
   sv2name_raw = fetch.property_values(all_svs, 'name', max_pages=max_pages)
   uncurated_names = {
       sv: names[0] if names else sv for sv, names in sv2name_raw.items()
@@ -344,8 +347,7 @@ def get_sv_unit(all_svs: List[str]) -> Dict:
 
 
 def get_sv_description(all_svs: List[str]) -> Dict:
-  max_pages = None if is_feature_enabled(
-      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  max_pages = _get_max_pages()
   sv2desc_dc = fetch.property_values(all_svs,
                                      'description',
                                      max_pages=max_pages)
@@ -362,8 +364,7 @@ def get_sv_description(all_svs: List[str]) -> Dict:
 
 
 def get_sv_footnote(all_svs: List[str]) -> Dict:
-  max_pages = None if is_feature_enabled(
-      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  max_pages = _get_max_pages()
   sv2footnote_raw = fetch.property_values(all_svs,
                                           'footnote',
                                           max_pages=max_pages)

--- a/server/lib/nl/common/variable.py
+++ b/server/lib/nl/common/variable.py
@@ -19,11 +19,12 @@ from typing import Dict, List, Set, Tuple
 
 from flask import current_app
 
+from server.lib.feature_flags import ENABLE_NL_V2NODE_FETCHALL
+from server.lib.feature_flags import is_feature_enabled
 import server.lib.fetch as fetch
 import server.lib.nl.common.constants as constants
 import server.lib.nl.common.topic as topic
 import server.lib.nl.common.utils as utils
-from server.lib.feature_flags import is_feature_enabled, ENABLE_NL_V2NODE_FETCHALL
 from server.lib.nl.explore.params import DCNames
 import server.lib.shared as shared
 import server.services.datacommons as dc
@@ -135,10 +136,13 @@ def _fetch_indirect_siblings(
   # Batch 1: Fetch parents for all identified SVGs
   svgs_to_expand = list({sv2svg[sv] for sv in svs_needing_indirect})
   parents_resp = {}
-  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  max_pages = None if is_feature_enabled(
+      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
   if svgs_to_expand:
-    parents_resp = fetch.property_values(svgs_to_expand, "specializationOf",
-                                         True, max_pages=max_pages)
+    parents_resp = fetch.property_values(svgs_to_expand,
+                                         "specializationOf",
+                                         True,
+                                         max_pages=max_pages)
 
   # Collect parents
   svg_to_parent = {}
@@ -153,8 +157,10 @@ def _fetch_indirect_siblings(
   # Batch 2: Fetch siblings for all parents
   siblings_resp = {}
   if all_parents:
-    siblings_resp = fetch.property_values(all_parents, "specializationOf",
-                                          False, max_pages=max_pages)
+    siblings_resp = fetch.property_values(all_parents,
+                                          "specializationOf",
+                                          False,
+                                          max_pages=max_pages)
 
   # Collect all sibling SVGs
   parent_to_siblings = {}
@@ -200,7 +206,8 @@ def extend_svs(svs: List[str]):
   """
   if not svs:
     return {}
-  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  max_pages = None if is_feature_enabled(
+      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
   sv2svgs = fetch.property_values(svs, "memberOf", True, max_pages=max_pages)
   sv2svg = {sv: svg[0] for sv, svg in sv2svgs.items() if svg}
   svg2childsvs = {}
@@ -290,7 +297,8 @@ def extend_svs(svs: List[str]):
 def get_sv_name(all_svs: List[str],
                 sv_chart_titles: Dict,
                 dc: str = DCNames.MAIN_DC.value) -> Dict:
-  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  max_pages = None if is_feature_enabled(
+      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
   sv2name_raw = fetch.property_values(all_svs, 'name', max_pages=max_pages)
   uncurated_names = {
       sv: names[0] if names else sv for sv, names in sv2name_raw.items()
@@ -336,8 +344,11 @@ def get_sv_unit(all_svs: List[str]) -> Dict:
 
 
 def get_sv_description(all_svs: List[str]) -> Dict:
-  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
-  sv2desc_dc = fetch.property_values(all_svs, 'description', max_pages=max_pages)
+  max_pages = None if is_feature_enabled(
+      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  sv2desc_dc = fetch.property_values(all_svs,
+                                     'description',
+                                     max_pages=max_pages)
   sv2desc_dc = {sv: desc[0] if desc else '' for sv, desc in sv2desc_dc.items()}
   sv_desc_map = {}
   for sv in all_svs:
@@ -351,8 +362,11 @@ def get_sv_description(all_svs: List[str]) -> Dict:
 
 
 def get_sv_footnote(all_svs: List[str]) -> Dict:
-  max_pages = None if is_feature_enabled(ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
-  sv2footnote_raw = fetch.property_values(all_svs, 'footnote', max_pages=max_pages)
+  max_pages = None if is_feature_enabled(
+      ENABLE_NL_V2NODE_FETCHALL) else DEFAULT_MAX_PAGES
+  sv2footnote_raw = fetch.property_values(all_svs,
+                                          'footnote',
+                                          max_pages=max_pages)
   uncurated_footnotes = {
       sv: footnotes[0] if footnotes else ''
       for sv, footnotes in sv2footnote_raw.items()

--- a/server/tests/lib/nl/variable_test.py
+++ b/server/tests/lib/nl/variable_test.py
@@ -83,7 +83,7 @@ class TestVariableExtension(unittest.TestCase):
     sibling_svg = "dc/g/Person_PovertyStatus_Male"
 
     # Property values side effect to handle the multi-stage traversal
-    def property_values_side_effect(nodes, prop, out=True):
+    def property_values_side_effect(nodes, prop, out=True, **kwargs):
       if prop == "memberOf" and out:
         # Initial direct group lookup
         return {sv: [svg]}


### PR DESCRIPTION
StatVar names were falling back to DCIDs when requesting properties for large lists because the results were being truncated by the default Spanner page size limit of 500.

This PR conditionally enables fetching all pages for `property_values` calls in variable.py, controlled by the `enable_nl_v2node_fetchall` feature flag