### PR TITLE
Separate property value calls in triples fetch

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -121,6 +121,18 @@
     "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
+    "name": "use_separate_property_value_calls",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls instead of a single wildcard query to avoid Spanner edge starvation."
+  },
+  {
+    "name": "use_separate_property_value_calls_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls specifically when using Spanner."
+  },
+  {
     "name": "use_v2_resolve_for_nl_search_vars",
     "enabled": true,
     "owner": "shixiao",

--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -120,6 +120,18 @@
     "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
+    "name": "use_separate_property_value_calls",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls instead of a single wildcard query to avoid Spanner edge starvation."
+  },
+  {
+    "name": "use_separate_property_value_calls_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls specifically when using Spanner."
+  },
+  {
     "name": "use_v2_resolve_for_nl_search_vars",
     "enabled": false,
     "owner": "shixiao",

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -120,6 +120,18 @@
     "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
+    "name": "use_separate_property_value_calls",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls instead of a single wildcard query to avoid Spanner edge starvation."
+  },
+  {
+    "name": "use_separate_property_value_calls_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls specifically when using Spanner."
+  },
+  {
     "name": "use_v2_resolve_for_nl_search_vars",
     "enabled": true,
     "owner": "shixiao",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -121,6 +121,18 @@
     "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
+    "name": "use_separate_property_value_calls",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls instead of a single wildcard query to avoid Spanner edge starvation."
+  },
+  {
+    "name": "use_separate_property_value_calls_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls specifically when using Spanner."
+  },
+  {
     "name": "use_v2_resolve_for_nl_search_vars",
     "enabled": false,
     "owner": "shixiao",

--- a/server/config/feature_flag_configs/staging.json
+++ b/server/config/feature_flag_configs/staging.json
@@ -121,6 +121,18 @@
     "description": "Enables Croissant JSON-LD metadata on dataset pages."
   },
   {
+    "name": "use_separate_property_value_calls",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls instead of a single wildcard query to avoid Spanner edge starvation."
+  },
+  {
+    "name": "use_separate_property_value_calls_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls specifically when using Spanner."
+  },
+  {
     "name": "use_v2_resolve_for_nl_search_vars",
     "enabled": true,
     "owner": "shixiao",

--- a/server/lib/feature_flags.py
+++ b/server/lib/feature_flags.py
@@ -44,6 +44,8 @@ CROISSANT_EXTENDED_FEATURE = 'show_croissant_extended_feature'
 DISABLE_EXPLORE_MORE_IN_NL_SEARCH = 'disable_explore_more_in_nl_search'
 DISABLE_EXPLORE_MORE_IN_NL_SEARCH_FOR_SPANNER = 'disable_explore_more_in_nl_search_for_spanner'
 DIVERT_TO_SPANNER = 'divert_to_spanner'
+USE_SEPARATE_PROPERTY_VALUE_CALLS = 'use_separate_property_value_calls'
+USE_SEPARATE_PROPERTY_VALUE_CALLS_FOR_SPANNER = 'use_separate_property_value_calls_for_spanner'
 
 
 def is_feature_override_enabled(feature_name: str, request=None) -> bool:

--- a/server/routes/shared_api/node.py
+++ b/server/routes/shared_api/node.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Node data endpoints."""
-from concurrent.futures import as_completed
-from concurrent.futures import ThreadPoolExecutor
+import asyncio
 from dataclasses import dataclass
 import json
 import re
@@ -52,7 +51,7 @@ class PropertySpec:
 
 
 @bp.route('/triples/<path:direction>/<path:dcid>')
-def triples(direction, dcid):
+async def triples(direction, dcid):
   """Returns all the triples given a node dcid."""
   if direction != 'in' and direction != 'out':
     return "Invalid direction provided, please use 'in' or 'out'", 400
@@ -67,14 +66,15 @@ def triples(direction, dcid):
 
   if use_separate_calls:
     # 1. Fetch the list of properties for the node
-    props_dict = fetch.properties([dcid], out)
+    props_dict = await asyncio.to_thread(fetch.properties, [dcid], out)
     props = props_dict.get(dcid, [])
 
-    # 2. Query each property individually in parallel
     result = {}
+    if not props:
+      return result
 
     # Extract all request globals from parent g to propagate to worker threads
-    parent_g = {k: getattr(g, k) for k in g}
+    parent_g = g.__dict__.copy()
 
     def fetch_prop_values(prop, parent_g_data):
       # Restore request globals in the worker thread's context
@@ -83,24 +83,25 @@ def triples(direction, dcid):
       prop_expr = f"->{prop}" if out else f"<-{prop}"
       return prop, dc.v2node_paginated([dcid], prop_expr, max_pages=1)
 
-    with ThreadPoolExecutor(max_workers=len(props) if props else 1) as executor:
-      futures = []
-      for prop in props:
-        # Dynamically wrap each task invocation with a copy of request context
-        # and pass the parent globals
-        wrapped_task = copy_current_request_context(
-            lambda p=prop: fetch_prop_values(p, parent_g))
-        futures.append(executor.submit(wrapped_task))
+    # Dynamically wrap each task invocation with a copy of request context
+    # and pass the parent globals
+    tasks = []
+    for prop in props:
+      wrapped_task = copy_current_request_context(
+          lambda p=prop: fetch_prop_values(p, parent_g))
+      tasks.append(asyncio.to_thread(wrapped_task))
 
-      for future in as_completed(futures):
-        prop, resp = future.result()
-        # Extract values for this property and add to result
-        for _, node_arcs in resp.get('data', {}).items():
-          for p, val in node_arcs.get('arcs', {}).items():
-            result.setdefault(p, []).extend(val.get('nodes', []))
+    resps = await asyncio.gather(*tasks)
+
+    for prop, resp in resps:
+      # Extract values for this property and add to result
+      for _, node_arcs in resp.get('data', {}).items():
+        for p, val in node_arcs.get('arcs', {}).items():
+          result.setdefault(p, []).extend(val.get('nodes', []))
     return result
 
-  return fetch.triples([dcid], out).get(dcid, {})
+  fallback_resp = await asyncio.to_thread(fetch.triples, [dcid], out)
+  return fallback_resp.get(dcid, {})
 
 
 @bp.route('/propvals/<path:direction>', methods=['GET', 'POST'])

--- a/server/routes/shared_api/node.py
+++ b/server/routes/shared_api/node.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Node data endpoints."""
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 import json
 import re
 from typing import List
 
 import flask
+from flask import copy_current_request_context
+from flask import g
 from flask import request
 from flask import Response
 
@@ -66,15 +70,34 @@ def triples(direction, dcid):
     props_dict = fetch.properties([dcid], out)
     props = props_dict.get(dcid, [])
 
-    # 2. Query each property individually
+    # 2. Query each property individually in parallel
     result = {}
-    for prop in props:
+
+    # Extract all request globals from parent g to propagate to worker threads
+    parent_g = {k: getattr(g, k) for k in g}
+
+    def fetch_prop_values(prop, parent_g_data):
+      # Restore request globals in the worker thread's context
+      for k, v in parent_g_data.items():
+        setattr(g, k, v)
       prop_expr = f"->{prop}" if out else f"<-{prop}"
-      resp = dc.v2node_paginated([dcid], prop_expr, max_pages=1)
-      # Extract values for this property and add to result
-      for node, node_arcs in resp.get('data', {}).items():
-        for p, val in node_arcs.get('arcs', {}).items():
-          result.setdefault(p, []).extend(val.get('nodes', []))
+      return prop, dc.v2node_paginated([dcid], prop_expr, max_pages=1)
+
+    with ThreadPoolExecutor(max_workers=len(props) if props else 1) as executor:
+      futures = []
+      for prop in props:
+        # Dynamically wrap each task invocation with a copy of request context
+        # and pass the parent globals
+        wrapped_task = copy_current_request_context(
+            lambda p=prop: fetch_prop_values(p, parent_g))
+        futures.append(executor.submit(wrapped_task))
+
+      for future in as_completed(futures):
+        prop, resp = future.result()
+        # Extract values for this property and add to result
+        for _, node_arcs in resp.get('data', {}).items():
+          for p, val in node_arcs.get('arcs', {}).items():
+            result.setdefault(p, []).extend(val.get('nodes', []))
     return result
 
   return fetch.triples([dcid], out).get(dcid, {})

--- a/server/routes/shared_api/node.py
+++ b/server/routes/shared_api/node.py
@@ -22,6 +22,12 @@ from flask import request
 from flask import Response
 
 from server.lib import fetch
+from server.lib.feature_flags import DIVERT_TO_SPANNER
+from server.lib.feature_flags import is_feature_enabled
+from server.lib.feature_flags import USE_SEPARATE_PROPERTY_VALUE_CALLS
+from server.lib.feature_flags import \
+    USE_SEPARATE_PROPERTY_VALUE_CALLS_FOR_SPANNER
+import server.services.datacommons as dc
 
 bp = flask.Blueprint('api_node', __name__, url_prefix='/api/node')
 
@@ -46,7 +52,32 @@ def triples(direction, dcid):
   """Returns all the triples given a node dcid."""
   if direction != 'in' and direction != 'out':
     return "Invalid direction provided, please use 'in' or 'out'", 400
-  return fetch.triples([dcid], direction == 'out').get(dcid, {})
+
+  # Check if the feature flag to use separate calls is enabled
+  use_separate_calls = (
+      is_feature_enabled(USE_SEPARATE_PROPERTY_VALUE_CALLS) or
+      (is_feature_enabled(DIVERT_TO_SPANNER) and
+       is_feature_enabled(USE_SEPARATE_PROPERTY_VALUE_CALLS_FOR_SPANNER)))
+
+  out = direction == 'out'
+
+  if use_separate_calls:
+    # 1. Fetch the list of properties for the node
+    props_dict = fetch.properties([dcid], out)
+    props = props_dict.get(dcid, [])
+
+    # 2. Query each property individually
+    result = {}
+    for prop in props:
+      prop_expr = f"->{prop}" if out else f"<-{prop}"
+      resp = dc.v2node_paginated([dcid], prop_expr, max_pages=1)
+      # Extract values for this property and add to result
+      for node, node_arcs in resp.get('data', {}).items():
+        for p, val in node_arcs.get('arcs', {}).items():
+          result.setdefault(p, []).extend(val.get('nodes', []))
+    return result
+
+  return fetch.triples([dcid], out).get(dcid, {})
 
 
 @bp.route('/propvals/<path:direction>', methods=['GET', 'POST'])

--- a/server/tests/routes/shared_api/node_separate_calls_test.py
+++ b/server/tests/routes/shared_api/node_separate_calls_test.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from web_app import app
+
+
+class TestNodeApiSeparateCalls(unittest.TestCase):
+
+  @patch('server.routes.shared_api.node.is_feature_enabled')
+  @patch('server.routes.shared_api.node.fetch.triples')
+  def test_triples_fallback_when_flag_disabled(self, mock_triples, mock_flag):
+    # Setup mocks
+    mock_flag.return_value = False
+    mock_triples.return_value = {'dc/g/Demographics': {'memberOf': []}}
+
+    # Call endpoint
+    response = app.test_client().get('/api/node/triples/in/dc/g/Demographics')
+
+    # Assertions
+    self.assertEqual(response.status_code, 200)
+    mock_triples.assert_called_once_with(['dc/g/Demographics'], False)
+    self.assertEqual(response.get_json(), {'memberOf': []})
+
+  @patch('server.routes.shared_api.node.is_feature_enabled')
+  @patch('server.routes.shared_api.node.fetch.properties')
+  @patch('server.routes.shared_api.node.dc.v2node_paginated')
+  def test_triples_separate_calls_when_flag_enabled(self, mock_v2node,
+                                                    mock_properties, mock_flag):
+    # Setup flags: enabled
+    mock_flag.side_effect = lambda f: f == 'use_separate_property_value_calls'
+
+    # Mock properties returned
+    mock_properties.return_value = {
+        'dc/g/Demographics': ['memberOf', 'specializationOf']
+    }
+
+    # Mock individual responses
+    def v2node_side_effect(nodes, prop, max_pages):
+      if 'memberOf' in prop:
+        return {
+            'data': {
+                'dc/g/Demographics': {
+                    'arcs': {
+                        'memberOf': {
+                            'nodes': [{
+                                'dcid': 'Count_Person',
+                                'name': 'Person Count'
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+      elif 'specializationOf' in prop:
+        return {
+            'data': {
+                'dc/g/Demographics': {
+                    'arcs': {
+                        'specializationOf': {
+                            'nodes': [{
+                                'dcid': 'dc/g/Root',
+                                'name': 'Root Variables'
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+      return {}
+
+    mock_v2node.side_effect = v2node_side_effect
+
+    # Call endpoint
+    response = app.test_client().get('/api/node/triples/in/dc/g/Demographics')
+
+    # Assertions
+    self.assertEqual(response.status_code, 200)
+    mock_properties.assert_called_once_with(['dc/g/Demographics'], False)
+    self.assertEqual(mock_v2node.call_count, 2)
+    mock_v2node.assert_any_call(['dc/g/Demographics'],
+                                '<-memberOf',
+                                max_pages=1)
+    mock_v2node.assert_any_call(['dc/g/Demographics'],
+                                '<-specializationOf',
+                                max_pages=1)
+
+    expected_response = {
+        'memberOf': [{
+            'dcid': 'Count_Person',
+            'name': 'Person Count'
+        }],
+        'specializationOf': [{
+            'dcid': 'dc/g/Root',
+            'name': 'Root Variables'
+        }]
+    }
+    self.assertEqual(response.get_json(), expected_response)


### PR DESCRIPTION
## Description

This PR resolves missing arcs on the browser page when using the Spanner backend. 

In Spanner, a large number of edges can result in pagination where not all properties appear on the browser page. This occurs because Spanner pagination is not done with individual properties taken into consideration, meaning the first page may not contain all properties. Even if the first page did contain examples of all properties, this would not in itself guarantee that we would get all the edges shown via Bigtable.

Increasing pagination is not viable because sequentially fetching many pages results in extremely long network calls and returns far more information than can be displayed comfortably on the page (without causing frontend lag). 

To fix this, the triples route first fetches the list of properties for the node, and then resolves the values for each property via separate, individual V2 API calls (capped at 1 page each). This replicates Bigtable's parallel property-specific query behavior, preventing any single property from starving others while maintaining page-load performance.

## Flags

Two flags are introduced in this PR. These mirror the flag strategy of [PR 6515](https://github.com/datacommonsorg/website/pull/6515), where we have a flag tied to Spanner diversion and an overall flag that enables this new functionality regardless of Spanner diversion state.

* `use_separate_property_value_calls`
* `use_separate_property_value_calls_for_spanner`

The flags do not exist in `production.json`. In all other environments, the Spanner diversion version of the flag is set to true and the standard version is set to false.

## Testing

Testing URL:

* http://localhost:8080/browser/dc/g/Demographics

Locally you can test BT by setting your diversion flag to 0. You can test Spanner by setting it to 100.

The above page should look the same as production in BT (it should follow the same path as before).

In Spanner:
* With the `use_separate_property_value_calls_for_spanner` on (or the general version on), we should now see all properties, and up to 500 rows associated with each property
* With the flag off, we should see a single property (due to the pagination issue).