### PR TITLE
Use paginated results for /provenance

### DIFF
--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -433,8 +433,8 @@ def multiple_property_values(nodes: List[str],
       # }
   """
   props_expression = f"[{', '.join(props)}]"
-  resp = dc.v2node_paginated(nodes, '{}{}'.format('->' if out else '<-',
-                                        props_expression), max_pages)
+  resp = dc.v2node_paginated(
+      nodes, '{}{}'.format('->' if out else '<-', props_expression), max_pages)
 
   # Parse response into a structured dictionary
   result: Dict[str, Dict[str, List[str]]] = {}

--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -408,7 +408,8 @@ def property_values(nodes, prop, out=True, constraints='', max_pages=1):
 
 def multiple_property_values(nodes: List[str],
                              props: List[str],
-                             out=True) -> Dict[str, Dict[str, List[str]]]:
+                             out=True,
+                             max_pages=1) -> Dict[str, Dict[str, List[str]]]:
   """
   Fetches specified properties for given nodes using the /v2/node API.
 
@@ -416,6 +417,7 @@ def multiple_property_values(nodes: List[str],
       nodes (List[str]): List of node dcids.
       props (List[str]): Properties to retrieve for each node.
       out (bool): If True, fetches outgoing properties; otherwise, incoming (default: True).
+      max_pages (int): The maximum number of pages to fetch.
 
   Returns:
       dict: A dictionary mapping each node to its properties and their values.
@@ -431,8 +433,8 @@ def multiple_property_values(nodes: List[str],
       # }
   """
   props_expression = f"[{', '.join(props)}]"
-  resp = dc.v2node(nodes, '{}{}'.format('->' if out else '<-',
-                                        props_expression))
+  resp = dc.v2node_paginated(nodes, '{}{}'.format('->' if out else '<-',
+                                        props_expression), max_pages)
 
   # Parse response into a structured dictionary
   result: Dict[str, Dict[str, List[str]]] = {}

--- a/server/lib/fetch.py
+++ b/server/lib/fetch.py
@@ -417,7 +417,7 @@ def multiple_property_values(nodes: List[str],
       nodes (List[str]): List of node dcids.
       props (List[str]): Properties to retrieve for each node.
       out (bool): If True, fetches outgoing properties; otherwise, incoming (default: True).
-      max_pages (int): The maximum number of pages to fetch.
+      max_pages (int | None): The maximum number of pages to fetch. If None, fetches all pages.
 
   Returns:
       dict: A dictionary mapping each node to its properties and their values.

--- a/server/routes/browser/api.py
+++ b/server/routes/browser/api.py
@@ -36,9 +36,9 @@ def provenance():
     return jsonify({})
 
   properties_to_fetch = ['name']
-  prop_resp = fetch.multiple_property_values(prov_dcids, 
+  prop_resp = fetch.multiple_property_values(prov_dcids,
                                              properties_to_fetch,
-                                             True, 
+                                             True,
                                              max_pages=None)
 
   result = {}

--- a/server/routes/browser/api.py
+++ b/server/routes/browser/api.py
@@ -26,15 +26,20 @@ bp = flask.Blueprint('api_browser', __name__, url_prefix='/api/browser')
 @cache.cached(timeout=TIMEOUT, query_string=True)
 def provenance():
   """Return provenance name for all available data sources."""
-  prov_resp = fetch.property_values(['Provenance'], 'typeOf', False, max_pages=None)
+  prov_resp = fetch.property_values(['Provenance'],
+                                    'typeOf',
+                                    False,
+                                    max_pages=None)
   prov_dcids = prov_resp.get('Provenance', [])
 
   if not prov_dcids:
     return jsonify({})
 
   properties_to_fetch = ['name']
-  prop_resp = fetch.multiple_property_values(prov_dcids, properties_to_fetch,
-                                             True, max_pages=None)
+  prop_resp = fetch.multiple_property_values(prov_dcids, 
+                                             properties_to_fetch,
+                                             True, 
+                                             max_pages=None)
 
   result = {}
   for dcid, props in prop_resp.items():

--- a/server/routes/browser/api.py
+++ b/server/routes/browser/api.py
@@ -26,7 +26,7 @@ bp = flask.Blueprint('api_browser', __name__, url_prefix='/api/browser')
 @cache.cached(timeout=TIMEOUT, query_string=True)
 def provenance():
   """Return provenance name for all available data sources."""
-  prov_resp = fetch.property_values(['Provenance'], 'typeOf', False)
+  prov_resp = fetch.property_values(['Provenance'], 'typeOf', False, max_pages=None)
   prov_dcids = prov_resp.get('Provenance', [])
 
   if not prov_dcids:
@@ -34,7 +34,7 @@ def provenance():
 
   properties_to_fetch = ['name']
   prop_resp = fetch.multiple_property_values(prov_dcids, properties_to_fetch,
-                                             True)
+                                             True, max_pages=None)
 
   result = {}
   for dcid, props in prop_resp.items():


### PR DESCRIPTION
On local with spanner prod db, Schema provenance was not displaying on browser pages.

The browser pages call /provenance to get provenance dcids and names, but previously was only fetching the first page. It seems that now Schema is on the second page so was not getting returned.

This PR updates the calls in /provenance to use v2node_paginated and fetch all pages (max_pages=None) so that all provenances are shown. This includes swapping multiple_property_values to use v2node_paginated. 

Tested: on local, now Count_Person browser page shows the Schema provenance
<img width="1280" height="680" alt="Screenshot 2026-07-21 at 3 17 15 PM" src="https://github.com/user-attachments/assets/a3c44436-046f-4923-9fdc-a9efcd48f2aa" />

