### PR TITLE
Update redirects README to reflect current behavior.

### DIFF
--- a/server/routes/redirects/README.md
+++ b/server/routes/redirects/README.md
@@ -1,6 +1,6 @@
 The `redirects.json` file in this directory is stored in a GCS bucket and
-read by the production Flask server on each redirection call (to achieve
-immediate update without rollout/restart).
+read by the Flask server on server start. A rollout/restart is required
+for these changes to be read and take effect in production.
 
 Redirects can be used at datacommons.org/link/<REDIRECT-NAME>
 


### PR DESCRIPTION
## Description

The README.md in `server/routes/redirects/README.md` that describes how to update redirect mapping is incorrect/out-of-date.

While the description of how to update the mapping (via the `gcloud storage cp`) is correct, the description of when those changes are picked up by production is not. 

The file states that production reads this redirect mapping on each redirection call, resulting in the immediate pickup of these changes. This is incorrect. The bucket is read when the Flask server starts (in `__init__.py`).

This PR updates the README.md to correct the description.