### PR TITLE
[Feature Flags] Turn on gated Spanner paths in production

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -70,7 +70,7 @@
     "enabled": true,
     "owner": "nick-nlb",
     "description": "Diverts traffic to Spanner database backend.",
-    "rollout_percentage": 25
+    "rollout_percentage": 0
   },
   {
     "name": "metadata_modal",

--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -54,11 +54,23 @@
     "description": "Enables the data_overview/<place> routes."
   },
   {
+    "name": "disable_explore_more_in_nl_search",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow."
+  },
+  {
+    "name": "disable_explore_more_in_nl_search_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Bypasses the gathering and processing of explore more related queries in the explore flow specifically when using Spanner."
+  },
+  {
     "name": "divert_to_spanner",
     "enabled": true,
     "owner": "nick-nlb",
     "description": "Diverts traffic to Spanner database backend.",
-    "rollout_percentage": 0
+    "rollout_percentage": 25
   },
   {
     "name": "metadata_modal",
@@ -71,6 +83,18 @@
     "enabled": false,
     "owner": "juliawu",
     "description": "Enables the new ranking page UI"
+  },
+  {
+    "name": "use_separate_property_value_calls",
+    "enabled": false,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls instead of a single wildcard query to avoid Spanner edge starvation."
+  },
+  {
+    "name": "use_separate_property_value_calls_for_spanner",
+    "enabled": true,
+    "owner": "nick-nlb",
+    "description": "Gates the use of separate property value calls specifically when using Spanner."
   },
   {
     "name": "use_v2_resolve_for_nl_search_vars",


### PR DESCRIPTION
## Description

This PR turns on Spanner paths in production for:

* Disabling the explore more (due to latency issues in Spanner)
* Moving `triples` to separate calls per property (due to how Spanner handles these calls differently than BT).