### PR TITLE
Spanner cohort overrides

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -22,6 +22,8 @@ from flask import redirect
 from flask import request
 from flask_babel import Babel
 import flask_cors
+from google.api_core.exceptions import Forbidden
+from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.exceptions import NotFound
 from google.api_core.exceptions import PermissionDenied
 from google.cloud import secretmanager
@@ -90,8 +92,11 @@ def _get_api_key(env_keys=[], gcp_project='', gcp_path=''):
       logging.warning(
           f'No key found at {gcp_path} of the configured GCP project.')
       return ''
-    except PermissionDenied as e:
+    except (PermissionDenied, Forbidden) as e:
       logging.warning(e)
+      return ''
+    except GoogleAPICallError as e:
+      logging.warning(f'Error fetching key {gcp_path} from GCP project: {e}')
       return ''
 
   # If key is not found, return an empty string

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -403,6 +403,13 @@ def create_app(nl_root=DEFAULT_NL_ROOT):
                                               cfg.SECRET_PROJECT,
                                               'maps-api-key')
 
+  app.config['DB_COHORT_FORCE_SPANNER_IPS'] = _get_api_key(
+      ['DB_COHORT_FORCE_SPANNER_IPS'], cfg.SECRET_PROJECT,
+      'db-cohort-force-spanner-ips')
+  app.config['DB_COHORT_FORCE_NON_SPANNER_IPS'] = _get_api_key(
+      ['DB_COHORT_FORCE_NON_SPANNER_IPS'], cfg.SECRET_PROJECT,
+      'db-cohort-force-non-spanner-ips')
+
   if cfg.LOCAL:
     app.config['LOCAL'] = True
 

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -127,7 +127,8 @@ def is_feature_enabled(feature_name: str, app=None, request=None) -> bool:
 
 
 def ip_in_list(ip_str: str, ip_patterns: list[str]) -> bool:
-  """Checks if an IP address matches any of the IP address or CIDR network patterns.
+  """
+  Checks if an IP address matches any of the IP address or CIDR network patterns.
 
   Args:
     ip_str: Client IP address string (e.g., '192.168.1.1' or '2001:db8::1').

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -14,6 +14,7 @@
 """Common library for functions related to feature flags"""
 
 import hashlib
+import ipaddress
 import random
 
 from flask import current_app
@@ -125,6 +126,37 @@ def is_feature_enabled(feature_name: str, app=None, request=None) -> bool:
   return is_feature_enabled
 
 
+def ip_in_list(ip_str: str, ip_patterns: list[str]) -> bool:
+  """Checks if an IP address matches any of the IP address or CIDR network patterns.
+
+  Args:
+    ip_str: Client IP address string (e.g., '192.168.1.1' or '2001:db8::1').
+    ip_patterns: List of IP addresses or CIDR subnets (e.g., ['192.168.1.1', '10.0.0.0/8']).
+
+  Returns:
+    True if the IP matches any pattern, False otherwise.
+  """
+  if not ip_str or not ip_patterns:
+    return False
+  try:
+    ip = ipaddress.ip_address(ip_str)
+  except ValueError:
+    return False
+
+  for pattern in ip_patterns:
+    try:
+      if '/' in pattern:
+        network = ipaddress.ip_network(pattern, strict=False)
+        if ip in network:
+          return True
+      else:
+        if ip == ipaddress.ip_address(pattern):
+          return True
+    except ValueError:
+      pass
+  return False
+
+
 def assign_spanner_cohort(app, request) -> bool:
   """Deterministically assigns the request to a Spanner cohort if enabled.
 
@@ -147,12 +179,6 @@ def assign_spanner_cohort(app, request) -> bool:
   if not flag_config.get('enabled', False):
     return False
 
-  rollout_percentage = flag_config.get('rollout_percentage', 0)
-  if rollout_percentage >= 100:
-    return True
-  if rollout_percentage <= 0:
-    return False
-
   # Extract the original client IP (the first/leftmost IP in the X-Forwarded-For chain)
   ip = request.headers.get('X-Forwarded-For', request.remote_addr) or ''
   ip = ip.split(',')[0].strip()
@@ -162,6 +188,30 @@ def assign_spanner_cohort(app, request) -> bool:
   # Handle IPv4 with port (contains exactly one colon, e.g., 198.51.100.1:443)
   elif ip.count(':') == 1:
     ip = ip.split(':')[0]
+
+  # Check IP-based cohort overrides
+  force_non_spanner_raw = app.config.get(
+      'DB_COHORT_FORCE_NON_SPANNER_IPS') or ''
+  if force_non_spanner_raw:
+    force_non_spanner_ips = [
+        i.strip() for i in force_non_spanner_raw.split(',') if i.strip()
+    ]
+    if ip_in_list(ip, force_non_spanner_ips):
+      return False
+
+  force_spanner_raw = app.config.get('DB_COHORT_FORCE_SPANNER_IPS') or ''
+  if force_spanner_raw:
+    force_spanner_ips = [
+        i.strip() for i in force_spanner_raw.split(',') if i.strip()
+    ]
+    if ip_in_list(ip, force_spanner_ips):
+      return True
+
+  rollout_percentage = flag_config.get('rollout_percentage', 0)
+  if rollout_percentage >= 100:
+    return True
+  if rollout_percentage <= 0:
+    return False
 
   ua = request.headers.get('User-Agent', '') or ''
   salt = app.config.get('SPANNER_DIVERT_SALT',

--- a/server/tests/lib/feature_flag_test.py
+++ b/server/tests/lib/feature_flag_test.py
@@ -16,6 +16,8 @@
 
 import unittest
 
+from flask import g
+
 from server.__init__ import create_app
 from server.lib.feature_flags import FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM
 from server.lib.feature_flags import FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM
@@ -122,8 +124,6 @@ class TestFeatureFlags(unittest.TestCase):
 
   def test_spanner_diversion_cohort_assignment(self):
     """Test deterministic cohort assignment for divert_to_spanner."""
-    from flask import g
-
     mock_feature_flags(self.app, ["divert_to_spanner"], True, rolloutPercent=50)
 
     # Request 1: IP '192.168.1.1', UA 'Mozilla/5.0'
@@ -192,10 +192,6 @@ class TestFeatureFlags(unittest.TestCase):
 
   def test_spanner_diversion_ip_overrides(self):
     """Test cohort overrides based on client IP addresses/subnets."""
-    from flask import g
-
-    from server.lib.feature_flags import assign_spanner_cohort
-
     # 1. Force to Spanner cohort (0% rollout, but IP is overridden to Spanner)
     mock_feature_flags(self.app, ["divert_to_spanner"], True, rolloutPercent=0)
     self.app.config["DB_COHORT_FORCE_SPANNER_IPS"] = "192.168.1.1,10.0.0.0/8"

--- a/server/tests/lib/feature_flag_test.py
+++ b/server/tests/lib/feature_flag_test.py
@@ -189,3 +189,81 @@ class TestFeatureFlags(unittest.TestCase):
     with self.client as c:
       c.get('/?disable_feature=divert_to_spanner')
       self.assertFalse(g.use_spanner)
+
+  def test_spanner_diversion_ip_overrides(self):
+    """Test cohort overrides based on client IP addresses/subnets."""
+    from flask import g
+
+    from server.lib.feature_flags import assign_spanner_cohort
+
+    # 1. Force to Spanner cohort (0% rollout, but IP is overridden to Spanner)
+    mock_feature_flags(self.app, ["divert_to_spanner"], True, rolloutPercent=0)
+    self.app.config["DB_COHORT_FORCE_SPANNER_IPS"] = "192.168.1.1,10.0.0.0/8"
+    self.app.config["DB_COHORT_FORCE_NON_SPANNER_IPS"] = ""
+
+    with self.client as c:
+      c.get('/', headers={'X-Forwarded-For': '192.168.1.1'})
+      self.assertTrue(g.use_spanner)
+
+    with self.client as c:
+      c.get('/',
+            headers={'X-Forwarded-For': '10.5.2.3'})  # matches CIDR 10.0.0.0/8
+      self.assertTrue(g.use_spanner)
+
+    with self.client as c:
+      c.get('/', headers={'X-Forwarded-For': '192.168.1.2'})  # does not match
+      self.assertFalse(g.use_spanner)
+
+    # 2. Force to Non-Spanner cohort (100% rollout, but IP is overridden to non-Spanner)
+    mock_feature_flags(self.app, ["divert_to_spanner"],
+                       True,
+                       rolloutPercent=100)
+    self.app.config["DB_COHORT_FORCE_SPANNER_IPS"] = ""
+    self.app.config[
+        "DB_COHORT_FORCE_NON_SPANNER_IPS"] = "192.168.1.1,10.0.0.0/8"
+
+    with self.client as c:
+      c.get('/', headers={'X-Forwarded-For': '192.168.1.1'})
+      self.assertFalse(g.use_spanner)
+
+    with self.client as c:
+      c.get('/',
+            headers={'X-Forwarded-For': '10.5.2.3'})  # matches CIDR 10.0.0.0/8
+      self.assertFalse(g.use_spanner)
+
+    with self.client as c:
+      c.get('/', headers={'X-Forwarded-For': '192.168.1.2'})  # does not match
+      self.assertTrue(g.use_spanner)
+
+    # 3. URL Parameter Precedence (URL parameter wins over IP override)
+    mock_feature_flags(self.app, ["divert_to_spanner"], True, rolloutPercent=0)
+    self.app.config["DB_COHORT_FORCE_SPANNER_IPS"] = "192.168.1.1"
+    self.app.config["DB_COHORT_FORCE_NON_SPANNER_IPS"] = ""
+    with self.client as c:
+      # IP says yes, but URL disable override says no
+      c.get('/?disable_feature=divert_to_spanner',
+            headers={'X-Forwarded-For': '192.168.1.1'})
+      self.assertFalse(g.use_spanner)
+
+    mock_feature_flags(self.app, ["divert_to_spanner"],
+                       True,
+                       rolloutPercent=100)
+    self.app.config["DB_COHORT_FORCE_SPANNER_IPS"] = ""
+    self.app.config["DB_COHORT_FORCE_NON_SPANNER_IPS"] = "192.168.1.1"
+    with self.client as c:
+      # IP says no, but URL enable override says yes
+      c.get('/?enable_feature=divert_to_spanner',
+            headers={'X-Forwarded-For': '192.168.1.1'})
+      self.assertTrue(g.use_spanner)
+
+    # 4. Conflict Precedence (non-Spanner override wins if IP is in both)
+    mock_feature_flags(self.app, ["divert_to_spanner"], True, rolloutPercent=50)
+    self.app.config["DB_COHORT_FORCE_SPANNER_IPS"] = "192.168.1.1"
+    self.app.config["DB_COHORT_FORCE_NON_SPANNER_IPS"] = "192.168.1.1"
+    with self.client as c:
+      c.get('/', headers={'X-Forwarded-For': '192.168.1.1'})
+      self.assertFalse(g.use_spanner)
+
+    # Clean up configs
+    self.app.config["DB_COHORT_FORCE_SPANNER_IPS"] = ""
+    self.app.config["DB_COHORT_FORCE_NON_SPANNER_IPS"] = ""


### PR DESCRIPTION
## Related PR

[6432](https://github.com/datacommonsorg/website/pull/6432)

## Description

This PR introduces client IP-based cohort overrides for the Spanner database diversion feature. This allows specific client IP addresses (or CIDR subnets) to be explicitly forced into or excluded from the Spanner cohort, bypassing the random percentage-based rollout.

*   Configured the Flask application to fetch `DB_COHORT_FORCE_SPANNER_IPS` and `DB_COHORT_FORCE_NON_SPANNER_IPS` values from Secret Manager/environment configs.
*   Updated `assign_spanner_cohort` to check for exclusion (`DB_COHORT_FORCE_NON_SPANNER_IPS`) and inclusion (`DB_COHORT_FORCE_SPANNER_IPS`) overrides. IP overrides are processed before percentage-based rollout checks.
*   In the event that an IP matches both forcing and exclusion lists, exclusion (non-Spanner) takes precedence.

## Testing

### Setting up Mixer 

To set up testing of this PR, you will need to run a local version of mixer that:
* has `--use_spanner_graph=false` (i.e., we are still primarily on BT and require diversion to go to Spanner)
* has the `UseSpannerGraph: true` directive set to true in `deploy/featureflags/local.yaml` (i.e., Spanner is enabled)

With the `local.yaml` file so updated, you can start mixer with:

```
./run_server.sh \
    --feature_flags_path=$PWD/deploy/featureflags/local.yaml \
    --spanner_graph_info="$(cat deploy/storage/spanner_graph_info.yaml)" \
    --use_spanner_graph=false \
    --use_base_bigtable=true \
    --embeddings_server_url=http://localhost:6060
```

### Website

Once mixer is set up, you can test the various combinations:

* `local.env` set to `divert_to_spanner` 0, environmental override to spanner on [should be Spanner]
* `local.env` set to `divert_to_spanner` 0, environmental override to non-spanner on [should be BT]
* `local.env` set to `divert_to_spanner` 0, no environmental override [should be BT]

* `local.env` set to `divert_to_spanner` 100, environmental override to spanner on [should be spanner]
* `local.env` set to `divert_to_spanner` 100, environmental override to non-spanner on [should be BT]
* `local.env` set to `divert_to_spanner` 100, no environmental override [should be Spanner]

* `local.env` set to `divert_to_spanner` 1, environmental override to spanner on [should be spanner]
* `local.env` set to `divert_to_spanner` 1, environmental override to non-spanner on [should be BT]
* `local.env` set to `divert_to_spanner` 1, no environmental override [should be BT]

* `local.env` set to `divert_to_spanner` 99, environmental override to spanner on [should be spanner]
* `local.env` set to `divert_to_spanner` 99, environmental override to non-spanner on [should be BT]
* `local.env` set to `divert_to_spanner` 99, no environmental override [should be Spanner]

The environmental overrides are:

**None:**
```
./run_server.sh -m -l
```

**Non-Spanner:**
```
DB_COHORT_FORCE_NON_SPANNER_IPS="127.0.0.1,::1" ./run_server.sh -m -l
```

**Spanner:**
```
DB_COHORT_FORCE_SPANNER_IPS="127.0.0.1,::1" ./run_server.sh -m -l
```

## Codacy

Some of the Codacy errors are incompatible with our Python linter and cannot be fixed. Others are inconsistent with similar docstrings in the same file (and elsewhere in our repository). 
