### PR TITLE
Integration tests create override scaffolding

### DIFF
--- a/server/integration_tests/explore_test.py
+++ b/server/integration_tests/explore_test.py
@@ -20,6 +20,7 @@ import unittest
 from langdetect import detect as detect_lang
 import requests
 
+from server.integration_tests.utils import post_request
 from shared.lib.constants import TEST_SURFACE_HEADER
 from shared.lib.test_server import NLWebServerTestCase
 
@@ -35,7 +36,7 @@ _MAX_FOOTNOTE_LENGTH = 500
 class ExploreTest(NLWebServerTestCase):
 
   def run_fulfillment(self, test_dir, req_json, failure='', test='', i18n=''):
-    resp = requests.post(
+    resp = post_request(
         self.get_server_url() +
         f'/api/explore/fulfill?test={test}&i18n={i18n}&client=test_fulfill',
         json=req_json,
@@ -54,7 +55,7 @@ class ExploreTest(NLWebServerTestCase):
                     reranker=''):
     ctx = {}
     for q in queries:
-      resp = requests.post(
+      resp = post_request(
           self.get_server_url() +
           f'/api/explore/detect?q={q}&test={test}&i18n={i18n}&client=test_detect&idx={idx}&reranker={reranker}',
           json={
@@ -83,7 +84,7 @@ class ExploreTest(NLWebServerTestCase):
                              var_threshold=''):
     ctx = []
     for (index, q) in enumerate(queries):
-      resp = requests.post(
+      resp = post_request(
           self.get_server_url() +
           f'/api/explore/detect-and-fulfill?q={q}&test={test}&i18n={i18n}&mode={mode}&client=test_detect-and-fulfill&default_place={default_place}&idx={idx}&varThreshold={var_threshold}',
           json={

--- a/server/integration_tests/nl_test.py
+++ b/server/integration_tests/nl_test.py
@@ -18,6 +18,7 @@ import os
 from langdetect import detect as detect_lang
 import requests
 
+from server.integration_tests.utils import post_request
 from shared.lib.test_server import NLWebServerTestCase
 
 _dir = os.path.dirname(os.path.abspath(__file__))
@@ -53,7 +54,7 @@ class NLTest(NLWebServerTestCase):
     ctx = {}
     for i, q in enumerate(queries):
       print('Issuing ', test_dir, f'query[{i}]', q)
-      resp = requests.post(
+      resp = post_request(
           self.get_server_url() +
           f'/api/explore/detect-and-fulfill?q={q}&idx={idx}&detector={detector}&test={test}&i18n={i18n}&mode={mode}&client=test',
           json={

--- a/server/integration_tests/utils.py
+++ b/server/integration_tests/utils.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility functions for integration tests."""
+
+import contextlib
+import urllib.parse
+
+import requests
+
+# Central dictionary of feature flags to override for all integration tests.
+# Set value to True to force enable, False to force disable.
+FEATURE_OVERRIDES = {}
+
+
+def post_request(url, **kwargs):
+  """Wraps requests.post, automatically appending override parameters to the URL."""
+  parsed_url = urllib.parse.urlparse(url)
+  query_params = urllib.parse.parse_qs(parsed_url.query)
+
+  for flag, enabled in FEATURE_OVERRIDES.items():
+    param_name = 'enable_feature' if enabled else 'disable_feature'
+    if param_name not in query_params:
+      query_params[param_name] = []
+    if flag not in query_params[param_name]:
+      query_params[param_name].append(flag)
+
+  # Reconstruct the URL query string
+  flat_params = []
+  for k, vs in query_params.items():
+    for v in vs:
+      flat_params.append((k, v))
+  new_query = urllib.parse.urlencode(flat_params)
+
+  new_url = urllib.parse.urlunparse((
+      parsed_url.scheme,
+      parsed_url.netloc,
+      parsed_url.path,
+      parsed_url.params,
+      new_query,
+      parsed_url.fragment,
+  ))
+  return requests.post(new_url, **kwargs)
+
+
+@contextlib.contextmanager
+def feature_overrides(overrides):
+  """Temporarily overrides feature flags in integration tests."""
+  original = FEATURE_OVERRIDES.copy()
+  FEATURE_OVERRIDES.update(overrides)
+  try:
+    yield
+  finally:
+    FEATURE_OVERRIDES.clear()
+    FEATURE_OVERRIDES.update(original)

--- a/server/integration_tests/utils.py
+++ b/server/integration_tests/utils.py
@@ -25,8 +25,11 @@ FEATURE_OVERRIDES = {}
 
 def post_request(url, **kwargs):
   """Wraps requests.post, automatically appending override parameters to the URL."""
+  if not FEATURE_OVERRIDES:
+    return requests.post(url, **kwargs)
+
   parsed_url = urllib.parse.urlparse(url)
-  query_params = urllib.parse.parse_qs(parsed_url.query)
+  query_params = urllib.parse.parse_qs(parsed_url.query, keep_blank_values=True)
 
   for flag, enabled in FEATURE_OVERRIDES.items():
     param_name = 'enable_feature' if enabled else 'disable_feature'

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -55,8 +55,8 @@ def is_feature_override_enabled(feature_name: str, request=None) -> bool:
   """
   if request is None:
     return False
-  return request.args.get(
-      FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM) == feature_name
+  return feature_name in request.args.getlist(
+      FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM)
 
 
 def is_feature_override_disabled(feature_name: str, request=None) -> bool:
@@ -71,8 +71,8 @@ def is_feature_override_disabled(feature_name: str, request=None) -> bool:
   """
   if request is None:
     return False
-  return request.args.get(
-      FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM) == feature_name
+  return feature_name in request.args.getlist(
+      FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM)
 
 
 def is_feature_enabled(feature_name: str, app=None, request=None) -> bool:

--- a/server/tests/lib/feature_flag_test.py
+++ b/server/tests/lib/feature_flag_test.py
@@ -60,6 +60,14 @@ class TestFeatureFlags(unittest.TestCase):
     # Return False if request is not provided
     self.assertFalse(
         is_feature_override_enabled(TEST_FEATURE_FLAG, request=None))
+    # Return True for multiple overrides
+    response = self.client.get(
+        f"/?{FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM}=flag_a&{FEATURE_FLAG_URL_OVERRIDE_ENABLE_PARAM}=flag_b"
+    )
+    self.assertTrue(
+        is_feature_override_enabled("flag_a", request=response.request))
+    self.assertTrue(
+        is_feature_override_enabled("flag_b", request=response.request))
 
   def test_is_feature_override_disabled_helper(self):
     """Tests the is_feature_override_disabled helper function."""
@@ -79,6 +87,14 @@ class TestFeatureFlags(unittest.TestCase):
     # Return False if request is not provided
     self.assertFalse(
         is_feature_override_disabled(TEST_FEATURE_FLAG, request=None))
+    # Return True for multiple overrides
+    response = self.client.get(
+        f"/?{FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM}=flag_a&{FEATURE_FLAG_URL_OVERRIDE_DISABLE_PARAM}=flag_b"
+    )
+    self.assertTrue(
+        is_feature_override_disabled("flag_a", request=response.request))
+    self.assertTrue(
+        is_feature_override_disabled("flag_b", request=response.request))
 
   def test_feature_flag_enabled_by_app_config(self):
     """Should return true if feature flag is enabled in config"""


### PR DESCRIPTION
## Description

This PR adds scaffolding to the integration tests to allow the overriding of environmental feature flags in the test.

The motivation for this is that:
* The tests use autopush's feature flags.
* There is no way to request that tests use feature flags that are different that what will appear on autopush.
* Autopush at any given moment may not represent the long term (or even current) shape of what the NL search will do and therefore what the goldens should be (that is the case now).

This PR also updates feature flag handling in website to allow for the inclusion of multiple enable/disable flag overrides on the URL at once.