### PR TITLE
update custom.json to default using 0.6 threshold for spanner embedding

### DIFF
--- a/server/config/feature_flag_configs/custom.json
+++ b/server/config/feature_flag_configs/custom.json
@@ -133,7 +133,7 @@
   },
   {
     "name": "use_config_threshold_for_spanner_embedding",
-    "enabled": false,
+    "enabled": true,
     "owner": "shixiao",
     "description": "Gates the use of config SPANNER_EMBEDDING_THRESHOLD. If false, it will use the default threshold."
   },


### PR DESCRIPTION
update custom.json to default using 0.6 threshold for spanner embedding, this custom.json will be read into DCP and set it to use the 0.6 threshold