### PR TITLE
[dcp] Set default SPANNER_SEARCH_CONFIG_PATH to dcp_default.yaml

### DIFF
--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -88,10 +88,12 @@ if [[ $USE_SPANNER_GRAPH == "true" ]]; then
     fi
     
     SPANNER_CONFIG_YAML="{project: \"$GCP_PROJECT_ID\", instance: \"$GCP_SPANNER_INSTANCE_ID\", database: \"$GCP_SPANNER_DATABASE_NAME\"}"
-    
+    SPANNER_SEARCH_CONFIG_PATH=${SPANNER_SEARCH_CONFIG_PATH:-"/workspace/internal/server/spanner/spanner_config/dcp_default.yaml"}
+
     # 2. Enable V2 API for Mixer
     MIXER_ARGS+=(
         "--spanner_graph_info=$SPANNER_CONFIG_YAML"
+        "--spanner_search_config_path=$SPANNER_SEARCH_CONFIG_PATH"
         "--use_spanner_graph=true"
         "--feature_flags_path=deploy/featureflags/dcp.yaml"
     )


### PR DESCRIPTION
## Goal
Default `SPANNER_SEARCH_CONFIG_PATH` to `/workspace/internal/server/spanner/spanner_config/dcp_default.yaml` if unset, and forward `--spanner_search_config_path` to Mixer in Data Commons Platform (DCP) service container startup script.

## Key Aspects of the Approach
- In `build/cdc_services/run.sh`, when `USE_SPANNER_GRAPH == "true"`:
  - Set default `SPANNER_SEARCH_CONFIG_PATH` environment variable to `/workspace/internal/server/spanner/spanner_config/dcp_default.yaml` (targeting `base_text_embedding` for custom DCP instances).
  - Append `--spanner_search_config_path=$SPANNER_SEARCH_CONFIG_PATH` to `MIXER_ARGS` array.

## Testing & Verification
- Verified bash script syntax with `bash -n build/cdc_services/run.sh` (PASSED).
- Corresponds to `datcom-mixer` [PR #2039](https://github.com/datacommonsorg/mixer/pull/2039).