### PR TITLE
update filter with dual vars and the test to reflect the actual test case

### DIFF
--- a/server/integration_tests/nl_test.py
+++ b/server/integration_tests/nl_test.py
@@ -248,9 +248,9 @@ class NLTestDemo(NLTest):
             # This should be a place comparison for a single more prominent SV.
             "Poverty vs. Obesity in California and Florida",
             # Filter query with top cities.
-            "California cities with hispanic population over 10000",
+            "California cities with hispanic population over 20000",
             # Filter query with another SV.
-            "Prevalence of Asthma in California cities with hispanic population over 10000",
+            "Prevalence of Asthma in California cities with hispanic population over 20000",
         ],
         # Use heuristic because LLM fallback is not very deterministic.
         detector='heuristic',

--- a/server/integration_tests/test_data/multisv/query_3/chart_config.json
+++ b/server/integration_tests/test_data/multisv/query_3/chart_config.json
@@ -26,7 +26,7 @@
                     "statVarKey": [
                       "Count_Person_HispanicOrLatino_multiple_place_bar_block"
                     ],
-                    "title": "Hispanic Population (${date}) - Top 7 of 294",
+                    "title": "Hispanic Population (${date}) - Top 7 of 174",
                     "type": "BAR"
                   }
                 ]

--- a/server/integration_tests/test_data/multisv/query_4/chart_config.json
+++ b/server/integration_tests/test_data/multisv/query_4/chart_config.json
@@ -26,7 +26,7 @@
                     "statVarKey": [
                       "Percent_Person_WithAsthma_multiple_place_bar_block"
                     ],
-                    "title": "Asthma (${date}) - Top 7 of 294",
+                    "title": "Asthma (${date}) - Top 7 of 174",
                     "type": "BAR"
                   }
                 ]

--- a/server/lib/nl/fulfillment/filter_with_dual_vars.py
+++ b/server/lib/nl/fulfillment/filter_with_dual_vars.py
@@ -145,7 +145,7 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
   if end_date:
     sv_place_latest_date = utils.get_predicted_latest_date(
         existing_svs, state.date_range)
-  selected_svs = [sv for sv in selected_svs if sv in existing_svs]
+  selected_svs = list(dict.fromkeys(sv for sv in selected_svs if sv in existing_svs))
   if not selected_svs:
     state.uttr.counters.err('filter-with-dual-vars_selectedexistencefailed',
                             selected_svs)

--- a/server/lib/nl/fulfillment/filter_with_dual_vars.py
+++ b/server/lib/nl/fulfillment/filter_with_dual_vars.py
@@ -145,7 +145,8 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
   if end_date:
     sv_place_latest_date = utils.get_predicted_latest_date(
         existing_svs, state.date_range)
-  selected_svs = list(dict.fromkeys(sv for sv in selected_svs if sv in existing_svs))
+  selected_svs = list(
+      dict.fromkeys(sv for sv in selected_svs if sv in existing_svs))
   if not selected_svs:
     state.uttr.counters.err('filter-with-dual-vars_selectedexistencefailed',
                             selected_svs)

--- a/server/lib/nl/fulfillment/filter_with_dual_vars.py
+++ b/server/lib/nl/fulfillment/filter_with_dual_vars.py
@@ -145,7 +145,7 @@ def populate(state: PopulateState, chart_vars: ChartVars, places: List[Place],
   if end_date:
     sv_place_latest_date = utils.get_predicted_latest_date(
         existing_svs, state.date_range)
-  selected_svs = list(existing_svs.keys())
+  selected_svs = [sv for sv in selected_svs if sv in existing_svs]
   if not selected_svs:
     state.uttr.counters.err('filter-with-dual-vars_selectedexistencefailed',
                             selected_svs)


### PR DESCRIPTION
The test case "Counties in California where income is over 50000" with filter_test condition would invoke FILTER_WITH_DUAL_VARS query type with multiple nodes after threshold change.

The using of v2/observation with v2/node would return the observation in random order, here it force to preserve the order of SVs

The test case "California cities with hispanic population over 10000" with filter_test condition would invoke FILTER_WITH_DUAL_VARS and wrongly capture dc/topic/sdg_10.c.1 with content "sdg 10 c 1" on "10000" to be filtered on and causing weird behavior. Change the test case to "California cities with hispanic population over 20000" to avoid this wrong capture and reflect the test on testing filter to top cities by population