### PR TITLE
Stop releases of datacommons-data in Custom DC release pipeline

### DIFF
--- a/build/ci/cloudbuild.push_cdc_stable.yaml
+++ b/build/ci/cloudbuild.push_cdc_stable.yaml
@@ -61,16 +61,19 @@ steps:
     waitFor: ["get-label"]
 
   # Step 3: Data management container
-  - id: build-and-tag-stable-data
-    name: gcr.io/datcom-ci/deploy-tool
-    entrypoint: bash
-    args:
-      - -c
-      - |
-        set -e
-        image_label=$(cat "$_IMAGE_LABEL_PATH")
-        ./scripts/build_cdc_data_and_tag_stable.sh $image_label
-    waitFor: ["get-label"]
+  # TODO: Uncomment when we turn back on the datacommons-data pipeline.
+  # There are currently breaking changes to datacommons-data, so we
+  # will not be releasing updates to it for now.
+  # - id: build-and-tag-stable-data
+  #   name: gcr.io/datcom-ci/deploy-tool
+  #   entrypoint: bash
+  #   args:
+  #     - -c
+  #     - |
+  #       set -e
+  #       image_label=$(cat "$_IMAGE_LABEL_PATH")
+  #       ./scripts/build_cdc_data_and_tag_stable.sh $image_label
+  #   waitFor: ["get-label"]
 
 substitutions:
   _IMAGE_LABEL_PATH: "/workspace/tmp_cdc_stable_image_label.txt"


### PR DESCRIPTION
Comments out the release step of `datacommons-data` in the Custom DC release pipeline.

Because there are now breaking changes to `datacommons-data`, we will not be making new releases moving forward. This PR comments out the Cloud Build step that updates the stable tag for `datacommons-data`.