### PR TITLE
Update facet matching logic to fallback to provenanceId

### DIFF
--- a/static/js/shared/stat_types.ts
+++ b/static/js/shared/stat_types.ts
@@ -23,6 +23,7 @@
 // TODO (nick-next): comment the client library version to document that `StatMetadata` matches.
 
 export interface StatMetadata {
+  provenanceId?: string;
   importName?: string;
   provenanceUrl?: string;
   measurementMethod?: string;

--- a/static/js/utils/data_fetch_utils.ts
+++ b/static/js/utils/data_fetch_utils.ts
@@ -129,7 +129,9 @@ export function findMatchingFacets(
     if (
       !highlightFacet ||
       (!_.isEmpty(highlightFacet.importName) &&
-        highlightFacet.importName !== f.importName) ||
+        (f.importName
+          ? highlightFacet.importName !== f.importName
+          : f.provenanceId !== `dc/base/${highlightFacet.importName}`)) ||
       (!_.isEmpty(highlightFacet.measurementMethod) &&
         highlightFacet.measurementMethod !== f.measurementMethod) ||
       (!_.isEmpty(highlightFacet.unit) && highlightFacet.unit !== f.unit) ||

--- a/static/js/utils/data_fetch_utils.ts
+++ b/static/js/utils/data_fetch_utils.ts
@@ -129,7 +129,7 @@ export function findMatchingFacets(
     if (
       !highlightFacet ||
       (!_.isEmpty(highlightFacet.importName) &&
-        (f.importName
+        (!_.isEmpty(f.importName)
           ? highlightFacet.importName !== f.importName
           : f.provenanceId !== `dc/base/${highlightFacet.importName}`)) ||
       (!_.isEmpty(highlightFacet.measurementMethod) &&

--- a/static/js/utils/tests/data_fetch_utils.test.ts
+++ b/static/js/utils/tests/data_fetch_utils.test.ts
@@ -386,6 +386,21 @@ test("findMatchingFacets", () => {
     })
   ).toEqual(["facet_2"]);
 
+  // Test: Fallback to provenanceId match when importName is empty string.
+  // Situation: Highlight criteria has importName 'StormNOAA_Agg', facet has provenanceId 'dc/base/StormNOAA_Agg' and empty importName.
+  // Expectation: Matches and returns the facet ID.
+  const facetsFallbackEmptyImport = {
+    facet_2_empty_import: {
+      importName: "",
+      provenanceId: "dc/base/StormNOAA_Agg",
+    },
+  };
+  expect(
+    findMatchingFacets(facetsFallbackEmptyImport, {
+      facetMetadata: { importName: "StormNOAA_Agg" },
+    })
+  ).toEqual(["facet_2_empty_import"]);
+
   // Test: No match on wrong importName.
   // Situation: Highlight criteria has importName 'StormNOAA_Agg', facet has importName 'Different_Import'.
   // Expectation: Does not match (returns empty array).

--- a/static/js/utils/tests/data_fetch_utils.test.ts
+++ b/static/js/utils/tests/data_fetch_utils.test.ts
@@ -415,4 +415,3 @@ test("findMatchingFacets", () => {
     })
   ).toEqual([]);
 });
-

--- a/static/js/utils/tests/data_fetch_utils.test.ts
+++ b/static/js/utils/tests/data_fetch_utils.test.ts
@@ -20,7 +20,12 @@ import { when } from "jest-when";
 
 import { TEST_SURFACE, TEST_SURFACE_HEADER } from "../../shared/constants";
 import { stringifyFn } from "../axios";
-import { getBestUnit, getPoint, getPointWithin } from "../data_fetch_utils";
+import {
+  findMatchingFacets,
+  getBestUnit,
+  getPoint,
+  getPointWithin,
+} from "../data_fetch_utils";
 
 const TEST_UNIT = "unit";
 const CHILD_TYPE = "childType";
@@ -350,3 +355,64 @@ test("getPointWithin", () => {
     expect(resp).toEqual(TEST_PROCESSED_RESPONSE_1_2_ALIGNED);
   });
 });
+
+test("findMatchingFacets", () => {
+  // Test: Direct importName match.
+  // Situation: Highlight criteria has importName 'StormNOAA_Agg', facet has importName 'StormNOAA_Agg'.
+  // Expectation: Matches and returns the facet ID.
+  const facetsDirect = {
+    facet_1: {
+      importName: "StormNOAA_Agg",
+      provenanceId: "dc/base/StormNOAA_Agg",
+    },
+  };
+  expect(
+    findMatchingFacets(facetsDirect, {
+      facetMetadata: { importName: "StormNOAA_Agg" },
+    })
+  ).toEqual(["facet_1"]);
+
+  // Test: Fallback to provenanceId match.
+  // Situation: Highlight criteria has importName 'StormNOAA_Agg', facet has provenanceId 'dc/base/StormNOAA_Agg' but no importName.
+  // Expectation: Matches and returns the facet ID.
+  const facetsFallback = {
+    facet_2: {
+      provenanceId: "dc/base/StormNOAA_Agg",
+    },
+  };
+  expect(
+    findMatchingFacets(facetsFallback, {
+      facetMetadata: { importName: "StormNOAA_Agg" },
+    })
+  ).toEqual(["facet_2"]);
+
+  // Test: No match on wrong importName.
+  // Situation: Highlight criteria has importName 'StormNOAA_Agg', facet has importName 'Different_Import'.
+  // Expectation: Does not match (returns empty array).
+  const facetsMismatchImport = {
+    facet_3: {
+      importName: "Different_Import",
+      provenanceId: "dc/base/StormNOAA_Agg",
+    },
+  };
+  expect(
+    findMatchingFacets(facetsMismatchImport, {
+      facetMetadata: { importName: "StormNOAA_Agg" },
+    })
+  ).toEqual([]);
+
+  // Test: No match on wrong provenanceId prefix.
+  // Situation: Highlight criteria has importName 'StormNOAA_Agg', facet has provenanceId 'other/prefix/StormNOAA_Agg' and no importName.
+  // Expectation: Does not match (returns empty array).
+  const facetsMismatchProvenance = {
+    facet_4: {
+      provenanceId: "other/prefix/StormNOAA_Agg",
+    },
+  };
+  expect(
+    findMatchingFacets(facetsMismatchProvenance, {
+      facetMetadata: { importName: "StormNOAA_Agg" },
+    })
+  ).toEqual([]);
+});
+


### PR DESCRIPTION
## Description

Spanner no longer includes import names. However, we do use import names as a component for matching facets (in order to preselect a facet in the highlighted chart section of the explore page).

This PR adds logic similar to that found in the metadata API, to provide fallback logic for when the import name is not provided in the facet, but is given as a facet selector.  Import names will not be provided in facet logic going forward; however, the fallback logic will handle existing URLs to prevent existing links from changing behavior.

This error was surfaced in a webdriver test (test_highlight_chart_facet_selector). This test now passes in production Spanner.