### PR TITLE
feat: Add Croissant JSON-LD metadata for Datasets

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -1,11 +1,5 @@
 [
   {
-    "name": "show_croissant_json_ld",
-    "enabled": false,
-    "owner": "dtulsyan",
-    "description": "Enables Croissant JSON-LD metadata on dataset pages."
-  },
-  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",
@@ -94,6 +88,12 @@
     "enabled": false,
     "owner": "javiervazquez",
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
+  },
+  {
+    "name": "show_croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
     "name": "use_v2_api",

--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "show_croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
+  },
+  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -1,11 +1,5 @@
 [
   {
-    "name": "show_croissant_json_ld",
-    "enabled": false,
-    "owner": "dtulsyan",
-    "description": "Enables Croissant JSON-LD metadata on dataset pages."
-  },
-  {
     "name": "autocomplete",
     "enabled": false,
     "owner": "gmechali",
@@ -94,6 +88,12 @@
     "enabled": false,
     "owner": "javiervazquez",
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
+  },
+  {
+    "name": "show_croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
     "name": "use_v2_api",

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "show_croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
+  },
+  {
     "name": "autocomplete",
     "enabled": false,
     "owner": "gmechali",

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -1,11 +1,5 @@
 [
   {
-    "name": "show_croissant_json_ld",
-    "enabled": false,
-    "owner": "dtulsyan",
-    "description": "Enables Croissant JSON-LD metadata on dataset pages."
-  },
-  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",
@@ -94,6 +88,12 @@
     "enabled": false,
     "owner": "javiervazquez",
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
+  },
+  {
+    "name": "show_croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
     "name": "use_v2_api",

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "show_croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
+  },
+  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -1,11 +1,5 @@
 [
   {
-    "name": "show_croissant_json_ld",
-    "enabled": true,
-    "owner": "dtulsyan",
-    "description": "Enables Croissant JSON-LD metadata on dataset pages."
-  },
-  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",
@@ -94,6 +88,12 @@
     "enabled": false,
     "owner": "javiervazquez",
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
+  },
+  {
+    "name": "show_croissant_json_ld",
+    "enabled": true,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
     "name": "use_v2_api",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "show_croissant_json_ld",
+    "enabled": true,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
+  },
+  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",

--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "show_croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Feature flag to enable Croissant JSON-LD for Dataset nodes."
+  },
+  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",

--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -1,11 +1,5 @@
 [
   {
-    "name": "show_croissant_json_ld",
-    "enabled": false,
-    "owner": "dtulsyan",
-    "description": "Feature flag to enable Croissant JSON-LD for Dataset nodes."
-  },
-  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -1,11 +1,5 @@
 [
   {
-    "name": "show_croissant_json_ld",
-    "enabled": false,
-    "owner": "dtulsyan",
-    "description": "Enables Croissant JSON-LD metadata on dataset pages."
-  },
-  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",
@@ -94,6 +88,12 @@
     "enabled": false,
     "owner": "javiervazquez",
     "description": "Makes the page overview feature, generated from query and relevant stat vars, generally available."
+  },
+  {
+    "name": "show_croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
     "name": "use_v2_api",

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "show_croissant_json_ld",
+    "enabled": false,
+    "owner": "dtulsyan",
+    "description": "Enables Croissant JSON-LD metadata on dataset pages."
+  },
+  {
     "name": "autocomplete",
     "enabled": true,
     "owner": "gmechali",

--- a/server/lib/croissant_metadata.py
+++ b/server/lib/croissant_metadata.py
@@ -16,18 +16,19 @@ import logging
 import server.lib.feature_flags as feature_flags_lib
 import server.services.datacommons as dc
 import server.lib.fetch as fetch
+import requests
 
 
 def build_dataset_metadata(dcid: str) -> dict:
   """Builds a Croissant JSON-LD dictionary for a Dataset node."""
 
+  if not feature_flags_lib.is_feature_enabled(
+      feature_flags_lib.CROISSANT_JSON_LD_FEATURE):
+    return {}
+
   # Verify the node is actually a Dataset node
   node_types = fetch.property_values([dcid], 'typeOf').get(dcid, [])
   if 'Dataset' not in node_types:
-    return {}
-
-  if not feature_flags_lib.is_feature_enabled(
-      feature_flags_lib.CROISSANT_JSON_LD_FEATURE):
     return {}
 
   json_ld_data = {
@@ -128,14 +129,14 @@ def build_dataset_metadata(dcid: str) -> dict:
                          {}).get("nodes", [])
           if s_url_nodes:
             source_obj["url"] = s_url_nodes[0].get("value")
-        except Exception as e:
+        except (ValueError, requests.exceptions.RequestException) as e:
           logging.warning("Error fetching source URL for %s: %s", s_dcid, e)
-          raise
+          # Continue without the URL
 
       json_ld_data["creator"] = [source_obj]
 
-  except Exception as e:
+  except (ValueError, requests.exceptions.RequestException) as e:
     logging.error("Error fetching metadata for %s: %s", dcid, e)
-    raise
+    return {}
 
   return json_ld_data

--- a/server/lib/croissant_metadata.py
+++ b/server/lib/croissant_metadata.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import server.lib.feature_flags as feature_flags_lib
+import server.services.datacommons as dc
+import server.lib.fetch as fetch
+
+
+def build_dataset_metadata(dcid: str) -> dict:
+  """Builds a Croissant JSON-LD dictionary for a Dataset node."""
+
+  # Verify the node is actually a Dataset node
+  node_types = fetch.property_values([dcid], 'typeOf').get(dcid, [])
+  if 'Dataset' not in node_types:
+    return {}
+
+  if not feature_flags_lib.is_feature_enabled(
+      feature_flags_lib.CROISSANT_JSON_LD_FEATURE):
+    return {}
+
+  json_ld_data = {
+      "@context": {
+          "@language": "en",
+          "@vocab": "https://schema.org/",
+          "sc": "https://schema.org/",
+          "cr": "http://mlcommons.org/croissant/",
+          "rai": "http://mlcommons.org/croissant/RAI/",
+          "dct": "http://purl.org/dc/terms/",
+          "citeAs": "cr:citeAs",
+          "column": "cr:column",
+          "conformsTo": "dct:conformsTo",
+          "data": {
+              "@id": "cr:data",
+              "@type": "@json"
+          },
+          "dataType": {
+              "@id": "cr:dataType",
+              "@type": "@vocab"
+          },
+          "examples": {
+              "@id": "cr:examples",
+              "@type": "@json"
+          },
+          "extract": "cr:extract",
+          "field": "cr:field",
+          "fileProperty": "cr:fileProperty",
+          "fileObject": "cr:fileObject",
+          "fileSet": "cr:fileSet",
+          "format": "cr:format",
+          "includes": "cr:includes",
+          "isLiveDataset": "cr:isLiveDataset",
+          "jsonPath": "cr:jsonPath",
+          "key": "cr:key",
+          "md5": "cr:md5",
+          "parentField": "cr:parentField",
+          "path": "cr:path",
+          "recordSet": "cr:recordSet",
+          "references": "cr:references",
+          "regex": "cr:regex",
+          "repeated": "cr:repeated",
+          "replace": "cr:replace",
+          "separator": "cr:separator",
+          "source": "cr:source",
+          "subField": "cr:subField",
+          "transform": "cr:transform"
+      },
+      "@type":
+          "Dataset",
+      "conformsTo":
+          "http://mlcommons.org/croissant/1.0",
+      "description":
+          f"This dataset contains all the data related to dataset {dcid}",
+      "url":
+          f"https://datacommons.org/browser/{dcid}",
+      "publisher": {
+          "@type": "Organization",
+          "name": "Data Commons",
+          "url": "https://datacommons.org"
+      }
+  }
+
+  try:
+    resp = dc.v2node([dcid], "->[name,description,license,source]")
+    data = (resp.get("data") or {}).get(dcid) or {}
+    arcs = data.get("arcs") or {}
+
+    name_nodes = (arcs.get("name") or {}).get("nodes", [])
+    if name_nodes:
+      json_ld_data["name"] = name_nodes[0].get("value")
+
+    desc_nodes = (arcs.get("description") or {}).get("nodes", [])
+    if desc_nodes:
+      json_ld_data["description"] = desc_nodes[0].get(
+          "value", json_ld_data["description"])
+
+    # Fetch license
+    license_nodes = (arcs.get("license") or {}).get("nodes", [])
+    if license_nodes:
+      json_ld_data["license"] = license_nodes[0].get("value")
+
+    # Fetch source
+    source_nodes = (arcs.get("source") or {}).get("nodes", [])
+    if source_nodes:
+      s_node = source_nodes[0]
+      s_name = s_node.get("name", s_node.get("value", ""))
+      s_dcid = s_node.get("dcid", "")
+
+      source_obj = {"@type": "Organization", "name": s_name}
+
+      # Fetch its external URL
+      if s_dcid:
+        try:
+          s_resp = dc.v2node([s_dcid], "->url")
+          s_url_nodes = ((((s_resp.get("data") or {}).get(s_dcid) or
+                           {}).get("arcs") or {}).get("url") or
+                         {}).get("nodes", [])
+          if s_url_nodes:
+            source_obj["url"] = s_url_nodes[0].get("value")
+        except Exception as e:
+          logging.warning("Error fetching source URL for %s: %s", s_dcid, e)
+          raise
+
+      json_ld_data["creator"] = [source_obj]
+
+  except Exception as e:
+    logging.error("Error fetching metadata for %s: %s", dcid, e)
+    raise
+
+  return json_ld_data

--- a/server/lib/croissant_metadata.py
+++ b/server/lib/croissant_metadata.py
@@ -16,18 +16,12 @@ import logging
 
 import requests
 
-import server.lib.feature_flags as feature_flags_lib
 import server.lib.fetch as fetch
 import server.services.datacommons as dc
 
 
 def build_dataset_metadata(dcid: str) -> dict:
   """Builds a Croissant JSON-LD dictionary for a Dataset node."""
-
-  if not feature_flags_lib.is_feature_enabled(
-      feature_flags_lib.CROISSANT_JSON_LD_FEATURE):
-    return {}
-
   json_ld_data = {
       "@context": {
           "@language": "en",
@@ -90,7 +84,7 @@ def build_dataset_metadata(dcid: str) -> dict:
   }
 
   try:
-    resp = dc.v2node([dcid], "->[name,description,license,source]")
+    resp = dc.v2node([dcid], "->[name,description,license,isPartOf]")
     data = (resp.get("data") or {}).get(dcid) or {}
     arcs = data.get("arcs") or {}
 
@@ -109,7 +103,7 @@ def build_dataset_metadata(dcid: str) -> dict:
       json_ld_data["license"] = license_nodes[0].get("value")
 
     # Fetch source
-    source_nodes = (arcs.get("source") or {}).get("nodes", [])
+    source_nodes = (arcs.get("isPartOf") or {}).get("nodes", [])
     if source_nodes:
       s_node = source_nodes[0]
       s_name = s_node.get("name", s_node.get("value", ""))
@@ -120,12 +114,9 @@ def build_dataset_metadata(dcid: str) -> dict:
       # Fetch its external URL
       if s_dcid:
         try:
-          s_resp = dc.v2node([s_dcid], "->url")
-          s_url_nodes = ((((s_resp.get("data") or {}).get(s_dcid) or
-                           {}).get("arcs") or {}).get("url") or
-                         {}).get("nodes", [])
-          if s_url_nodes:
-            source_obj["url"] = s_url_nodes[0].get("value")
+          urls = fetch.property_values([s_dcid], "url")
+          if urls.get(s_dcid):
+            source_obj["url"] = urls[s_dcid][0]
         except (ValueError, requests.exceptions.RequestException) as e:
           logging.warning("Error fetching source URL for %s: %s", s_dcid, e)
 

--- a/server/lib/croissant_metadata.py
+++ b/server/lib/croissant_metadata.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import logging
-import server.lib.feature_flags as feature_flags_lib
-import server.services.datacommons as dc
-import server.lib.fetch as fetch
+
 import requests
+
+import server.lib.feature_flags as feature_flags_lib
+import server.lib.fetch as fetch
+import server.services.datacommons as dc
 
 
 def build_dataset_metadata(dcid: str) -> dict:
@@ -80,7 +82,7 @@ def build_dataset_metadata(dcid: str) -> dict:
       "@type":
           "Dataset",
       "conformsTo":
-          "http://mlcommons.org/croissant/1.0",
+          "http://mlcommons.org/croissant/1.1",
       "description":
           f"This dataset contains all the data related to dataset {dcid}",
       "url":
@@ -131,7 +133,6 @@ def build_dataset_metadata(dcid: str) -> dict:
             source_obj["url"] = s_url_nodes[0].get("value")
         except (ValueError, requests.exceptions.RequestException) as e:
           logging.warning("Error fetching source URL for %s: %s", s_dcid, e)
-          # Continue without the URL
 
       json_ld_data["creator"] = [source_obj]
 

--- a/server/lib/croissant_metadata.py
+++ b/server/lib/croissant_metadata.py
@@ -28,11 +28,6 @@ def build_dataset_metadata(dcid: str) -> dict:
       feature_flags_lib.CROISSANT_JSON_LD_FEATURE):
     return {}
 
-  # Verify the node is actually a Dataset node
-  node_types = fetch.property_values([dcid], 'typeOf').get(dcid, [])
-  if 'Dataset' not in node_types:
-    return {}
-
   json_ld_data = {
       "@context": {
           "@language": "en",

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -36,6 +36,7 @@ NEW_RANKING_PAGE = 'new_ranking_page'
 # This flag controls the switching of detect-and-fulfill API to use v2/resolve from current nl search vars
 USE_V2_RESOLVE_FOR_NL_SEARCH_VARS = 'use_v2_resolve_for_nl_search_vars'
 ENABLE_NL_V2NODE_FETCHALL = 'enable_nl_v2node_fetchall'
+CROISSANT_JSON_LD_FEATURE = 'show_croissant_json_ld'
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:

--- a/server/routes/browser/html.py
+++ b/server/routes/browser/html.py
@@ -22,6 +22,7 @@ from flask import current_app
 from flask import g
 from flask import render_template
 
+import server.lib.croissant_metadata as croissant_metadata_lib
 import server.lib.render as lib_render
 import server.lib.shared as shared_api
 
@@ -47,7 +48,11 @@ def browser_node(dcid):
       node_name = api_name
   except Exception as e:
     logging.info(e)
+
+  json_ld_data = croissant_metadata_lib.build_dataset_metadata(dcid)
+
   return render_template('/browser/node.html',
                          dcid=dcid,
                          node_name=node_name,
+                         json_ld_data=json_ld_data,
                          maps_api_key=current_app.config['MAPS_API_KEY'])

--- a/server/routes/browser/html.py
+++ b/server/routes/browser/html.py
@@ -23,6 +23,7 @@ from flask import g
 from flask import render_template
 
 import server.lib.croissant_metadata as croissant_metadata_lib
+import server.lib.fetch as fetch
 import server.lib.render as lib_render
 import server.lib.shared as shared_api
 
@@ -42,14 +43,20 @@ def bio_browser_main():
 @bp.route('/<path:dcid>')
 def browser_node(dcid):
   node_name = dcid
+  node_types = []
   try:
-    api_name = shared_api.names([dcid]).get(dcid)
-    if api_name:
-      node_name = api_name
+    node_info = fetch.multiple_property_values([dcid], ["name", "typeOf"])
+    dcid_info = node_info.get(dcid, {})
+    names = dcid_info.get("name", [])
+    if names:
+      node_name = names[0]
+    node_types = dcid_info.get("typeOf", [])
   except Exception as e:
     logging.info(e)
 
-  json_ld_data = croissant_metadata_lib.build_dataset_metadata(dcid)
+  json_ld_data = {}
+  if 'Dataset' in node_types:
+    json_ld_data = croissant_metadata_lib.build_dataset_metadata(dcid)
 
   return render_template('/browser/node.html',
                          dcid=dcid,

--- a/server/routes/browser/html.py
+++ b/server/routes/browser/html.py
@@ -23,6 +23,7 @@ from flask import g
 from flask import render_template
 
 import server.lib.croissant_metadata as croissant_metadata_lib
+import server.lib.feature_flags as feature_flags_lib
 import server.lib.fetch as fetch
 import server.lib.render as lib_render
 import server.lib.shared as shared_api
@@ -44,19 +45,29 @@ def bio_browser_main():
 def browser_node(dcid):
   node_name = dcid
   node_types = []
-  try:
-    node_info = fetch.multiple_property_values([dcid], ["name", "typeOf"])
-    dcid_info = node_info.get(dcid, {})
-    names = dcid_info.get("name", [])
-    if names:
-      node_name = names[0]
-    node_types = dcid_info.get("typeOf", [])
-  except Exception as e:
-    logging.info(e)
-
   json_ld_data = {}
-  if 'Dataset' in node_types:
-    json_ld_data = croissant_metadata_lib.build_dataset_metadata(dcid)
+
+  if feature_flags_lib.is_feature_enabled(
+      feature_flags_lib.CROISSANT_JSON_LD_FEATURE):
+    try:
+      node_info = fetch.multiple_property_values([dcid], ["name", "typeOf"])
+      dcid_info = node_info.get(dcid, {})
+      names = dcid_info.get("name", [])
+      if names:
+        node_name = names[0]
+      node_types = dcid_info.get("typeOf", [])
+    except Exception as e:
+      logging.info(e)
+
+    if 'Dataset' in node_types:
+      json_ld_data = croissant_metadata_lib.build_dataset_metadata(dcid)
+  else:
+    try:
+      api_name = shared_api.names([dcid]).get(dcid)
+      if api_name:
+        node_name = api_name
+    except Exception as e:
+      logging.info(e)
 
   return render_template('/browser/node.html',
                          dcid=dcid,

--- a/server/templates/browser/node.html
+++ b/server/templates/browser/node.html
@@ -21,6 +21,11 @@
    {% set title = node_name + ' - Knowledge Graph' %}
 
    {% block head %}
+   {% if json_ld_data %}
+     <script type="application/ld+json">
+       {{ json_ld_data | tojson }}
+     </script>
+   {% endif %}
    <link rel="stylesheet" href={{url_for('static', filename='css/browser.min.css', t=config['VERSION'])}} >
    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
    {% endblock %}

--- a/server/tests/lib/croissant_metadata_test.py
+++ b/server/tests/lib/croissant_metadata_test.py
@@ -160,13 +160,12 @@ class TestCroissantMetadata(unittest.TestCase):
   @patch('server.lib.croissant_metadata.fetch.property_values')
   def test_api_exception(self, mock_property_values, mock_is_feature_enabled,
                          mock_v2node):
-    # Test that exceptions during data fetching are raised
+    # Test that exceptions during data fetching are handled by returning {}
     mock_property_values.return_value = {TEST_DATASET_DCID: ["Dataset"]}
     mock_is_feature_enabled.return_value = True
 
-    mock_v2node.side_effect = Exception("API Error")
+    mock_v2node.side_effect = ValueError("API Error")
 
-    with self.assertRaises(Exception) as context:
-      build_dataset_metadata(TEST_DATASET_DCID)
+    result = build_dataset_metadata(TEST_DATASET_DCID)
 
-    self.assertTrue("API Error" in str(context.exception))
+    self.assertEqual(result, {})

--- a/server/tests/lib/croissant_metadata_test.py
+++ b/server/tests/lib/croissant_metadata_test.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from server.lib.croissant_metadata import build_dataset_metadata
+
+TEST_DATASET_DCID = "dc/d/UsCensusBureau_AmericanCommunitySurveyAcs"
+
+
+class TestCroissantMetadata(unittest.TestCase):
+
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_not_a_dataset(self, mock_property_values):
+    # Test that if a node is not a Dataset node (e.g. it's a Country), it instantly returns {}
+    mock_property_values.return_value = {TEST_DATASET_DCID: ["Country"]}
+    result = build_dataset_metadata(TEST_DATASET_DCID)
+    self.assertEqual(result, {})
+
+  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_feature_flag_disabled(self, mock_property_values,
+                                 mock_is_feature_enabled):
+    # Test that if the croissant feature flag is off, it returns {}
+    mock_property_values.return_value = {TEST_DATASET_DCID: ["Dataset"]}
+    mock_is_feature_enabled.return_value = False
+    result = build_dataset_metadata(TEST_DATASET_DCID)
+    self.assertEqual(result, {})
+
+  @patch('server.lib.croissant_metadata.dc.v2node')
+  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_missing_properties_handled_gracefully(self, mock_property_values,
+                                                 mock_is_feature_enabled,
+                                                 mock_v2node):
+    # Test the relaxed logic: missing properties don't cause it to return {}, they just aren't populated
+    mock_property_values.return_value = {TEST_DATASET_DCID: ["Dataset"]}
+    mock_is_feature_enabled.return_value = True
+
+    # Empty node data, no name/desc/license/source
+    mock_v2node.return_value = {"data": {TEST_DATASET_DCID: {"arcs": {}}}}
+
+    result = build_dataset_metadata(TEST_DATASET_DCID)
+
+    # The default properties should still exist
+    self.assertEqual(result.get("@type"), "Dataset")
+    self.assertEqual(result.get("url"),
+                     f"https://datacommons.org/browser/{TEST_DATASET_DCID}")
+    self.assertEqual(result.get("conformsTo"),
+                     "http://mlcommons.org/croissant/1.0")
+    self.assertIn("@context", result)
+    self.assertEqual(
+        result.get("publisher"), {
+            "@type": "Organization",
+            "name": "Data Commons",
+            "url": "https://datacommons.org"
+        })
+
+    # Specific fields should just not exist or use the default values
+    self.assertNotIn("name", result)
+    self.assertEqual(
+        result.get("description"),
+        f"This dataset contains all the data related to dataset {TEST_DATASET_DCID}"
+    )
+    self.assertNotIn("license", result)
+    self.assertNotIn("creator", result)
+
+  @patch('server.lib.croissant_metadata.dc.v2node')
+  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_success(self, mock_property_values, mock_is_feature_enabled,
+                   mock_v2node):
+    # Test a perfect flow with all metadata present
+    mock_property_values.return_value = {TEST_DATASET_DCID: ["Dataset"]}
+    mock_is_feature_enabled.return_value = True
+
+    def mock_v2node_side_effect(dcids, prop):
+      if prop == "->[name,description,license,source]":
+        return {
+            "data": {
+                TEST_DATASET_DCID: {
+                    "arcs": {
+                        "name": {
+                            "nodes": [{
+                                "value": "DatasetName"
+                            }]
+                        },
+                        "description": {
+                            "nodes": [{
+                                "value": "Dataset Description"
+                            }]
+                        },
+                        "license": {
+                            "nodes": [{
+                                "value": "CC-BY"
+                            }]
+                        },
+                        "source": {
+                            "nodes": [{
+                                "dcid": "SomeSource",
+                                "name": "SourceName"
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+      if prop == "->url":
+        return {
+            "data": {
+                "SomeSource": {
+                    "arcs": {
+                        "url": {
+                            "nodes": [{
+                                "value": "https://example.com"
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+      return {}
+
+    mock_v2node.side_effect = mock_v2node_side_effect
+
+    result = build_dataset_metadata(TEST_DATASET_DCID)
+
+    self.assertEqual(result.get("@type"), "Dataset")
+    self.assertEqual(result.get("name"), "DatasetName")
+    self.assertEqual(result.get("description"), "Dataset Description")
+    self.assertEqual(result.get("license"), "CC-BY")
+    self.assertEqual(result.get("creator")[0].get("name"), "SourceName")
+    self.assertEqual(result.get("creator")[0].get("url"), "https://example.com")
+    self.assertEqual(result.get("url"),
+                     f"https://datacommons.org/browser/{TEST_DATASET_DCID}")
+    self.assertEqual(
+        result.get("publisher"), {
+            "@type": "Organization",
+            "name": "Data Commons",
+            "url": "https://datacommons.org"
+        })
+    self.assertIn("@context", result)
+    self.assertEqual(result.get("conformsTo"),
+                     "http://mlcommons.org/croissant/1.0")
+
+  @patch('server.lib.croissant_metadata.dc.v2node')
+  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
+  @patch('server.lib.croissant_metadata.fetch.property_values')
+  def test_api_exception(self, mock_property_values, mock_is_feature_enabled,
+                         mock_v2node):
+    # Test that exceptions during data fetching are raised
+    mock_property_values.return_value = {TEST_DATASET_DCID: ["Dataset"]}
+    mock_is_feature_enabled.return_value = True
+
+    mock_v2node.side_effect = Exception("API Error")
+
+    with self.assertRaises(Exception) as context:
+      build_dataset_metadata(TEST_DATASET_DCID)
+
+    self.assertTrue("API Error" in str(context.exception))

--- a/server/tests/lib/croissant_metadata_test.py
+++ b/server/tests/lib/croissant_metadata_test.py
@@ -59,7 +59,7 @@ class TestCroissantMetadata(unittest.TestCase):
     self.assertEqual(result.get("url"),
                      f"https://datacommons.org/browser/{TEST_DATASET_DCID}")
     self.assertEqual(result.get("conformsTo"),
-                     "http://mlcommons.org/croissant/1.0")
+                     "http://mlcommons.org/croissant/1.1")
     self.assertIn("@context", result)
     self.assertEqual(
         result.get("publisher"), {
@@ -153,7 +153,7 @@ class TestCroissantMetadata(unittest.TestCase):
         })
     self.assertIn("@context", result)
     self.assertEqual(result.get("conformsTo"),
-                     "http://mlcommons.org/croissant/1.0")
+                     "http://mlcommons.org/croissant/1.1")
 
   @patch('server.lib.croissant_metadata.dc.v2node')
   @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')

--- a/server/tests/lib/croissant_metadata_test.py
+++ b/server/tests/lib/croissant_metadata_test.py
@@ -22,31 +22,17 @@ TEST_DATASET_DCID = "dc/d/UsCensusBureau_AmericanCommunitySurveyAcs"
 
 class TestCroissantMetadata(unittest.TestCase):
 
-  @patch('server.lib.croissant_metadata.fetch.property_values')
-  def test_not_a_dataset(self, mock_property_values):
-    # Test that if a node is not a Dataset node (e.g. it's a Country), it instantly returns {}
-    mock_property_values.return_value = {TEST_DATASET_DCID: ["Country"]}
-    result = build_dataset_metadata(TEST_DATASET_DCID)
-    self.assertEqual(result, {})
-
   @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
-  @patch('server.lib.croissant_metadata.fetch.property_values')
-  def test_feature_flag_disabled(self, mock_property_values,
-                                 mock_is_feature_enabled):
+  def test_feature_flag_disabled(self, mock_is_feature_enabled):
     # Test that if the croissant feature flag is off, it returns {}
-    mock_property_values.return_value = {TEST_DATASET_DCID: ["Dataset"]}
     mock_is_feature_enabled.return_value = False
     result = build_dataset_metadata(TEST_DATASET_DCID)
     self.assertEqual(result, {})
 
   @patch('server.lib.croissant_metadata.dc.v2node')
   @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
-  @patch('server.lib.croissant_metadata.fetch.property_values')
-  def test_missing_properties_handled_gracefully(self, mock_property_values,
-                                                 mock_is_feature_enabled,
+  def test_missing_properties_handled_gracefully(self, mock_is_feature_enabled,
                                                  mock_v2node):
-    # Test the relaxed logic: missing properties don't cause it to return {}, they just aren't populated
-    mock_property_values.return_value = {TEST_DATASET_DCID: ["Dataset"]}
     mock_is_feature_enabled.return_value = True
 
     # Empty node data, no name/desc/license/source
@@ -79,11 +65,8 @@ class TestCroissantMetadata(unittest.TestCase):
 
   @patch('server.lib.croissant_metadata.dc.v2node')
   @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
-  @patch('server.lib.croissant_metadata.fetch.property_values')
-  def test_success(self, mock_property_values, mock_is_feature_enabled,
-                   mock_v2node):
+  def test_success(self, mock_is_feature_enabled, mock_v2node):
     # Test a perfect flow with all metadata present
-    mock_property_values.return_value = {TEST_DATASET_DCID: ["Dataset"]}
     mock_is_feature_enabled.return_value = True
 
     def mock_v2node_side_effect(dcids, prop):
@@ -157,11 +140,8 @@ class TestCroissantMetadata(unittest.TestCase):
 
   @patch('server.lib.croissant_metadata.dc.v2node')
   @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
-  @patch('server.lib.croissant_metadata.fetch.property_values')
-  def test_api_exception(self, mock_property_values, mock_is_feature_enabled,
-                         mock_v2node):
+  def test_api_exception(self, mock_is_feature_enabled, mock_v2node):
     # Test that exceptions during data fetching are handled by returning {}
-    mock_property_values.return_value = {TEST_DATASET_DCID: ["Dataset"]}
     mock_is_feature_enabled.return_value = True
 
     mock_v2node.side_effect = ValueError("API Error")

--- a/server/tests/lib/croissant_metadata_test.py
+++ b/server/tests/lib/croissant_metadata_test.py
@@ -22,18 +22,8 @@ TEST_DATASET_DCID = "dc/d/UsCensusBureau_AmericanCommunitySurveyAcs"
 
 class TestCroissantMetadata(unittest.TestCase):
 
-  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
-  def test_feature_flag_disabled(self, mock_is_feature_enabled):
-    # Test that if the croissant feature flag is off, it returns {}
-    mock_is_feature_enabled.return_value = False
-    result = build_dataset_metadata(TEST_DATASET_DCID)
-    self.assertEqual(result, {})
-
   @patch('server.lib.croissant_metadata.dc.v2node')
-  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
-  def test_missing_properties_handled_gracefully(self, mock_is_feature_enabled,
-                                                 mock_v2node):
-    mock_is_feature_enabled.return_value = True
+  def test_missing_properties_handled_gracefully(self, mock_v2node):
 
     # Empty node data, no name/desc/license/source
     mock_v2node.return_value = {"data": {TEST_DATASET_DCID: {"arcs": {}}}}
@@ -63,14 +53,14 @@ class TestCroissantMetadata(unittest.TestCase):
     self.assertNotIn("license", result)
     self.assertNotIn("creator", result)
 
+  @patch('server.lib.croissant_metadata.fetch.property_values')
   @patch('server.lib.croissant_metadata.dc.v2node')
-  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
-  def test_success(self, mock_is_feature_enabled, mock_v2node):
+  def test_success(self, mock_v2node, mock_property_values):
     # Test a perfect flow with all metadata present
-    mock_is_feature_enabled.return_value = True
+    mock_property_values.return_value = {"SomeSource": ["https://example.com"]}
 
     def mock_v2node_side_effect(dcids, prop):
-      if prop == "->[name,description,license,source]":
+      if prop == "->[name,description,license,isPartOf]":
         return {
             "data": {
                 TEST_DATASET_DCID: {
@@ -90,24 +80,10 @@ class TestCroissantMetadata(unittest.TestCase):
                                 "value": "CC-BY"
                             }]
                         },
-                        "source": {
+                        "isPartOf": {
                             "nodes": [{
                                 "dcid": "SomeSource",
                                 "name": "SourceName"
-                            }]
-                        }
-                    }
-                }
-            }
-        }
-      if prop == "->url":
-        return {
-            "data": {
-                "SomeSource": {
-                    "arcs": {
-                        "url": {
-                            "nodes": [{
-                                "value": "https://example.com"
                             }]
                         }
                     }
@@ -139,10 +115,8 @@ class TestCroissantMetadata(unittest.TestCase):
                      "http://mlcommons.org/croissant/1.1")
 
   @patch('server.lib.croissant_metadata.dc.v2node')
-  @patch('server.lib.croissant_metadata.feature_flags_lib.is_feature_enabled')
-  def test_api_exception(self, mock_is_feature_enabled, mock_v2node):
+  def test_api_exception(self, mock_v2node):
     # Test that exceptions during data fetching are handled by returning {}
-    mock_is_feature_enabled.return_value = True
 
     mock_v2node.side_effect = ValueError("API Error")
 


### PR DESCRIPTION
- Dynamically injects Croissant JSON-LD metadata into the <head> of Dataset pages in the Data Commons browser.

- Introduces the 'show_croissant_json_ld' feature flag to safely toggle this behavior across different environments.