### PR TITLE
Fix contained related places when pagination occurs

### DIFF
--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -453,7 +453,7 @@ def multiple_property_values(nodes: List[str],
   return result
 
 
-def raw_property_values(nodes, prop, out=True, constraints=''):
+def raw_property_values(nodes, prop, out=True, constraints='', max_pages=1):
   """Returns full property values data out of REST API response.
 
   The response is the following format:
@@ -470,8 +470,16 @@ def raw_property_values(nodes, prop, out=True, constraints=''):
   }
 
   """
-  resp = dc.v2node(nodes, '{}{}{}'.format('->' if out else '<-', prop,
-                                          constraints))
+  from server.lib.feature_flags import is_feature_enabled
+  from server.lib.feature_flags import USE_V2_API
+
+  if is_feature_enabled(USE_V2_API):
+    resp = dc.v2node_paginated(
+        nodes, '{}{}{}'.format('->' if out else '<-', prop, constraints),
+        max_pages)
+  else:
+    resp = dc.v2node(nodes, '{}{}{}'.format('->' if out else '<-', prop,
+                                            constraints))
   result = {}
   for node, node_arcs in resp.get('data', {}).items():
     result[node] = node_arcs.get('arcs', {}).get(prop, {}).get('nodes', [])

--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -454,7 +454,7 @@ def multiple_property_values(nodes: List[str],
 
 
 def raw_property_values(nodes, prop, out=True, constraints='', max_pages=1):
-  """Returns full property values data out of REST API response.
+  """Returns raw property value dictionaries from the REST API, fetching up to max_pages of results.
 
   The response is the following format:
   {

--- a/server/routes/place/api.py
+++ b/server/routes/place/api.py
@@ -149,23 +149,17 @@ async def related_places(place_dcid: str):
   place = place_utils.fetch_place(place_dcid, g.locale)
 
   # Fetch the child place types, find type to highlight.
-  ordered_child_place_types = await asyncio.to_thread(
-      place_utils.get_child_place_types, place)
+  ordered_child_place_types, child_places_by_type = await asyncio.to_thread(
+      place_utils.get_child_places_by_type, place)
   primary_child_place_type = ordered_child_place_types[
       0] if ordered_child_place_types else None
 
   async def get_related_place_dcids_async(
-      place: Place
-  ) -> tuple[list[str], list[str], list[Place], list[str], list[list[str]]]:
+      place: Place) -> tuple[list[str], list[str], list[Place], list[str]]:
     """Helper function to execute asynchronously the calls to fetch the DCIDs
-     for the child places, nearby places, similar places, parent places and peer places within parent.
+     for nearby places, similar places, parent places and peer places within parent.
      Returns lists of DCIDs or Places for each type of related places."""
 
-    child_tasks = [
-        asyncio.to_thread(place_utils.fetch_child_place_dcids, place,
-                          child_place_type)
-        for child_place_type in ordered_child_place_types
-    ]
     nearby_task = asyncio.to_thread(place_utils.fetch_nearby_place_dcids, place,
                                     g.locale)
     similar_task = asyncio.to_thread(place_utils.fetch_similar_place_dcids,
@@ -175,14 +169,18 @@ async def related_places(place_dcid: str):
     peers_within_parent_task = asyncio.to_thread(
         place_utils.fetch_peer_places_within, place.dcid, place.types)
 
-    nearby_place_dcids, similar_place_dcids, parent_places, peers_within_parent, *child_results = await asyncio.gather(
-        nearby_task, similar_task, parent_places_task, peers_within_parent_task,
-        *child_tasks)
-    return nearby_place_dcids, similar_place_dcids, parent_places, peers_within_parent, *child_results
+    nearby_place_dcids, similar_place_dcids, parent_places, peers_within_parent = await asyncio.gather(
+        nearby_task, similar_task, parent_places_task, peers_within_parent_task)
+    return nearby_place_dcids, similar_place_dcids, parent_places, peers_within_parent
 
-  # Fetches nearby, similar, parent, peers within parent, and child places concurrently.
-  nearby_place_dcids, similar_place_dcids, parent_places, peers_within_parent, *child_results = await get_related_place_dcids_async(
+  # Fetches nearby, similar, parent, and peers within parent concurrently.
+  nearby_place_dcids, similar_place_dcids, parent_places, peers_within_parent = await get_related_place_dcids_async(
       place)
+
+  # Populate child_results from the data fetched by get_child_places_by_type
+  child_results = [
+      child_places_by_type.get(t, []) for t in ordered_child_place_types
+  ]
 
   # Dedupes the child places but preserves ordering.
   child_place_dcids = place_utils.dedupe_preserve_order(child_results)

--- a/server/routes/place/utils.py
+++ b/server/routes/place/utils.py
@@ -668,6 +668,72 @@ def get_child_place_types(place: Place) -> list[str]:
   return []
 
 
+# TODO(nick-nlb): look at other uses of the very similar get_child_place_types, and migrate them
+#                 to use this function instead.
+def get_child_places_by_type(
+    place: Place) -> Tuple[List[str], Dict[str, List[str]]]:
+  """
+  Determines the child place types for a given place and returns a tuple containing the
+  matched types and the places grouped by type.
+  """
+  ordered_child_place_types = []
+  # Attempt to directly match a child place type using the custom expressions.
+  for f in PLACE_MATCH_EXPRESSIONS:
+    matched_child_place_type = f(place)
+    if matched_child_place_type:
+      ordered_child_place_types = [matched_child_place_type]
+      break
+
+  if not ordered_child_place_types:
+    # Determine the order of child place types based on the parent type.
+    ordered_child_place_types = DEFAULT_CHILD_PLACE_TYPES
+    for place_type in place.types:
+      if place_type in PLACE_TYPES_TO_CHILD_PLACE_TYPES:
+        ordered_child_place_types = PLACE_TYPES_TO_CHILD_PLACE_TYPES[place_type]
+        break
+
+  # Construct constraint to filter by expected child types.
+  child_types_str = ",".join(ordered_child_place_types)
+  constraints = f"{{typeOf:[{child_types_str}]}}"
+
+  # Fetch child places matching the expected types for the given place.
+  raw_property_values_response = fetch.raw_property_values(
+      nodes=[place.dcid],
+      prop="containedInPlace+",
+      out=False,
+      constraints=constraints,
+      max_pages=None)
+
+  # Collect all types of child places found in the property values response.
+  child_place_types = set()
+  type_to_dcids = {}
+  for raw_property_value in raw_property_values_response.get(place.dcid, []):
+    dcid = raw_property_value.get("dcid")
+    if not dcid:
+      continue
+    types = raw_property_value.get("types", [])
+    child_place_types.update(types)
+    for t in types:
+      if t not in type_to_dcids:
+        type_to_dcids[t] = []
+      type_to_dcids[t].append(dcid)
+
+  child_place_type_candidates = []
+  # Return the child place types that match the ordered list of possible child types.
+  for place_type_candidate in ordered_child_place_types:
+    if place_type_candidate in child_place_types:
+      child_place_type_candidates.append(place_type_candidate)
+
+  # Filter the map to only include candidates
+  filtered_type_to_dcids = {
+      t: type_to_dcids[t]
+      for t in child_place_type_candidates
+      if t in type_to_dcids
+  }
+
+  return child_place_type_candidates, filtered_type_to_dcids
+
+
 def get_child_place_type_to_highlight(place: Place) -> str:
   """Returns the child place type to highlight"""
   ordered_child_place_types = get_child_place_types(place)

--- a/server/routes/place/utils.py
+++ b/server/routes/place/utils.py
@@ -631,16 +631,24 @@ def get_child_place_types(place: Place) -> list[str]:
     if matched_child_place_type:
       return [matched_child_place_type]
 
-  # Fetch all possible child places for the given place using its containment property.
-  raw_property_values_response = fetch.raw_property_values(
-      nodes=[place.dcid], prop="containedInPlace", out=False)
-
   # Determine the order of child place types based on the parent type.
   ordered_child_place_types = DEFAULT_CHILD_PLACE_TYPES
   for place_type in place.types:
     if place_type in PLACE_TYPES_TO_CHILD_PLACE_TYPES:
       ordered_child_place_types = PLACE_TYPES_TO_CHILD_PLACE_TYPES[place_type]
       break
+
+  # Construct constraint to filter by expected child types.
+  child_types_str = ",".join(ordered_child_place_types)
+  constraints = f"{{typeOf:[{child_types_str}]}}"
+
+  # Fetch child places matching the expected types for the given place.
+  raw_property_values_response = fetch.raw_property_values(
+      nodes=[place.dcid],
+      prop="containedInPlace",
+      out=False,
+      constraints=constraints,
+      max_pages=None)
 
   # Collect all types of child places found in the property values response.
   child_place_types = set()

--- a/server/tests/routes/place/mock_data.py
+++ b/server/tests/routes/place/mock_data.py
@@ -116,14 +116,7 @@ def create_contained_in_data(types_list):
 
 
 def create_contained_in_data_from_places(places: List[Place]) -> Dict[str, any]:
-  """Creates mock containedInPlace data from a list of Place objects.
-
-  Args:
-    places: List of Place objects.
-
-  Returns:
-    Mock data structure for containedInPlace.
-  """
+  """Creates mock containedInPlace data from a list of Place objects."""
   data = {
       "arcs": {
           "containedInPlace": {

--- a/server/tests/routes/place/mock_data.py
+++ b/server/tests/routes/place/mock_data.py
@@ -115,6 +115,34 @@ def create_contained_in_data(types_list):
   return data
 
 
+def create_contained_in_data_from_places(places: List[Place]) -> Dict[str, any]:
+  """Creates mock containedInPlace data from a list of Place objects.
+
+  Args:
+    places: List of Place objects.
+
+  Returns:
+    Mock data structure for containedInPlace.
+  """
+  data = {
+      "arcs": {
+          "containedInPlace": {
+              "nodes": []
+          },
+          "containedInPlace+": {
+              "nodes": []
+          }
+      }
+  }
+
+  for place in places:
+    node = {"dcid": place.dcid, "types": place.types}
+    data["arcs"]["containedInPlace"]["nodes"].append(node)
+    data["arcs"]["containedInPlace+"]["nodes"].append(node)
+
+  return data
+
+
 def mock_dc_api_data(stat_var: str,
                      places: List[str],
                      dc_obs_point: bool = False,

--- a/server/tests/routes/place/related_places_test.py
+++ b/server/tests/routes/place/related_places_test.py
@@ -19,10 +19,10 @@ from unittest import mock
 from flask import Flask
 from flask import g
 from flask import jsonify
-from flask_caching import Cache
 import pytest
 
 from server.lib import fetch
+from server.lib.cache import cache
 from server.routes.place import api
 from server.routes.place.types import Place
 from server.routes.place.types import RelatedPlacesApiResponse
@@ -62,14 +62,14 @@ class TestRelatedPlaces(unittest.IsolatedAsyncioTestCase):
   def setup_app_context(self, request):
     """Setup the app context and cache for each test."""
     self.app = request.getfixturevalue('app')
-    self.cache = Cache(self.app)
+    cache.init_app(self.app)
     self.app_context = self.app.app_context()
 
   def setUp(self):
     super().setUp()
 
     self.mock_v2node = self.patch(dc, "v2node")
-    self.v2node_api_response_index = 0
+    self.mock_v2node_paginated = self.patch(dc, "v2node_paginated")
     self.mock_obs_point = self.patch(dc, "obs_point")
     self.mock_obs_point_within = self.patch(dc, "obs_point_within")
     self.mock_descendent_places = self.patch(fetch, "descendent_places")
@@ -101,20 +101,19 @@ class TestRelatedPlaces(unittest.IsolatedAsyncioTestCase):
     self.mock_descendent_places.side_effect = fetch_descendent_places_side_effect
 
   def tearDown(self):
-    self.cache.clear()
+    cache.clear()
     super().tearDown()
 
-  def mock_v2node_api_data(self, response_list: list[dict]):
-
-    def mock_v2node_side_effect(nodes, props):
-      value = {
-          "data":
-              response_list[self.v2node_api_response_index % len(response_list)]
-      }
-      self.v2node_api_response_index += 1
-      return value
+  def mock_v2node_api_data(self, data_child_places: dict,
+                           data_place_data: dict):
+    # Route response dynamically based on the requested property to bypass async race conditions
+    def mock_v2node_side_effect(nodes, prop, *args, **kwargs):
+      if "containedInPlace" in prop:
+        return {"data": data_child_places}
+      return {"data": data_place_data}
 
     self.mock_v2node.side_effect = mock_v2node_side_effect
+    self.mock_v2node_paginated.side_effect = mock_v2node_side_effect
 
   def patch(self, module, name):
     patcher = mock.patch.object(module, name)
@@ -128,11 +127,14 @@ class TestRelatedPlaces(unittest.IsolatedAsyncioTestCase):
       g.locale = 'en'
       data_child_places = {
           mock_data.CALIFORNIA.dcid:
-              mock_data.create_contained_in_data(["County"]),
+              mock_data.create_contained_in_data_from_places(
+                  [mock_data.SAN_MATEO_COUNTY]),
           mock_data.USA.dcid:
-              mock_data.create_contained_in_data(["State"]),
+              mock_data.create_contained_in_data_from_places(
+                  [mock_data.CALIFORNIA, mock_data.ARIZONA,
+                   mock_data.NEW_YORK]),
           mock_data.SAN_MATEO_COUNTY.dcid:
-              mock_data.create_contained_in_data(["City"]),
+              mock_data.create_contained_in_data_from_places([]),
       }
       data_place_data = {
           mock_data.SAN_MATEO_COUNTY.dcid: mock_data.SAN_MATEO_COUNTY_API_DATA,
@@ -142,28 +144,25 @@ class TestRelatedPlaces(unittest.IsolatedAsyncioTestCase):
           mock_data.EARTH.dcid: mock_data.EARTH_API_DATA
       }
 
-      self.mock_v2node_api_data([
-          data_child_places, data_place_data, data_place_data, data_place_data,
-          data_place_data
-      ])
+      self.mock_v2node_api_data(data_child_places, data_place_data)
 
       response = self.app.test_client().get(
           '/api/place/related-places/geoId/06')
 
       actual = response.get_json()
       expected = jsonify(
-          RelatedPlacesApiResponse(place=Place(dcid=mock_data.CALIFORNIA.dcid,
-                                               name=mock_data.CALIFORNIA.dcid,
-                                               types=[]),
-                                   similarPlaces=[],
-                                   childPlaces=[mock_data.SAN_MATEO_COUNTY],
-                                   parentPlaces=[
-                                       mock_data.USA, mock_data.NORTH_AMERICA,
-                                       mock_data.EARTH
-                                   ],
-                                   peersWithinParent=[],
-                                   childPlaceType="County",
-                                   nearbyPlaces=[])).get_json()
+          RelatedPlacesApiResponse(
+              place=Place(dcid=mock_data.CALIFORNIA.dcid,
+                          name=mock_data.CALIFORNIA.name,
+                          types=mock_data.CALIFORNIA.types),
+              similarPlaces=[],
+              childPlaces=[mock_data.SAN_MATEO_COUNTY],
+              parentPlaces=[
+                  mock_data.USA, mock_data.NORTH_AMERICA, mock_data.EARTH
+              ],
+              peersWithinParent=[],
+              childPlaceType="County",
+              nearbyPlaces=[])).get_json()
 
       self.assertEqual(response.status_code, 200)
 
@@ -184,11 +183,14 @@ class TestRelatedPlaces(unittest.IsolatedAsyncioTestCase):
       g.locale = 'es'
       data_child_places = {
           mock_data.CALIFORNIA.dcid:
-              mock_data.create_contained_in_data(["County"]),
+              mock_data.create_contained_in_data_from_places(
+                  [mock_data.SAN_MATEO_COUNTY]),
           mock_data.USA.dcid:
-              mock_data.create_contained_in_data(["State"]),
+              mock_data.create_contained_in_data_from_places(
+                  [mock_data.CALIFORNIA, mock_data.ARIZONA,
+                   mock_data.NEW_YORK]),
           mock_data.SAN_MATEO_COUNTY.dcid:
-              mock_data.create_contained_in_data(["City"]),
+              mock_data.create_contained_in_data_from_places([]),
       }
       data_place_data = {
           mock_data.SAN_MATEO_COUNTY.dcid: mock_data.SAN_MATEO_COUNTY_API_DATA,
@@ -198,10 +200,7 @@ class TestRelatedPlaces(unittest.IsolatedAsyncioTestCase):
           mock_data.EARTH.dcid: mock_data.EARTH_API_DATA
       }
 
-      self.mock_v2node_api_data([
-          data_child_places, data_place_data, data_place_data, data_place_data,
-          data_place_data
-      ])
+      self.mock_v2node_api_data(data_child_places, data_place_data)
 
       response = self.app.test_client().get(
           '/api/place/related-places/geoId/06?hl=es')
@@ -217,8 +216,8 @@ class TestRelatedPlaces(unittest.IsolatedAsyncioTestCase):
       expected = jsonify(
           RelatedPlacesApiResponse(
               place=Place(dcid=mock_data.CALIFORNIA.dcid,
-                          name=mock_data.CALIFORNIA.dcid,
-                          types=[]),
+                          name=mock_data.CALIFORNIA.name + 'es',
+                          types=mock_data.CALIFORNIA.types),
               similarPlaces=[],
               childPlaces=[
                   Place(dcid=mock_data.SAN_MATEO_COUNTY.dcid,


### PR DESCRIPTION
## Issue

b/515861634

## Description

When using Spanner, the related places at the bottom of a the places page could be either incomplete or not shown at all. An example of this is the place page for [San Mateo County](http://localhost:8080/place/geoId/06081), where a BT-backed mixer will show a set of places, and a Spanner-backed mixer will not (see screenshots below).

The reason for this was Spanner pagination combined with the way that the Flask backend was making the request. 

Flask was requesting all containedInPlace nodes, regardless of the type, and then filtering out to show relevant child place types within Flask. San Mateo, as an example, contained hundreds of non-place contained nodes (EPAReportingFacility, VehicleCrashIncidents) that are pulled out by the query before any relevant places appear.  With BT, this worked (albeit with unnecessarily large payloads). With Spanner, the pagination means that no relevant places are retrieved on the first page, and no places are then displayed.

## Solution

This PR implements two approaches to solve this problem. The first is to resolve all paginated pages in the `raw_property_values` call. This involved updating the `raw_property_values` in a similar way to how `property_values` had already been updated, in order to allow pagination to be handled. 

This in itself does solve the problem, but the multiple Spanner calls to resolve the pagination add in latency (for the sake of retrieving nodes, many of which we do not need). 

The second arm of the solution is to update the property values call itself to filter by the place types that we are interested, giving us a payload that only consists of types that we will use. In practice, with the Mixer-level filtering in place, pagination will be invoked less often.

## Notes

There was a pre-existing inefficiency in the code whereby the original code fetched all the child places in order to determine the place types, and then later fetched the child places again.

I've updated this to now fetch the child places and the place types at the same time (returning them both at the same time). The new function that does this is largely similar to the the previous one, but I left the previous one intact as it is to limit the surface of the changes (adding in a TODO to migrate other uses of the functions to the new function and to remove the older function).

## Testing

### Local

In master, this page will produce results locally when using a Mixer backed with BT, and no results when using a mixer backed with Spanner.

In this branch, Spanner will give the same results as BT.

[San Mateo County](http://localhost:8080/place/geoId/06081)

### Production

Production can also serve as a working reference of the page (see the "Places in San Mateo County" section at the bottom of the page).

[San Mateo County](https://datacommons.org/place/geoId/06081)

## Screenshot

The following is the section that is missing with Spanner in master (but available otherwise, and now with this PR in Spanner).

<img width="2630" height="556" alt="image" src="https://github.com/user-attachments/assets/29ac19b8-71f4-447a-85ec-022313e5f0c1" />
