### PR TITLE
Paginate descendent places

### DIFF
--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -523,12 +523,13 @@ def descendent_places(nodes, descendent_type, max_pages=None):
                          max_pages=max_pages)
 
 
-def raw_descendent_places(nodes, descendent_type):
+def raw_descendent_places(nodes, descendent_type, max_pages=None):
   return raw_property_values(
       nodes,
       'containedInPlace+',
       out=False,
-      constraints='{{typeOf:{}}}'.format(descendent_type))
+      constraints='{{typeOf:{}}}'.format(descendent_type),
+      max_pages=max_pages)
 
 
 def resolve_id(nodes, in_prop, out_prop):

--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -511,7 +511,7 @@ def triples(nodes, out=True, max_pages=1):
   return result
 
 
-def descendent_places(nodes, descendent_type, max_pages=1):
+def descendent_places(nodes, descendent_type, max_pages=None):
   # When the only node being requested is also the descendent_type, fetch all nodes of that type.
   if nodes and len(nodes) == 1 and nodes[0] == descendent_type:
     return property_values(nodes, "typeOf", out=False, max_pages=max_pages)


### PR DESCRIPTION
## Description

With Spanner [correctly] paginating the results of `v2` node, the `descendent_places` call in Flask was only delivering partial results (the first page) for larger collections of descendents.

This PR sets `default max_pages` to `None` in `descendent_places` to allow fetching all pages (triggering a fetch of all places).

## Screenshots

The following screenshots are taken using Spanner as a backend:

### Before

<img width="2036" height="1976" alt="image" src="https://github.com/user-attachments/assets/6d27e3c7-e120-47c5-9448-76495154aec4" />

### After

<img width="2058" height="1968" alt="image" src="https://github.com/user-attachments/assets/63840002-370d-4e3b-ae9a-1de0f4ad6141" />
