### PR TITLE
[Feature Flags] Introduce flags to gate explore more functionality

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -18,6 +18,18 @@
     "description": "Enables the data_overview/<place> routes."
   },
   {
+    "name": "disable_explore_more_in_nl_search",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow."
+  },
+  {
+    "name": "disable_explore_more_in_nl_search_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow specifically when using Spanner."
+  },
+  {
     "name": "divert_to_spanner",
     "enabled": true,
     "owner": "nick-nlb",

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -18,6 +18,18 @@
     "description": "Enables the data_overview/<place> routes."
   },
   {
+    "name": "disable_explore_more_in_nl_search",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow."
+  },
+  {
+    "name": "disable_explore_more_in_nl_search_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow specifically when using Spanner."
+  },
+  {
     "name": "divert_to_spanner",
     "enabled": false,
     "owner": "nick-nlb",

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -18,6 +18,18 @@
     "description": "Enables the data_overview/<place> routes."
   },
   {
+    "name": "disable_explore_more_in_nl_search",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow."
+  },
+  {
+    "name": "disable_explore_more_in_nl_search_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow specifically when using Spanner."
+  },
+  {
     "name": "divert_to_spanner",
     "enabled": false,
     "owner": "nick-nlb",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -18,6 +18,18 @@
     "description": "Enables the data_overview/<place> routes."
   },
   {
+    "name": "disable_explore_more_in_nl_search",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow."
+  },
+  {
+    "name": "disable_explore_more_in_nl_search_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow specifically when using Spanner."
+  },
+  {
     "name": "divert_to_spanner",
     "enabled": true,
     "owner": "nick-nlb",

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -18,6 +18,18 @@
     "description": "Enables the data_overview/<place> routes."
   },
   {
+    "name": "disable_explore_more_in_nl_search",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow."
+  },
+  {
+    "name": "disable_explore_more_in_nl_search_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow specifically when using Spanner."
+  },
+  {
     "name": "divert_to_spanner",
     "enabled": true,
     "owner": "nick-nlb",

--- a/server/integration_tests/utils.py
+++ b/server/integration_tests/utils.py
@@ -20,7 +20,9 @@ import requests
 
 # Central dictionary of feature flags to override for all integration tests.
 # Set value to True to force enable, False to force disable.
-FEATURE_OVERRIDES = {}
+FEATURE_OVERRIDES = {
+    'disable_explore_more_in_nl_search_for_spanner': False,
+}
 
 
 def post_request(url, **kwargs):

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -41,6 +41,9 @@ USE_V2_RESOLVE_FOR_NL_SEARCH_VARS = 'use_v2_resolve_for_nl_search_vars'
 ENABLE_NL_V2NODE_FETCHALL = 'enable_nl_v2node_fetchall'
 CROISSANT_JSON_LD_FEATURE = 'show_croissant_json_ld'
 CROISSANT_EXTENDED_FEATURE = 'show_croissant_extended_feature'
+DISABLE_EXPLORE_MORE_IN_NL_SEARCH = 'disable_explore_more_in_nl_search'
+DISABLE_EXPLORE_MORE_IN_NL_SEARCH_FOR_SPANNER = 'disable_explore_more_in_nl_search_for_spanner'
+DIVERT_TO_SPANNER = 'divert_to_spanner'
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:
@@ -101,7 +104,7 @@ def is_feature_enabled(feature_name: str, app=None, request=None) -> bool:
   if request is None and has_request_context():
     request = flask_request
 
-  if feature_name == 'divert_to_spanner' and has_request_context():
+  if feature_name == DIVERT_TO_SPANNER and has_request_context():
     from flask import g
     if 'use_spanner' not in g:
       g.use_spanner = assign_spanner_cohort(app, request)
@@ -170,14 +173,14 @@ def assign_spanner_cohort(app, request) -> bool:
     True if client is in the Spanner diversion cohort, False otherwise.
   """
   # Check for URL parameter overrides
-  if is_feature_override_enabled('divert_to_spanner', request):
+  if is_feature_override_enabled(DIVERT_TO_SPANNER, request):
     return True
-  if is_feature_override_disabled('divert_to_spanner', request):
+  if is_feature_override_disabled(DIVERT_TO_SPANNER, request):
     return False
 
   # Check feature flag configuration
   feature_flags = app.config.get('FEATURE_FLAGS', {})
-  flag_config = feature_flags.get('divert_to_spanner', {})
+  flag_config = feature_flags.get(DIVERT_TO_SPANNER, {})
   if not flag_config.get('enabled', False):
     return False
 

--- a/server/lib/nl/explore/fulfiller_bridge.py
+++ b/server/lib/nl/explore/fulfiller_bridge.py
@@ -66,18 +66,17 @@ def fulfill(uttr: nl_uttr.Utterance, cb_config: base.Config) -> FulfillResp:
 
   plotted_orig_vars = _get_plotted_orig_vars(state)
 
-  disable_explore_more = (
-      is_feature_enabled(DISABLE_EXPLORE_MORE_IN_NL_SEARCH) or
-      (is_feature_enabled(DIVERT_TO_SPANNER) and
-       is_feature_enabled(DISABLE_EXPLORE_MORE_IN_NL_SEARCH_FOR_SPANNER)))
-
   explore_peer_groups = {}
   if (not state.uttr.insight_ctx.get(params.Params.EXP_MORE_DISABLED) and
-      not params.is_special_dc(state.uttr.insight_ctx) and
-      not disable_explore_more):
-    explore_more_chart_vars_map = _get_explore_more_chart_vars(state)
-    explore_peer_groups = extension.chart_vars_to_explore_peer_groups(
-        state, explore_more_chart_vars_map)
+      not params.is_special_dc(state.uttr.insight_ctx)):
+    disable_explore_more = (
+        is_feature_enabled(DISABLE_EXPLORE_MORE_IN_NL_SEARCH) or
+        (is_feature_enabled(DIVERT_TO_SPANNER) and
+         is_feature_enabled(DISABLE_EXPLORE_MORE_IN_NL_SEARCH_FOR_SPANNER)))
+    if not disable_explore_more:
+      explore_more_chart_vars_map = _get_explore_more_chart_vars(state)
+      explore_peer_groups = extension.chart_vars_to_explore_peer_groups(
+          state, explore_more_chart_vars_map)
 
   related_things = related.compute_related_things(state, plotted_orig_vars,
                                                   explore_peer_groups)

--- a/server/lib/nl/explore/fulfiller_bridge.py
+++ b/server/lib/nl/explore/fulfiller_bridge.py
@@ -19,6 +19,11 @@ import time
 from typing import cast, Dict, List
 
 from server.config.subject_page_pb2 import SubjectPageConfig
+from server.lib.feature_flags import DISABLE_EXPLORE_MORE_IN_NL_SEARCH
+from server.lib.feature_flags import \
+    DISABLE_EXPLORE_MORE_IN_NL_SEARCH_FOR_SPANNER
+from server.lib.feature_flags import DIVERT_TO_SPANNER
+from server.lib.feature_flags import is_feature_enabled
 from server.lib.nl.common import constants
 from server.lib.nl.common import utils
 import server.lib.nl.common.utterance as nl_uttr
@@ -61,9 +66,15 @@ def fulfill(uttr: nl_uttr.Utterance, cb_config: base.Config) -> FulfillResp:
 
   plotted_orig_vars = _get_plotted_orig_vars(state)
 
+  disable_explore_more = (
+      is_feature_enabled(DISABLE_EXPLORE_MORE_IN_NL_SEARCH) or
+      (is_feature_enabled(DIVERT_TO_SPANNER) and
+       is_feature_enabled(DISABLE_EXPLORE_MORE_IN_NL_SEARCH_FOR_SPANNER)))
+
   explore_peer_groups = {}
   if (not state.uttr.insight_ctx.get(params.Params.EXP_MORE_DISABLED) and
-      not params.is_special_dc(state.uttr.insight_ctx)):
+      not params.is_special_dc(state.uttr.insight_ctx) and
+      not disable_explore_more):
     explore_more_chart_vars_map = _get_explore_more_chart_vars(state)
     explore_peer_groups = extension.chart_vars_to_explore_peer_groups(
         state, explore_more_chart_vars_map)


### PR DESCRIPTION
## Description

This PR introduces the ability to disable the "explore more" feature (related queries and extension variables) in the NL search/explore flow, either globally or specifically for requests routed to the Spanner database cohort.

The motivation for gating the functionality is that this particular path within the NL search adds a significant amount of latency to the search when in Spanner. 

As an example, "Jobs in texas" takes on average 48 seconds, with a p95 of 72 seconds. When the explore more path is excluded from the search, this drops to 1.84 and 1.99 seconds respectively. This order of magitude was witnessed over an array of queries.

## Flags

The PR adds two flags. The first, `disable_explore_more_in_nl_search` is an overall gating of the functionality. If this is set to `false`, then the explore more functionality will not be available in any environment regardless of the other flag setting.

The second, `disable_explore_more_in_nl_search_for_spanner` gates the explore more functionality only when the request would be diverted to Spanner (i.e. the user is in the Spanner cohort).

The reason for the first flag is so that we can continue turning down the explore more functionality even after migration is complete (and we turn on Spanner globally, removing website diversion). We may not need it if we can improve latency before then, but it exists as a backstop.

## Functionality

The explore more functionality manifests as a block below certain charts, offering links to other similar topics:

<img width="1219" height="369" alt="image" src="https://github.com/user-attachments/assets/86f87a91-2118-432e-abb2-c818b66b911f" />

## Testing

With Spanner diversion set to 0 (putting you in the BT cohort):

* `disable_explore_more_in_nl_search` = `true` should suppress the explore more functionality.
* `disable_explore_more_in_nl_search` = `false` shoudl result in the explore more functionality showing.
* `disable_explore_more_in_nl_search_for_spanner` should have no effect at all.

With Spanner diversion at 100 (putting you the Spanner cohort)
* `disable_explore_more_in_nl_search` set to `true` should suppress the explore more functionality.
* `disable_explore_more_in_nl_search` = `false` and `disable_explore_more_in_nl_search_for_spanner` = `false` should result in the functionality showing
* `disable_explore_more_in_nl_search` = `false` and `disable_explore_more_in_nl_search_for_spanner` = `true` should result in the functionality not showing.

A URL you can use to test the functional change is:

http://localhost:8080/explore#q=Cancer+in+Illinois&client=ui_query

A URL you can use to test the non-functional change (demonstrating the load-speed difference) is:

http://localhost:8080/explore?enable_feature=enable_stat_var_autocomplete#q=Jobs%20in%20Texas