### PR TITLE
Prioritize specific Place types over place in ranking

### DIFF
--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -466,9 +466,8 @@ def _get_best_type(types_list):
     return ''
 
   if 'Place' in types_list:
-    has_other_ranking_type = any(
-        t in PLACE_TYPE_RANK and t != 'Place' for t in types_list)
-    if has_other_ranking_type:
+    has_other_type = any(t != 'Place' for t in types_list)
+    if has_other_type:
       types_list = [t for t in types_list if t != 'Place']
 
   # Sort types by rank (highest rank first)

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -466,9 +466,9 @@ def _get_best_type(types_list):
     return ''
 
   if 'Place' in types_list:
-    has_other_type = any(t != 'Place' for t in types_list)
-    if has_other_type:
-      types_list = [t for t in types_list if t != 'Place']
+    filtered_types = [t for t in types_list if t != 'Place']
+    if filtered_types:
+      types_list = filtered_types
 
   # Sort types by rank (highest rank first)
   # If ranks are tied, prefer types that don't start with 'AdministrativeArea'

--- a/server/tests/services/datacommons_test.py
+++ b/server/tests/services/datacommons_test.py
@@ -405,8 +405,9 @@ class TestGetBestType(unittest.TestCase):
     self.assertEqual(_get_best_type(['State', 'Place']), 'State')
     self.assertEqual(_get_best_type(['Place', 'Country']), 'Country')
 
-    # List with Place and custom non-ranking type -> should keep Place
-    self.assertEqual(_get_best_type(['SomeCustomType', 'Place']), 'Place')
+    # List with Place and custom non-ranking type -> should exclude Place
+    self.assertEqual(_get_best_type(['SomeCustomType', 'Place']),
+                     'SomeCustomType')
 
     # List with multiple ranking types and Place -> should exclude Place and return State
     self.assertEqual(_get_best_type(['City', 'State', 'Place']), 'State')


### PR DESCRIPTION
## Description

This PR updates the place ranking determinator to prioritize any custom Place over the generic place.

This resolves an issue where, when Spanner had given the San Francisco Bay Area both "AdministrativeArea" and "Place" as a type, the ranking algorithm did not take "AdministrativeArea" into consideration because it didn't explicitly appear in the ranking list (thus causing it to incorrectly resolve to place, and therefore appear in the list of parent places.

## Testing

When using production Spanner as the database backing local mixer:

http://localhost:8080/api/place/related-places/geoId/06081?hl=en

This link will show San Francisco Bay Area in master before the fix, and exclude it afterwards.