### PR TITLE
Custom DC header layout fix

### DIFF
--- a/server/templates/custom_dc/custom/base.html
+++ b/server/templates/custom_dc/custom/base.html
@@ -69,7 +69,7 @@ For more details, please see https://docs.datacommons.org/custom_dc/custom_ui.ht
   <script src={{url_for('static', filename='base.js', t=config['VERSION'])}} async></script>
 </head>
 
-<body>
+<body {% if is_hide_header_search_bar %}class="no-header-search-bar"{% endif %}>
 {# Set page locale and pass header/footer configuration to base.js #}
 <div id="metadata-base" class="d-none"
     data-header="{{ HEADER_MENU }}"

--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -342,11 +342,16 @@
 .search-section-container.sticky {
   position: fixed;
   left: 0;
+  top: $header-desktop-height;
   background-color: var(--gm-3-ref-primary-primary-99);
   z-index: 9;
   box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.1);
   padding: 16px 0;
   transition: all ease-out 0.2s;
+
+  @media (max-width: 1068px) {
+    top: $header-mobile-no-search-height;
+  }
 
   .search-section {
     margin: 0;


### PR DESCRIPTION
## Issue

[b/525139384](b/525139384])

## Description

This PR addresses two separate but related issues:

* In custom DC, the no-header-search-bar class was not being applied on pages where the search bar was hidden. This meant that in mobile, the header bar was always the "double-decker" header bar even when there was no search bar to display.
* The shrinking sticky search bar didn't have a top and so incorrectly remained in its static position. This latter issue would have also applied to base DC, if it weren't for that in base DC the search bar is kept in the header.

## Screenshots

### Search bar layout

#### Old

<img width="1206" height="396" alt="image" src="https://github.com/user-attachments/assets/5841ad20-1c5e-4461-afc0-80da5c44ebc1" />

#### New

<img width="1544" height="336" alt="image" src="https://github.com/user-attachments/assets/6b9d9082-8dbd-4d95-9cd5-1b52d56f98ff" />

### Custom header height

#### Old

<img width="1044" height="468" alt="image" src="https://github.com/user-attachments/assets/d42eaea5-3d70-4fe6-a931-d81da879c8cc" />

#### New

<img width="1044" height="476" alt="image" src="https://github.com/user-attachments/assets/1e07fe03-0828-49d6-a749-662bed6281f2" />
