### PR TITLE
[cdc_services] Set DC_AGENT_API_ROOT and DC_USE_AGENT_API defaults

### DIFF
--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -152,7 +152,9 @@ ENV WEBSITE_MIXER_API_ROOT=http://127.0.0.1:8081 \
     ENABLE_MCP=true \
     DC_TYPE=custom \
     DC_API_BASE_URL=http://127.0.0.1:8081/v2 \
-    CUSTOM_DC_URL=http://127.0.0.1:7070
+    CUSTOM_DC_URL=http://127.0.0.1:7070 \
+    DC_AGENT_API_ROOT=http://localhost:8081/v2 \
+    DC_USE_AGENT_API=true
 
 WORKDIR /workspace
 

--- a/build/cdc_services/Dockerfile
+++ b/build/cdc_services/Dockerfile
@@ -153,7 +153,7 @@ ENV WEBSITE_MIXER_API_ROOT=http://127.0.0.1:8081 \
     DC_TYPE=custom \
     DC_API_BASE_URL=http://127.0.0.1:8081/v2 \
     CUSTOM_DC_URL=http://127.0.0.1:7070 \
-    DC_AGENT_API_ROOT=http://localhost:8081/v2 \
+    DC_AGENT_API_ROOT=http://127.0.0.1:8081/v2 \
     DC_USE_AGENT_API=true
 
 WORKDIR /workspace


### PR DESCRIPTION
## Description

Sets default environment variables in `build/cdc_services/Dockerfile`:
- `DC_AGENT_API_ROOT=http://127.0.0.1:8081/v2`
- `DC_USE_AGENT_API=true`