### PR TITLE
Update gunicorn threads

### DIFF
--- a/build/web_server/Dockerfile
+++ b/build/web_server/Dockerfile
@@ -53,4 +53,4 @@ COPY shared/. /workspace/shared/
 WORKDIR /workspace
 # The number of workers (8) is the number of requests that the app can support
 # at a time.
-CMD exec gunicorn --preload --timeout 1000 --bind :8080 -w 4 --threads 8 web_app:app
+CMD exec gunicorn --preload --timeout 1000 --bind :8080 -w 8 --threads 4 web_app:app

--- a/build/web_server/Dockerfile
+++ b/build/web_server/Dockerfile
@@ -53,4 +53,4 @@ COPY shared/. /workspace/shared/
 WORKDIR /workspace
 # The number of workers (8) is the number of requests that the app can support
 # at a time.
-CMD exec gunicorn --preload --timeout 1000 --bind :8080 -w 8 web_app:app
+CMD exec gunicorn --preload --timeout 1000 --bind :8080 -w 4 --threads 8 web_app:app

--- a/build/web_server/Dockerfile
+++ b/build/web_server/Dockerfile
@@ -51,6 +51,6 @@ RUN npm run-script build
 COPY server/. /workspace/server/
 COPY shared/. /workspace/shared/
 WORKDIR /workspace
-# The number of workers (8) is the number of requests that the app can support
+# 8 workers with 4 threads each allows the app to support up to 32 concurrent requests
 # at a time.
 CMD exec gunicorn --preload --timeout 1000 --bind :8080 -w 8 --threads 4 web_app:app


### PR DESCRIPTION
we are doing 4 thread per worker on 8 workers, this increase the concurrency handling from 8 to 32

Context:
Synchronous Web Server Connection and Socket Timeouts

The Flask-based web application is running under Gunicorn using synchronous workers that frequently experience socket write timeouts (TimeoutError: [Errno 110] Connection timed out inside the sock.sendall(data) method).
When the application experiences high traffic, the synchronous worker processes block while writing responses back to downstream clients. This limits the application's capacity to process incoming requests concurrently.

This blocking behavior prevents the Python container from responding to the local HTTP /healthz check in under the configured 1-second timeout limit. As a result, the website container fails the readiness check, transitioning the system state of the pods to unready and degrading the entire GKE deployment.
