### PR TITLE
Turn on v2 API in production

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -55,13 +55,13 @@
   },
   {
     "name": "new_ranking_page",
-    "enabled": true,
+    "enabled": false,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
   },
   {
     "name": "use_v2_api",
-    "enabled": false,
+    "enabled": true,
     "owner": "juliawu",
     "description": "Enables features that rely on the V2 REST APIs"
   },


### PR DESCRIPTION
Turns ON the `use_v2_api` feature flag in production.