### PR TITLE
Turn off v2 API on prod

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -61,7 +61,7 @@
   },
   {
     "name": "use_v2_api",
-    "enabled": true,
+    "enabled": false,
     "owner": "juliawu",
     "description": "Enables features that rely on the V2 REST APIs"
   },


### PR DESCRIPTION
Reverts #6317 and turns off the `use_v2_api` flag in production.