### PR TITLE
Fix substitution parsing error in Cloud Build cdc-services config

### DIFF
--- a/build/ci/cloudbuild.push_cdc_services_image.yaml
+++ b/build/ci/cloudbuild.push_cdc_services_image.yaml
@@ -29,8 +29,10 @@ steps:
           git rev-parse --short=7 HEAD > website_hash.txt
           git rev-parse --short=7 HEAD:mixer > mixer_hash.txt
         else
-          echo "${_WEBSITE_HASH:-unknown}" > website_hash.txt
-          echo "${_MIXER_HASH:-unknown}" > mixer_hash.txt
+          web_hash="$_WEBSITE_HASH"
+          mix_hash="$_MIXER_HASH"
+          echo "${web_hash:-unknown}" > website_hash.txt
+          echo "${mix_hash:-unknown}" > mixer_hash.txt
         fi
 
   - id: push-cdc-services-image


### PR DESCRIPTION
Google Cloud Build's parsing engine fails to recognize template variables when bash-style parameter expansion (default values like `${VAR:-default}`) is applied directly to them. This causes gcloud to report the variables as "unused" and fail the build submission with an INVALID_ARGUMENT error.

This change fixes it by assigning the substitution variables to standard bash variables first, then applying the fallback logic on those local variables.

Failed Command:
```bash
./scripts/push_cdc_services_image.sh un-sdmx-calinc-01
```

Error Message:
```
ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: generic::invalid_argument: key "_MIXER_HASH" in the substitution data is not matched in the template;key "_WEBSITE_HASH" in the substitution data is not matched in the template
- '@type': type.googleapis.com/google.rpc.DebugInfo
  detail: 'generic::invalid_argument: key "_MIXER_HASH" in the substitution data is
    not matched in the template;key "_WEBSITE_HASH" in the substitution data is not
    matched in the template'
```

After making this change and re-running the command, I got a successful image push [log](https://pantheon.corp.google.com/cloud-build/builds/099a8fdf-c06d-4822-86d9-4950c7902b20;step=1?e=13803378&mods=-monitoring_api_staging&project=datcom-ci)
