### PR TITLE
feat: Add Croissant JSON-LD metadata to provenance pages

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -112,5 +112,11 @@
     "enabled": true,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on provenance pages."
   }
 ]

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -112,5 +112,11 @@
     "enabled": false,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD SEO metadata on provenance pages."
   }
 ]

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -112,5 +112,11 @@
     "enabled": true,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD SEO metadata on provenance pages."
   }
 ]

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -112,5 +112,11 @@
     "enabled": true,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "croissant_json_ld",
+    "enabled": true,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD SEO metadata on provenance pages."
   }
 ]

--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -76,5 +76,11 @@
     "enabled": true,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD SEO metadata on provenance pages."
   }
 ]

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -112,5 +112,11 @@
     "enabled": true,
     "owner": "alyssaguo",
     "description": "Enables using the Vertex AI search application for stat var searches."
+  },
+  {
+    "name": "croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD SEO metadata on provenance pages."
   }
 ]

--- a/server/lib/croissant_metadata.py
+++ b/server/lib/croissant_metadata.py
@@ -1,0 +1,125 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import server.services.datacommons as dc
+
+def build_dataset_metadata(dcid: str) -> dict:
+  """Builds a Croissant JSON-LD dictionary for a provenance node."""
+  json_ld_data = {
+      "@context": {
+          "@language": "en",
+          "@vocab": "https://schema.org/",
+          "sc": "https://schema.org/",
+          "cr": "http://mlcommons.org/croissant/",
+          "rai": "http://mlcommons.org/croissant/RAI/",
+          "dct": "http://purl.org/dc/terms/",
+          "citeAs": "cr:citeAs",
+          "column": "cr:column",
+          "conformsTo": "dct:conformsTo",
+          "data": {
+              "@id": "cr:data",
+              "@type": "@json"
+          },
+          "dataType": {
+              "@id": "cr:dataType",
+              "@type": "@vocab"
+          },
+          "examples": {
+              "@id": "cr:examples",
+              "@type": "@json"
+          },
+          "extract": "cr:extract",
+          "field": "cr:field",
+          "fileProperty": "cr:fileProperty",
+          "fileObject": "cr:fileObject",
+          "fileSet": "cr:fileSet",
+          "format": "cr:format",
+          "includes": "cr:includes",
+          "isLiveDataset": "cr:isLiveDataset",
+          "jsonPath": "cr:jsonPath",
+          "key": "cr:key",
+          "md5": "cr:md5",
+          "parentField": "cr:parentField",
+          "path": "cr:path",
+          "recordSet": "cr:recordSet",
+          "references": "cr:references",
+          "regex": "cr:regex",
+          "repeated": "cr:repeated",
+          "replace": "cr:replace",
+          "separator": "cr:separator",
+          "source": "cr:source",
+          "subField": "cr:subField",
+          "transform": "cr:transform"
+      },
+      "@type":
+          "Dataset",
+      "conformsTo":
+          "http://mlcommons.org/croissant/1.0",
+      "description":
+          f"This dataset contains all the data related to provenance {dcid}",
+      "url":
+          f"https://datacommons.org/browser/{dcid}",
+      "publisher": {
+          "@type": "Organization",
+          "name": "Data Commons",
+          "url": "https://datacommons.org"
+      }
+  }
+
+  try:
+    resp = dc.v2node([dcid], "->*")
+    data = resp.get("data", {}).get(dcid, {})
+    arcs = data.get("arcs", {})
+
+    # Extract the name from the isPartOf node (the Dataset)
+    is_part_of_nodes = arcs.get("isPartOf", {}).get("nodes", [])
+    if is_part_of_nodes and "name" in is_part_of_nodes[0]:
+      json_ld_data["name"] = is_part_of_nodes[0]["name"]
+
+    if "description" in arcs and arcs["description"].get("nodes"):
+      json_ld_data["description"] = arcs["description"]["nodes"][0].get(
+          "value", json_ld_data["description"])
+
+    # Fetch license
+    if "license" in arcs and arcs["license"].get("nodes"):
+      json_ld_data["license"] = arcs["license"]["nodes"][0].get("value")
+
+    # Fetch source
+    source_nodes = arcs.get("source", {}).get("nodes", [])
+
+    if source_nodes:
+      s_node = source_nodes[0]
+      s_name = s_node.get("name", s_node.get("value", ""))
+      s_dcid = s_node.get("dcid", "")
+
+      source_obj = {"@type": "Organization", "name": s_name}
+
+      # Fetch its external URL
+      if s_dcid:
+        try:
+          s_resp = dc.v2node([s_dcid], "->url")
+          s_url_nodes = s_resp.get("data", {}).get(s_dcid, {}).get(
+              "arcs", {}).get("url", {}).get("nodes", [])
+          if s_url_nodes:
+            source_obj["url"] = s_url_nodes[0].get("value")
+        except Exception as e:
+          logging.error("Error fetching source URL for %s: %s", s_dcid, e)
+
+      json_ld_data["creator"] = [source_obj]
+
+  except Exception as e:
+    logging.error("Error fetching metadata for %s: %s", dcid, e)
+
+  return json_ld_data

--- a/server/lib/croissant_metadata.py
+++ b/server/lib/croissant_metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,23 @@
 # limitations under the License.
 
 import logging
+import server.lib.feature_flags as feature_flags_lib
 import server.services.datacommons as dc
+import server.lib.fetch as fetch
+
 
 def build_dataset_metadata(dcid: str) -> dict:
   """Builds a Croissant JSON-LD dictionary for a provenance node."""
+
+  # Verify the node is actually a Provenance node (works for all DCP users)
+  node_types = fetch.property_values([dcid], 'typeOf').get(dcid, [])
+  if 'Provenance' not in node_types:
+    return {}
+
+  if not feature_flags_lib.is_feature_enabled(
+      feature_flags_lib.CROISSANT_JSON_LD_FEATURE):
+    return {}
+
   json_ld_data = {
       "@context": {
           "@language": "en",
@@ -79,47 +92,77 @@ def build_dataset_metadata(dcid: str) -> dict:
   }
 
   try:
-    resp = dc.v2node([dcid], "->*")
-    data = resp.get("data", {}).get(dcid, {})
-    arcs = data.get("arcs", {})
+    resp = dc.v2node(
+        [dcid], "->[provenanceCategory,isPartOf,description,license,source]")
+    data = (resp.get("data") or {}).get(dcid) or {}
+    arcs = data.get("arcs") or {}
+
+    # Check if the node has a required provenance category
+    prov_category_nodes = (arcs.get("provenanceCategory") or
+                           {}).get("nodes", [])
+    valid_categories = {
+        "StatisticsProvenance", "AggregatedStatisticsProvenance"
+    }
+    is_valid_category = any(
+        n.get("dcid") in valid_categories or n.get("value") in valid_categories
+        for n in prov_category_nodes)
+
+    if not is_valid_category:
+      return {}
 
     # Extract the name from the isPartOf node (the Dataset)
-    is_part_of_nodes = arcs.get("isPartOf", {}).get("nodes", [])
-    if is_part_of_nodes and "name" in is_part_of_nodes[0]:
-      json_ld_data["name"] = is_part_of_nodes[0]["name"]
+    is_part_of_nodes = (arcs.get("isPartOf") or {}).get("nodes", [])
+    if not is_part_of_nodes or "name" not in is_part_of_nodes[0]:
+      logging.info(
+          "Skipping Croissant JSON-LD for %s: Missing 'isPartOf' or 'name'",
+          dcid)
+      return {}
+    json_ld_data["name"] = is_part_of_nodes[0]["name"]
 
-    if "description" in arcs and arcs["description"].get("nodes"):
-      json_ld_data["description"] = arcs["description"]["nodes"][0].get(
-          "value", json_ld_data["description"])
+    desc_nodes = (arcs.get("description") or {}).get("nodes", [])
+    if not desc_nodes:
+      logging.info("Skipping Croissant JSON-LD for %s: Missing 'description'",
+                   dcid)
+      return {}
+    json_ld_data["description"] = desc_nodes[0].get("value",
+                                                    json_ld_data["description"])
 
     # Fetch license
-    if "license" in arcs and arcs["license"].get("nodes"):
-      json_ld_data["license"] = arcs["license"]["nodes"][0].get("value")
+    license_nodes = (arcs.get("license") or {}).get("nodes", [])
+    if not license_nodes:
+      logging.info("Skipping Croissant JSON-LD for %s: Missing 'license'", dcid)
+      return {}
+    json_ld_data["license"] = license_nodes[0].get("value")
 
     # Fetch source
-    source_nodes = arcs.get("source", {}).get("nodes", [])
+    source_nodes = (arcs.get("source") or {}).get("nodes", [])
+    if not source_nodes:
+      logging.info("Skipping Croissant JSON-LD for %s: Missing 'source'", dcid)
+      return {}
 
-    if source_nodes:
-      s_node = source_nodes[0]
-      s_name = s_node.get("name", s_node.get("value", ""))
-      s_dcid = s_node.get("dcid", "")
+    s_node = source_nodes[0]
+    s_name = s_node.get("name", s_node.get("value", ""))
+    s_dcid = s_node.get("dcid", "")
 
-      source_obj = {"@type": "Organization", "name": s_name}
+    source_obj = {"@type": "Organization", "name": s_name}
 
-      # Fetch its external URL
-      if s_dcid:
-        try:
-          s_resp = dc.v2node([s_dcid], "->url")
-          s_url_nodes = s_resp.get("data", {}).get(s_dcid, {}).get(
-              "arcs", {}).get("url", {}).get("nodes", [])
-          if s_url_nodes:
-            source_obj["url"] = s_url_nodes[0].get("value")
-        except Exception as e:
-          logging.error("Error fetching source URL for %s: %s", s_dcid, e)
+    # Fetch its external URL
+    if s_dcid:
+      try:
+        s_resp = dc.v2node([s_dcid], "->url")
+        s_url_nodes = ((((s_resp.get("data") or {}).get(s_dcid) or
+                         {}).get("arcs") or {}).get("url") or
+                       {}).get("nodes", [])
+        if s_url_nodes:
+          source_obj["url"] = s_url_nodes[0].get("value")
+      except Exception as e:
+        logging.error("Error fetching source URL for %s: %s", s_dcid, e)
+        raise
 
-      json_ld_data["creator"] = [source_obj]
+    json_ld_data["creator"] = [source_obj]
 
   except Exception as e:
     logging.error("Error fetching metadata for %s: %s", dcid, e)
+    raise
 
   return json_ld_data

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -37,6 +37,7 @@ NEW_RANKING_PAGE = 'new_ranking_page'
 USE_V2_RESOLVE_FOR_NL_SEARCH_VARS = 'use_v2_resolve_for_nl_search_vars'
 ENABLE_NL_V2NODE_FETCHALL = 'enable_nl_v2node_fetchall'
 NL_USE_V2RESOLVE_FEATURE_FLAG = 'nl_use_v2resolve'
+CROISSANT_JSON_LD_FEATURE = 'croissant_json_ld'
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:

--- a/server/routes/browser/html.py
+++ b/server/routes/browser/html.py
@@ -22,9 +22,10 @@ from flask import current_app
 from flask import g
 from flask import render_template
 
+import server.lib.croissant_metadata as croissant_metadata_lib
+import server.lib.feature_flags as feature_flags_lib
 import server.lib.render as lib_render
 import server.lib.shared as shared_api
-import server.services.datacommons as dc
 
 bp = Blueprint('browser', __name__, url_prefix='/browser')
 
@@ -52,110 +53,8 @@ def browser_node(dcid):
   json_ld_data = {}
   # Provenance nodes start with dc/base/
   if dcid.startswith("dc/base/"):
-    json_ld_data = {
-        "@context": {
-            "@language": "en",
-            "@vocab": "https://schema.org/",
-            "sc": "https://schema.org/",
-            "cr": "http://mlcommons.org/croissant/",
-            "rai": "http://mlcommons.org/croissant/RAI/",
-            "dct": "http://purl.org/dc/terms/",
-            "citeAs": "cr:citeAs",
-            "column": "cr:column",
-            "conformsTo": "dct:conformsTo",
-            "data": {
-                "@id": "cr:data",
-                "@type": "@json"
-            },
-            "dataType": {
-                "@id": "cr:dataType",
-                "@type": "@vocab"
-            },
-            "examples": {
-                "@id": "cr:examples",
-                "@type": "@json"
-            },
-            "extract": "cr:extract",
-            "field": "cr:field",
-            "fileProperty": "cr:fileProperty",
-            "fileObject": "cr:fileObject",
-            "fileSet": "cr:fileSet",
-            "format": "cr:format",
-            "includes": "cr:includes",
-            "isLiveDataset": "cr:isLiveDataset",
-            "jsonPath": "cr:jsonPath",
-            "key": "cr:key",
-            "md5": "cr:md5",
-            "parentField": "cr:parentField",
-            "path": "cr:path",
-            "recordSet": "cr:recordSet",
-            "references": "cr:references",
-            "regex": "cr:regex",
-            "repeated": "cr:repeated",
-            "replace": "cr:replace",
-            "separator": "cr:separator",
-            "source": "cr:source",
-            "subField": "cr:subField",
-            "transform": "cr:transform"
-        },
-        "@type":
-            "Dataset",
-        "conformsTo":
-            "http://mlcommons.org/croissant/1.0",
-        "description":
-            f"This dataset contains all the data related to provenance {dcid}",
-        "url":
-            f"https://datacommons.org/browser/{dcid}",
-        "publisher": {
-            "@type": "Organization",
-            "name": "Data Commons",
-            "url": "https://datacommons.org"
-        }
-    }
-
-    try:
-      resp = dc.v2node([dcid], "->*")
-      data = resp.get("data", {}).get(dcid, {})
-      arcs = data.get("arcs", {})
-
-      # Extract the name from the isPartOf node (the Dataset)
-      is_part_of_nodes = arcs.get("isPartOf", {}).get("nodes", [])
-      if is_part_of_nodes and "name" in is_part_of_nodes[0]:
-        json_ld_data["name"] = is_part_of_nodes[0]["name"]
-
-      if "description" in arcs and arcs["description"].get("nodes"):
-        json_ld_data["description"] = arcs["description"]["nodes"][0].get(
-            "value", json_ld_data["description"])
-
-      # Fetch license
-      if "license" in arcs and arcs["license"].get("nodes"):
-        json_ld_data["license"] = arcs["license"]["nodes"][0].get("value")
-
-      # Fetch source
-      source_nodes = arcs.get("source", {}).get("nodes", [])
-
-      if source_nodes:
-        s_node = source_nodes[0]
-        s_name = s_node.get("name", s_node.get("value", ""))
-        s_dcid = s_node.get("dcid", "")
-
-        source_obj = {"@type": "Organization", "name": s_name}
-
-        # Fetch its external URL
-        if s_dcid:
-          try:
-            s_resp = dc.v2node([s_dcid], "->url")
-            s_url_nodes = s_resp.get("data", {}).get(s_dcid, {}).get(
-                "arcs", {}).get("url", {}).get("nodes", [])
-            if s_url_nodes:
-              source_obj["url"] = s_url_nodes[0].get("value")
-          except Exception as e:
-            logging.error("Error fetching source URL for %s: %s", s_dcid, e)
-
-        json_ld_data["creator"] = [source_obj]
-
-    except Exception as e:
-      logging.error("Error fetching metadata for %s: %s", dcid, e)
+    if feature_flags_lib.is_feature_enabled(feature_flags_lib.CROISSANT_JSON_LD_FEATURE):
+      json_ld_data = croissant_metadata_lib.build_dataset_metadata(dcid)
 
   return render_template('/browser/node.html',
                          dcid=dcid,

--- a/server/routes/browser/html.py
+++ b/server/routes/browser/html.py
@@ -24,6 +24,7 @@ from flask import render_template
 
 import server.lib.render as lib_render
 import server.lib.shared as shared_api
+import server.services.datacommons as dc
 
 bp = Blueprint('browser', __name__, url_prefix='/browser')
 
@@ -47,7 +48,117 @@ def browser_node(dcid):
       node_name = api_name
   except Exception as e:
     logging.info(e)
+
+  json_ld_data = {}
+  # Provenance nodes start with dc/base/
+  if dcid.startswith("dc/base/"):
+    json_ld_data = {
+        "@context": {
+            "@language": "en",
+            "@vocab": "https://schema.org/",
+            "sc": "https://schema.org/",
+            "cr": "http://mlcommons.org/croissant/",
+            "rai": "http://mlcommons.org/croissant/RAI/",
+            "dct": "http://purl.org/dc/terms/",
+            "citeAs": "cr:citeAs",
+            "column": "cr:column",
+            "conformsTo": "dct:conformsTo",
+            "data": {
+                "@id": "cr:data",
+                "@type": "@json"
+            },
+            "dataType": {
+                "@id": "cr:dataType",
+                "@type": "@vocab"
+            },
+            "examples": {
+                "@id": "cr:examples",
+                "@type": "@json"
+            },
+            "extract": "cr:extract",
+            "field": "cr:field",
+            "fileProperty": "cr:fileProperty",
+            "fileObject": "cr:fileObject",
+            "fileSet": "cr:fileSet",
+            "format": "cr:format",
+            "includes": "cr:includes",
+            "isLiveDataset": "cr:isLiveDataset",
+            "jsonPath": "cr:jsonPath",
+            "key": "cr:key",
+            "md5": "cr:md5",
+            "parentField": "cr:parentField",
+            "path": "cr:path",
+            "recordSet": "cr:recordSet",
+            "references": "cr:references",
+            "regex": "cr:regex",
+            "repeated": "cr:repeated",
+            "replace": "cr:replace",
+            "separator": "cr:separator",
+            "source": "cr:source",
+            "subField": "cr:subField",
+            "transform": "cr:transform"
+        },
+        "@type":
+            "Dataset",
+        "conformsTo":
+            "http://mlcommons.org/croissant/1.0",
+        "description":
+            f"This dataset contains all the data related to provenance {dcid}",
+        "url":
+            f"https://datacommons.org/browser/{dcid}",
+        "publisher": {
+            "@type": "Organization",
+            "name": "Data Commons",
+            "url": "https://datacommons.org"
+        }
+    }
+
+    try:
+      resp = dc.v2node([dcid], "->*")
+      data = resp.get("data", {}).get(dcid, {})
+      arcs = data.get("arcs", {})
+
+      # Extract the name from the isPartOf node (the Dataset)
+      is_part_of_nodes = arcs.get("isPartOf", {}).get("nodes", [])
+      if is_part_of_nodes and "name" in is_part_of_nodes[0]:
+        json_ld_data["name"] = is_part_of_nodes[0]["name"]
+
+      if "description" in arcs and arcs["description"].get("nodes"):
+        json_ld_data["description"] = arcs["description"]["nodes"][0].get(
+            "value", json_ld_data["description"])
+
+      # Fetch license
+      if "license" in arcs and arcs["license"].get("nodes"):
+        json_ld_data["license"] = arcs["license"]["nodes"][0].get("value")
+
+      # Fetch source
+      source_nodes = arcs.get("source", {}).get("nodes", [])
+
+      if source_nodes:
+        s_node = source_nodes[0]
+        s_name = s_node.get("name", s_node.get("value", ""))
+        s_dcid = s_node.get("dcid", "")
+
+        source_obj = {"@type": "Organization", "name": s_name}
+
+        # Fetch its external URL
+        if s_dcid:
+          try:
+            s_resp = dc.v2node([s_dcid], "->url")
+            s_url_nodes = s_resp.get("data", {}).get(s_dcid, {}).get(
+                "arcs", {}).get("url", {}).get("nodes", [])
+            if s_url_nodes:
+              source_obj["url"] = s_url_nodes[0].get("value")
+          except Exception as e:
+            logging.error("Error fetching source URL for %s: %s", s_dcid, e)
+
+        json_ld_data["creator"] = [source_obj]
+
+    except Exception as e:
+      logging.error("Error fetching metadata for %s: %s", dcid, e)
+
   return render_template('/browser/node.html',
                          dcid=dcid,
                          node_name=node_name,
+                         json_ld_data=json_ld_data,
                          maps_api_key=current_app.config['MAPS_API_KEY'])

--- a/server/routes/browser/html.py
+++ b/server/routes/browser/html.py
@@ -23,7 +23,6 @@ from flask import g
 from flask import render_template
 
 import server.lib.croissant_metadata as croissant_metadata_lib
-import server.lib.feature_flags as feature_flags_lib
 import server.lib.render as lib_render
 import server.lib.shared as shared_api
 
@@ -50,11 +49,7 @@ def browser_node(dcid):
   except Exception as e:
     logging.info(e)
 
-  json_ld_data = {}
-  # Provenance nodes start with dc/base/
-  if dcid.startswith("dc/base/"):
-    if feature_flags_lib.is_feature_enabled(feature_flags_lib.CROISSANT_JSON_LD_FEATURE):
-      json_ld_data = croissant_metadata_lib.build_dataset_metadata(dcid)
+  json_ld_data = croissant_metadata_lib.build_dataset_metadata(dcid)
 
   return render_template('/browser/node.html',
                          dcid=dcid,

--- a/server/templates/browser/node.html
+++ b/server/templates/browser/node.html
@@ -23,7 +23,7 @@
    {% block head %}
     {% if json_ld_data %}
     <script type="application/ld+json">
-      {{ json_ld_data | tojson | safe }}
+      {{ json_ld_data | tojson}}
     </script>
     {% endif %}
    <link rel="stylesheet" href={{url_for('static', filename='css/browser.min.css', t=config['VERSION'])}} >

--- a/server/templates/browser/node.html
+++ b/server/templates/browser/node.html
@@ -21,6 +21,11 @@
    {% set title = node_name + ' - Knowledge Graph' %}
 
    {% block head %}
+    {% if json_ld_data %}
+    <script type="application/ld+json">
+      {{ json_ld_data | tojson | safe }}
+    </script>
+    {% endif %}
    <link rel="stylesheet" href={{url_for('static', filename='css/browser.min.css', t=config['VERSION'])}} >
    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
    {% endblock %}

--- a/server/tests/lib/croissant_metadata_test.py
+++ b/server/tests/lib/croissant_metadata_test.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from server.lib.croissant_metadata import build_dataset_metadata
+
+
+class TestCroissantMetadata(unittest.TestCase):
+
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_not_a_provenance(self, mock_property_values):
+    # Test that if a node is not a Provenance node (e.g. it's a Country), it instantly returns {}
+    mock_property_values.return_value = {"dc/base/FakeNode": ["Country"]}
+    result = build_dataset_metadata("dc/base/FakeNode")
+    self.assertEqual(result, {})
+
+  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_feature_flag_disabled(self, mock_property_values,
+                                 mock_is_feature_enabled):
+    # Test that if the croissant feature flag is off, it returns {}
+    mock_property_values.return_value = {
+        "dc/base/ACSED5YrSurvey": ["Provenance"]
+    }
+    mock_is_feature_enabled.return_value = False
+    result = build_dataset_metadata("dc/base/ACSED5YrSurvey")
+    self.assertEqual(result, {})
+
+  @patch('server.lib.croissant_metadata.dc.v2node')
+  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_invalid_provenance_category(self, mock_property_values,
+                                       mock_is_feature_enabled, mock_v2node):
+    # Test that if the provenanceCategory is not StatisticsProvenance or AggregatedStatisticsProvenance, it returns {}
+    mock_property_values.return_value = {
+        "dc/base/ACSED5YrSurvey": ["Provenance"]
+    }
+    mock_is_feature_enabled.return_value = True
+
+    mock_v2node.return_value = {
+        "data": {
+            "dc/base/ACSED5YrSurvey": {
+                "arcs": {
+                    # Provide an INVALID category here
+                    "provenanceCategory": {
+                        "nodes": [{
+                            "dcid": "SomeRandomCategory"
+                        }]
+                    },
+                }
+            }
+        }
+    }
+
+    result = build_dataset_metadata("dc/base/ACSED5YrSurvey")
+    self.assertEqual(result, {})
+
+  @patch('server.lib.croissant_metadata.dc.v2node')
+  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_missing_property_fail_fast(self, mock_property_values,
+                                      mock_is_feature_enabled, mock_v2node):
+    # Test the "fail fast" logic: if it's missing a required property (like description), it returns {}
+    mock_property_values.return_value = {
+        "dc/base/ACSED5YrSurvey": ["Provenance"]
+    }
+    mock_is_feature_enabled.return_value = True
+
+    # Missing description
+    mock_v2node.return_value = {
+        "data": {
+            "dc/base/ACSED5YrSurvey": {
+                "arcs": {
+                    "provenanceCategory": {
+                        "nodes": [{
+                            "dcid": "StatisticsProvenance"
+                        }]
+                    },
+                    "isPartOf": {
+                        "nodes": [{
+                            "dcid": "SomeDataset",
+                            "name": "Some Dataset Name"
+                        }]
+                    },
+                    # description is intentionally missing
+                    "license": {
+                        "nodes": [{
+                            "value": "CC-BY"
+                        }]
+                    },
+                    "source": {
+                        "nodes": [{
+                            "dcid": "SomeSource",
+                            "name": "Some Source Name"
+                        }]
+                    }
+                }
+            }
+        }
+    }
+
+    result = build_dataset_metadata("dc/base/ACSED5YrSurvey")
+    self.assertEqual(result, {})
+
+  @patch('server.lib.croissant_metadata.dc.v2node')
+  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_success(self, mock_property_values, mock_is_feature_enabled,
+                   mock_v2node):
+    # Test a perfect flow with all metadata present
+    mock_property_values.return_value = {
+        "dc/base/ACSED5YrSurvey": ["Provenance"]
+    }
+    mock_is_feature_enabled.return_value = True
+
+    # We need side_effect because the function calls v2node twice (once for node data, once for source URL)
+    def mock_v2node_side_effect(dcids, prop):
+      if prop == "->[provenanceCategory,isPartOf,description,license,source]":
+        return {
+            "data": {
+                "dc/base/ACSED5YrSurvey": {
+                    "arcs": {
+                        "provenanceCategory": {
+                            "nodes": [{
+                                "dcid": "StatisticsProvenance"
+                            }]
+                        },
+                        "isPartOf": {
+                            "nodes": [{
+                                "dcid": "SomeDataset",
+                                "name": "DatasetName"
+                            }]
+                        },
+                        "description": {
+                            "nodes": [{
+                                "value": "Dataset Description"
+                            }]
+                        },
+                        "license": {
+                            "nodes": [{
+                                "value": "CC-BY"
+                            }]
+                        },
+                        "source": {
+                            "nodes": [{
+                                "dcid": "SomeSource",
+                                "name": "SourceName"
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+      if prop == "->url":
+        return {
+            "data": {
+                "SomeSource": {
+                    "arcs": {
+                        "url": {
+                            "nodes": [{
+                                "value": "https://example.com"
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+      return {}
+
+    mock_v2node.side_effect = mock_v2node_side_effect
+
+    result = build_dataset_metadata("dc/base/ACSED5YrSurvey")
+
+    self.assertEqual(result.get("@type"), "Dataset")
+    self.assertEqual(result.get("name"), "DatasetName")
+    self.assertEqual(result.get("description"), "Dataset Description")
+    self.assertEqual(result.get("license"), "CC-BY")
+    self.assertEqual(result.get("creator")[0].get("name"), "SourceName")
+    self.assertEqual(result.get("creator")[0].get("url"), "https://example.com")
+    self.assertEqual(result.get("url"),
+                     "https://datacommons.org/browser/dc/base/ACSED5YrSurvey")


### PR DESCRIPTION
This feature dynamically generates and injects Croissant dataset metadata (JSON-LD format) into the Knowledge Graph Browser for provenance nodes (dc/base/*).

- Queries the Mixer V2 Node API to retrieve dataset properties like name, description, license, and creator source.
- Injects the JSON-LD script into the node.html template for SEO and metadata crawlers.