### PR TITLE
[cdc_services] pass --host_project flag to mixer in run.sh

### DIFF
--- a/build/cdc_services/run.sh
+++ b/build/cdc_services/run.sh
@@ -96,6 +96,7 @@ if [[ $USE_SPANNER_GRAPH == "true" ]]; then
         "--spanner_search_config_path=$SPANNER_SEARCH_CONFIG_PATH"
         "--use_spanner_graph=true"
         "--feature_flags_path=deploy/featureflags/dcp.yaml"
+        "--host_project=$GCP_PROJECT_ID"
     )
 fi
 


### PR DESCRIPTION
## Description
Passes `--host_project=$GCP_PROJECT_ID` as an argument to Mixer in `build/cdc_services/run.sh` when `USE_SPANNER_GRAPH=true` is set.

Follow up to https://github.com/datacommonsorg/mixer/pull/1995 now that [project id is required](https://github.com/datacommonsorg/mixer/blob/6c26fea0393f3a7a35457e826a95f12eaf60a980/internal/embedder/embedder.go#L66)