### PR TITLE
[v0/v1 migration] Remove use_v2_api feature flag from production config

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -66,12 +66,6 @@
     "description": "Enables the new ranking page UI"
   },
   {
-    "name": "use_v2_api",
-    "enabled": true,
-    "owner": "juliawu",
-    "description": "Enables features that rely on the V2 REST APIs"
-  },
-  {
     "name": "use_v2_resolve_for_nl_search_vars",
     "enabled": true,
     "owner": "shixiao",


### PR DESCRIPTION
## Related PRs

[6355](https://github.com/datacommonsorg/website/pull/6355)
[6396](https://github.com/datacommonsorg/website/pull/6396)
[6404](https://github.com/datacommonsorg/website/pull/6404)

## Description

Remove `use_v2_api` feature flag from production configuration.

This is a follow-up to 6355 and 6396 (linked above) that removed all usage of those flags from the codebase, and precedes 6404 (also linked above).

Flag removal summary:
* Flag removed from codebase [done - 6355, 6396]
* Flag removed from production config [this PR]
* Flag removed from remaining configs [pending - 6404]