### PR TITLE
[Feature Flags] Introduce production flags to gate explore more functionality

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -12,6 +12,18 @@
     "description": "Enables the biomed_nl experimental features by registering the experiments/biomed_nl api and html routes."
   },
   {
+    "name": "disable_explore_more_in_nl_search",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow."
+  },
+  {
+    "name": "disable_explore_more_in_nl_search_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow specifically when using Spanner."
+  },
+  {
     "name": "enable_stat_var_autocomplete",
     "enabled": false,
     "owner": "gmechali",


### PR DESCRIPTION
## Related PR

[6510](https://github.com/datacommonsorg/website/pull/6510)

## Description

This PR introduces the flags from above PR 6510 into production. It sets the overall flag to false, and the spanner flag to true. See original PR for a detailed description of the functionality.