### PR TITLE
[cdc-data] Skip GCS embeddings generation for DCP

### DIFF
--- a/build/cdc_data/run.sh
+++ b/build/cdc_data/run.sh
@@ -87,8 +87,8 @@ cd $WORKSPACE_DIR
 if [[ $DATA_RUN_MODE == "schemaupdate" ]]; then
     echo "Skipping embeddings builder because run mode is 'schemaupdate'."
     echo "Schema update complete."
-elif [[ $DATA_RUN_MODE == "dcpbridge" ]]; then
-    : # skip legacy gcs embeddings for DCP
+elif [[ $DATA_RUN_MODE == "dcpbridge" && $ENABLE_SPANNER_EMBEDDINGS == "true" ]]; then
+    : # skip GCS embeddings for DCP
 else
     echo "Starting embeddings builder..."
     # Run embeddings builder.

--- a/build/cdc_data/run.sh
+++ b/build/cdc_data/run.sh
@@ -87,7 +87,10 @@ cd $WORKSPACE_DIR
 if [[ $DATA_RUN_MODE == "schemaupdate" ]]; then
     echo "Skipping embeddings builder because run mode is 'schemaupdate'."
     echo "Schema update complete."
+elif [[ $DATA_RUN_MODE == "dcpbridge" ]]; then
+    : # skip legacy gcs embeddings for DCP
 else
+    echo "Starting embeddings builder..."
     # Run embeddings builder.
     python3 -m tools.nl.embeddings.build_embeddings \
         --embeddings_name=$CUSTOM_EMBEDDINGS_INDEX \


### PR DESCRIPTION
Starting for M0.5 and onwards, we will only support Spanner embeddings for DCP.