### PR TITLE
Fix slow local startup caused by secret manager initialization

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -52,6 +52,8 @@ BLOCKLIST_SVG_FILE = "/datacommons/svg/blocklist_svg.json"
 
 DEFAULT_NL_ROOT = "http://127.0.0.1:6060"
 
+# Module-level singleton for the Secret Manager client.
+# Lazily initialized and used by _get_api_key() to avoid repeated initialization.
 _secret_client = None
 
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -52,6 +52,8 @@ BLOCKLIST_SVG_FILE = "/datacommons/svg/blocklist_svg.json"
 
 DEFAULT_NL_ROOT = "http://127.0.0.1:6060"
 
+_secret_client = None
+
 
 def _get_api_key(env_keys=[], gcp_project='', gcp_path=''):
   """Gets an api key first from the environment, then from GCP secrets.
@@ -72,7 +74,11 @@ def _get_api_key(env_keys=[], gcp_project='', gcp_path=''):
   # Try to get the key from secrets
   if gcp_project and gcp_path:
     try:
-      secret_client = secretmanager.SecretManagerServiceClient()
+      global _secret_client
+      if not _secret_client:
+        _secret_client = secretmanager.SecretManagerServiceClient(
+            transport="rest")
+      secret_client = _secret_client
       secret_name = secret_client.secret_version_path(gcp_project, gcp_path,
                                                       'latest')
       secret_response = secret_client.access_secret_version(name=secret_name)


### PR DESCRIPTION
## Issue
b/516817315

## Description

Following an update to `grpcio` from `1.76.0` to `1.80.0`, we started to see a major lag in Flask server startup when running locally on MacOS.

For reference, the grpcio update was in [Website: 6172](https://github.com/datacommonsorg/website/pull/6172). It was effected because of a major vulnerability in a library that used `grpcio` as a dependency.

This change likely altered behavior in terms of default timeouts, retry policies, etc, in such a way that the observed delay began to manifest.

## The Fix

There are two parts to this fix. One is to refactor the secret manager client to a singleton. The pattern used here is similar to that found in `server/lib/vertex_ai.py` (without the threading locking as this only occurs on server start up).

This does solve the problem in itself, but produced warnings because of how Flask works in debug mode. It forks a child worker for actually serving the requests (with the master monitoring the file system for changes, among other things). The gRPC connections are long-lived and are forked along with the child worker, causing a warning in the underlying library that this is not safe. 

The second part to the fix is to switch the transport to rest. This fixes the problem even without the refactoring (as well as the above issue with refactoring, because the rest requests are stateless and do not maintain a persistent connection, and so have no fork safety issues.