### PR TITLE
[Feature Flags] Enable Spanner in local and dev

### DIFF
--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -31,9 +31,10 @@
   },
   {
     "name": "divert_to_spanner",
-    "enabled": false,
+    "enabled": true,
     "owner": "nick-nlb",
-    "description": "Diverts traffic to Spanner database backend."
+    "description": "Diverts traffic to Spanner database backend.",
+    "rollout_percentage": 100
   },
   {
     "name": "enable_chart_hyperlink",

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -34,7 +34,7 @@
     "enabled": true,
     "owner": "nick-nlb",
     "description": "Diverts traffic to Spanner database backend.",
-    "rollout_percentage": 0
+    "rollout_percentage": 100
   },
   {
     "name": "enable_chart_hyperlink",


### PR DESCRIPTION
## Description

As we prepare to roll out Spanner more broadly, this PR sets local to divert to Spanner by default. 

We also set dev to divert to Spanner. The dev environment has previously used Spanner via mixer, rather than website diversion.