### PR TITLE
[feature-flags] Remove deprecated enable_gemini_3_flash feature flag from production config

### DIFF
--- a/server/config/feature_flag_configs/production.json
+++ b/server/config/feature_flag_configs/production.json
@@ -30,13 +30,6 @@
     "description": "Enables the follow up questions generated from related topics to general audience."
   },
   {
-    "name": "enable_gemini_3_flash",
-    "deprecated": true,
-    "enabled": true,
-    "owner": "shixiao",
-    "description": "Enables Gemini 3 Flash for NL detection."
-  },
-  {
     "name": "page_overview_ga",
     "enabled": false,
     "owner": "javiervazquez",


### PR DESCRIPTION
## Related PR

[6345](https://github.com/datacommonsorg/website/pull/6345)

## Description

This PR removes the `enable_gemini_3_flash` flag from `production.json`. The flag was deprecated in the related PR (which also removed the flag from the configs of other environments).