### PR TITLE
Add command-line flag for headful webdriver testing mode

### DIFF
--- a/docs/webdriver.md
+++ b/docs/webdriver.md
@@ -61,9 +61,10 @@ If the API changes or data becomes stale, you must regenerate recordings.
 ## Troubleshooting
 
 ### Disable Headless Mode
-To see the browser while debugging:
-1.  Open `server/webdriver/base_utils.py`.
-2.  Comment out `chrome_options.add_argument('--headless=new')`.
+To see the browser while debugging, run the test runner with the `--non-headless` flag:
+```bash
+./run_test.sh -w --non-headless -k "my_test_name"
+```
 
 ### Screenshots
 Capture the state of the page for debugging:

--- a/run_test.sh
+++ b/run_test.sh
@@ -387,6 +387,7 @@ function help {
   echo "--record        Run in record mode (regenerate recordings)"
   echo "--replay        Run in replay mode (default)"
   echo "--live          Run in live mode (no recording)"
+  echo "--non-headless  Run webdriver tests in non-headless (headful) mode"
   echo "--clean         Delete existing recordings before running (requires --record and full run)"
   echo "--cdc           Run Custom DC webdriver tests"
   echo "                Respects the STARTUP_WAIT_SEC environment variable for startup wait time (default 10)."
@@ -426,6 +427,10 @@ while [[ "$#" -gt 0 ]]; do
         ;;
     --live)
         export WEBDRIVER_RECORDING_MODE=live
+        shift
+        ;;
+    --non-headless)
+        export WEBDRIVER_NON_HEADLESS=true
         shift
         ;;
     --clean)

--- a/server/webdriver/base_utils.py
+++ b/server/webdriver/base_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utilities used by the base webddriver test."""
 
+import os
 from typing import List
 
 from selenium import webdriver
@@ -36,7 +37,8 @@ LONG_TIMEOUT = 120  # seconds
 def create_driver(preferences=None):
   # These options are needed to run ChromeDriver inside a Docker without a UI.
   chrome_options = Options()
-  chrome_options.add_argument('--headless=new')
+  if os.environ.get('WEBDRIVER_NON_HEADLESS') != 'true':
+    chrome_options.add_argument('--headless=new')
   chrome_options.add_argument('--no-sandbox')
   chrome_options.add_argument('--disable-dev-shm-usage')
   chrome_options.add_argument('--hide-scrollbars')

--- a/server/webdriver/base_utils.py
+++ b/server/webdriver/base_utils.py
@@ -37,7 +37,7 @@ LONG_TIMEOUT = 120  # seconds
 def create_driver(preferences=None):
   # These options are needed to run ChromeDriver inside a Docker without a UI.
   chrome_options = Options()
-  if os.environ.get('WEBDRIVER_NON_HEADLESS') != 'true':
+  if os.environ.get('WEBDRIVER_NON_HEADLESS', '').lower() not in ('true', '1'):
     chrome_options.add_argument('--headless=new')
   chrome_options.add_argument('--no-sandbox')
   chrome_options.add_argument('--disable-dev-shm-usage')


### PR DESCRIPTION
## Description

It is sometimes helpful when debugging webdriver tests to be able to run them in "headful" mode (i.e., to see the tests running in an instance of the browser).

There were instructions in the `webdriver.md` file for running the webdriver tests this way involving editing the `base_utils.py` file temporarily.

This PR gives an alternative to make this process easier by adding a `--non-headless` flag to the tests.