### PR TITLE
[datacommons-services] Switch DCP feature flags to dcp.yaml and enable KeyValueStore read overrides

### DIFF
--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -91,11 +91,11 @@ if [[ $USE_SPANNER_GRAPH == "true" ]]; then
     SPANNER_CONFIG_YAML="{project: \"$GCP_PROJECT_ID\", instance: \"$GCP_SPANNER_INSTANCE_ID\", database: \"$GCP_SPANNER_DATABASE_NAME\"}"
     
     # 2. Enable V2 API for Mixer
-    MIXER_ARGS+=("--spanner_graph_info=$SPANNER_CONFIG_YAML" "--use_spanner_graph=true")
-
-    if [[ $RESOLVE_WITH_SPANNER_EMBEDDINGS == "true" || $ENABLE_UNIQUE_HISTORY_RECORDS == "true" ]]; then
-        MIXER_ARGS+=('--feature_flags_path=deploy/featureflags/custom.yaml')
-    fi
+    MIXER_ARGS+=(
+        "--spanner_graph_info=$SPANNER_CONFIG_YAML"
+        "--use_spanner_graph=true"
+        "--feature_flags_path=deploy/featureflags/dcp.yaml"
+    )
 fi
 
 # Start mixer.

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -22,7 +22,6 @@ export TOKENIZERS_PARALLELISM=false
 export OMP_NUM_THREADS=1
 
 export NL_SERVER_PORT=${NL_SERVER_PORT:-6060}
-export RESOLVE_WITH_SPANNER_EMBEDDINGS=${RESOLVE_WITH_SPANNER_EMBEDDINGS:-"false"}
 
 # If OUTPUT_DIR is not specified and the deprecated GCS_DATA_PATH is, use that as OUTPUT_DIR.
 if [[ $OUTPUT_DIR == "" && $GCS_DATA_PATH != "" ]]; then
@@ -77,14 +76,14 @@ if [[ $USE_SPANNER_GRAPH == "true" ]]; then
     
     # 1. Dynamically update feature flags for Website and Mixer
     python3 update_dcp_flags.py
-
-    # TODO: Rename this to existing GOOGLE_CLOUD_PROJECT.
-    
-    # Use existing GCP project ID, or fetch it from Metadata Server if empty
-    GCP_PROJECT_ID=${GCP_PROJECT_ID:-$(python3 -c "import urllib.request; req = urllib.request.Request('http://metadata.google.internal/computeMetadata/v1/project/project-id', headers={'Metadata-Flavor': 'Google'}); print(urllib.request.urlopen(req).read().decode())" 2>/dev/null)}
+    # Resolve Project ID across standard environment variables, or fall back to Compute/Cloud Run Metadata Server
+    GCP_PROJECT_ID=${GCP_PROJECT_ID:-${GOOGLE_CLOUD_PROJECT:-$PROJECT_ID}}
+    if [[ -z "$GCP_PROJECT_ID" ]]; then
+        GCP_PROJECT_ID=$(python3 -c "import urllib.request; req = urllib.request.Request('http://metadata.google.internal/computeMetadata/v1/project/project-id', headers={'Metadata-Flavor': 'Google'}); print(urllib.request.urlopen(req).read().decode())" 2>/dev/null)
+    fi
     
     if [[ -z "$GCP_PROJECT_ID" ]]; then
-        echo "ERROR: Failed to resolve Project ID."
+        echo "ERROR: GCP_PROJECT_ID (or GOOGLE_CLOUD_PROJECT / PROJECT_ID) not specified and could not be resolved from metadata."
         exit 1
     fi
     

--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -79,7 +79,7 @@ if [[ $USE_SPANNER_GRAPH == "true" ]]; then
     # Resolve Project ID across standard environment variables, or fall back to Compute/Cloud Run Metadata Server
     GCP_PROJECT_ID=${GCP_PROJECT_ID:-${GOOGLE_CLOUD_PROJECT:-$PROJECT_ID}}
     if [[ -z "$GCP_PROJECT_ID" ]]; then
-        GCP_PROJECT_ID=$(python3 -c "import urllib.request; req = urllib.request.Request('http://metadata.google.internal/computeMetadata/v1/project/project-id', headers={'Metadata-Flavor': 'Google'}); print(urllib.request.urlopen(req).read().decode())" 2>/dev/null)
+        GCP_PROJECT_ID=$(python3 -c "import urllib.request; req = urllib.request.Request('http://metadata.google.internal/computeMetadata/v1/project/project-id', headers={'Metadata-Flavor': 'Google'}); print(urllib.request.urlopen(req).read().decode())" 2>/dev/null) || true
     fi
     
     if [[ -z "$GCP_PROJECT_ID" ]]; then

--- a/build/cdc_services/update_dcp_flags.py
+++ b/build/cdc_services/update_dcp_flags.py
@@ -41,9 +41,11 @@ def update_mixer_flags():
         data['flags'] = {}
         
     # Dynamically inject flags based on explicit environment variable settings
+    # TODO: Clean up RESOLVE_WITH_SPANNER_EMBEDDINGS override since DCP is fully migrated to Spanner embeddings and canonical flags reside directly in dcp.yaml.
     if 'RESOLVE_WITH_SPANNER_EMBEDDINGS' in os.environ:
         data['flags']['EnableSpannerSearchEmbeddings'] = os.environ['RESOLVE_WITH_SPANNER_EMBEDDINGS'].lower() == 'true'
         
+    # TODO(gmechali): Clean up ENABLE_UNIQUE_HISTORY_RECORDS override once completely removed from Terraform and dcp.yaml provides canonical default.
     if 'ENABLE_UNIQUE_HISTORY_RECORDS' in os.environ:
         data['flags']['UseNewIngestionHistorySchema'] = os.environ['ENABLE_UNIQUE_HISTORY_RECORDS'].lower() == 'true'
         

--- a/build/cdc_services/update_dcp_flags.py
+++ b/build/cdc_services/update_dcp_flags.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Dynamically generates/updates the DCP feature flags file (deploy/featureflags/custom.yaml)
+Dynamically generates/updates the DCP feature flags file (deploy/featureflags/dcp.yaml)
 and website feature flags file (server/config/feature_flag_configs/custom.json)
 based on environment variables.
 
@@ -26,7 +26,7 @@ import os
 import yaml
 
 def update_mixer_flags():
-    ff_path = 'deploy/featureflags/custom.yaml'
+    ff_path = 'deploy/featureflags/dcp.yaml'
     
     # Read existing custom flags if they exist
     data = {}
@@ -40,12 +40,15 @@ def update_mixer_flags():
     if 'flags' not in data or data['flags'] is None:
         data['flags'] = {}
         
-    # Dynamically inject flags based on environment variables
-    if os.environ.get('RESOLVE_WITH_SPANNER_EMBEDDINGS') == 'true':
-        data['flags']['EnableSpannerSearchEmbeddings'] = True
+    # Dynamically inject flags based on explicit environment variable settings
+    if 'RESOLVE_WITH_SPANNER_EMBEDDINGS' in os.environ:
+        data['flags']['EnableSpannerSearchEmbeddings'] = os.environ['RESOLVE_WITH_SPANNER_EMBEDDINGS'].lower() == 'true'
         
-    if os.environ.get('ENABLE_UNIQUE_HISTORY_RECORDS') == 'true':
-        data['flags']['UseNewIngestionHistorySchema'] = True
+    if 'ENABLE_UNIQUE_HISTORY_RECORDS' in os.environ:
+        data['flags']['UseNewIngestionHistorySchema'] = os.environ['ENABLE_UNIQUE_HISTORY_RECORDS'].lower() == 'true'
+        
+    if 'USE_SPANNER_KEY_VALUE_STORE' in os.environ:
+        data['flags']['UseSpannerKeyValueStore'] = os.environ['USE_SPANNER_KEY_VALUE_STORE'].lower() == 'true'
         
     # Write back clean YAML
     os.makedirs(os.path.dirname(ff_path), exist_ok=True)


### PR DESCRIPTION
Updates `cdc_services` serving container bootstrapping to use canonical feature flag file `deploy/featureflags/dcp.yaml`.

### Changes
1. **Simplified Feature Flag Loading (`run.sh`):** Whenever `USE_SPANNER_GRAPH == "true"` (indicating a DCP deployment), Mixer always loads `--feature_flags_path=deploy/featureflags/dcp.yaml` cleanly rather than relying on convoluted conditional flag evaluations.
2. **Bidirectional Environment Overrides (`update_dcp_flags.py`):** Checks whether container variables (`RESOLVE_WITH_SPANNER_EMBEDDINGS`, `ENABLE_UNIQUE_HISTORY_RECORDS`, and `USE_SPANNER_KEY_VALUE_STORE`) are explicitly defined in `os.environ` right right on startup and sets their corresponding feature flag booleans directly across the generated configuration.

---

### 🚨 Merge Dependencies / Blockers
This pull request requires **https://github.com/datacommonsorg/mixer/pull/1997** to be submitted first so that `deploy/featureflags/dcp.yaml` exists in the base Mixer directory when initializing container configurations.
