### PR TITLE
fix(build): remove apt-get upgrade from nodejs_server Dockerfile

### DIFF
--- a/build/nodejs_server/Dockerfile
+++ b/build/nodejs_server/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM node:18.14.0-slim
 
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get update
 RUN apt-get install -y python3 pkg-config build-essential libpixman-1-dev libcairo2-dev libpango1.0-dev
 # install roboto font in the container so that nodejs server can use it when
 # drawing the charts.


### PR DESCRIPTION
## Goal
Fix a blocking build failure in `build/nodejs_server/Dockerfile` during the `website-on-push-to-branch` Cloud Build pipeline.

## Problem
In `build/nodejs_server/Dockerfile`, `RUN apt-get update && apt-get -y upgrade` runs against `node:18.14.0-slim` (Debian 11 Bullseye). Because Debian Bullseye reached EOL for standard security support, upstream security mirrors return HTTP 404 for archived packages (`e2fsprogs`, `libssl1.1`) during full OS upgrades, causing Cloud Build Step 4 (`push-nodejs-server`) to fail with exit code 100:
```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/e/e2fsprogs/e2fsprogs_1.46.2-2%2bdeb11u1_amd64.deb  404  Not Found
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0%2bdeb11u8_amd64.deb  404  Not Found
```

## Solution
Remove `&& apt-get -y upgrade` from `build/nodejs_server/Dockerfile`.
Per official Docker best practices, running `apt-get upgrade` inside container builds should be avoided as it causes non-deterministic builds and breaks when base distributions transition.

## Verification
Verified via side-by-side standalone Cloud Build runs of `build/nodejs_server/Dockerfile`:

* **Reproduced Failure on `master` (HEAD `1fab4b2`):**
  * Build ID: `5f689349-2308-439d-a9ba-090d613fa2bb`
  * Logs: [Console Link](https://console.cloud.google.com/cloud-build/builds/5f689349-2308-439d-a9ba-090d613fa2bb?project=496370955550)
  * Result: **Failed** at `apt-get update && apt-get -y upgrade` with exit code 100 (`404 Not Found` fetching `libssl1.1` and `libss2`).

* **Successful Run on Fix Branch (`fix-nodejs-server-docker-build`):**
  * Build ID: `8c4a070e-a635-4da6-820b-167cbcade717`
  * Logs: [Console Link](https://console.cloud.google.com/cloud-build/builds/8c4a070e-a635-4da6-820b-167cbcade717?project=496370955550)
  * Result: **`SUCCESS`** (completed in 3m57s with all packages installed and container packaged).