### PR TITLE
Remove duplicate and unused feature flag nl_use_v2resolve

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -84,12 +84,6 @@
     "description": "Enables the new ranking page UI"
   },
   {
-    "name": "nl_use_v2resolve",
-    "enabled": false,
-    "owner": "calinc",
-    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
-  },
-  {
     "name": "page_overview_ga",
     "enabled": false,
     "owner": "javiervazquez",

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -84,12 +84,6 @@
     "description": "Enables the new ranking page UI"
   },
   {
-    "name": "nl_use_v2resolve",
-    "enabled": false,
-    "owner": "calinc",
-    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
-  },
-  {
     "name": "page_overview_ga",
     "enabled": false,
     "owner": "javiervazquez",

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -84,12 +84,6 @@
     "description": "Enables the new ranking page UI"
   },
   {
-    "name": "nl_use_v2resolve",
-    "enabled": false,
-    "owner": "calinc",
-    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
-  },
-  {
     "name": "page_overview_ga",
     "enabled": false,
     "owner": "javiervazquez",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -84,12 +84,6 @@
     "description": "Enables the new ranking page UI"
   },
   {
-    "name": "nl_use_v2resolve",
-    "enabled": false,
-    "owner": "calinc",
-    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
-  },
-  {
     "name": "page_overview_ga",
     "enabled": false,
     "owner": "javiervazquez",

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -84,12 +84,6 @@
     "description": "Enables the new ranking page UI"
   },
   {
-    "name": "nl_use_v2resolve",
-    "enabled": false,
-    "owner": "calinc",
-    "description": "Enables detect-and-fulfill to use v2resolve for statvar resolution instead of direct NL server calls."
-  },
-  {
     "name": "page_overview_ga",
     "enabled": false,
     "owner": "javiervazquez",

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -36,7 +36,6 @@ NEW_RANKING_PAGE = 'new_ranking_page'
 # This flag controls the switching of detect-and-fulfill API to use v2/resolve from current nl search vars
 USE_V2_RESOLVE_FOR_NL_SEARCH_VARS = 'use_v2_resolve_for_nl_search_vars'
 ENABLE_NL_V2NODE_FETCHALL = 'enable_nl_v2node_fetchall'
-NL_USE_V2RESOLVE_FEATURE_FLAG = 'nl_use_v2resolve'
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:


### PR DESCRIPTION
This flag was a duplicate of use_v2_resolve_for_nl_search_vars which is the one actually being used.
