### PR TITLE
Fix place duplication

### DIFF
--- a/static/js/browser/browser.ts
+++ b/static/js/browser/browser.ts
@@ -52,7 +52,7 @@ window.addEventListener("load", (): void => {
   Promise.all([typesPromise, numStatVarsPromise])
     .then(([typesData, numStatVars]) => {
       const types = typesData[dcid] || [];
-      const listOfTypes = types.map((type) => type.dcid);
+      const listOfTypes = Array.from(new Set(types.map((type) => type.dcid)));
       const nodeTypes = getNodeTypes(dcid, listOfTypes, statVarId);
       const pageDisplayType = getPageDisplayType(listOfTypes, statVarId);
       ReactDOM.render(

--- a/static/js/browser/browser.ts
+++ b/static/js/browser/browser.ts
@@ -52,7 +52,7 @@ window.addEventListener("load", (): void => {
   Promise.all([typesPromise, numStatVarsPromise])
     .then(([typesData, numStatVars]) => {
       const types = typesData[dcid] || [];
-      const listOfTypes = Array.from(new Set(types.map((type) => type.dcid)));
+      const listOfTypes = [...new Set(types.map((type) => type.dcid))];
       const nodeTypes = getNodeTypes(dcid, listOfTypes, statVarId);
       const pageDisplayType = getPageDisplayType(listOfTypes, statVarId);
       ReactDOM.render(


### PR DESCRIPTION
## Description

In Spanner, we now sometimes have multiple place types for an individual place (because of different place types introduced from different provenances).

This PR deduplicates the list before displaying it.

## Note

There were two options for where to perform this update:
* Deduplicate the final list in the frontend
* Deduplicate the results of `raw_property_values`

I opted for the former, as it is far safer (it has a negligible blast radius). We can review a deeper deduplication subsequently in `raw_property_values`.

## Screenshots

### Before

<img width="2260" height="824" alt="image" src="https://github.com/user-attachments/assets/a20e0eda-12a1-4401-8bb1-cab90c2a214a" />

### After

<img width="2234" height="928" alt="image" src="https://github.com/user-attachments/assets/f094d6bc-4f60-4f56-b7ad-6acbfa9237ad" />
