### PR TITLE
[feature-flags] Remove deprecated logic from tests

### DIFF
--- a/server/tests/lib/util_test.py
+++ b/server/tests/lib/util_test.py
@@ -1800,8 +1800,9 @@ class TestFeatureFlagsTest(unittest.TestCase):
         data = json.load(f)
 
       features = [
-          item.get("name") for item in data if isinstance(item, dict) and
-          "name" in item and not item.get("deprecated", False)
+          item.get("name")
+          for item in data
+          if isinstance(item, dict) and "name" in item
       ]
       duplicate_features = [f for f in features if features.count(f) > 1]
 


### PR DESCRIPTION
## Description

Before this PR, the feature-flag tests filtered the list of feature flags in any given environment's feature flag list by `deprecated`. 

With this behavior, the tests passed when a flag was marked as deprecated in production, and completely removed from other environments.  However, flag deployment in `scripts/update_gcs_feature_flags.sh` did not exclude deprecated flags from considerations. This mismatch resulted in the standard tests passing, but the deployment script subsequently failing.

The attribute `deprecated` is purely an indicator to us, to mark a flag as being on the path to being removed, and plays no role in actual flag behavior. Marking a flag as deprecated is effectively a no-op. Most critically, a deprecated flag that is set to true is still in force in that environment.

Following from the fact that deprecation plays no roll in actually turning down a flag, deprecation status should play no roll in tests. In other words, the behavior of the deployment script best fits how the flags work.

This PR updates the feature flag test logic so that flags marked as deprecated no longer affect test results.

## Note

We can still use the deprecated flag as intended, as an indicator to us that a flag is due to be removed but that development lifecycle is such that we are not able to remove the flag yet. 

However, we cannot (as we couldn't already during feature flag deployment) mark a production flag as deprecated in order to get around the requirement that a flag that exists in production has been removed in another environment.

As a separate note (but relating to something that surfaced during the removal of the feature flag that surfaced this issue), we should adhere to a process by which a PR that adds, alters or removes a flag in production contains no other functionality but that single update, and alters no other files other than `production.json`. This means that the complete removal of a flag set will be, by design, a multi-PR process.