### PR TITLE
update autopush local and dev feature flag to use 0.6 threshold for spanner embeddings in detect-and-fulfill

### DIFF
--- a/server/config/feature_flag_configs/autopush.json
+++ b/server/config/feature_flag_configs/autopush.json
@@ -134,7 +134,7 @@
   },
   {
     "name": "use_config_threshold_for_spanner_embedding",
-    "enabled": false,
+    "enabled": true,
     "owner": "shixiao",
     "description": "Gates the use of config SPANNER_EMBEDDING_THRESHOLD. If false, it will use the default threshold."
   },

--- a/server/config/feature_flag_configs/dev.json
+++ b/server/config/feature_flag_configs/dev.json
@@ -134,7 +134,7 @@
   },
   {
     "name": "use_config_threshold_for_spanner_embedding",
-    "enabled": false,
+    "enabled": true,
     "owner": "shixiao",
     "description": "Gates the use of config SPANNER_EMBEDDING_THRESHOLD. If false, it will use the default threshold."
   },

--- a/server/config/feature_flag_configs/local.json
+++ b/server/config/feature_flag_configs/local.json
@@ -134,7 +134,7 @@
   },
   {
     "name": "use_config_threshold_for_spanner_embedding",
-    "enabled": false,
+    "enabled": true,
     "owner": "shixiao",
     "description": "Gates the use of config SPANNER_EMBEDDING_THRESHOLD. If false, it will use the default threshold."
   },


### PR DESCRIPTION
This PR update the local, dev, autopush threshold feature flag to use the 0.6 threshold from Config. Separating it from https://github.com/datacommonsorg/website/pull/6571

Will merge staging feature flag change after staging cut on Thursday.