### PR TITLE
Improve place page resilience when no provenance urls are given

### DIFF
--- a/static/js/place/place_overview.tsx
+++ b/static/js/place/place_overview.tsx
@@ -51,12 +51,14 @@ const PlaceOverviewTable = (props: {
     const url = dataRow.provenanceUrl;
     if (url) {
       try {
-        new URL(url);
-        sourceUrls.add(url);
+        const parsedUrl = new URL(url);
+        if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
+          sourceUrls.add(url);
+        }
       } catch (e) {
         // Skip invalid URL
       }
-    } 
+    }
   });
 
   return (

--- a/static/js/place/place_overview.tsx
+++ b/static/js/place/place_overview.tsx
@@ -46,11 +46,18 @@ const PlaceOverviewTable = (props: {
   const containerRef = useRef(null);
   const dataRows = props.placeOverviewTableApiResponse.data;
 
-  const sourceUrls = new Set(
-    dataRows.map((dataRow) => {
-      return dataRow.provenanceUrl;
-    })
-  );
+  const sourceUrls = new Set<string>();
+  dataRows.forEach((dataRow) => {
+    const url = dataRow.provenanceUrl;
+    if (url) {
+      try {
+        new URL(url);
+        sourceUrls.add(url);
+      } catch (e) {
+        // Skip invalid URL
+      }
+    } 
+  });
 
   return (
     <div data-testid="place-overview-table">


### PR DESCRIPTION
## Description

Add URL validation to provenance source extraction to prevent invalid URL strings. This makes the page more resilient to payloads that contain no provenance urls.

This will be a no-op in production, or when using BT locally.

However, when using Spanner (staging) locally, this will allow the pages to display. There remains a data issue that needs to be fixed upstream, but this makes the frontend more appropriately resilient.

## Testing

When running local Mixer with BT, the page below will be identical between master and this branch.

When running on local Mixer with Spanner (staging) it will be broken in master, but display in this branch. 

http://localhost:8080/place/geoId/06