### PR TITLE
modify the golden tests to adjust for 0.6 threshold

### DIFF
--- a/server/integration_tests/nl_test.py
+++ b/server/integration_tests/nl_test.py
@@ -215,7 +215,7 @@ class NLTestDemo(NLTest):
         [
             # We have no stats on this, so we should return SF overview.
             # Two places should be detected but San Francisco is the main place.
-            'Number of Shakespeare fans in San Francisco and Chicago.',
+            'Total number of Shakespeare fans in San Francisco and Chicago.',
             # We should support comparison across multiple places in a single query.
             # Since there are multiple places we shouldn't need the trigger word "compare".
             'Crime in California and Florida',


### PR DESCRIPTION
The related test is supposed to fallback to the place it self when we don't have SV matched. Added a redundant word to reduce the top match SV from 0.60x to 0.5x