### PR TITLE
[DCP Ingestion] Cleanup run.sh to use the new script

### DIFF
--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -175,6 +175,7 @@ COPY --from=download /tmp/datcom-nl-models /tmp/datcom-nl-models
 
 # Copy executable script.
 COPY build/cdc_services/run.sh .
+COPY build/cdc_services/update_dcp_flags.py .
 
 # Make script executable.
 RUN chmod +x run.sh

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -93,7 +93,7 @@ if [[ $USE_SPANNER_GRAPH == "true" ]]; then
     # 2. Enable V2 API for Mixer
     MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true")
 
-    if [[ $RESOLVE_WITH_SPANNER_EMBEDDINGS == "true" || $ENABLE_UNIQUE_HISTORY_RECORDS == "true" || $ENABLE_UNIQUE_INGESTION_RUNS == "true" ]]; then
+    if [[ $RESOLVE_WITH_SPANNER_EMBEDDINGS == "true" || $ENABLE_UNIQUE_HISTORY_RECORDS == "true" ]]; then
         MIXER_ARGS+=('--feature_flags_path=deploy/featureflags/custom.yaml')
     fi
 fi

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -76,7 +76,7 @@ if [[ $USE_SPANNER_GRAPH == "true" ]]; then
     echo "Spanner Graph detected. Enabling V2 API for Website and Mixer."
     
     # 1. Dynamically update feature flags for Website and Mixer
-    python3 deploy/featureflags/update_dcp_flags.py
+    python3 update_dcp_flags.py
 
     # TODO: Rename this to existing GOOGLE_CLOUD_PROJECT.
     

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -75,27 +75,8 @@ fi
 if [[ $USE_SPANNER_GRAPH == "true" ]]; then
     echo "Spanner Graph detected. Enabling V2 API for Website and Mixer."
     
-    # 1. Dynamically enable feature flags in custom.json for Website
-    # TODO: Delete this once every customer is on DCP, and we can just update custom.json.
-    python3 -c "
-import json
-import os
-path = 'server/config/feature_flag_configs/custom.json'
-try:
-    with open(path) as f:
-        data = json.load(f)
-    for flag in data:
-        if flag.get('name') == 'enable_nl_v2node_fetchall':
-            flag['enabled'] = True
-        if os.environ.get('RESOLVE_WITH_SPANNER_EMBEDDINGS') == 'true':
-            if flag.get('name') == 'use_v2_resolve_for_nl_search_vars':
-                flag['enabled'] = True
-    with open(path, 'w') as f:
-        json.dump(data, f, indent=2)
-    print('Successfully enabled feature flags in custom.json')
-except Exception as e:
-    print(f'Warning: Failed to auto-enable feature flags in custom.json: {e}')
-"
+    # 1. Dynamically update feature flags for Website and Mixer
+    python3 deploy/featureflags/update_dcp_flags.py
 
     # TODO: Rename this to existing GOOGLE_CLOUD_PROJECT.
     
@@ -112,11 +93,7 @@ except Exception as e:
     # 2. Enable V2 API for Mixer
     MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true")
 
-    # 3. Use mixer custom feature flags
-
-    # Currently we only read custom feature flags when we enable resolving with spanner embeddings.
-    # We will eventually always resolve from spanner embeddings.
-    if [[ $RESOLVE_WITH_SPANNER_EMBEDDINGS == "true" ]]; then
+    if [[ $RESOLVE_WITH_SPANNER_EMBEDDINGS == "true" || $ENABLE_UNIQUE_HISTORY_RECORDS == "true" || $ENABLE_UNIQUE_INGESTION_RUNS == "true" ]]; then
         MIXER_ARGS+=('--feature_flags_path=deploy/featureflags/custom.yaml')
     fi
 fi

--- a/build/cdc_services/update_dcp_flags.py
+++ b/build/cdc_services/update_dcp_flags.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Dynamically generates/updates the DCP feature flags file (deploy/featureflags/custom.yaml)
+and website feature flags file (server/config/feature_flag_configs/custom.json)
+based on environment variables.
+
+This is executed during container startup (e.g. build/cdc_services/run.sh)
+to configure Mixer's and Website's runtime behaviors based on deployment settings.
+"""
+
+import json
+import os
+import yaml
+
+def update_mixer_flags():
+    ff_path = 'deploy/featureflags/custom.yaml'
+    
+    # Read existing custom flags if they exist
+    data = {}
+    if os.path.exists(ff_path):
+        with open(ff_path, 'r') as f:
+            try:
+                data = yaml.safe_load(f) or {}
+            except yaml.YAMLError:
+                pass
+                
+    if 'flags' not in data or data['flags'] is None:
+        data['flags'] = {}
+        
+    # Dynamically inject flags based on environment variables
+    if os.environ.get('RESOLVE_WITH_SPANNER_EMBEDDINGS') == 'true':
+        data['flags']['EnableSpannerSearchEmbeddings'] = True
+        
+    if os.environ.get('ENABLE_UNIQUE_HISTORY_RECORDS') == 'true' or os.environ.get('ENABLE_UNIQUE_INGESTION_RUNS') == 'true':
+        data['flags']['UseNewIngestionHistorySchema'] = True
+        
+    # Write back clean YAML
+    os.makedirs(os.path.dirname(ff_path), exist_ok=True)
+    with open(ff_path, 'w') as f:
+        yaml.safe_dump(data, f, default_flow_style=False)
+    print('Successfully generated Mixer custom feature flags')
+
+def update_website_flags():
+    web_ff_path = 'server/config/feature_flag_configs/custom.json'
+    if not os.path.exists(web_ff_path):
+        return  # Gracefully skip if website codebase is not present (e.g. local mixer tests)
+
+    try:
+        with open(web_ff_path, 'r') as f:
+            data = json.load(f)
+            
+        for flag in data:
+            if flag.get('name') == 'enable_nl_v2node_fetchall':
+                flag['enabled'] = True
+            if os.environ.get('RESOLVE_WITH_SPANNER_EMBEDDINGS') == 'true':
+                if flag.get('name') == 'use_v2_resolve_for_nl_search_vars':
+                    flag['enabled'] = True
+                    
+        with open(web_ff_path, 'w') as f:
+            json.dump(data, f, indent=2)
+        print('Successfully enabled feature flags in custom.json')
+    except Exception as e:
+        print(f'Warning: Failed to auto-enable feature flags in custom.json: {e}')
+
+def main():
+    update_mixer_flags()
+    update_website_flags()
+
+if __name__ == '__main__':
+    main()

--- a/build/cdc_services/update_dcp_flags.py
+++ b/build/cdc_services/update_dcp_flags.py
@@ -44,7 +44,7 @@ def update_mixer_flags():
     if os.environ.get('RESOLVE_WITH_SPANNER_EMBEDDINGS') == 'true':
         data['flags']['EnableSpannerSearchEmbeddings'] = True
         
-    if os.environ.get('ENABLE_UNIQUE_HISTORY_RECORDS') == 'true' or os.environ.get('ENABLE_UNIQUE_INGESTION_RUNS') == 'true':
+    if os.environ.get('ENABLE_UNIQUE_HISTORY_RECORDS') == 'true':
         data['flags']['UseNewIngestionHistorySchema'] = True
         
     # Write back clean YAML

--- a/build/cdc_services/update_dcp_flags.py
+++ b/build/cdc_services/update_dcp_flags.py
@@ -49,9 +49,12 @@ def update_mixer_flags():
         
     # Write back clean YAML
     os.makedirs(os.path.dirname(ff_path), exist_ok=True)
+    serialized = yaml.safe_dump(data, default_flow_style=False)
     with open(ff_path, 'w') as f:
-        yaml.safe_dump(data, f, default_flow_style=False)
-    print('Successfully generated Mixer custom feature flags')
+        f.write(serialized)
+    print(f"--- Generated Mixer feature flags ({ff_path}) ---")
+    print(serialized)
+    print("-------------------------------------------------")
 
 def update_website_flags():
     web_ff_path = 'server/config/feature_flag_configs/custom.json'
@@ -69,9 +72,12 @@ def update_website_flags():
                 if flag.get('name') == 'use_v2_resolve_for_nl_search_vars':
                     flag['enabled'] = True
                     
+        serialized = json.dumps(data, indent=2)
         with open(web_ff_path, 'w') as f:
-            json.dump(data, f, indent=2)
-        print('Successfully enabled feature flags in custom.json')
+            f.write(serialized)
+        print(f"--- Generated Website feature flags ({web_ff_path}) ---")
+        print(serialized)
+        print("---------------------------------------------------")
     except Exception as e:
         print(f'Warning: Failed to auto-enable feature flags in custom.json: {e}')
 


### PR DESCRIPTION
I moved the feature flag parsing for DCP in a python script that will be more maintainable.

Adds the mixer flag for the spanner embeddings resolver this way, and the new staleness computation logic.
