### PR TITLE
Update place matching expressions to account for change in place types

### DIFF
--- a/server/routes/place/utils.py
+++ b/server/routes/place/utils.py
@@ -600,7 +600,7 @@ PLACE_TYPES_TO_CHILD_PLACE_TYPES = {
 # These are used for overriding or customizing the default hierarchy in certain cases.
 PLACE_MATCH_EXPRESSIONS: Callable[[Place], str | None] = [
     # Matches "Earth" (type "Place") and returns "Continent"
-    lambda place: "Continent" if "Place" in place.types else None,
+    lambda place: "Continent" if place.types == ["Place"] else None,
     # Use "State" instead of AdministrativeArea1 for country/USA
     lambda place: "State" if place.dcid == "country/USA" else None,
     # Use "Country" for all  "UNGeoRegion"


### PR DESCRIPTION
## Description

Update PLACE_MATCH_EXPRESSIONS to strictly match "Place" type only for continents (this allows us to tolerate underlying data where many places that have other types also now have type "Place").

A note that this does rely on the invariant that Earth will only be of type "Place". This is the case in both BT and Spanner. We were previously relying on a similar but slightly different set of invariants, that Earth would have type Place, and that it would be the only place that had type Place.