### PR TITLE
fix(build): update nodejs_server base image to node:18.20.8-bookworm-slim

### DIFF
--- a/build/nodejs_server/Dockerfile
+++ b/build/nodejs_server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:18.14.0-slim
+FROM node:18-bookworm-slim
 
 RUN apt-get update
 RUN apt-get install -y python3 pkg-config build-essential libpixman-1-dev libcairo2-dev libpango1.0-dev

--- a/build/nodejs_server/Dockerfile
+++ b/build/nodejs_server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:18-bookworm-slim
+FROM node:18.20.8-bookworm-slim
 
 RUN apt-get update
 RUN apt-get install -y python3 pkg-config build-essential libpixman-1-dev libcairo2-dev libpango1.0-dev


### PR DESCRIPTION
### Summary
Direct follow-up to #6633. Upgrades `build/nodejs_server/Dockerfile` from `node:18.14.0-slim` (Debian 11 Bullseye) to `node:18.20.8-bookworm-slim` (Debian 12 Bookworm).

### Root Cause
* **Debian 11 EOL:** Debian 11 (Bullseye) reached final LTS End-of-Life on August 31, 2026. Upstream mirrors (`deb.debian.org` and `security.debian.org`) have decommissioned Bullseye packages in favor of `archive.debian.org`.
* **Build Failure:** Container builds fail during `apt-get install` with `404 Not Found` (specifically on `libglib2.0-bin`).
* **Context on #6633:** Removing `apt-get -y upgrade` in #6633 bypassed the initial 404 error on `e2fsprogs`. While an initial test build succeeded because regional CDN edge caches had not yet expired, subsequent builds failed on downstream EOL dependencies during `apt-get install`.

### Solution
* Upgrade the base image to `node:18.20.8-bookworm-slim` (Debian 12 Bookworm), which is actively supported through 2028.
* Pins the exact patch version for build reproducibility and eliminates floating tag drift.
* Aligns the `nodejs_server` base OS with `web_server` and `nl_server`.

### Testing & Safety
* **Deterministic Origin Verification (`No-Cache` Side-by-Side):**
  To eliminate regional CDN edge cache masking, tested package installation with `Acquire::http::No-Cache=true` (forcing direct upstream origin queries):
  * **Master base image (`node:18.14.0-slim`):**
    ```bash
    docker run --rm --platform linux/amd64 node:18.14.0-slim sh -c '
      echo "Acquire::http::No-Cache \"true\"; Acquire::http::No-Store \"true\";" > /etc/apt/apt.conf.d/99nocache && \
      apt-get update && \
      apt-get install -y python3 pkg-config build-essential libpixman-1-dev libcairo2-dev libpango1.0-dev fonts-roboto'
    ```
    **Result:** Consistently failed with `404 Not Found` (fetching `xz-utils`, exit code 100).

  * **This PR base image (`node:18.20.8-bookworm-slim`):**
    ```bash
    docker run --rm --platform linux/amd64 node:18.20.8-bookworm-slim sh -c '
      echo "Acquire::http::No-Cache \"true\"; Acquire::http::No-Store \"true\";" > /etc/apt/apt.conf.d/99nocache && \
      apt-get update && \
      apt-get install -y python3 pkg-config build-essential libpixman-1-dev libcairo2-dev libpango1.0-dev fonts-roboto'
    ```
    **Result:** Succeeded with exit code 0; all 229 packages installed cleanly from live Debian 12 mirrors.

* **Cloud Build Verification:**
  ```bash
  gcloud builds submit . --config=cloudbuild-nodejs-test.yaml --project=datcom-website-dev
  ```
  **Result:** Succeeded in 2m 52s (Build ID: `bc52c58c-07e9-4d7c-b48d-1a0332954da0`).

* **Runtime Compatibility:** Stays on Node 18 (`18.20.8` vs `18.14.0`) with zero changes to application code, ports (`8080`), or routes. Verified `/nodejs/healthz` (`HTTP 200 OK`) and native in-memory canvas rendering.