### PR TITLE
Exclude Place from type ranking 

### DIFF
--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -463,6 +463,12 @@ def _get_best_type(types_list):
   if not types_list:
     return ''
 
+  if 'Place' in types_list:
+    has_other_ranking_type = any(
+        t in PLACE_TYPE_RANK and t != 'Place' for t in types_list)
+    if has_other_ranking_type:
+      types_list = [t for t in types_list if t != 'Place']
+
   # Sort types by rank (highest rank first)
   # If ranks are tied, prefer types that don't start with 'AdministrativeArea'
   def sort_key(t):

--- a/server/tests/services/datacommons_test.py
+++ b/server/tests/services/datacommons_test.py
@@ -22,6 +22,7 @@ from requests import Response
 
 from server.lib.cache import cache
 from server.lib.cache import should_skip_cache
+from server.services.datacommons import _get_best_type
 from server.services.datacommons import nl_search_vars
 from server.services.datacommons import nl_search_vars_in_parallel
 from server.services.datacommons import v2node_paginated
@@ -376,3 +377,29 @@ class TestServiceDataCommonsNLSearchVarsInParallel(
 
         self.assertEqual(result, {"idx1": idx1_result, "idx2": idx2_result})
         self.assertEqual(mock_post.call_count, 2)
+
+
+class TestGetBestType(unittest.TestCase):
+
+  def test_get_best_type(self):
+    # Empty list
+    self.assertEqual(_get_best_type([]), '')
+
+    # List with Place and other ranking type -> should exclude Place
+    self.assertEqual(_get_best_type(['State', 'Place']), 'State')
+    self.assertEqual(_get_best_type(['Place', 'Country']), 'Country')
+
+    # List with Place and custom non-ranking type -> should keep Place
+    self.assertEqual(_get_best_type(['SomeCustomType', 'Place']), 'Place')
+
+    # List with multiple ranking types and Place -> should exclude Place and return State
+    self.assertEqual(_get_best_type(['City', 'State', 'Place']), 'State')
+
+    # List with no Place -> should return highest rank
+    self.assertEqual(_get_best_type(['City', 'State']), 'State')
+
+    # List with only Place -> should return Place
+    self.assertEqual(_get_best_type(['Place']), 'Place')
+
+    # List with only custom non-ranking type -> should return it
+    self.assertEqual(_get_best_type(['SomeCustomType']), 'SomeCustomType')


### PR DESCRIPTION
## Issue

[b/530339277](https://b.corp.google.com/issues/530339277)

## Related PR

This PR supercedes [6421](https://github.com/datacommonsorg/website/pull/6421), implementing a change that solves the immediate issues while limiting the changes effect on ranking determination in general.

## Description

This PR updates the ranking determination (whereby the preferred place type is chosen when multiple exist) to exclude "Place" whenever there is another valid option.

## Testing

All of the following examples should be tested using a localhost pointing to the latest version of mixer using the Staging spanner instance.

### Maps being dropped in explore pages

Maps are being dropped from explore pages in master (but not in this PR).

[Localhost - fixed](http://localhost:8080/explore?enable_feature=enable_stat_var_autocomplete#q=unemployment+us+states&client=ui_query)

[Dev - broken](https://dev.datacommons.org/explore?enable_feature=enable_stat_var_autocomplete#q=unemployment+us+states&client=ui_query)

### Chosen place name in search

The chosen place names in search are sometimes ill-chosen (selecting Administrative Area over a more specific name such as "State"). This can be seen in the same search, with the text "Unemployment Rate in Administrative Area 1 Places of United States" rather than "Unemployment Rate in States of United States"

[Localhost - fixed](http://localhost:8080/explore?enable_feature=enable_stat_var_autocomplete#q=unemployment+us+states&client=ui_query)

[Dev - broken](https://dev.datacommons.org/explore?enable_feature=enable_stat_var_autocomplete#q=unemployment+us+states&client=ui_query)

### Map Tool - contained places error

The map tool is sometimes unable to determine contained places, causing errors and an empty contained place select box.

[Localhost - fixed](http://localhost:8080/tools/map#%26sv%3DUnemploymentRate_Person%26pc%3D0%26denom%3DCount_Person%26pd%3DgeoId%2F34%26ept%3DCounty)

[Dev - broken](https://dev.datacommons.org/tools/map#%26sv%3DUnemploymentRate_Person%26pc%3D0%26denom%3DCount_Person%26pd%3DgeoId%2F34%26ept%3DCounty)

### Search incorrectly shows place summary

[Localhost - fixed](http://localhost:8080/explore?sv=Count_BlizzardEvent&p=country/USA&imp=StormNOAA_Agg&chartType=RANKING_WITH_MAP&obsPer=P1Y) (This matches prod, with no place summary).

[Dev - broken](https://dev.datacommons.org/explore?sv=Count_BlizzardEvent&p=country/USA&imp=StormNOAA_Agg&chartType=RANKING_WITH_MAP&obsPer=P1Y) (You can see the place summary at the top of this page)

### Single place results in search

Another item found in the bugbash was: "Dev only has data for a single state / prod uses data for the entire country" (in this case, it was Guam being the only place showing for the United States). This is also fixed by this PR (the offending chart no longer shows at all, matching prod).