### PR TITLE
Set new ranking page flag to false

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -79,7 +79,7 @@
   },
   {
     "name": "new_ranking_page",
-    "enabled": true,
+    "enabled": false,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
   },

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -79,7 +79,7 @@
   },
   {
     "name": "new_ranking_page",
-    "enabled": true,
+    "enabled": false,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
   },

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -79,7 +79,7 @@
   },
   {
     "name": "new_ranking_page",
-    "enabled": true,
+    "enabled": false,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
   },


### PR DESCRIPTION
Set the `new_ranking_page` flag to `false` in all environments except dev.

Because of the changes made in https://github.com/datacommonsorg/website/pull/6353, we want the default behavior of the ranking pages to be a HTTP 503 unless we explicitly enable the new ranking pages for testing. We're leaving the flag to `true` in the dev environment to enable testing down the road.

The custom and production environments already had this flag set to false.