### PR TITLE
Tune website container readiness probe parameters

### DIFF
--- a/deploy/helm_charts/dc_website/templates/deployment.yaml
+++ b/deploy/helm_charts/dc_website/templates/deployment.yaml
@@ -77,8 +77,9 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
-            failureThreshold: 1
+            failureThreshold: 3
             periodSeconds: 10
+            timeoutSeconds: 5
           resources:
             limits:
               memory: "4G"


### PR DESCRIPTION
### Summary
Updates the `website` container's `readinessProbe` configuration in the Helm deployment chart by increasing `timeoutSeconds` to `5` and `failureThreshold` to `3`.

### Context & Motivation
Previously, `readinessProbe` used `failureThreshold: 1` and omitted `timeoutSeconds` (defaulting to `1s`). Under concurrent request traffic, when all 8 synchronous Gunicorn workers are momentarily occupied, incoming `/healthz` probe requests queue briefly in the socket backlog. If a single probe took slightly over 1 second to respond, Kubelet immediately marked the pod unready (`1/2 Ready`), leading to readiness flapping and cascading into Google Cloud Load Balancer 502s (`failed_to_pick_backend`).

### Changes
* Set `timeoutSeconds: 5` (up from default 1s) to give workers sufficient headroom to finish in-flight requests and return `/healthz`.
* Set `failureThreshold: 3` (up from 1) so that a transient 1-second load spike does not immediately take the pod out of the backend pool.