### PR TITLE
feat: Add Explore dataset link if json-ld data exists

### DIFF
--- a/server/templates/browser/node.html
+++ b/server/templates/browser/node.html
@@ -30,7 +30,7 @@
 
    {% block content %}
    <div class="container">
-       <div id="node" data-dcid="{{dcid}}" data-nn="{{node_name}}"></div>
+       <div id="node" data-dcid="{{dcid}}" data-nn="{{node_name}}" data-has-json-ld="{{ 'true' if json_ld_data else 'false' }}"></div>
    </div>
    {% endblock %}
 

--- a/static/css/browser.scss
+++ b/static/css/browser.scss
@@ -35,6 +35,16 @@
   line-height: 1.2rem;
 }
 
+.explore-dataset-link {
+  display: inline-flex;
+  align-items: center;
+  font-weight: normal;
+
+  svg {
+    margin-left: 4px;
+  }
+}
+
 .observations-table .node-table tr > td:last-of-type {
   width: 70%;
 }

--- a/static/js/browser/app.tsx
+++ b/static/js/browser/app.tsx
@@ -23,6 +23,7 @@ import React from "react";
 
 import { GoogleMap } from "../components/google_map";
 import { ASYNC_ELEMENT_HOLDER_CLASS } from "../constants/css_constants";
+import { ArrowForward } from "../components/elements/icons/arrow_forward";
 import { StatVarHierarchyType } from "../shared/types";
 import { StatVarHierarchy } from "../stat_var_hierarchy/stat_var_hierarchy";
 import { ImageSection } from "./image_section";
@@ -46,11 +47,13 @@ interface BrowserPagePropType {
   statVarId: string;
   nodeTypes: string[];
   shouldShowStatVarHierarchy: boolean;
+  hasJsonLdData?: boolean;
 }
 
 interface BrowserPageStateType {
   provenanceNames: { [key: string]: string };
   dataFetched: boolean;
+  datasetSource?: string;
 }
 
 function setListenerForScrollTo(): void {
@@ -102,6 +105,7 @@ export class BrowserPage extends React.Component<
     this.state = {
       dataFetched: false,
       provenanceNames: {},
+      datasetSource: "",
     };
   }
 
@@ -152,7 +156,19 @@ export class BrowserPage extends React.Component<
             <h2 className="browser-header-subtitle">dcid: {this.props.dcid}</h2>
             <h2 className="browser-header-subtitle">
               typeOf: {this.props.nodeTypes.join(", ")}
+              {this.props.hasJsonLdData && this.props.nodeTypes.includes("Dataset") && this.state.datasetSource && (
+                <>
+                  {" \u2022 "}
+                  <a
+                    href={`/tools/statvar#s=${this.state.datasetSource}&d=${this.props.dcid}`}
+                    style={{ display: "inline-flex", alignItems: "center", fontWeight: "normal" }}
+                  >
+                    Explore dataset <ArrowForward style={{ marginLeft: "4px" }} />
+                  </a>
+                </>
+              )}
             </h2>
+
           </>
         )}
         <div id="overview-map">
@@ -218,18 +234,34 @@ export class BrowserPage extends React.Component<
   }
 
   private fetchData(): void {
-    axios
-      .get("/api/browser/provenance")
-      .then((resp) => {
-        const provenance = resp.data;
+    const promises: Promise<any>[] = [axios.get("/api/browser/provenance")];
+    if (this.props.hasJsonLdData && this.props.nodeTypes.includes("Dataset")) {
+      promises.push(
+        axios.get(`/api/node/propvals/out?prop=isPartOf&dcids=${this.props.dcid}`)
+      );
+    }
+
+    Promise.all(promises)
+      .then((resps) => {
+        const provenance = resps[0].data;
         const provenanceNames = {};
         for (const provId in provenance) {
           const provenanceName = provenance[provId].name;
           provenanceNames[provId] = provenanceName;
         }
+
+        let datasetSource = "";
+        if (resps.length > 1) {
+          const isPartOfResp = resps[1].data[this.props.dcid] || [];
+          if (isPartOfResp.length > 0) {
+            datasetSource = isPartOfResp[0].dcid;
+          }
+        }
+
         this.setState({
           dataFetched: true,
           provenanceNames,
+          datasetSource,
         });
       })
       .catch((e) => {

--- a/static/js/browser/app.tsx
+++ b/static/js/browser/app.tsx
@@ -21,9 +21,9 @@
 import axios from "axios";
 import React from "react";
 
+import { ArrowForward } from "../components/elements/icons/arrow_forward";
 import { GoogleMap } from "../components/google_map";
 import { ASYNC_ELEMENT_HOLDER_CLASS } from "../constants/css_constants";
-import { ArrowForward } from "../components/elements/icons/arrow_forward";
 import { StatVarHierarchyType } from "../shared/types";
 import { StatVarHierarchy } from "../stat_var_hierarchy/stat_var_hierarchy";
 import { ImageSection } from "./image_section";
@@ -156,19 +156,22 @@ export class BrowserPage extends React.Component<
             <h2 className="browser-header-subtitle">dcid: {this.props.dcid}</h2>
             <h2 className="browser-header-subtitle">
               typeOf: {this.props.nodeTypes.join(", ")}
-              {this.props.hasJsonLdData && this.props.nodeTypes.includes("Dataset") && this.state.datasetSource && (
-                <>
-                  {" \u2022 "}
-                  <a
-                    href={`/tools/statvar#s=${this.state.datasetSource}&d=${this.props.dcid}`}
-                    style={{ display: "inline-flex", alignItems: "center", fontWeight: "normal" }}
-                  >
-                    Explore dataset <ArrowForward style={{ marginLeft: "4px" }} />
-                  </a>
-                </>
-              )}
+              {this.props.hasJsonLdData &&
+                this.props.nodeTypes.includes("Dataset") &&
+                this.state.datasetSource && (
+                  <>
+                    {" \u2022 "}
+                    <a
+                      className="explore-dataset-link"
+                      href={`/tools/statvar#s=${encodeURIComponent(
+                        this.state.datasetSource
+                      )}&d=${encodeURIComponent(this.props.dcid)}`}
+                    >
+                      Explore dataset <ArrowForward />
+                    </a>
+                  </>
+                )}
             </h2>
-
           </>
         )}
         <div id="overview-map">
@@ -237,7 +240,11 @@ export class BrowserPage extends React.Component<
     const promises: Promise<any>[] = [axios.get("/api/browser/provenance")];
     if (this.props.hasJsonLdData && this.props.nodeTypes.includes("Dataset")) {
       promises.push(
-        axios.get(`/api/node/propvals/out?prop=isPartOf&dcids=${this.props.dcid}`)
+        axios.get(
+          `/api/node/propvals/out?prop=isPartOf&dcids=${encodeURIComponent(
+            this.props.dcid
+          )}`
+        )
       );
     }
 

--- a/static/js/browser/browser.ts
+++ b/static/js/browser/browser.ts
@@ -31,6 +31,8 @@ const TYPE_OF_OBSERVATION = "StatVarObservation";
 window.addEventListener("load", (): void => {
   const dcid = document.getElementById("node").dataset.dcid;
   const nodeName = document.getElementById("node").dataset.nn;
+  const hasJsonLdData =
+    document.getElementById("node").dataset.hasJsonLd === "true";
   const urlParams = new URLSearchParams(window.location.search);
   const statVarId = urlParams.get("statVar") || "";
   if (!_.isEmpty(statVarId)) {
@@ -61,6 +63,7 @@ window.addEventListener("load", (): void => {
           pageDisplayType,
           shouldShowStatVarHierarchy: numStatVars > 0 && _.isEmpty(statVarId),
           statVarId,
+          hasJsonLdData,
         }),
         document.getElementById("node")
       );
@@ -74,6 +77,7 @@ window.addEventListener("load", (): void => {
           pageDisplayType: PageDisplayType.GENERAL,
           shouldShowStatVarHierarchy: false,
           statVarId,
+          hasJsonLdData,
         }),
         document.getElementById("node")
       );


### PR DESCRIPTION
- Add an inline 'Explore dataset' link next to the 'typeOf: Dataset' header in the Knowledge Graph browser.

- Gate the new UI and its associated API fetch behind the presence of json_ld_data, ensuring it only appears when valid Croissant metadata has been generated.