### PR TITLE
fix(frontend): remove provenance url from facet metadata enrichment payload

### DIFF
--- a/static/js/shared/facet_selector/facet_option_content.test.tsx
+++ b/static/js/shared/facet_selector/facet_option_content.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from "@emotion/react";
+import { render, RenderResult, screen } from "@testing-library/react";
+import React from "react";
+
+import theme from "../../theme/theme";
+import { FacetOptionContent } from "./facet_option_content";
+
+describe("FacetOptionContent", () => {
+  const renderWithTheme = (ui: React.ReactElement): RenderResult =>
+    render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+
+  // Test: Primary title derivation from provenanceName and no detail pollution.
+  // Situation: Facet has provenanceName and provenanceId, but no sourceName or importName.
+  // Expectation: Title displays provenanceName; the raw provenanceId segment is not rendered as a detail item.
+  it("renders provenanceName as title and does not leak provenanceId segment into details", () => {
+    renderWithTheme(
+      <FacetOptionContent
+        metadata={{
+          provenanceName: "U.S. Census Bureau",
+          provenanceId: "dc/base/Census",
+        }}
+      />
+    );
+
+    expect(screen.getByText("U.S. Census Bureau")).toBeTruthy();
+    expect(screen.queryByText("Census")).toBeNull();
+  });
+
+  // Test: Fallback to displayName.
+  // Situation: Facet lacks provenanceName, but displayName is supplied.
+  // Expectation: Title displays displayName.
+  it("renders displayName as title when provenanceName is absent", () => {
+    renderWithTheme(
+      <FacetOptionContent
+        displayName="Custom Display Source"
+        metadata={{
+          provenanceId: "dc/base/Census",
+        }}
+      />
+    );
+
+    expect(screen.getByText("Custom Display Source")).toBeTruthy();
+  });
+
+  // Test: Fallback to sourceName.
+  // Situation: Facet has sourceName but no provenanceName or displayName.
+  // Expectation: Title displays sourceName.
+  it("renders sourceName as title when provenanceName is absent", () => {
+    renderWithTheme(
+      <FacetOptionContent
+        metadata={{
+          sourceName: "Census.gov",
+          provenanceId: "dc/base/Census",
+        }}
+      />
+    );
+
+    expect(screen.getByText("Census.gov")).toBeTruthy();
+  });
+
+  // Test: Precedence of importName over provenanceId segment.
+  // Situation: Facet has importName and provenanceId, but no provenanceName or sourceName.
+  // Expectation: Title displays importName.
+  it("renders importName as title over raw provenanceId segment", () => {
+    renderWithTheme(
+      <FacetOptionContent
+        metadata={{
+          importName: "CensusACS5YearSurvey",
+          provenanceId: "dc/base/Census",
+        }}
+      />
+    );
+
+    expect(screen.getByText("CensusACS5YearSurvey")).toBeTruthy();
+    expect(screen.queryByText("Census")).toBeNull();
+  });
+
+  // Test: Fallback to trailing segment of provenanceId.
+  // Situation: Enrichment failed; provenanceName, sourceName, and importName are all absent, but provenanceId exists.
+  // Expectation: Title displays the trailing segment of provenanceId.
+  it("renders trailing segment of provenanceId when all human-readable names are absent", () => {
+    renderWithTheme(
+      <FacetOptionContent
+        metadata={{
+          provenanceId: "dc/base/EurostatData",
+        }}
+      />
+    );
+
+    expect(screen.getByText("EurostatData")).toBeTruthy();
+  });
+
+  // Test: Fallback to measurementMethod when provenance identifiers are missing.
+  // Situation: Facet lacks all provenance names and provenanceId, but has measurementMethod.
+  // Expectation: Title displays measurementMethod and does not duplicate it in the details list.
+  it("renders measurementMethod as title when provenance identifiers are absent and deduplicates in details", () => {
+    const { container } = renderWithTheme(
+      <FacetOptionContent
+        metadata={{
+          measurementMethod: "CensusSurvey",
+        }}
+      />
+    );
+
+    expect(screen.getByText("CensusSurvey")).toBeTruthy();
+    const detailItems = container.querySelectorAll("ul li");
+    expect(detailItems.length).toBe(0);
+  });
+
+  // Test: Legitimate secondary detail rendering.
+  // Situation: Facet has both provenanceName and sourceName.
+  // Expectation: Primary title is provenanceName; detail list contains sourceName.
+  it("renders sourceName as detail item when provenanceName is the primary title", () => {
+    renderWithTheme(
+      <FacetOptionContent
+        metadata={{
+          provenanceName: "U.S. Census Bureau",
+          sourceName: "Census.gov",
+          provenanceId: "dc/base/Census",
+        }}
+      />
+    );
+
+    expect(screen.getByText("U.S. Census Bureau")).toBeTruthy();
+    expect(screen.getByText("Census.gov")).toBeTruthy();
+    expect(screen.queryByText("Census")).toBeNull();
+  });
+
+  // Test: Empty metadata renders combined dataset option.
+  // Situation: Empty metadata object provided for chart and download modes.
+  // Expectation: Renders localized combined dataset messages for charts and download respectively.
+  it("renders combined dataset option message when metadata is empty", () => {
+    const { rerender } = renderWithTheme(
+      <FacetOptionContent metadata={{}} mode="chart" />
+    );
+    expect(
+      screen.getByText(
+        "Plot data points using one or more of the facets below to maximize coverage."
+      )
+    ).toBeTruthy();
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <FacetOptionContent metadata={{}} mode="download" />
+      </ThemeProvider>
+    );
+    expect(
+      screen.getByText(
+        "Combine data using one or more of the facets below to maximize coverage."
+      )
+    ).toBeTruthy();
+  });
+
+  // Test: Unit display formatting and symbol preservation.
+  // Situation: Facet has unit symbol (e.g. "%") without unitDisplayName.
+  // Expectation: Renders raw unit symbol without stripping via startCase.
+  it("renders raw unit symbol when unitDisplayName is absent", () => {
+    renderWithTheme(
+      <FacetOptionContent
+        metadata={{
+          provenanceId: "dc/base/Census",
+          unit: "%",
+        }}
+      />
+    );
+
+    expect(screen.getByText("Unit • %")).toBeTruthy();
+  });
+
+  // Test: Unit display name formatting with startCase.
+  // Situation: Facet has unitDisplayName.
+  // Expectation: Applies startCase to unitDisplayName.
+  it("applies startCase to unitDisplayName", () => {
+    renderWithTheme(
+      <FacetOptionContent
+        metadata={{
+          provenanceId: "dc/base/Census",
+          unitDisplayName: "metric_ton",
+        }}
+      />
+    );
+
+    expect(screen.getByText("Unit • Metric Ton")).toBeTruthy();
+  });
+});

--- a/static/js/shared/facet_selector/facet_option_content.tsx
+++ b/static/js/shared/facet_selector/facet_option_content.tsx
@@ -96,10 +96,18 @@ export function FacetOptionContent({
         : facetSelectionComponentMessages.CombinedDatasetForChartsOption
     );
   } else {
+    const provenanceIdSegment = metadata.provenanceId
+      ?.split("/")
+      .filter(Boolean)
+      .pop();
     const sourceTitle =
       displayName || metadata.sourceName || metadata.importName;
-    primaryTitle = metadata.provenanceName || sourceTitle;
-    if (primaryTitle !== sourceTitle) {
+    primaryTitle =
+      metadata.provenanceName ||
+      sourceTitle ||
+      provenanceIdSegment ||
+      metadata.measurementMethod;
+    if (primaryTitle !== sourceTitle && sourceTitle) {
       firstDetailItem = sourceTitle;
     }
   }
@@ -185,13 +193,22 @@ export function FacetOptionContent({
             </li>
           )}
         {firstDetailItem && <li>{firstDetailItem}</li>}
-        {metadata.measurementMethodDescription && (
-          <li>{metadata.measurementMethodDescription}</li>
-        )}
-        {metadata.unitDisplayName && (
+        {(metadata.measurementMethodDescription ||
+          metadata.measurementMethod) &&
+          primaryTitle !==
+            (metadata.measurementMethodDescription ||
+              metadata.measurementMethod) && (
+            <li>
+              {metadata.measurementMethodDescription ||
+                metadata.measurementMethod}
+            </li>
+          )}
+        {(metadata.unitDisplayName || metadata.unit) && (
           <li>
             {intl.formatMessage(metadataComponentMessages.Unit)} •{" "}
-            {startCase(metadata.unitDisplayName)}
+            {metadata.unitDisplayName
+              ? startCase(metadata.unitDisplayName)
+              : metadata.unit}
           </li>
         )}
         {metadata.scalingFactor && (

--- a/static/js/shared/facet_selector/facet_option_content.tsx
+++ b/static/js/shared/facet_selector/facet_option_content.tsx
@@ -125,6 +125,9 @@ export function FacetOptionContent({
         : humanizedPeriod;
   }
 
+  const methodDetail =
+    metadata.measurementMethodDescription || metadata.measurementMethod;
+
   return (
     <div
       className={`${SELECTOR_PREFIX}-facet-option-title`}
@@ -203,6 +206,9 @@ export function FacetOptionContent({
                 metadata.measurementMethod}
             </li>
           )}
+        {methodDetail && primaryTitle !== methodDetail && (
+          <li>{methodDetail}</li>
+        )}
         {(metadata.unitDisplayName || metadata.unit) && (
           <li>
             {intl.formatMessage(metadataComponentMessages.Unit)} •{" "}

--- a/static/js/tools/shared/metadata/metadata_fetcher.test.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.test.ts
@@ -31,7 +31,8 @@ describe("fetchFacetsWithMetadata", () => {
 
   // Test: Payload sanitization and client-side URL retention.
   // Situation: Facets containing external provenanceUrl query strings are enriched via API.
-  // Expectation: provenanceUrl is excluded from the POST request body, but retained in returned client objects alongside enriched metadata.
+  // Expectation: provenanceUrl is excluded from the POST request body, but retained in returned client objects
+  // alongside enriched metadata.
   it("strips provenanceUrl from outgoing payload and retains it in merged result", async () => {
     const inputFacets: FacetResponse = {
       Count_Person: {
@@ -179,7 +180,9 @@ describe("fetchFacetsWithMetadata", () => {
 
   // Test: Multi-variable and multi-facet payload sanitization and merge.
   // Situation: Multiple statistical variables with multiple facets, some with provenanceUrl and some without.
-  // Expectation: All provenanceUrls are stripped from outgoing POST body, original provenanceUrls are retained in merged output, facets without provenanceUrl do not gain a provenanceUrl property, and enriched fields are merged across all facets.
+  // Expectation: All provenanceUrls are stripped from outgoing POST body, original provenanceUrls are retained in
+  // merged output, facets without provenanceUrl do not gain a provenanceUrl property, and enriched fields are merged
+  // across all facets.
   it("sanitizes and merges multiple stat vars and facets, preserving absence of provenanceUrl", async () => {
     const inputFacets: FacetResponse = {
       Count_Person: {

--- a/static/js/tools/shared/metadata/metadata_fetcher.test.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable camelcase */
+import { FacetResponse } from "../../../utils/data_fetch_utils";
+import { fetchFacetsWithMetadata } from "./metadata_fetcher";
+
+describe("fetchFacetsWithMetadata", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // Test: Payload sanitization and client-side URL retention.
+  // Situation: Facets containing external provenanceUrl query strings are enriched via API.
+  // Expectation: provenanceUrl is excluded from the POST request body, but retained in returned client objects alongside enriched metadata.
+  it("strips provenanceUrl from outgoing payload and retains it in merged result", async () => {
+    const inputFacets: FacetResponse = {
+      Count_Person: {
+        facet1: {
+          importName: "CensusACS5YearSurvey",
+          provenanceId: "dc/base/Census",
+          provenanceUrl:
+            "https://census.gov/data?query=test&id=123&token=abc%20def",
+          measurementMethod: "CensusSurvey",
+        },
+      },
+    };
+
+    const mockEnrichedResponse: FacetResponse = {
+      Count_Person: {
+        facet1: {
+          importName: "CensusACS5YearSurvey",
+          provenanceId: "dc/base/Census",
+          sourceName: "Census.gov",
+          provenanceName: "U.S. Census Bureau",
+          dateRangeStart: "2015",
+          dateRangeEnd: "2020",
+        },
+      },
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockEnrichedResponse),
+    });
+    global.fetch = mockFetch;
+
+    const result = await fetchFacetsWithMetadata(inputFacets, {
+      entities: ["geoId/06"],
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledOptions] = mockFetch.mock.calls[0];
+    expect(calledUrl).toBe("/api/metadata/facets");
+    expect(calledOptions.method).toBe("POST");
+
+    const sentPayload = JSON.parse(calledOptions.body);
+    // Verify provenanceUrl was stripped from outgoing payload
+    expect(
+      sentPayload.facets.Count_Person.facet1.provenanceUrl
+    ).toBeUndefined();
+    expect(sentPayload.facets.Count_Person.facet1.importName).toBe(
+      "CensusACS5YearSurvey"
+    );
+    expect(sentPayload.facets.Count_Person.facet1.provenanceId).toBe(
+      "dc/base/Census"
+    );
+
+    // Verify returned object retains original provenanceUrl and merged metadata
+    expect(result.Count_Person.facet1.provenanceUrl).toBe(
+      "https://census.gov/data?query=test&id=123&token=abc%20def"
+    );
+    expect(result.Count_Person.facet1.sourceName).toBe("Census.gov");
+    expect(result.Count_Person.facet1.provenanceName).toBe(
+      "U.S. Census Bureau"
+    );
+    expect(result.Count_Person.facet1.dateRangeStart).toBe("2015");
+    expect(result.Count_Person.facet1.dateRangeEnd).toBe("2020");
+  });
+
+  // Test: Fallback on HTTP error.
+  // Situation: The enrichment endpoint returns HTTP 403 Forbidden (Cloud Armor block).
+  // Expectation: The function returns original facets with provenanceUrl intact without crashing.
+  it("returns original facets with provenanceUrl intact when API returns non-200", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {
+      /* ignore */
+    });
+
+    const inputFacets: FacetResponse = {
+      Count_Person: {
+        facet1: {
+          importName: "EurostatData",
+          provenanceId: "dc/base/Eurostat",
+          provenanceUrl: "https://ec.europa.eu/eurostat/wdds/rest/data/v2/nl",
+        },
+      },
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+    });
+
+    const result = await fetchFacetsWithMetadata(inputFacets, {});
+
+    expect(result).toBe(inputFacets);
+    expect(result.Count_Person.facet1.provenanceUrl).toBe(
+      "https://ec.europa.eu/eurostat/wdds/rest/data/v2/nl"
+    );
+    expect(consoleSpy).toHaveBeenCalledWith("Failed to enrich facets via API");
+
+    consoleSpy.mockRestore();
+  });
+
+  // Test: Fallback on network exception.
+  // Situation: fetch throws a network rejection.
+  // Expectation: The exception is caught and original facets are returned intact.
+  it("returns original facets with provenanceUrl intact when fetch throws", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {
+      /* ignore */
+    });
+
+    const inputFacets: FacetResponse = {
+      Count_Person: {
+        facet1: {
+          importName: "EurostatData",
+          provenanceUrl: "https://ec.europa.eu/eurostat",
+        },
+      },
+    };
+
+    global.fetch = jest.fn().mockRejectedValue(new Error("Connection refused"));
+
+    const result = await fetchFacetsWithMetadata(inputFacets, {});
+
+    expect(result).toBe(inputFacets);
+    expect(result.Count_Person.facet1.provenanceUrl).toBe(
+      "https://ec.europa.eu/eurostat"
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Error enriching facets:",
+      expect.any(Error)
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  // Test: Empty facets input.
+  // Situation: fetchFacetsWithMetadata called with an empty facet dictionary.
+  // Expectation: Returns empty object immediately without dispatching a network request.
+  it("returns immediately without calling fetch if facets object is empty", async () => {
+    const mockFetch = jest.fn();
+    global.fetch = mockFetch;
+
+    const result = await fetchFacetsWithMetadata({}, {});
+
+    expect(result).toEqual({});
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // Test: Multi-variable and multi-facet payload sanitization and merge.
+  // Situation: Multiple statistical variables with multiple facets, some with provenanceUrl and some without.
+  // Expectation: All provenanceUrls are stripped from outgoing POST body, original provenanceUrls are retained in merged output, facets without provenanceUrl do not gain a provenanceUrl property, and enriched fields are merged across all facets.
+  it("sanitizes and merges multiple stat vars and facets, preserving absence of provenanceUrl", async () => {
+    const inputFacets: FacetResponse = {
+      Count_Person: {
+        facet1: {
+          importName: "CensusACS5YearSurvey",
+          provenanceUrl: "https://census.gov/data?query=test",
+        },
+        facet2: {
+          importName: "CensusPEP",
+          measurementMethod: "CensusPEPSurvey",
+        },
+      },
+      Median_Income_Person: {
+        facet3: {
+          importName: "BLSData",
+          provenanceUrl: "https://bls.gov/data/income",
+          unit: "USDollar",
+        },
+      },
+    };
+
+    const mockEnrichedResponse: FacetResponse = {
+      Count_Person: {
+        facet1: {
+          sourceName: "Census.gov",
+          provenanceName: "U.S. Census Bureau",
+        },
+        facet2: {
+          sourceName: "Census.gov",
+          provenanceName: "U.S. Census Bureau Population Estimates",
+        },
+      },
+      Median_Income_Person: {
+        facet3: {
+          sourceName: "BLS",
+          provenanceName: "Bureau of Labor Statistics",
+          unitDisplayName: "US Dollar",
+        },
+      },
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockEnrichedResponse),
+    });
+    global.fetch = mockFetch;
+
+    const result = await fetchFacetsWithMetadata(inputFacets, {
+      entities: ["geoId/06"],
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, calledOptions] = mockFetch.mock.calls[0];
+    const sentPayload = JSON.parse(calledOptions.body);
+
+    // Verify provenanceUrl stripped across all stat vars and facets
+    expect(
+      sentPayload.facets.Count_Person.facet1.provenanceUrl
+    ).toBeUndefined();
+    expect(sentPayload.facets.Count_Person.facet1.importName).toBe(
+      "CensusACS5YearSurvey"
+    );
+    expect(
+      sentPayload.facets.Median_Income_Person.facet3.provenanceUrl
+    ).toBeUndefined();
+    expect(sentPayload.facets.Median_Income_Person.facet3.importName).toBe(
+      "BLSData"
+    );
+
+    // Verify facet2 never had provenanceUrl in sent payload
+    expect("provenanceUrl" in sentPayload.facets.Count_Person.facet2).toBe(
+      false
+    );
+
+    // Verify returned merged output
+    expect(result.Count_Person.facet1.provenanceUrl).toBe(
+      "https://census.gov/data?query=test"
+    );
+    expect(result.Count_Person.facet1.provenanceName).toBe(
+      "U.S. Census Bureau"
+    );
+
+    // Verify facet without provenanceUrl does not have provenanceUrl property
+    expect("provenanceUrl" in result.Count_Person.facet2).toBe(false);
+    expect(result.Count_Person.facet2.measurementMethod).toBe(
+      "CensusPEPSurvey"
+    );
+    expect(result.Count_Person.facet2.provenanceName).toBe(
+      "U.S. Census Bureau Population Estimates"
+    );
+
+    expect(result.Median_Income_Person.facet3.provenanceUrl).toBe(
+      "https://bls.gov/data/income"
+    );
+    expect(result.Median_Income_Person.facet3.provenanceName).toBe(
+      "Bureau of Labor Statistics"
+    );
+    expect(result.Median_Income_Person.facet3.unitDisplayName).toBe(
+      "US Dollar"
+    );
+  });
+});

--- a/static/js/tools/shared/metadata/metadata_fetcher.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.ts
@@ -118,7 +118,7 @@ export async function fetchFacetsWithMetadata(
         mergedFacets[sv][facetId] = {
           ...facet,
           ...enriched,
-          ...(facet.provenanceUrl !== undefined
+          ...(facet?.provenanceUrl !== undefined
             ? { provenanceUrl: facet.provenanceUrl }
             : {}),
         };

--- a/static/js/tools/shared/metadata/metadata_fetcher.ts
+++ b/static/js/tools/shared/metadata/metadata_fetcher.ts
@@ -85,11 +85,20 @@ export async function fetchFacetsWithMetadata(
       ...(surface ? getSurfaceHeader(surface) : {}),
     };
 
+    const sanitizedFacets: FacetResponse = {};
+    for (const [sv, svFacets] of Object.entries(facets)) {
+      sanitizedFacets[sv] = {};
+      for (const [facetId, facet] of Object.entries(svFacets)) {
+        sanitizedFacets[sv][facetId] = { ...facet };
+        delete sanitizedFacets[sv][facetId].provenanceUrl;
+      }
+    }
+
     const response = await fetch(`${apiRoot}/api/metadata/facets`, {
       method: "POST",
       headers,
       body: JSON.stringify({
-        facets,
+        facets: sanitizedFacets,
         statVars,
         entities: entityContext.entities,
         parentPlace: entityContext.parentPlace,
@@ -100,7 +109,22 @@ export async function fetchFacetsWithMetadata(
       console.error("Failed to enrich facets via API");
       return facets;
     }
-    return await response.json();
+    const enrichedFacets: FacetResponse = await response.json();
+    const mergedFacets: FacetResponse = {};
+    for (const [sv, svFacets] of Object.entries(facets)) {
+      mergedFacets[sv] = {};
+      for (const [facetId, facet] of Object.entries(svFacets)) {
+        const enriched = enrichedFacets?.[sv]?.[facetId] || {};
+        mergedFacets[sv][facetId] = {
+          ...facet,
+          ...enriched,
+          ...(facet.provenanceUrl !== undefined
+            ? { provenanceUrl: facet.provenanceUrl }
+            : {}),
+        };
+      }
+    }
+    return mergedFacets;
   } catch (e) {
     console.error("Error enriching facets:", e);
     return facets;


### PR DESCRIPTION
## Issue

[556879875](b/556879875)

## Description

Cloud Armor Rule 2000 (OWASP CRS false positive) blocked `POST /api/metadata/facets` requests because the payloads contained the provenanceUrl. This provenanceUrl was a part of the unenriched facet, but was not required by the `/api/metadata/facets` endpoint in order to fulfill its purpose of enriching the facets.

This PR does the following:
* It strips the external `provenanceUrl` URLs from the request payload, to prevent those Cloud Armor false positives.
* It improves the fallback display in the event that a facet enrichment request does fail, displaying unenriched facet information rather than blank lines.
* It adds tests for this functionality.

## Note

The diff is quite large but most of this is tests. Functional changes make up a small portion of the lines.

## Screenshots

### Enriched facets (successful call)

<img width="1282" height="1310" alt="image" src="https://github.com/user-attachments/assets/f64e6315-6295-410c-a6fa-e0d56d528ef6" />

### Unenriched facets (simulated unsuccessful call)

<img width="1336" height="1044" alt="image" src="https://github.com/user-attachments/assets/463e3d5c-6176-43db-a1d7-368b894b0c0b" />

## Next Steps

In Autopush or Staging, we should validate that this solves the initial Cloud Armor false positive by enabling the rule and verifying that these calls still resolve successfully.

Once that has been confirmed, and once this is in production, the rule can be re-enabled in production.

## Codacy

The codacy complaint (a long line) is fixed, but the codacy report and error below is staled. The issue doesn't exist anymore (and the actual report is showing "Up to standards" if you drill into the codacy report).