### PR TITLE
Fix incorrect website hash on /version page of Custom DC

### DIFF
--- a/scripts/build_and_tag_cdc_image.sh
+++ b/scripts/build_and_tag_cdc_image.sh
@@ -91,9 +91,9 @@ else
   # temporary commit hash created during the autopush submodule update process
   # in scripts/update_submods_for_cdc_autopush.sh.
   # Otherwise, fall back to resolving hashes from the current HEAD.
-  if [[ "$commits_label" =~ ^[0-9a-f]{7,40}-[0-9a-f]{7,40}-[0-9a-f]{7,40}$ ]]; then
-    WEBSITE_HASH=$(echo "$commits_label" | cut -d'-' -f1)
-    MIXER_HASH=$(echo "$commits_label" | cut -d'-' -f2)
+  if [[ "$commits_label" =~ ^([0-9a-f]{7,40})-([0-9a-f]{7,40})-[0-9a-f]{7,40}$ ]]; then
+    WEBSITE_HASH="${BASH_REMATCH[1]}"
+    MIXER_HASH="${BASH_REMATCH[2]}"
   else
     WEBSITE_HASH=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "")
     MIXER_HASH=$(git rev-parse --short=7 HEAD:mixer 2>/dev/null || echo "")

--- a/scripts/build_and_tag_cdc_image.sh
+++ b/scripts/build_and_tag_cdc_image.sh
@@ -86,8 +86,18 @@ if echo "$list_result" | grep -q $commits_label; then
 
 else
   # Build and push a fresh image, adding commits label and release label.
-  WEBSITE_HASH=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "")
-  MIXER_HASH=$(git rev-parse --short=7 HEAD:mixer 2>/dev/null || echo "")
+  # If the commits label matches a combined git hash pattern (website-mixer-import),
+  # extract the individual hashes directly from the label. This avoids using the
+  # temporary commit hash created during the autopush submodule update process
+  # in scripts/update_submods_for_cdc_autopush.sh.
+  # Otherwise, fall back to resolving hashes from the current HEAD.
+  if [[ "$commits_label" =~ ^[0-9a-f]{7,40}-[0-9a-f]{7,40}-[0-9a-f]{7,40}$ ]]; then
+    WEBSITE_HASH=$(echo "$commits_label" | cut -d'-' -f1)
+    MIXER_HASH=$(echo "$commits_label" | cut -d'-' -f2)
+  else
+    WEBSITE_HASH=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "")
+    MIXER_HASH=$(git rev-parse --short=7 HEAD:mixer 2>/dev/null || echo "")
+  fi
   docker build -f "$dockerfile" \
     --build-arg MIXER_HASH="$MIXER_HASH" \
     --build-arg WEBSITE_HASH="$WEBSITE_HASH" \


### PR DESCRIPTION
Fixes incorrect website hash showing up on /version page of Custom DC

## Context

After #6381, there is now a bug where the autopush deployment of Custom DC will show an incorrect githash for the website. This is because during deployment, a temporary commit is made to update the submodules, and that commit gets shown instead. Because it is a temporary commit that doesn't correspond to a commit on our website master branch, the link shown on /version leads to a 404 page. 

## Fix

This PR updates the deployment scripts to pull the website and mixer hashes from the `<website hash>-<mixer hash>-<import hash>` commit label that is available during custom DC deployment. This avoids using the temporary commit hash.

## Testing Strategy

I manually replicated each of the steps of https://source.cloud.google.com/datcom-ci/deployment/+/master:cloudbuild-compose-autopush.yaml (Google corp access required) locally on my machine with a dummy release tag after peppering build_and_tag_cdc_image.sh with echo statements to verify the correct githash was being set.
