### PR TITLE
fix: remove MIXER_HASH from website VERSION string

### DIFF
--- a/run_server.sh
+++ b/run_server.sh
@@ -42,7 +42,6 @@ PORT=8080
 ENABLE_MODEL=false
 
 export WEBSITE_HASH=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "")
-export MIXER_HASH=$(git rev-parse --short=7 HEAD:mixer 2>/dev/null || echo "")
 
 
 function help {

--- a/server/app_env/_base.py
+++ b/server/app_env/_base.py
@@ -56,8 +56,7 @@ class Config:
   ENV = ''
   # Name of the site. The name is changed for custom instance.
   NAME = 'Data Commons'
-  VERSION = '{}-{}'.format(os.environ.get('WEBSITE_HASH'),
-                           os.environ.get('MIXER_HASH'))
+  VERSION = os.environ.get('WEBSITE_HASH', '')
   API_ROOT = 'http://127.0.0.1:8081'  # Port for Kubernetes ESP.
   SECRET_PROJECT = ''
   # Deprecated. Use the GOOGLE_ANALYTICS_TAG_ID environment variable instead of GA_ACCOUNT


### PR DESCRIPTION
## Description

This PR updates the static asset cache-buster `VERSION` configuration to use only `WEBSITE_HASH`, eliminating the `-None` suffix that previously triggered Cloud Armor WAF false positives.

### Background & Root Cause
In `server/app_env/_base.py`, `VERSION` was defined as:
```python
VERSION = '{}-{}'.format(os.environ.get('WEBSITE_HASH'), os.environ.get('MIXER_HASH'))
```
Because Mixer runs as a separate microservice and `MIXER_HASH` is not injected into the `dc-website` container environment in GKE, `os.environ.get('MIXER_HASH')` evaluated to `None`. This produced `VERSION = "<website_hash>-None"` (e.g. `6fa4ed3-None`), which was appended to all static CSS/JS resource URLs (e.g. `/static/disaster_dashboard.js?t=6fa4ed3-None`).

Under OWASP ModSecurity Core Rule Set v4.2.2, the `-None` query argument matched the regex for Unix command flags in rule `owasp-crs-v042200-id932239-rce` (`-n[a-z0-9_]`), leading to legitimate web traffic getting blocked by Cloud Armor.

### Changes
1. **`server/app_env/_base.py`**: Changed `VERSION` to `os.environ.get('WEBSITE_HASH', '')`.
2. **`run_server.sh`**: Removed dead `export MIXER_HASH=...` export.

> [!NOTE]
> Runtime reporting of the Mixer version (such as on the `/version` status page and in BigTable metadata logging) is unaffected, as it queries Mixer live via gRPC (`dc.version().get('gitHash')`).

### Testing
- [x] Ran code formatters via `uv run --project server --group lint ...`.
- [x] Verified `/version` route and template continue to use dynamic gRPC Mixer versioning.