### PR TITLE
fix: add X-Api-Key to CORS allowed headers in nginx configuration

### DIFF
--- a/build/cdc_services/nginx.conf
+++ b/build/cdc_services/nginx.conf
@@ -16,7 +16,7 @@ http {
         if ($request_method = OPTIONS) {
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,X-Requested-With' always;
+            add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,X-Requested-With,X-Api-Key' always;
             add_header 'Access-Control-Max-Age' 3600;
             
             # Respond with 204 No Content for OPTIONS requests
@@ -35,7 +35,7 @@ http {
         # Add CORS headers to normal (non-OPTIONS) responses as well
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,X-Requested-With' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,X-Requested-With,X-Api-Key' always;
     }
 
     # Make MCP server available at /mcp


### PR DESCRIPTION
This is required when X-Api-Key header is used for auth instead of key query param