### PR TITLE
fix(build): remove latest tag from cloudbuild.push_image.yaml

### DIFF
--- a/build/ci/cloudbuild.push_image.yaml
+++ b/build/ci/cloudbuild.push_image.yaml
@@ -57,10 +57,8 @@ steps:
           --build-arg MIXER_HASH=$(cat mixer_hash.txt) \
           --build-arg WEBSITE_HASH=$(cat website_hash.txt) \
           --tag gcr.io/$_PROJECT_ID/datacommons-services:${_TAG} \
-          --tag gcr.io/$_PROJECT_ID/datacommons-services:latest \
           .
         docker push gcr.io/$_PROJECT_ID/datacommons-services:${_TAG}
-        docker push gcr.io/$_PROJECT_ID/datacommons-services:latest
     waitFor: ["resolve-hashes"]
 
   - id: push-nl-server
@@ -95,10 +93,8 @@ steps:
         DOCKER_BUILDKIT=1
         docker build -f build/website_cron_testing/Dockerfile \
           --tag gcr.io/$_PROJECT_ID/website-cron-testing:${_TAG} \
-          --tag gcr.io/$_PROJECT_ID/website-cron-testing:latest \
           .
         docker push gcr.io/$_PROJECT_ID/website-cron-testing:${_TAG}
-        docker push gcr.io/$_PROJECT_ID/website-cron-testing:latest
     waitFor: ["-"]
 
 substitutions:


### PR DESCRIPTION
## Goal
Remove the automatic pushing of the `:latest` tag in `build/ci/cloudbuild.push_image.yaml` during manual/dev container image builds.

## Key Aspects of the Approach
* Removed `--tag ...:latest` build options and `docker push ...:latest` steps for both `datacommons-services` and `website-cron-testing` images in `build/ci/cloudbuild.push_image.yaml`.
* Guarantees that ad-hoc/dev image pushes (e.g. via `./scripts/push_image.sh`) only push to the explicitly provided tag (`_TAG`, such as `dev-<git-hash>`), preserving tag isolation for downstream environments.

## Testing & Verification
* Verified `build/ci/cloudbuild.push_image.yaml` step definitions against image tagging expectations.