### PR TITLE
[DCP] Clean up cdc_data preprocessor image dependencies

### DIFF
--- a/build/cdc_data/Dockerfile
+++ b/build/cdc_data/Dockerfile
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# #### Stage 1: Download base dc model from GCS. ####
-FROM google/cloud-sdk:slim AS model-downloader
-
-# Remove auth check since these are public buckets and we don't have credentials within the container.
-# Copy model.
-RUN gcloud config set auth/disable_credentials True \
-    && mkdir -p /tmp/datcom-nl-models \
-    && gcloud storage cp --recursive gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2/ /tmp/datcom-nl-models/
-    
-# #### Stage 2: Python runtime. ####
+# #### Python runtime. ####
 FROM python:3.11.14-slim AS runner
 
 ARG ENV
@@ -30,23 +20,9 @@ ENV ENV=${ENV}
 
 WORKDIR /workspace
 
-# Install curl and Google Cloud SDK for auto-triggering workflows
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
-    && curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts \
-    && rm -rf /var/lib/apt/lists/*
-ENV PATH="/root/google-cloud-sdk/bin:${PATH}"
-
-# Copy models
-COPY --from=model-downloader /tmp/datcom-nl-models /tmp/datcom-nl-models
 
 # Copy simple importer requirements.
 COPY import/simple/requirements.txt ./import/simple/requirements.txt
-
-# Copy embeddings builder requirements.
-# Copy nl_requirements.txt and torch_requirements.txt since they are referenced by embeddings requirements.txt
-COPY tools/nl/embeddings/requirements.txt ./tools/nl/embeddings/requirements.txt
-COPY nl_requirements.txt ./nl_requirements.txt
-COPY torch_requirements.txt ./torch_requirements.txt
 
 ARG PIP_DISABLE_PIP_VERSION_CHECK=1
 ARG PIP_NO_CACHE_DIR=1
@@ -55,23 +31,9 @@ ARG PIP_NO_CACHE_DIR=1
 RUN python -m venv /workspace/venv
 ENV PATH="/workspace/venv/bin:$PATH"
 
-# TODO: Install requirements for embeddings importer and data importer in separate virtual envs.
-# Install embeddings importer requirements.
+# Install simple importer requirements.
 RUN pip3 install -r ./import/simple/requirements.txt
 
-# Install data requirements.
-# Force install CPU version of torch
-RUN pip3 install -r ./torch_requirements.txt --index-url https://download.pytorch.org/whl/cpu \
-    && pip3 install -r ./tools/nl/embeddings/requirements.txt
-
-# Copy the embeddings builder module.
-COPY tools/nl/embeddings/. ./tools/nl/embeddings/
-# Copy the shared module.
-COPY shared/. ./shared/
-# Copy nl_server module. Some scripts from here are used by the embeddings builder.
-COPY nl_server/. /workspace/nl_server/
-# Copy yaml files used by the embeddings builder.
-COPY deploy/nl/. /datacommons/nl/
 # Copy simple importer.
 COPY import/simple/ ./import/simple/
 

--- a/build/cdc_data/run.sh
+++ b/build/cdc_data/run.sh
@@ -53,16 +53,6 @@ WORKSPACE_DIR=$(pwd)
 
 # Paths based off of OUTPUT_DIR.
 DC_OUTPUT_DIR=$OUTPUT_DIR/datacommons
-DC_NL_EMBEDDINGS_DIR=$DC_OUTPUT_DIR/nl/embeddings
-ADDITIONAL_CATALOG_PATH=$DC_NL_EMBEDDINGS_DIR/custom_catalog.yaml
-
-# The custom embeddings index type.
-# See: https://github.com/datacommonsorg/website/blob/2dabf815b82dcd5ff226ed94d8bbdab545ffd4d7/nl_server/custom_dc_env.yaml#L6
-CUSTOM_EMBEDDINGS_INDEX=user_all_minilm_mem
-
-# Set IS_CUSTOM_DC var to true.
-# This is used by the embeddings builder to set up a custom dc env.
-export IS_CUSTOM_DC=true
 
 if [[ $USE_SQLITE == "true" ]]; then
     # Set SQLITE_PATH for sqlite imports.
@@ -81,20 +71,4 @@ python3 -m stats.main \
     --mode=$DATA_RUN_MODE \
     "$@"
 
-# cd back to workspace dir to run the embeddings builder.
-cd $WORKSPACE_DIR
-
-if [[ $DATA_RUN_MODE == "schemaupdate" ]]; then
-    echo "Skipping embeddings builder because run mode is 'schemaupdate'."
-    echo "Schema update complete."
-elif [[ $DATA_RUN_MODE == "dcpbridge" && $ENABLE_SPANNER_EMBEDDINGS == "true" ]]; then
-    : # skip GCS embeddings for DCP
-else
-    echo "Starting embeddings builder..."
-    # Run embeddings builder.
-    python3 -m tools.nl.embeddings.build_embeddings \
-        --embeddings_name=$CUSTOM_EMBEDDINGS_INDEX \
-    --output_dir=$DC_NL_EMBEDDINGS_DIR \
-    --additional_catalog_path=$ADDITIONAL_CATALOG_PATH
-  echo "Data loading complete."
-fi
+echo "Data loading complete."


### PR DESCRIPTION
## Description
This PR simplifies the `datacommons-data` preprocessor image by removing unused embeddings, NLP dependencies, and CLI tools (`google-cloud-sdk`).

### Rationale & Changes
- **Removed Google Cloud SDK & `curl` (`build/cdc_data/Dockerfile`):** We no longer trigger downstream ingestion workflows from within the preprocessor container. Instead, the workflow directly triggers the preprocessor Cloud Run job, completely eliminating the need for `gcloud` inside the image.
- **Removed NLP Models & PyTorch (`build/cdc_data/Dockerfile` & `run.sh`):** Embeddings generation has been moved out of preprocessing and is now handled during Spanner loading (`Ingestion Helper` / Spanner vector capabilities). Removed Stage 1 (`model-downloader`), heavy ML libraries, and local `build_embeddings` execution from `run.sh`.

### Benefits
- **Image Size Reduction:** Shrinks the preprocessor Docker image from **~4.5GB to < 300MB**.
- **Cold-Start Performance:** Eliminates tens of thousands of `gcloud` overlay files and huge PyTorch weights from filesystem extraction, speeding up cold-start container download times (`ContainerReady`) by **>5x** (~1m20s down to ~14s).
