### PR TITLE
Header z-index fix

### DIFF
--- a/static/css/core.scss
+++ b/static/css/core.scss
@@ -76,7 +76,7 @@ body.no-header-search-bar {
   left: 0;
   right: 0;
   top: 0;
-  z-index: 100;
+  z-index: 1000;
   background-color: white;
   box-shadow: 0 1px 2px rgb(94, 94, 94, 0.1);
 }

--- a/static/css/explore.scss
+++ b/static/css/explore.scss
@@ -37,7 +37,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 10;
+  z-index: 1000;
 }
 
 #main-nav {


### PR DESCRIPTION
## Issue

[b/525123954](b/525123954)

## Description

This PR fixes a z-index layering issue where page-level loading spinner screens render on top of the main website header and its dropdown menu. 

When a visualization tool (Map, Timeline, Scatter, Download, or StatVar Explorer) enters a loading state, the spinner covers the header dropdown menu, making its contents unclickable.

To fix this, we increased the z-index of the fixed header components to `1000`, positioning them above the loading spinner screens (`z-index: 100`) while keeping them below modals and backdrop layers:

## Notes

Setting the container z-index to `1000` matches the z-index level of the header drawer and desktop rich menus. They will renderabove content/spinners, but will still be correctly covered by modal backdrops when modals are open.

## Testing

1. Start the local server and go to the Map Explorer: `http://localhost:8080/tools/map`.
2. Select a variable or trigger a place change to show the loading spinner.
3. While the spinner is active, click to open the header menu.
4. Verify that the dropdown menu is visible on top of the spinner and that the header links are clickable.
5. Check other tools (Timeline, Scatter, etc.) and the Explore page to ensure consistent behavior.