### PR TITLE
Update simulated typing to only update the query in the input

### DIFF
--- a/static/js/apps/explore/app.tsx
+++ b/static/js/apps/explore/app.tsx
@@ -162,7 +162,6 @@ export function App(props: AppProps): ReactElement {
             <AutoPlay
               autoPlayQuery={autoPlayQuery}
               inputQuery={(query): void => {
-                setQuery(query);
                 setStoreQueryString(query);
               }}
               disableDelay={loadingStatus === LoadingStatus.DEMO_INIT}


### PR DESCRIPTION
## Description

During `/demo` autoplay, `AutoPlay`'s `inputQuery` callback was calling `setQuery` on every typed character. This caused the search result header (under "Data related to your research question") to mutate live with each keystroke before the query was actually submitted.

<img width="1892" height="236" alt="image" src="https://github.com/user-attachments/assets/81fd6b26-4618-493e-a07a-6b85aeadb1f0" />

This PR removes `setQuery` from the `inputQuery` callback so that simulated typing only updates the search bar input via `setStoreQueryString`, leaving the active search results unchanged until the new query is submitted.