### PR TITLE
Use env var for setting v2/resolve target param when resolver=indicator

### DIFF
--- a/server/app_env/_base.py
+++ b/server/app_env/_base.py
@@ -120,3 +120,5 @@ class Config:
   # - /nl/eval/retrieval_generation (RIG Eval)
   # - /nl/eval/retrieval_generation_sxs (SxS Eval)
   ENABLE_DATAGEMMA_EVAL_TOOLS = False
+  # Target parameter for v2/resolve API calls when resolver=indicator
+  V2_RESOLVE_INDICATORS_TARGET = os.environ.get('V2_RESOLVE_INDICATORS_TARGET', '')

--- a/server/app_env/_base.py
+++ b/server/app_env/_base.py
@@ -121,4 +121,5 @@ class Config:
   # - /nl/eval/retrieval_generation_sxs (SxS Eval)
   ENABLE_DATAGEMMA_EVAL_TOOLS = False
   # Target parameter for v2/resolve API calls when resolver=indicator
-  V2_RESOLVE_INDICATORS_TARGET = os.environ.get('V2_RESOLVE_INDICATORS_TARGET', '')
+  V2_RESOLVE_INDICATORS_TARGET = os.environ.get('V2_RESOLVE_INDICATORS_TARGET',
+                                                '')

--- a/server/routes/shared_api/stat_var_search_v2.py
+++ b/server/routes/shared_api/stat_var_search_v2.py
@@ -27,9 +27,12 @@ def stat_var_v2_search(query: str, entities: list[str]) -> list[dict[str, str]]:
 
 def _resolve_candidates(query: str) -> list[dict[str, str]]:
   """Resolves a natural language query to a list of candidate DCIDs."""
-  resolve_resp = dc.resolve(nodes=[query],
-                            prop="<-description->dcid",
-                            resolver="indicator")
+  resolve_resp = dc.resolve(
+      nodes=[query],
+      prop="<-description->dcid",
+      resolver="indicator",
+      target="base_and_custom",
+  )
 
   candidates = []
   for ent in resolve_resp.get("entities", []):

--- a/server/routes/shared_api/stat_var_search_v2.py
+++ b/server/routes/shared_api/stat_var_search_v2.py
@@ -27,6 +27,7 @@ def stat_var_v2_search(query: str, entities: list[str]) -> list[dict[str, str]]:
 
 def _resolve_candidates(query: str) -> list[dict[str, str]]:
   """Resolves a natural language query to a list of candidate DCIDs."""
+  # Statvar search explicitly queries both base and custom indicators.
   resolve_resp = dc.resolve(
       nodes=[query],
       prop="<-description->dcid",

--- a/server/routes/shared_api/stat_var_search_v2.py
+++ b/server/routes/shared_api/stat_var_search_v2.py
@@ -27,12 +27,9 @@ def stat_var_v2_search(query: str, entities: list[str]) -> list[dict[str, str]]:
 
 def _resolve_candidates(query: str) -> list[dict[str, str]]:
   """Resolves a natural language query to a list of candidate DCIDs."""
-  url = dc.get_service_url("/v2/resolve")
-  resolve_resp = dc.post(url, {
-      "nodes": [query],
-      "property": "<-description->dcid",
-      "resolver": "indicator"
-  })
+  resolve_resp = dc.resolve(nodes=[query],
+                            prop="<-description->dcid",
+                            resolver="indicator")
 
   candidates = []
   for ent in resolve_resp.get("entities", []):

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -666,7 +666,7 @@ def get_series_dates(parent_entity, child_type, variables):
   return {"datesByVariable": resp_dates, "facets": all_facets}
 
 
-def resolve(nodes, prop, resolver="place", target=""):
+def resolve(nodes, prop, resolver="place", target=None):
   """Resolves nodes based on the given property.
 
     Args:
@@ -675,7 +675,7 @@ def resolve(nodes, prop, resolver="place", target=""):
         resolver: The resolver to use (default: "place").
         target: Optional target parameter to scope resolution.
     """
-  if not target and resolver == "indicator":
+  if target is None and resolver == "indicator":
     target = os.environ.get("V2_RESOLVE_INDICATORS_TARGET", "")
   url = get_service_url("/v2/resolve")
   req = {"nodes": nodes, "property": prop, "resolver": resolver}

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -17,6 +17,7 @@ import asyncio
 import collections
 import json
 import logging
+import os
 from typing import Dict, List
 
 from flask import current_app
@@ -665,16 +666,22 @@ def get_series_dates(parent_entity, child_type, variables):
   return {"datesByVariable": resp_dates, "facets": all_facets}
 
 
-def resolve(nodes, prop, resolver="place"):
+def resolve(nodes, prop, resolver="place", target=""):
   """Resolves nodes based on the given property.
 
     Args:
         nodes: A list of node dcids.
         prop: Property expression indicating the property to resolve.
         resolver: The resolver to use (default: "place").
+        target: Optional target parameter to scope resolution.
     """
+  if not target:
+    target = os.environ.get("V2_RESOLVE_TARGET", "")
   url = get_service_url("/v2/resolve")
-  return post(url, {"nodes": nodes, "property": prop, "resolver": resolver})
+  req = {"nodes": nodes, "property": prop, "resolver": resolver}
+  if target:
+    req["target"] = target
+  return post(url, req)
 
 
 def nl_search_vars(

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -676,7 +676,7 @@ def resolve(nodes, prop, resolver="place", target=None):
         target: Optional target parameter to scope resolution.
     """
   if target is None and resolver == "indicator":
-    target = os.environ.get("V2_RESOLVE_INDICATORS_TARGET", "")
+    target = current_app.config.get("V2_RESOLVE_INDICATORS_TARGET", "")
   url = get_service_url("/v2/resolve")
   req = {"nodes": nodes, "property": prop, "resolver": resolver}
   if target:

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -17,7 +17,6 @@ import asyncio
 import collections
 import json
 import logging
-import os
 from typing import Dict, List
 
 from flask import current_app

--- a/server/services/datacommons.py
+++ b/server/services/datacommons.py
@@ -675,8 +675,8 @@ def resolve(nodes, prop, resolver="place", target=""):
         resolver: The resolver to use (default: "place").
         target: Optional target parameter to scope resolution.
     """
-  if not target:
-    target = os.environ.get("V2_RESOLVE_TARGET", "")
+  if not target and resolver == "indicator":
+    target = os.environ.get("V2_RESOLVE_INDICATORS_TARGET", "")
   url = get_service_url("/v2/resolve")
   req = {"nodes": nodes, "property": prop, "resolver": resolver}
   if target:

--- a/server/tests/routes/api/stats_test.py
+++ b/server/tests/routes/api/stats_test.py
@@ -266,6 +266,7 @@ class TestSearchStatVar(unittest.TestCase):
 
     def post_side_effect(url, req_json):
       if "/v2/resolve" in url:
+        assert req_json.get("target") == "base_and_custom"
         return {
             "entities": [{
                 "candidates": [{

--- a/server/tests/services/datacommons_test.py
+++ b/server/tests/services/datacommons_test.py
@@ -240,7 +240,6 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
 
   def setUp(self):
     self.app = Flask(__name__)
-    self.app.config["NL_ROOT"] = "fake_root"
     self.app_context = self.app.app_context()
     self.app_context.push()
 
@@ -297,9 +296,9 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
 
     assert mock_post.call_count == 1
 
-  @mock.patch.dict(os.environ, {"V2_RESOLVE_INDICATORS_TARGET": "sdmx_env"})
   @mock.patch("server.services.datacommons.post")
-  def test_resolve_indicator_with_target_env_var(self, mock_post):
+  def test_resolve_indicator_with_app_config_target(self, mock_post):
+    self.app.config["V2_RESOLVE_INDICATORS_TARGET"] = "sdmx_config"
 
     def side_effect(url, data, headers=None):
       assert url.endswith("/v2/resolve")
@@ -308,7 +307,7 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
               "nodes": ["foo", "bar"],
               "property": "<-description->dcid",
               "resolver": "indicator",
-              "target": "sdmx_env"
+              "target": "sdmx_config"
           })
       return {}
 
@@ -323,9 +322,9 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
 
     assert mock_post.call_count == 1
 
-  @mock.patch.dict(os.environ, {"V2_RESOLVE_INDICATORS_TARGET": "sdmx_env"})
   @mock.patch("server.services.datacommons.post")
-  def test_resolve_non_indicator_ignores_env_var(self, mock_post):
+  def test_resolve_non_indicator_ignores_app_config(self, mock_post):
+    self.app.config["V2_RESOLVE_INDICATORS_TARGET"] = "sdmx_config"
 
     def side_effect(url, data, headers=None):
       assert url.endswith("/v2/resolve")
@@ -348,10 +347,10 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
 
     assert mock_post.call_count == 1
 
-  @mock.patch.dict(os.environ, {"V2_RESOLVE_INDICATORS_TARGET": "sdmx_env"})
   @mock.patch("server.services.datacommons.post")
-  def test_resolve_indicator_explicit_empty_target_bypasses_env_var(
+  def test_resolve_indicator_explicit_empty_target_bypasses_config(
       self, mock_post):
+    self.app.config["V2_RESOLVE_INDICATORS_TARGET"] = "sdmx_config"
 
     def side_effect(url, data, headers=None):
       assert url.endswith("/v2/resolve")

--- a/server/tests/services/datacommons_test.py
+++ b/server/tests/services/datacommons_test.py
@@ -348,6 +348,33 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
 
     assert mock_post.call_count == 1
 
+  @mock.patch.dict(os.environ, {"V2_RESOLVE_INDICATORS_TARGET": "sdmx_env"})
+  @mock.patch("server.services.datacommons.post")
+  def test_resolve_indicator_explicit_empty_target_bypasses_env_var(
+      self, mock_post):
+
+    def side_effect(url, data, headers=None):
+      assert url.endswith("/v2/resolve")
+      self.assertEqual(
+          data, {
+              "nodes": ["foo", "bar"],
+              "property": "<-description->dcid",
+              "resolver": "indicator"
+          })
+      return {}
+
+    mock_post.side_effect = side_effect
+
+    from server.services.datacommons import resolve
+    resolve(
+        nodes=["foo", "bar"],
+        prop="<-description->dcid",
+        resolver="indicator",
+        target="",
+    )
+
+    assert mock_post.call_count == 1
+
 
 class TestServiceDataCommonsCacheSkip(unittest.TestCase):
 

--- a/server/tests/services/datacommons_test.py
+++ b/server/tests/services/datacommons_test.py
@@ -297,7 +297,7 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
 
     assert mock_post.call_count == 1
 
-  @mock.patch.dict(os.environ, {"V2_RESOLVE_TARGET": "sdmx_env"})
+  @mock.patch.dict(os.environ, {"V2_RESOLVE_INDICATORS_TARGET": "sdmx_env"})
   @mock.patch("server.services.datacommons.post")
   def test_resolve_indicator_with_target_env_var(self, mock_post):
 
@@ -319,6 +319,31 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
         nodes=["foo", "bar"],
         prop="<-description->dcid",
         resolver="indicator",
+    )
+
+    assert mock_post.call_count == 1
+
+  @mock.patch.dict(os.environ, {"V2_RESOLVE_INDICATORS_TARGET": "sdmx_env"})
+  @mock.patch("server.services.datacommons.post")
+  def test_resolve_non_indicator_ignores_env_var(self, mock_post):
+
+    def side_effect(url, data, headers=None):
+      assert url.endswith("/v2/resolve")
+      self.assertEqual(
+          data, {
+              "nodes": ["foo", "bar"],
+              "property": "<-description->dcid",
+              "resolver": "place"
+          })
+      return {}
+
+    mock_post.side_effect = side_effect
+
+    from server.services.datacommons import resolve
+    resolve(
+        nodes=["foo", "bar"],
+        prop="<-description->dcid",
+        resolver="place",
     )
 
     assert mock_post.call_count == 1

--- a/server/tests/services/datacommons_test.py
+++ b/server/tests/services/datacommons_test.py
@@ -271,6 +271,58 @@ class TestServiceDataCommonsResolveIndicator(unittest.TestCase):
 
     assert mock_post.call_count == 1
 
+  @mock.patch("server.services.datacommons.post")
+  def test_resolve_indicator_with_target_param(self, mock_post):
+
+    def side_effect(url, data, headers=None):
+      assert url.endswith("/v2/resolve")
+      self.assertEqual(
+          data, {
+              "nodes": ["foo", "bar"],
+              "property": "<-description->dcid",
+              "resolver": "indicator",
+              "target": "sdmx"
+          })
+      return {}
+
+    mock_post.side_effect = side_effect
+
+    from server.services.datacommons import resolve
+    resolve(
+        nodes=["foo", "bar"],
+        prop="<-description->dcid",
+        resolver="indicator",
+        target="sdmx",
+    )
+
+    assert mock_post.call_count == 1
+
+  @mock.patch.dict(os.environ, {"V2_RESOLVE_TARGET": "sdmx_env"})
+  @mock.patch("server.services.datacommons.post")
+  def test_resolve_indicator_with_target_env_var(self, mock_post):
+
+    def side_effect(url, data, headers=None):
+      assert url.endswith("/v2/resolve")
+      self.assertEqual(
+          data, {
+              "nodes": ["foo", "bar"],
+              "property": "<-description->dcid",
+              "resolver": "indicator",
+              "target": "sdmx_env"
+          })
+      return {}
+
+    mock_post.side_effect = side_effect
+
+    from server.services.datacommons import resolve
+    resolve(
+        nodes=["foo", "bar"],
+        prop="<-description->dcid",
+        resolver="indicator",
+    )
+
+    assert mock_post.call_count == 1
+
 
 class TestServiceDataCommonsCacheSkip(unittest.TestCase):
 


### PR DESCRIPTION
### Description
Loads `V2_RESOLVE_INDICATORS_TARGET` in Flask's `Config` class and updates `dc.resolve()` to read `current_app.config["V2_RESOLVE_INDICATORS_TARGET"]`.

### Changes
- **[server/app_env/_base.py](file:///Users/calinc/datcom-website/server/app_env/_base.py#L123)**: Added `V2_RESOLVE_INDICATORS_TARGET = os.environ.get('V2_RESOLVE_INDICATORS_TARGET', '')` to the `Config` class.
- **[server/services/datacommons.py](file:///Users/calinc/datcom-website/server/services/datacommons.py#L676)**: Updated `resolve()` to read `current_app.config.get("V2_RESOLVE_INDICATORS_TARGET", "")` when `target is None` and `resolver == "indicator"`.
- **[server/routes/shared_api/stat_var_search_v2.py](file:///Users/calinc/datcom-website/server/routes/shared_api/stat_var_search_v2.py#L28)**: Refactored `_resolve_candidates()` to call `dc.resolve(..., target="base_and_custom")`.
- **[server/tests/services/datacommons_test.py](file:///Users/calinc/datcom-website/server/tests/services/datacommons_test.py#L271)**: Added unit tests for Flask `app.config` integration, explicit `target` parameters, and explicit `target=""` bypasses.