### PR TITLE
Enable use_v2_api feature flag on custom DC

### DIFF
--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -97,7 +97,7 @@
   },
   {
     "name": "use_v2_api",
-    "enabled": false,
+    "enabled": true,
     "owner": "juliawu",
     "description": "Enables features that rely on the V2 REST APIs"
   },


### PR DESCRIPTION
Updates the `use_v2_api` to default to `true` on custom DC