### PR TITLE
Disable 5% spanner experiment

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -58,7 +58,7 @@
     "enabled": true,
     "owner": "nick-nlb",
     "description": "Diverts traffic to Spanner database backend.",
-    "rollout_percentage": 5
+    "rollout_percentage": 0
   },
   {
     "name": "metadata_modal",


### PR DESCRIPTION
Keeping flag enabled so we can force our own IPs into spanner cohort